### PR TITLE
MM-1265 Button to change roles now shows "click" mouse ptr when hovered over & change with loading more channels

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -135,6 +135,8 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		user.EmailVerified = true
 	}
 
+	user.EmailVerified = true
+
 	ruser := CreateUser(c, team, user)
 	if c.Err != nil {
 		return

--- a/api/user.go
+++ b/api/user.go
@@ -135,8 +135,6 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		user.EmailVerified = true
 	}
 
-	user.EmailVerified = true
-
 	ruser := CreateUser(c, team, user)
 	if c.Err != nil {
 		return

--- a/web/react/components/member_list_team.jsx
+++ b/web/react/components/member_list_team.jsx
@@ -92,10 +92,10 @@ var MemberListTeamItem = React.createClass({
                         <span className="caret"></span>
                     </a>
                     <ul className="dropdown-menu member-menu" role="menu" aria-labelledby="channel_header_dropdown">
-                        { showMakeAdmin ? <li role="presentation"><a role="menuitem" onClick={this.handleMakeAdmin}>Make Admin</a></li> : "" }
-                        { showMakeMember ? <li role="presentation"><a role="menuitem" onClick={this.handleMakeMember}>Make Member</a></li> : "" }
-                        { showMakeActive ? <li role="presentation"><a role="menuitem" onClick={this.handleMakeActive}>Make Active</a></li> : "" }
-                        { showMakeNotActive ? <li role="presentation"><a role="menuitem" onClick={this.handleMakeNotActive}>Make Inactive</a></li> : "" }
+                        { showMakeAdmin ? <li role="presentation"><a role="menuitem" href="#" onClick={this.handleMakeAdmin}>Make Admin</a></li> : "" }
+                        { showMakeMember ? <li role="presentation"><a role="menuitem" href="#" onClick={this.handleMakeMember}>Make Member</a></li> : "" }
+                        { showMakeActive ? <li role="presentation"><a role="menuitem" href="#" onClick={this.handleMakeActive}>Make Active</a></li> : "" }
+                        { showMakeNotActive ? <li role="presentation"><a role="menuitem" href="#" onClick={this.handleMakeNotActive}>Make Inactive</a></li> : "" }
                     </ul>
                 </div>
                 { server_error }

--- a/web/react/components/more_channels.jsx
+++ b/web/react/components/more_channels.jsx
@@ -79,7 +79,7 @@ module.exports = React.createClass({
                             <button data-toggle="modal" data-target="#new_channel" data-channeltype={this.state.channel_type} type="button" className="btn btn-primary channel-create-btn" onClick={this.handleNewChannel}>Create New Channel</button>
                         </div>
                         <div className="modal-body">
-                            {moreChannels ?
+                            {!moreChannels.loading ?
                                 (moreChannels.length ?
                                     <table className="more-channel-table table">
                                         <tbody>

--- a/web/react/components/more_channels.jsx
+++ b/web/react/components/more_channels.jsx
@@ -66,6 +66,11 @@ module.exports = React.createClass({
         if (this.state.channels != null)
             moreChannels = this.state.channels;
 
+        console.log("Check: " + moreChannels)
+
+        if (moreChannels)
+            console.log("Length: " + moreChannels.length)
+
         return (
             <div className="modal fade" id="more_channels" ref="modal" tabIndex="-1" role="dialog" aria-hidden="true">
                 <div className="modal-dialog">

--- a/web/react/components/more_channels.jsx
+++ b/web/react/components/more_channels.jsx
@@ -66,11 +66,6 @@ module.exports = React.createClass({
         if (this.state.channels != null)
             moreChannels = this.state.channels;
 
-        console.log("Check: " + moreChannels)
-
-        if (moreChannels)
-            console.log("Length: " + moreChannels.length)
-
         return (
             <div className="modal fade" id="more_channels" ref="modal" tabIndex="-1" role="dialog" aria-hidden="true">
                 <div className="modal-dialog">

--- a/web/react/stores/channel_store.jsx
+++ b/web/react/stores/channel_store.jsx
@@ -202,12 +202,17 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
     BrowserStore.setItem("more_channels", JSON.stringify(channels));
   },
   _getMoreChannels: function() {
-    var channels;
+    var channels = null;
     try {
         channels = JSON.parse(BrowserStore.getItem("more_channels"));
     }
     catch (err) {
 	}
+
+    if (channels == null) {
+        channels = {};
+        channels.loading = true;
+    }
 
     return channels;
   },

--- a/web/react/stores/channel_store.jsx
+++ b/web/react/stores/channel_store.jsx
@@ -209,10 +209,6 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
     catch (err) {
 	}
 
-	if (channels == null) {
-		channels = [];
-	}
-
     return channels;
   },
   _storeExtraInfos: function(extraInfos) {

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -104,7 +104,7 @@ module.exports.updateLastViewedAt = function() {
 module.exports.getMoreChannels = function(force) {
     if (isCallInProgress("getMoreChannels")) return;
 
-    if (!ChannelStore.getMoreAll() || force) {
+    if (ChannelStore.getMoreAll().loading || force) {
 
         callTracker["getMoreChannels"] = utils.getTimestamp();
         client.getMoreChannels(


### PR DESCRIPTION
The options to change member roles are now links so that they have the 'click' mouse hand when hovered over instead of the normal mouse pointer.  Also removed removed the initialization of the returned list of more channels in _getMoreChannels if it does not yet exist in browser storage.  This is to know the difference between when the list of more channels is being fetched from the server vs when there are no more "more channels" to join (this logic is used in the more_channels.jsx rendering to see if the "Loading..." animation should be shown or the message informing the user no more channels are able to be joined).