### PR TITLE
MM-934 Users can no longer "click n' drag" text boxes to resize them

### DIFF
--- a/web/react/components/edit_channel_modal.jsx
+++ b/web/react/components/edit_channel_modal.jsx
@@ -43,7 +43,7 @@ module.exports = React.createClass({
                     <h4 className="modal-title" ref="title">Edit {this.state.title} Description</h4>
                   </div>
                   <div className="modal-body">
-                    <textarea className="form-control" rows="6" ref="channelDesc" maxLength="1024" value={this.state.description} onChange={this.handleUserInput}></textarea>
+                    <textarea className="form-control" style={{resize: "none"}} rows="6" ref="channelDesc" maxLength="1024" value={this.state.description} onChange={this.handleUserInput}></textarea>
                   </div>
                   <div className="modal-footer">
                     <button type="button" className="btn btn-default" data-dismiss="modal">Close</button>

--- a/web/react/components/get_link_modal.jsx
+++ b/web/react/components/get_link_modal.jsx
@@ -38,7 +38,7 @@ module.exports = React.createClass({
                         <div className="modal-body">
                           <p>{"The link below is used for open " + strings.TeamPlural + " or if you allowed your " + strings.Team + " members to sign up using their " + strings.Company + " email addresses."}
                           </p>
-                          <textarea className="form-control" readOnly="true" value={this.state.value}></textarea>
+                          <textarea className="form-control" style={{resize: "none"}} readOnly="true" value={this.state.value}></textarea>
                         </div>
                         <div className="modal-footer">
                           <button type="button" className="btn btn-default" data-dismiss="modal">Close</button>

--- a/web/react/components/new_channel.jsx
+++ b/web/react/components/new_channel.jsx
@@ -122,7 +122,7 @@ module.exports = React.createClass({
                                 </div>
                                 <div className="form-group">
                                     <label className='control-label'>Description</label>
-                                    <textarea className="form-control" ref="channel_desc" rows="3" placeholder="Description" maxLength="1024"></textarea>
+                                    <textarea className="form-control" style={{resize: "none"}} ref="channel_desc" rows="3" placeholder="Description" maxLength="1024"></textarea>
                                 </div>
                                 { server_error }
                             </form>

--- a/web/sass-files/sass/partials/_base.scss
+++ b/web/sass-files/sass/partials/_base.scss
@@ -53,6 +53,7 @@ div.theme {
 
 .form-control {
   @include border-radius(2px);
+  resize: none;
 }
 
 .form-group {

--- a/web/sass-files/sass/partials/_base.scss
+++ b/web/sass-files/sass/partials/_base.scss
@@ -53,7 +53,6 @@ div.theme {
 
 .form-control {
   @include border-radius(2px);
-  resize: none;
 }
 
 .form-group {


### PR DESCRIPTION
Applies to text areas that allowed this behavior regarding channel descriptions and the get team link field.