### PR TITLE
[webui] fix bugs for pr #150 MM-895

### DIFF
--- a/web/react/components/channel_loader.jsx
+++ b/web/react/components/channel_loader.jsx
@@ -12,8 +12,6 @@ var Constants = require('../utils/constants.jsx');
 
 module.exports = React.createClass({
     componentDidMount: function() {
-		// Initalize stores
-		BrowserStore.initalize();
 
         /* Start initial aysnc loads */
         AsyncClient.getMe();

--- a/web/react/stores/browser_store.jsx
+++ b/web/react/stores/browser_store.jsx
@@ -1,44 +1,52 @@
 // Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
 // See License.txt for license information.
-
 var UserStore = require('../stores/user_store.jsx');
 
 // Also change model/utils.go ETAG_ROOT_VERSION
 var BROWSER_STORE_VERSION = '.1';
 
-module.exports.initalize = function() {
+var _initialized = false;
+
+function _initialize() {
 	var currentVersion = localStorage.getItem("local_storage_version");
 	if (currentVersion !== BROWSER_STORE_VERSION) {
 		localStorage.clear();
 		sessionStorage.clear();
 		localStorage.setItem("local_storage_version", BROWSER_STORE_VERSION);
 	}
+    _initialized = true;
 }
 
 module.exports.setItem = function(name, value) {
+    if (!_initialized) _initialize();
 	var user_id = UserStore.getCurrentId();
 	localStorage.setItem(user_id + "_" + name, value);
 };
 
 module.exports.getItem = function(name) {
+    if (!_initialized) _initialize();
 	var user_id = UserStore.getCurrentId();
 	return localStorage.getItem(user_id + "_" + name);
 };
 
 module.exports.removeItem = function(name) {
+    if (!_initialized) _initialize();
 	var user_id = UserStore.getCurrentId();
 	localStorage.removeItem(user_id + "_" + name);
 };
 
 module.exports.setGlobalItem = function(name, value) {
+    if (!_initialized) _initialize();
 	localStorage.setItem(name, value);
 };
 
 module.exports.getGlobalItem = function(name) {
+    if (!_initialized) _initialize();
 	return localStorage.getItem(name);
 };
 
 module.exports.removeGlobalItem = function(name) {
+    if (!_initialized) _initialize();
 	localStorage.removeItem(name);
 };
 
@@ -53,7 +61,7 @@ module.exports.actionOnItemsWithPrefix = function (prefix, action) {
 	var user_id = UserStore.getCurrentId();
 	var id_len = user_id.length;
 	var prefix_len = prefix.length;
-    for (key in localStorage) {
+    for (var key in localStorage) {
         if (key.substring(id_len, id_len + prefix_len) === prefix) {
 			var userkey = key.substring(id_len);
 			action(userkey, BrowserStore.getItem(key));
@@ -70,8 +78,8 @@ module.exports.isLocalStorageSupported = function() {
         localStorage.removeItem("testLocal", '1');
 
         return true;
-    } 
+    }
     catch (e) {
         return false;
     }
-}
+};

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -55,7 +55,7 @@ module.exports.getChannels = function(force, updateLastViewed, checkVersion) {
                 if (checkVersion) {
                     var serverVersion = xhr.getResponseHeader("X-Version-ID");
 
-                    if (UserStore.getLastVersion() == undefined) {
+                    if (!UserStore.getLastVersion()) {
                         UserStore.setLastVersion(serverVersion);
                     }
 


### PR DESCRIPTION
fixed next bugs:
* after relogin default channel posts not loaded (infinite show loading...)
(because ChannelStore.jsx set current_channel_id in localStorage (after recieved event CLICK_CHANNEL sended from pages/channel.jsx ) and only then executed BrowserStore.initialize which clear them in that ```BROWSER_STORE_VERSION``` wasn't matched)
In other words BrowserStore.initialize executed too late

* after relogin click by other channel caused reloading page
(because check for server version in async_client.jsx waiting ```null``` or ```undefined``` value from ```UserStore.getLastVersion()``` if version not present in localStorage but after pr #150 it has become empty string)

NOTICE: Think also pr #150 not considers that next values in localStorage must be not clear after logout (now we clear all) and must be 'global'(hasn't userid prefix) : last_domain, last_email, last_visited_name, last_version and local_storage_version

@crspeller look please