### PR TITLE
MM-832 Fixed not being able to open channel notifications settings menu in IE10

### DIFF
--- a/web/react/components/channel_notifications.jsx
+++ b/web/react/components/channel_notifications.jsx
@@ -21,7 +21,7 @@ module.exports = React.createClass({
             var notifyLevel = ChannelStore.getMember(channel_id).notify_level;
             var quietMode = false;
             if (notifyLevel === "quiet") quietMode = true;
-            self.setState({ notify_level: notifyLevel, quiet_mode: quietMode, title: button.getAttribute('data-channelid'), channel_id: channel_id });
+            self.setState({ notify_level: notifyLevel, quiet_mode: quietMode, title: button.getAttribute('data-title'), channel_id: channel_id });
         });
     },
     componentWillUnmount: function() {

--- a/web/react/components/channel_notifications.jsx
+++ b/web/react/components/channel_notifications.jsx
@@ -16,12 +16,12 @@ module.exports = React.createClass({
         var self = this;
         $(this.refs.modal.getDOMNode()).on('show.bs.modal', function(e) {
             var button = e.relatedTarget;
-            var channel_id = button.dataset.channelid;
+            var channel_id = button.getAttribute('data-channelid');
 
             var notifyLevel = ChannelStore.getMember(channel_id).notify_level;
             var quietMode = false;
             if (notifyLevel === "quiet") quietMode = true;
-            self.setState({ notify_level: notifyLevel, quiet_mode: quietMode, title: button.dataset.title, channel_id: channel_id });
+            self.setState({ notify_level: notifyLevel, quiet_mode: quietMode, title: button.getAttribute('data-channelid'), channel_id: channel_id });
         });
     },
     componentWillUnmount: function() {


### PR DESCRIPTION
Using "dataset" instead of the getAttribute function is unsupported in IE 10 and below (looks like it wasn't introduced until HTML5 which IE10 only partially supports apparently). Using the getAttribute function makes it forwards and backwards compatible with all browsers.