### PR TITLE
Manifest for mobile

### DIFF
--- a/web/static/config/manifest.json
+++ b/web/static/config/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Mattermost",
+  "icons": [
+    {
+      "src": "../static/iamges/icon50x50.gif",
+      "sizes": "50x50",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "portrait"
+}

--- a/web/templates/head.html
+++ b/web/templates/head.html
@@ -4,6 +4,19 @@
     <meta name="robots" content="noindex, nofollow">
 
     <title>{{ .Title }}</title>
+    
+    <!-- iOS add to homescreen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="{{ .Title }}">
+    <meta name="application-name" content="{{ .Title }}">
+    <meta name="format-detection" content="telephone=no">
+    <!-- iOS add to homescreen -->
+
+    <!-- Android add to homescreen -->
+    <link rel="manifest" href="/static/config/manifest.json">
+    <!-- Android add to homescreen -->
 
     <link rel="stylesheet" href="/static/css/bootstrap-3.3.1.min.css">
     <link rel="stylesheet" href="/static/css/jasny-bootstrap.min.css" rel="stylesheet">

--- a/web/templates/head.html
+++ b/web/templates/head.html
@@ -4,7 +4,7 @@
     <meta name="robots" content="noindex, nofollow">
 
     <title>{{ .Title }}</title>
-    
+
     <!-- iOS add to homescreen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
As per https://developer.chrome.com/multidevice/android/installtohomescreen I added both a manifest.json for android and some metatags for ios so mattermost can run without the browser ui.