### PR TITLE
MM-1047 Error code 200 IE 10 & 11 suppression within getMeSynchronous method

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -469,7 +469,7 @@ func getMe(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		result.Data.(*model.User).Sanitize(map[string]bool{})
 		w.Header().Set(model.HEADER_ETAG_SERVER, result.Data.(*model.User).Etag())
-		w.Header().Set("Expires", "-1")
+		w.Header().Set("Cache-Control", "max-age=0, public") // should refresh
 		w.Write([]byte(result.Data.(*model.User).ToJson()))
 		return
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -469,7 +469,7 @@ func getMe(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		result.Data.(*model.User).Sanitize(map[string]bool{})
 		w.Header().Set(model.HEADER_ETAG_SERVER, result.Data.(*model.User).Etag())
-		w.Header().Set("Cache-Control", "max-age=0, public") // should refresh
+		w.Header().Set("Expires", "-1")
 		w.Write([]byte(result.Data.(*model.User).ToJson()))
 		return
 	}

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -280,6 +280,7 @@ module.exports.getMeSynchronous = function(success, error) {
         url: "/api/v1/users/me",
         dataType: 'json',
         contentType: 'application/json',
+        cache: false,
         type: 'GET',
         success: function(data, textStatus, xhr) {
             current_user = data;

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -287,7 +287,7 @@ module.exports.getMeSynchronous = function(success, error) {
             if (success) success(data, textStatus, xhr);
         },
         error: function(xhr, status, err) {
-            if (error) {
+            if (xhr.status != 200 && error) {
                 e = handleError("getMeSynchronous", xhr, status, err);
                 error(e);
             };

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -286,7 +286,7 @@ module.exports.getMeSynchronous = function(success, error) {
             if (success) success(data, textStatus, xhr);
         },
         error: function(xhr, status, err) {
-            var ieChecker = window.navigator.userAgent;
+            var ieChecker = window.navigator.userAgent; // This and the condition below is used to check specifically for browsers IE10 & 11 to suppress a 200 'OK' error from appearing on login
             if (xhr.status != 200 || !(ieChecker.indexOf("Trident/7.0") > 0 || ieChecker.indexOf("Trident/6.0") > 0)) {
                 if (error) {
                     e = handleError("getMeSynchronous", xhr, status, err);

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -280,16 +280,18 @@ module.exports.getMeSynchronous = function(success, error) {
         url: "/api/v1/users/me",
         dataType: 'json',
         contentType: 'application/json',
-        //cache: false,
         type: 'GET',
         success: function(data, textStatus, xhr) {
             current_user = data;
             if (success) success(data, textStatus, xhr);
         },
         error: function(xhr, status, err) {
-            if (/*xhr.status != 200 && */error) {
-                e = handleError("getMeSynchronous", xhr, status, err);
-                error(e);
+            var ieChecker = window.navigator.userAgent;
+            if (xhr.status != 200 || !(ieChecker.indexOf("Trident/7.0") > 0 || ieChecker.indexOf("Trident/6.0") > 0)) {
+                if (error) {
+                    e = handleError("getMeSynchronous", xhr, status, err);
+                    error(e);
+                };
             };
         }
     });

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -280,14 +280,14 @@ module.exports.getMeSynchronous = function(success, error) {
         url: "/api/v1/users/me",
         dataType: 'json',
         contentType: 'application/json',
-        cache: false,
+        //cache: false,
         type: 'GET',
         success: function(data, textStatus, xhr) {
             current_user = data;
             if (success) success(data, textStatus, xhr);
         },
         error: function(xhr, status, err) {
-            if (xhr.status != 200 && error) {
+            if (/*xhr.status != 200 && */error) {
                 e = handleError("getMeSynchronous", xhr, status, err);
                 error(e);
             };


### PR DESCRIPTION
Error code 200 means everything is OK.  However IE 10 & 11 see fit to, well throw a fit within the getMeSynchronous method in the client.jsx file.  While this is not a great solution to the problem (the "error" is simply suppressed if the browser is detected to be IE 10 or 11 by checking the layout engine in-use (once again not optimal, but the easiest way to do it currently).  Hopefully a better solution can be found eventually but this will do the job for getting IE 10 & 11 support up and running and I've already spent too much time trying to fix this one issue that really isn't even an error as much as IE wants it to be.