### PR TITLE
MM-1430 Added the ability to have hashtags with dashes in them

### DIFF
--- a/model/utils.go
+++ b/model/utils.go
@@ -260,7 +260,7 @@ func Etag(parts ...interface{}) string {
 	return etag
 }
 
-var validHashtag = regexp.MustCompile(`^(#[A-Za-z]+[A-Za-z0-9_]*[A-Za-z0-9])$`)
+var validHashtag = regexp.MustCompile(`^(#[A-Za-z]+[A-Za-z0-9_\-]*[A-Za-z0-9])$`)
 var puncStart = regexp.MustCompile(`^[.,()&$!\[\]{}"':;\\]+`)
 var puncEnd = regexp.MustCompile(`[.,()&$#!\[\]{}"':;\\]+$`)
 

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -395,8 +395,8 @@ module.exports.textToJsx = function(text, options) {
 
     var inner = [];
 
-    // Function specific regexes
-    var hashRegex = /^href="#[^"]+"|(#[A-Za-z]+[A-Za-z0-9_]*[A-Za-z0-9])$/g;
+    // Function specific regex
+    var hashRegex = /^href="#[^"]+"|(#[A-Za-z]+[A-Za-z0-9_\-]*[A-Za-z0-9])$/g;
 
     var implicitKeywords = {};
     var keywordArray = UserStore.getCurrentMentionKeys();


### PR DESCRIPTION
Implementing the dashes was done with the two changes to our regex.
However, due to how SQL searching works, we needed to add this post filter so that only the exact match hashtags are gotten, not the fuzzy match that the query alone returns.