### PR TITLE
MM-1526 Desktop notifications no longer render carriage returns

### DIFF
--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -249,7 +249,7 @@ var SidebarLoggedIn = React.createClass({
 
                 var repRegex = new RegExp("<br>", "g");
                 var post = JSON.parse(msg.props.post);
-                var msg = post.message.replace(repRegex, "\n").replace("\n", "").replace("<mention>", "").replace("</mention>", "");
+                var msg = post.message.replace(repRegex, "\n").replace(/\n+/g, " ").replace("<mention>", "").replace("</mention>", "");
                 if (msg.length > 50) {
                     msg = msg.substring(0,49) + "...";
                 }

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -249,7 +249,7 @@ var SidebarLoggedIn = React.createClass({
 
                 var repRegex = new RegExp("<br>", "g");
                 var post = JSON.parse(msg.props.post);
-                var msg = post.message.replace(repRegex, "\n").split("\n")[0].replace("<mention>", "").replace("</mention>", "");
+                var msg = post.message.replace(repRegex, "\n").replace("\n", "").replace("<mention>", "").replace("</mention>", "");
                 if (msg.length > 50) {
                     msg = msg.substring(0,49) + "...";
                 }


### PR DESCRIPTION
Changed parse logic so any returns (or series of returns) are replaced with a single space in a desktop notification.  Emulates the logic that renders the "Commented on _user's_ message: ..." to save space in a limited area.