### PR TITLE
MM-1488 Changed code to dismiss mention list to not trigger when you click on the list itself

### DIFF
--- a/web/react/components/mention_list.jsx
+++ b/web/react/components/mention_list.jsx
@@ -23,8 +23,9 @@ module.exports = React.createClass({
                 }
             }
         );
-        $(document).click(function() {
-            if($('#'+self.props.id).length && $('#'+self.props.id).get(0) !== $(':focus').get(0)) {
+        $(document).click(function(e) {
+            if (!($('#'+self.props.id).is(e.target) || $('#'+self.props.id).has(e.target).length ||
+                ('mentionlist' in self.refs && $(self.refs['mentionlist'].getDOMNode()).has(e.target).length))) {
                 self.setState({mentionText: "-1"})
             }
         });


### PR DESCRIPTION
This is fixing an issue where the mention list is being dismissed even when the user clicks on an element of the mention list. Because of this, the mention list handler isn't even being called to auto-complete the mention in the attached text box.

I tested this with the three text boxes that support mentions (the main chat box, reply box, and edit window box) and it behaves as expected (ie clicking outside dismisses and clicking on a name populates it in the textbox).