### PR TITLE
MM-629 Empty messages with files attached now include text in the desktop notification describing the contents

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"path/filepath"
 )
 
 func InitPost(r *mux.Router) {
@@ -437,6 +438,19 @@ func fireAndForgetNotifications(post *model.Post, teamId, teamUrl string) {
 
 		message := model.NewMessage(teamId, post.ChannelId, post.UserId, model.ACTION_POSTED)
 		message.Add("post", post.ToJson())
+
+		if len(post.Filenames) != 0 {
+			message.Add("otherFile", "true")
+
+			for _, filename := range post.Filenames {
+				ext := filepath.Ext(filename)
+				if model.IsFileExtImage(ext) {
+					message.Add("image", "true")
+					break
+				}
+			}
+		}
+
 		if len(mentionedUsers) != 0 {
 			message.Add("mentions", model.ArrayToJson(mentionedUsers))
 		}

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -249,11 +249,27 @@ var SidebarLoggedIn = React.createClass({
 
                 var repRegex = new RegExp("<br>", "g");
                 var post = JSON.parse(msg.props.post);
+                var msgProps = msg.props;
                 var msg = post.message.replace(repRegex, "\n").replace(/\n+/g, " ").replace("<mention>", "").replace("</mention>", "");
+                
                 if (msg.length > 50) {
                     msg = msg.substring(0,49) + "...";
                 }
-                utils.notifyMe(title, username + " wrote: " + msg, channel);
+
+                if (msg.length === 0) {
+                    if (msgProps.image) {
+                        utils.notifyMe(title, username + " uploaded an image", channel);
+                    }
+                    else if (msgProps.otherFile) {
+                        utils.notifyMe(title, username + " uploaded a file", channel);
+                    }
+                    else {
+                        utils.notifyMe(title, username + " did something new", channel);
+                    }
+                }
+                else {
+                    utils.notifyMe(title, username + " wrote: " + msg, channel);
+                }
                 if (!user.notify_props || user.notify_props.desktop_sound === "true") {
                     utils.ding();
                 }


### PR DESCRIPTION
If a message has no text, but has an attached image or file, the desktop notification now says "uploaded an image" or "uploaded a file" respectively (if both, defaults to image).  Gets rid of seemingly "blank" notifications.