### PR TITLE
MM-983 Fixed file preview removal in IE10

### DIFF
--- a/web/react/components/file_preview.jsx
+++ b/web/react/components/file_preview.jsx
@@ -10,7 +10,7 @@ var Constants = require('../utils/constants.jsx');
 module.exports = React.createClass({
     handleRemove: function(e) {
         var previewDiv = e.target.parentNode.parentNode;
-        this.props.onRemove(previewDiv.dataset.filename);
+        this.props.onRemove(previewDiv.getAttribute('data-filename'));
     },
     render: function() {
         var previews = [];


### PR DESCRIPTION
Using "dataset" instead of the getAttribute function is unsupported in IE 10 and below (looks like it wasn't introduced until HTML5 which IE10 only partially supports apparently).  Using the getAttribute function makes it forwards and backwards compatible with all browsers.