### PR TITLE
MM-756 Don't mark channels as unread after user joined/left messages

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -366,7 +366,7 @@ func JoinChannel(c *Context, channelId string, role string) {
 
 			post := &model.Post{ChannelId: channel.Id, Message: fmt.Sprintf(
 				`User %v has joined this channel.`,
-				user.Username)}
+				user.Username), Type: model.POST_JOIN_LEAVE}
 			if _, err := CreatePost(c, post, false); err != nil {
 				l4g.Error("Failed to post join message %v", err)
 				c.Err = model.NewAppError("joinChannel", "Failed to send join request", "")
@@ -453,7 +453,7 @@ func leaveChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		post := &model.Post{ChannelId: channel.Id, Message: fmt.Sprintf(
 			`%v has left the channel.`,
-			user.Username)}
+			user.Username), Type: model.POST_JOIN_LEAVE}
 		if _, err := CreatePost(c, post, false); err != nil {
 			l4g.Error("Failed to post leave message %v", err)
 			c.Err = model.NewAppError("leaveChannel", "Failed to send leave message", "")
@@ -646,7 +646,7 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 
 			post := &model.Post{ChannelId: id, Message: fmt.Sprintf(
 				`%v added to the channel by %v`,
-				nUser.Username, oUser.Username)}
+				nUser.Username, oUser.Username), Type: model.POST_JOIN_LEAVE}
 			if _, err := CreatePost(c, post, false); err != nil {
 				l4g.Error("Failed to post add message %v", err)
 				c.Err = model.NewAppError("addChannelMember", "Failed to add member to channel", "")

--- a/model/post.go
+++ b/model/post.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	POST_DEFAULT = ""
+	POST_DEFAULT    = ""
+	POST_JOIN_LEAVE = "join_leave"
 )
 
 type Post struct {
@@ -100,7 +101,7 @@ func (o *Post) IsValid() *AppError {
 		return NewAppError("Post.IsValid", "Invalid hashtags", "id="+o.Id)
 	}
 
-	if !(o.Type == POST_DEFAULT) {
+	if !(o.Type == POST_DEFAULT || o.Type == POST_JOIN_LEAVE) {
 		return NewAppError("Post.IsValid", "Invalid type", "id="+o.Type)
 	}
 


### PR DESCRIPTION
Adds a separate post type for join/leave messages so that they can get special handling and changes it so that channel's aren't flagged as unread when those messages are automatically posted.