### PR TITLE
gui: fix mentions dropdown list for pc browsers

### DIFF
--- a/web/react/components/mention.jsx
+++ b/web/react/components/mention.jsx
@@ -8,8 +8,8 @@ module.exports = React.createClass({
     render: function() {
         return (
             <div className="mentions-name" onClick={this.handleClick}>
-                <img className="pull-left mention-img" src={"/api/v1/users/" + this.props.id + "/image"}/>
-                <span>@{this.props.username}</span><span style={{'color':'grey', 'marginLeft':'10px'}}>{this.props.name}</span>
+                <img className="mention-img" src={"/api/v1/users/" + this.props.id + "/image"}/>
+                <span>@{this.props.username}</span><span className="mention-fullname">{this.props.name}</span>
             </div>
         );
     }

--- a/web/sass-files/sass/partials/_mentions.scss
+++ b/web/sass-files/sass/partials/_mentions.scss
@@ -3,21 +3,19 @@
 	background: $primary-color;
 	position: relative;
 	z-index: 10;
-	padding-bottom: 1px;
+	padding-bottom: 2px;
 	@include border-radius(3px);
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
-	box-sizing: border-box;
 }
 
 .mentions--top {
 	position: absolute;
-    z-index:99999;
+    z-index: 1040;
 	.mentions-box {
 		position:absolute;
 		background-color:#fff;
-		border:1px solid #ddd;
-        overflow:scroll;
+		border: $border-gray;
+        overflow-x: hidden;
+        overflow-y: scroll;
         bottom:0;
 	}
 }
@@ -29,10 +27,10 @@
 	height:37px;
 	padding:2px;
 	z-index:101;
-}
-
-.mentions-name:hover {
-	background-color:#e8eaed;
+    cursor: pointer;
+    &:hover {
+        background-color:#e8eaed;
+    }
 }
 
 .mentions-text {
@@ -44,6 +42,11 @@
 	height:32px;
 	width:32px;
 	border-radius: 10%;
+}
+
+.mention-fullname {
+    color: grey;
+    padding-left: 10px;
 }
 
 .mention-highlight {


### PR DESCRIPTION
1) hide horizontal scrollbar ![mentions list](https://cloud.githubusercontent.com/assets/10889830/8384881/cf244626-1c4c-11e5-82a1-61979f0c9c02.png)


2) hide get out symbols under badge (was only in firefox) ![mention symbols get out from badge](https://cloud.githubusercontent.com/assets/10889830/8384886/d4bef180-1c4c-11e5-8dc3-a3568740aa48.png)


3) fix layer with userinfo is over mentions list ![mentions list overlay](https://cloud.githubusercontent.com/assets/10889830/8384888/d976de36-1c4c-11e5-8df4-d86eb5f01e5f.png)
