### PR TITLE
MM-825 Replace FullName field with separate FirstName and LastName fields and repurpose the existing FullName as Nickname

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -26,7 +26,7 @@ func SetupBenchmark() (*model.Team, *model.User, *model.Channel) {
 
 	team := &model.Team{Name: "Benchmark Team", Domain: "z-z-" + model.NewId() + "a", Email: "benchmark@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "benchmark@test.com", FullName: "Mr. Benchmarker", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "benchmark@test.com", Nickname: "Mr. Benchmarker", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 	Client.LoginByEmail(team.Domain, user.Email, "pwd")

--- a/api/auto_users.go
+++ b/api/auto_users.go
@@ -41,7 +41,7 @@ func CreateBasicUser(client *model.Client) *model.AppError {
 			return err
 		}
 		basicteam := result.Data.(*model.Team)
-		newuser := &model.User{TeamId: basicteam.Id, Email: BTEST_USER_EMAIL, FullName: BTEST_USER_NAME, Password: BTEST_USER_PASSWORD}
+		newuser := &model.User{TeamId: basicteam.Id, Email: BTEST_USER_EMAIL, Nickname: BTEST_USER_NAME, Password: BTEST_USER_PASSWORD}
 		result, err = client.CreateUser(newuser, "")
 		if err != nil {
 			return err
@@ -65,7 +65,7 @@ func (cfg *AutoUserCreator) createRandomUser() (*model.User, bool) {
 	user := &model.User{
 		TeamId:   cfg.teamID,
 		Email:    userEmail,
-		FullName: userName,
+		Nickname: userName,
 		Password: USER_PASSWORD}
 
 	result, err := cfg.client.CreateUser(user, "")

--- a/api/channel_benchmark_test.go
+++ b/api/channel_benchmark_test.go
@@ -138,7 +138,7 @@ func BenchmarkJoinChannel(b *testing.B) {
 	}
 
 	// Secondary test user to join channels created by primary test user
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "random@test.com", FullName: "That Guy", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "random@test.com", Nickname: "That Guy", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 	Client.LoginByEmail(team.Domain, user.Email, "pwd")

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -20,7 +20,7 @@ func TestCreateChannel(t *testing.T) {
 	team2 := &model.Team{Name: "Name Team 2", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -97,11 +97,11 @@ func TestCreateDirectChannel(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -152,15 +152,15 @@ func TestUpdateChannel(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	userTeamAdmin := &model.User{TeamId: team.Id, Email: team.Email, FullName: "Corey Hulen", Password: "pwd"}
+	userTeamAdmin := &model.User{TeamId: team.Id, Email: team.Email, Nickname: "Corey Hulen", Password: "pwd"}
 	userTeamAdmin = Client.Must(Client.CreateUser(userTeamAdmin, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userTeamAdmin.Id))
 
-	userChannelAdmin := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	userChannelAdmin := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	userChannelAdmin = Client.Must(Client.CreateUser(userChannelAdmin, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userChannelAdmin.Id))
 
-	userStd := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	userStd := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	userStd = Client.Must(Client.CreateUser(userStd, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userStd.Id))
 	userStd.Roles = ""
@@ -223,7 +223,7 @@ func TestUpdateChannelDesc(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -266,7 +266,7 @@ func TestUpdateChannelDesc(t *testing.T) {
 		t.Fatal("should have errored on bad channel desc")
 	}
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -285,7 +285,7 @@ func TestGetChannel(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -327,7 +327,7 @@ func TestGetMoreChannel(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -339,7 +339,7 @@ func TestGetMoreChannel(t *testing.T) {
 	channel2 := &model.Channel{DisplayName: "B Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel2 = Client.Must(Client.CreateChannel(channel2)).Data.(*model.Channel)
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -371,7 +371,7 @@ func TestJoinChannel(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -383,7 +383,7 @@ func TestJoinChannel(t *testing.T) {
 	channel3 := &model.Channel{DisplayName: "B Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel3 = Client.Must(Client.CreateChannel(channel3)).Data.(*model.Channel)
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -399,7 +399,7 @@ func TestJoinChannel(t *testing.T) {
 	data["user_id"] = user1.Id
 	rchannel := Client.Must(Client.CreateDirectChannel(data)).Data.(*model.Channel)
 
-	user3 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user3 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 
 	Client.LoginByEmail(team.Domain, user3.Email, "pwd")
@@ -415,7 +415,7 @@ func TestLeaveChannel(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -427,7 +427,7 @@ func TestLeaveChannel(t *testing.T) {
 	channel3 := &model.Channel{DisplayName: "B Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel3 = Client.Must(Client.CreateChannel(channel3)).Data.(*model.Channel)
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -464,11 +464,11 @@ func TestDeleteChannel(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	userTeamAdmin := &model.User{TeamId: team.Id, Email: team.Email, FullName: "Corey Hulen", Password: "pwd"}
+	userTeamAdmin := &model.User{TeamId: team.Id, Email: team.Email, Nickname: "Corey Hulen", Password: "pwd"}
 	userTeamAdmin = Client.Must(Client.CreateUser(userTeamAdmin, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userTeamAdmin.Id))
 
-	userChannelAdmin := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	userChannelAdmin := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	userChannelAdmin = Client.Must(Client.CreateUser(userChannelAdmin, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userChannelAdmin.Id))
 
@@ -500,7 +500,7 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal("should have failed to post to deleted channel")
 	}
 
-	userStd := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	userStd := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	userStd = Client.Must(Client.CreateUser(userStd, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userStd.Id))
 
@@ -534,7 +534,7 @@ func TestGetChannelExtraInfo(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -555,7 +555,7 @@ func TestAddChannelMember(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -564,7 +564,7 @@ func TestAddChannelMember(t *testing.T) {
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -613,11 +613,11 @@ func TestRemoveChannelMember(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	userTeamAdmin := &model.User{TeamId: team.Id, Email: team.Email, FullName: "Corey Hulen", Password: "pwd"}
+	userTeamAdmin := &model.User{TeamId: team.Id, Email: team.Email, Nickname: "Corey Hulen", Password: "pwd"}
 	userTeamAdmin = Client.Must(Client.CreateUser(userTeamAdmin, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userTeamAdmin.Id))
 
-	userChannelAdmin := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	userChannelAdmin := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	userChannelAdmin = Client.Must(Client.CreateUser(userChannelAdmin, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userChannelAdmin.Id))
 
@@ -633,7 +633,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
 
-	userStd := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	userStd := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	userStd = Client.Must(Client.CreateUser(userStd, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userStd.Id))
 
@@ -683,7 +683,7 @@ func TestUpdateNotifyLevel(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -746,7 +746,7 @@ func TestUpdateNotifyLevel(t *testing.T) {
 		t.Fatal("Should have errored - bad notify level")
 	}
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 
 	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
@@ -765,7 +765,7 @@ func TestFuzzyChannel(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 

--- a/api/command_test.go
+++ b/api/command_test.go
@@ -15,7 +15,7 @@ func TestSuggestRootCommands(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -58,7 +58,7 @@ func TestLogoutCommands(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -76,7 +76,7 @@ func TestJoinCommands(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -90,7 +90,7 @@ func TestJoinCommands(t *testing.T) {
 	channel2 = Client.Must(Client.CreateChannel(channel2)).Data.(*model.Channel)
 	Client.Must(Client.LeaveChannel(channel2.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 

--- a/api/file_test.go
+++ b/api/file_test.go
@@ -27,7 +27,7 @@ func TestUploadFile(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -114,7 +114,7 @@ func TestGetFile(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -176,7 +176,7 @@ func TestGetFile(t *testing.T) {
 		team2 := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 		team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-		user2 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+		user2 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 		user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 		store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -261,11 +261,11 @@ func TestGetPublicLink(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 

--- a/api/post.go
+++ b/api/post.go
@@ -298,11 +298,11 @@ func fireAndForgetNotifications(post *model.Post, teamId, teamUrl string) {
 						for _, k := range splitKeys {
 							keywordMap[k] = append(keywordMap[strings.ToLower(k)], profile.Id)
 						}
+					}
 
-						// If turned on, add the user's case sensitive first name
-						if profile.NotifyProps["first_name"] == "true" {
-							keywordMap[profile.FirstName] = append(keywordMap[profile.FirstName], profile.Id)
-						}
+					// If turned on, add the user's case sensitive first name
+					if profile.NotifyProps["first_name"] == "true" {
+						keywordMap[profile.FirstName] = append(keywordMap[profile.FirstName], profile.Id)
 					}
 
 					// Add @all to keywords if user has them turned on

--- a/api/post.go
+++ b/api/post.go
@@ -301,7 +301,7 @@ func fireAndForgetNotifications(post *model.Post, teamId, teamUrl string) {
 
 						// If turned on, add the user's case sensitive first name
 						if profile.NotifyProps["first_name"] == "true" {
-							splitName := strings.Split(profile.FullName, " ")
+							splitName := strings.Split(profile.Nickname, " ")
 							if len(splitName) > 0 && splitName[0] != "" {
 								keywordMap[splitName[0]] = append(keywordMap[splitName[0]], profile.Id)
 							}
@@ -395,10 +395,10 @@ func fireAndForgetNotifications(post *model.Post, teamId, teamUrl string) {
 						continue
 					}
 
-					firstName := strings.Split(profileMap[id].FullName, " ")[0]
+					firstName := strings.Split(profileMap[id].Nickname, " ")[0]
 
 					bodyPage := NewServerTemplatePage("post_body", teamUrl)
-					bodyPage.Props["FullName"] = firstName
+					bodyPage.Props["Nickname"] = firstName
 					bodyPage.Props["TeamName"] = teamName
 					bodyPage.Props["ChannelName"] = channelName
 					bodyPage.Props["BodyText"] = bodyText

--- a/api/post.go
+++ b/api/post.go
@@ -301,10 +301,7 @@ func fireAndForgetNotifications(post *model.Post, teamId, teamUrl string) {
 
 						// If turned on, add the user's case sensitive first name
 						if profile.NotifyProps["first_name"] == "true" {
-							splitName := strings.Split(profile.Nickname, " ")
-							if len(splitName) > 0 && splitName[0] != "" {
-								keywordMap[splitName[0]] = append(keywordMap[splitName[0]], profile.Id)
-							}
+							keywordMap[profile.FirstName] = append(keywordMap[profile.FirstName], profile.Id)
 						}
 					}
 
@@ -395,10 +392,8 @@ func fireAndForgetNotifications(post *model.Post, teamId, teamUrl string) {
 						continue
 					}
 
-					firstName := strings.Split(profileMap[id].Nickname, " ")[0]
-
 					bodyPage := NewServerTemplatePage("post_body", teamUrl)
-					bodyPage.Props["Nickname"] = firstName
+					bodyPage.Props["Nickname"] = profileMap[id].FirstName
 					bodyPage.Props["TeamName"] = teamName
 					bodyPage.Props["ChannelName"] = channelName
 					bodyPage.Props["BodyText"] = bodyText

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -21,11 +21,11 @@ func TestCreatePost(t *testing.T) {
 	team2 := &model.Team{Name: "Name Team 2", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -103,7 +103,7 @@ func TestCreatePost(t *testing.T) {
 		t.Fatal("Should have been forbidden")
 	}
 
-	user3 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user3 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user3.Id))
 
@@ -132,11 +132,11 @@ func TestCreateValetPost(t *testing.T) {
 	team2 := &model.Team{Name: "Name Team 2", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -188,7 +188,7 @@ func TestCreateValetPost(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		user3 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+		user3 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 		user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 		store.Must(Srv.Store.User().VerifyEmail(user3.Id))
 
@@ -224,11 +224,11 @@ func TestUpdatePost(t *testing.T) {
 	team2 := &model.Team{Name: "Name Team 2", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -292,7 +292,7 @@ func TestGetPosts(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -357,7 +357,7 @@ func TestSearchPosts(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -403,7 +403,7 @@ func TestSearchHashtagPosts(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -434,7 +434,7 @@ func TestGetPostsCache(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -483,11 +483,11 @@ func TestDeletePosts(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	userAdmin := &model.User{TeamId: team.Id, Email: team.Email, FullName: "Corey Hulen", Password: "pwd"}
+	userAdmin := &model.User{TeamId: team.Id, Email: team.Email, Nickname: "Corey Hulen", Password: "pwd"}
 	userAdmin = Client.Must(Client.CreateUser(userAdmin, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userAdmin.Id))
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -543,7 +543,7 @@ func TestEmailMention(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: "corey@test.com", FullName: "Bob Bobby", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: "corey@test.com", Nickname: "Bob Bobby", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
@@ -565,7 +565,7 @@ func TestFuzzyPosts(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 

--- a/api/team.go
+++ b/api/team.go
@@ -488,10 +488,10 @@ func InviteMembers(team *model.Team, user *model.User, invites []string) {
 			}
 
 			sender := ""
-			if len(strings.TrimSpace(user.FullName)) == 0 {
+			if len(strings.TrimSpace(user.Nickname)) == 0 {
 				sender = user.Username
 			} else {
-				sender = user.FullName
+				sender = user.Nickname
 			}
 
 			senderRole := ""

--- a/api/team.go
+++ b/api/team.go
@@ -487,12 +487,7 @@ func InviteMembers(team *model.Team, user *model.User, invites []string) {
 				teamUrl = fmt.Sprintf("http://%v.%v", team.Domain, utils.Cfg.ServiceSettings.Domain)
 			}
 
-			sender := ""
-			if len(strings.TrimSpace(user.Nickname)) == 0 {
-				sender = user.Username
-			} else {
-				sender = user.Nickname
-			}
+			sender := user.GetDisplayName()
 
 			senderRole := ""
 			if strings.Contains(user.Roles, model.ROLE_ADMIN) || strings.Contains(user.Roles, model.ROLE_SYSTEM_ADMIN) {

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -33,7 +33,7 @@ func TestCreateFromSignupTeam(t *testing.T) {
 	hash := model.HashPassword(fmt.Sprintf("%v:%v", data, utils.Cfg.ServiceSettings.InviteSalt))
 
 	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
-	user := model.User{Email: props["email"], FullName: "Corey Hulen", Password: "hello"}
+	user := model.User{Email: props["email"], Nickname: "Corey Hulen", Password: "hello"}
 
 	ts := model.TeamSignup{Team: team, User: user, Invites: []string{"corey@test.com"}, Data: data, Hash: hash}
 
@@ -77,7 +77,7 @@ func TestCreateTeam(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user := &model.User{TeamId: rteam.Data.(*model.Team).Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: rteam.Data.(*model.Team).Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -114,7 +114,7 @@ func TestFindTeamByEmail(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -142,7 +142,7 @@ func TestFindTeamByDomain(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -182,7 +182,7 @@ func TestFindTeamByEmailSend(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -206,7 +206,7 @@ func TestInviteMembers(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -235,11 +235,11 @@ func TestUpdateTeamName(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -310,7 +310,7 @@ func TestGetMyTeam(t *testing.T) {
 	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 
-	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	ruser, _ := Client.CreateUser(&user, "")
 	store.Must(Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
@@ -337,18 +337,18 @@ func TestUpdateValetFeature(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
 	team2 := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-	user3 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user3 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user3.Id))
 

--- a/api/user.go
+++ b/api/user.go
@@ -181,14 +181,14 @@ func CreateUser(c *Context, team *model.Team, user *model.User) *model.User {
 			l4g.Error("Encountered an issue joining default channels user_id=%s, team_id=%s, err=%v", ruser.Id, ruser.TeamId, err)
 		}
 
-		//fireAndForgetWelcomeEmail(strings.Split(ruser.Nickname, " ")[0], ruser.Email, team.Name, c.TeamUrl+"/channels/town-square")
+		//fireAndForgetWelcomeEmail(ruser.FirstName, ruser.Email, team.Name, c.TeamUrl+"/channels/town-square")
 
 		if user.EmailVerified {
 			if cresult := <-Srv.Store.User().VerifyEmail(ruser.Id); cresult.Err != nil {
 				l4g.Error("Failed to set email verified err=%v", cresult.Err)
 			}
 		} else {
-			FireAndForgetVerifyEmail(result.Data.(*model.User).Id, strings.Split(ruser.Nickname, " ")[0], ruser.Email, team.Name, c.TeamUrl)
+			FireAndForgetVerifyEmail(result.Data.(*model.User).Id, ruser.FirstName, ruser.Email, team.Name, c.TeamUrl)
 		}
 
 		ruser.Sanitize(map[string]bool{})

--- a/api/user.go
+++ b/api/user.go
@@ -181,14 +181,14 @@ func CreateUser(c *Context, team *model.Team, user *model.User) *model.User {
 			l4g.Error("Encountered an issue joining default channels user_id=%s, team_id=%s, err=%v", ruser.Id, ruser.TeamId, err)
 		}
 
-		//fireAndForgetWelcomeEmail(strings.Split(ruser.FullName, " ")[0], ruser.Email, team.Name, c.TeamUrl+"/channels/town-square")
+		//fireAndForgetWelcomeEmail(strings.Split(ruser.Nickname, " ")[0], ruser.Email, team.Name, c.TeamUrl+"/channels/town-square")
 
 		if user.EmailVerified {
 			if cresult := <-Srv.Store.User().VerifyEmail(ruser.Id); cresult.Err != nil {
 				l4g.Error("Failed to set email verified err=%v", cresult.Err)
 			}
 		} else {
-			FireAndForgetVerifyEmail(result.Data.(*model.User).Id, strings.Split(ruser.FullName, " ")[0], ruser.Email, team.Name, c.TeamUrl)
+			FireAndForgetVerifyEmail(result.Data.(*model.User).Id, strings.Split(ruser.Nickname, " ")[0], ruser.Email, team.Name, c.TeamUrl)
 		}
 
 		ruser.Sanitize(map[string]bool{})
@@ -207,7 +207,7 @@ func fireAndForgetWelcomeEmail(name, email, teamName, link string) {
 
 		subjectPage := NewServerTemplatePage("welcome_subject", link)
 		bodyPage := NewServerTemplatePage("welcome_body", link)
-		bodyPage.Props["FullName"] = name
+		bodyPage.Props["Nickname"] = name
 		bodyPage.Props["TeamName"] = teamName
 		bodyPage.Props["FeedbackName"] = utils.Cfg.EmailSettings.FeedbackName
 
@@ -226,7 +226,7 @@ func FireAndForgetVerifyEmail(userId, name, email, teamName, teamUrl string) {
 		subjectPage := NewServerTemplatePage("verify_subject", teamUrl)
 		subjectPage.Props["TeamName"] = teamName
 		bodyPage := NewServerTemplatePage("verify_body", teamUrl)
-		bodyPage.Props["FullName"] = name
+		bodyPage.Props["Nickname"] = name
 		bodyPage.Props["TeamName"] = teamName
 		bodyPage.Props["VerifyUrl"] = link
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -28,15 +28,15 @@ func TestCreateUser(t *testing.T) {
 	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 
-	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "hello"}
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "hello"}
 
 	ruser, err := Client.CreateUser(&user, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if ruser.Data.(*model.User).FullName != user.FullName {
-		t.Fatal("full name didn't match")
+	if ruser.Data.(*model.User).Nickname != user.Nickname {
+		t.Fatal("nickname didn't match")
 	}
 
 	if ruser.Data.(*model.User).Password != "" {
@@ -61,7 +61,7 @@ func TestCreateUser(t *testing.T) {
 		}
 	}
 
-	user2 := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "hello", Username: model.BOT_USERNAME}
+	user2 := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "hello", Username: model.BOT_USERNAME}
 
 	if _, err := Client.CreateUser(&user2, ""); err == nil {
 		t.Fatal("Should have failed using reserved bot name")
@@ -78,7 +78,7 @@ func TestCreateUserAllowedDomains(t *testing.T) {
 	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_INVITE, AllowedDomains: "spinpunch.com, @nowh.com,@hello.com"}
 	rteam, _ := Client.CreateTeam(&team)
 
-	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "hello"}
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "hello"}
 
 	_, err := Client.CreateUser(&user, "")
 	if err == nil {
@@ -98,7 +98,7 @@ func TestLogin(t *testing.T) {
 	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 
-	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	ruser, _ := Client.CreateUser(&user, "")
 	store.Must(Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
@@ -138,7 +138,7 @@ func TestLogin(t *testing.T) {
 	team2 := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_INVITE}
 	rteam2 := Client.Must(Client.CreateTeam(&team2))
 
-	user2 := model.User{TeamId: rteam2.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := model.User{TeamId: rteam2.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 
 	if _, err := Client.CreateUserFromSignup(&user2, "junk", "1231312"); err == nil {
 		t.Fatal("Should have errored, signed up without hashed email")
@@ -167,7 +167,7 @@ func TestSessions(t *testing.T) {
 	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 
-	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(ruser.Id))
 
@@ -224,11 +224,11 @@ func TestGetUser(t *testing.T) {
 	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 
-	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	ruser, _ := Client.CreateUser(&user, "")
 	store.Must(Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
-	user2 := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	ruser2, _ := Client.CreateUser(&user2, "")
 	store.Must(Srv.Store.User().VerifyEmail(ruser2.Data.(*model.User).Id))
 
@@ -295,7 +295,7 @@ func TestGetAudits(t *testing.T) {
 	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 
-	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	ruser, _ := Client.CreateUser(&user, "")
 	store.Must(Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
@@ -348,7 +348,7 @@ func TestUserCreateImage(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -364,7 +364,7 @@ func TestUserUploadProfileImage(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -463,7 +463,7 @@ func TestUserUpdate(t *testing.T) {
 
 	time1 := model.GetMillis()
 
-	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd", LastActivityAt: time1, LastPingAt: time1, Roles: ""}
+	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd", LastActivityAt: time1, LastPingAt: time1, Roles: ""}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -479,7 +479,7 @@ func TestUserUpdate(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	user.FullName = "Jim Jimmy"
+	user.Nickname = "Jim Jimmy"
 	user.TeamId = "12345678901234567890123456"
 	user.LastActivityAt = time2
 	user.LastPingAt = time2
@@ -489,8 +489,8 @@ func TestUserUpdate(t *testing.T) {
 	if result, err := Client.UpdateUser(user); err != nil {
 		t.Fatal(err)
 	} else {
-		if result.Data.(*model.User).FullName != "Jim Jimmy" {
-			t.Fatal("FullName did not update properly")
+		if result.Data.(*model.User).Nickname != "Jim Jimmy" {
+			t.Fatal("Nickname did not update properly")
 		}
 		if result.Data.(*model.User).TeamId != team.Id {
 			t.Fatal("TeamId should not have updated")
@@ -519,13 +519,13 @@ func TestUserUpdate(t *testing.T) {
 		t.Fatal("Should have errored")
 	}
 
-	user2 := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
 	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
 
-	user.FullName = "Tim Timmy"
+	user.Nickname = "Tim Timmy"
 
 	if _, err := Client.UpdateUser(user); err == nil {
 		t.Fatal("Should have errored")
@@ -538,7 +538,7 @@ func TestUserUpdatePassword(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -581,7 +581,7 @@ func TestUserUpdatePassword(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user2 := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 
 	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
@@ -597,11 +597,11 @@ func TestUserUpdateRoles(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -622,7 +622,7 @@ func TestUserUpdateRoles(t *testing.T) {
 	team2 := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-	user3 := &model.User{TeamId: team2.Id, Email: "test@nowhere.com", FullName: "Corey Hulen", Password: "pwd"}
+	user3 := &model.User{TeamId: team2.Id, Email: "test@nowhere.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user3.Id))
 
@@ -666,11 +666,11 @@ func TestUserUpdateActive(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	user2 := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
@@ -687,7 +687,7 @@ func TestUserUpdateActive(t *testing.T) {
 	team2 := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-	user3 := &model.User{TeamId: team2.Id, Email: "test@nowhere.com", FullName: "Corey Hulen", Password: "pwd"}
+	user3 := &model.User{TeamId: team2.Id, Email: "test@nowhere.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user3.Id))
 
@@ -730,7 +730,7 @@ func TestSendPasswordReset(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -770,7 +770,7 @@ func TestResetPassword(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -854,7 +854,7 @@ func TestUserUpdateNotify(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd", Roles: ""}
+	user := &model.User{TeamId: team.Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd", Roles: ""}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
@@ -933,7 +933,7 @@ func TestFuzzyUserCreate(t *testing.T) {
 			testEmail = utils.FUZZY_STRINGS_EMAILS[i]
 		}
 
-		user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + testEmail, FullName: testName, Password: "hello"}
+		user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + testEmail, Nickname: testName, Password: "hello"}
 
 		_, err := Client.CreateUser(&user, "")
 		if err != nil {
@@ -948,7 +948,7 @@ func TestStatuses(t *testing.T) {
 	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 
-	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(ruser.Id))
 

--- a/api/web_socket_test.go
+++ b/api/web_socket_test.go
@@ -20,7 +20,7 @@ func TestSocket(t *testing.T) {
 	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
@@ -39,7 +39,7 @@ func TestSocket(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", FullName: "Corey Hulen", Password: "pwd"}
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 	Client.LoginByEmail(team.Domain, user2.Email, "pwd")

--- a/manualtesting/manual_testing.go
+++ b/manualtesting/manual_testing.go
@@ -90,7 +90,7 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		user := &model.User{
 			TeamId:   teamID,
 			Email:    utils.RandomEmail(utils.Range{20, 20}, utils.LOWERCASE),
-			FullName: username[0],
+			Nickname: username[0],
 			Password: api.USER_PASSWORD}
 
 		result, err := client.CreateUser(user, "")

--- a/model/channel_extra.go
+++ b/model/channel_extra.go
@@ -10,7 +10,7 @@ import (
 
 type ExtraMember struct {
 	Id       string `json:"id"`
-	FullName string `json:"full_name"`
+	Nickname string `json:"nickname"`
 	Email    string `json:"email"`
 	Roles    string `json:"roles"`
 	Username string `json:"username"`
@@ -21,7 +21,7 @@ func (o *ExtraMember) Sanitize(options map[string]bool) {
 		o.Email = ""
 	}
 	if len(options) == 0 || !options["fullname"] {
-		o.FullName = ""
+		o.Nickname = ""
 	}
 }
 

--- a/model/channel_extra.go
+++ b/model/channel_extra.go
@@ -20,9 +20,6 @@ func (o *ExtraMember) Sanitize(options map[string]bool) {
 	if len(options) == 0 || !options["email"] {
 		o.Email = ""
 	}
-	if len(options) == 0 || !options["fullname"] {
-		o.Nickname = ""
-	}
 }
 
 type ChannelExtra struct {

--- a/model/user.go
+++ b/model/user.go
@@ -201,7 +201,8 @@ func (u *User) Sanitize(options map[string]bool) {
 		u.Email = ""
 	}
 	if len(options) != 0 && !options["fullname"] {
-		u.Nickname = ""
+		u.FirstName = ""
+		u.LastName = ""
 	}
 	if len(options) != 0 && !options["skypeid"] {
 		// TODO - fill in when SkypeId is added to user model

--- a/model/user.go
+++ b/model/user.go
@@ -237,6 +237,14 @@ func (u *User) AddNotifyProp(key string, value string) {
 	u.NotifyProps[key] = value
 }
 
+func (u *User) GetDisplayName() string {
+	if u.Nickname != "" {
+		return u.Nickname
+	} else {
+		return u.Username
+	}
+}
+
 // UserFromJson will decode the input and return a User
 func UserFromJson(data io.Reader) *User {
 	decoder := json.NewDecoder(data)

--- a/model/user.go
+++ b/model/user.go
@@ -38,6 +38,8 @@ type User struct {
 	Email              string    `json:"email"`
 	EmailVerified      bool      `json:"email_verified"`
 	Nickname           string    `json:"nickname"`
+	FirstName          string    `json:"first_name"`
+	LastName           string    `json:"last_name"`
 	Roles              string    `json:"roles"`
 	LastActivityAt     int64     `json:"last_activity_at"`
 	LastPingAt         int64     `json:"last_ping_at"`
@@ -84,6 +86,14 @@ func (u *User) IsValid() *AppError {
 
 	if len(u.Nickname) > 64 {
 		return NewAppError("User.IsValid", "Invalid nickname", "user_id="+u.Id)
+	}
+
+	if len(u.FirstName) > 64 {
+		return NewAppError("User.IsValid", "Invalid first name", "user_id="+u.Id)
+	}
+
+	if len(u.LastName) > 64 {
+		return NewAppError("User.IsValid", "Invalid last name", "user_id="+u.Id)
 	}
 
 	return nil

--- a/model/user.go
+++ b/model/user.go
@@ -37,7 +37,7 @@ type User struct {
 	AuthData           string    `json:"auth_data"`
 	Email              string    `json:"email"`
 	EmailVerified      bool      `json:"email_verified"`
-	FullName           string    `json:"full_name"`
+	Nickname           string    `json:"nickname"`
 	Roles              string    `json:"roles"`
 	LastActivityAt     int64     `json:"last_activity_at"`
 	LastPingAt         int64     `json:"last_ping_at"`
@@ -82,8 +82,8 @@ func (u *User) IsValid() *AppError {
 		return NewAppError("User.IsValid", "Invalid email", "user_id="+u.Id)
 	}
 
-	if len(u.FullName) > 64 {
-		return NewAppError("User.IsValid", "Invalid full name", "user_id="+u.Id)
+	if len(u.Nickname) > 64 {
+		return NewAppError("User.IsValid", "Invalid nickname", "user_id="+u.Id)
 	}
 
 	return nil
@@ -152,7 +152,7 @@ func (u *User) SetDefaultNotifications() {
 	u.NotifyProps["first_name"] = "false"
 	u.NotifyProps["all"] = "true"
 	u.NotifyProps["channel"] = "true"
-	splitName := strings.Split(u.FullName, " ")
+	splitName := strings.Split(u.Nickname, " ")
 	if len(splitName) > 0 && splitName[0] != "" {
 		u.NotifyProps["first_name"] = "true"
 		u.NotifyProps["mention_keys"] += "," + splitName[0]
@@ -191,7 +191,7 @@ func (u *User) Sanitize(options map[string]bool) {
 		u.Email = ""
 	}
 	if len(options) != 0 && !options["fullname"] {
-		u.FullName = ""
+		u.Nickname = ""
 	}
 	if len(options) != 0 && !options["skypeid"] {
 		// TODO - fill in when SkypeId is added to user model

--- a/model/user.go
+++ b/model/user.go
@@ -237,9 +237,23 @@ func (u *User) AddNotifyProp(key string, value string) {
 	u.NotifyProps[key] = value
 }
 
+func (u *User) GetFullName() string {
+	if u.FirstName != "" && u.LastName != "" {
+		return u.FirstName + " " + u.LastName
+	} else if u.FirstName != "" {
+		return u.FirstName
+	} else if u.LastName != "" {
+		return u.LastName
+	} else {
+		return ""
+	}
+}
+
 func (u *User) GetDisplayName() string {
 	if u.Nickname != "" {
 		return u.Nickname
+	} else if fullName := u.GetFullName(); fullName != "" {
+		return fullName
 	} else {
 		return u.Username
 	}

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -89,4 +89,21 @@ func TestUserIsValid(t *testing.T) {
 	if err := user.IsValid(); err != nil {
 		t.Fatal(err)
 	}
+
+	user.FirstName = ""
+	user.LastName = ""
+	if err := user.IsValid(); err != nil {
+		t.Fatal(err)
+	}
+
+	user.FirstName = strings.Repeat("01234567890", 20)
+	if err := user.IsValid(); err == nil {
+		t.Fatal(err)
+	}
+
+	user.FirstName = ""
+	user.LastName = strings.Repeat("01234567890", 20)
+	if err := user.IsValid(); err == nil {
+		t.Fatal(err)
+	}
 }

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -107,3 +107,16 @@ func TestUserIsValid(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestUserGetDisplayName(t *testing.T) {
+	user := User{FirstName: "first", LastName: "last", Username: "user"}
+
+	if displayName := user.GetDisplayName(); displayName != "user" {
+		t.Fatal("Display name should be username")
+	}
+
+	user.Nickname = "nickname"
+	if displayName := user.GetDisplayName(); displayName != "nickname" {
+		t.Fatal("Display name should be nickname")
+	}
+}

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -108,11 +108,41 @@ func TestUserIsValid(t *testing.T) {
 	}
 }
 
+func TestUserGetFullName(t *testing.T) {
+	user := User{}
+
+	if fullName := user.GetFullName(); fullName != "" {
+		t.Fatal("Full name should be blank")
+	}
+
+	user.FirstName = "first"
+	if fullName := user.GetFullName(); fullName != "first" {
+		t.Fatal("Full name should be first name")
+	}
+
+	user.FirstName = ""
+	user.LastName = "last"
+	if fullName := user.GetFullName(); fullName != "last" {
+		t.Fatal("Full name should be last name")
+	}
+
+	user.FirstName = "first"
+	if fullName := user.GetFullName(); fullName != "first last" {
+		t.Fatal("Full name should be first name and last name")
+	}
+}
+
 func TestUserGetDisplayName(t *testing.T) {
-	user := User{FirstName: "first", LastName: "last", Username: "user"}
+	user := User{Username: "user"}
 
 	if displayName := user.GetDisplayName(); displayName != "user" {
 		t.Fatal("Display name should be username")
+	}
+
+	user.FirstName = "first"
+	user.LastName = "last"
+	if displayName := user.GetDisplayName(); displayName != "first last" {
+		t.Fatal("Display name should be full name")
 	}
 
 	user.Nickname = "nickname"

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -80,12 +80,12 @@ func TestUserIsValid(t *testing.T) {
 	}
 
 	user.Email = "test@nowhere.com"
-	user.FullName = strings.Repeat("01234567890", 20)
+	user.Nickname = strings.Repeat("01234567890", 20)
 	if err := user.IsValid(); err == nil {
 		t.Fatal()
 	}
 
-	user.FullName = ""
+	user.Nickname = ""
 	if err := user.IsValid(); err != nil {
 		t.Fatal(err)
 	}

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -81,11 +81,11 @@ func (s SqlChannelStore) Save(channel *model.Channel) StoreChannel {
 			if strings.Contains(err.Error(), "Duplicate entry") && strings.Contains(err.Error(), "for key 'Name'") {
 				dupChannel := model.Channel{}
 				s.GetReplica().SelectOne(&dupChannel, "SELECT * FROM Channels WHERE TeamId=? AND Name=? AND DeleteAt > 0", channel.TeamId, channel.Name)
-				if (dupChannel.DeleteAt > 0) {
+				if dupChannel.DeleteAt > 0 {
 					result.Err = model.NewAppError("SqlChannelStore.Update", "A channel with that name was previously created", "id="+channel.Id+", "+err.Error())
 				} else {
 					result.Err = model.NewAppError("SqlChannelStore.Update", "A channel with that name already exists", "id="+channel.Id+", "+err.Error())
-				}			
+				}
 			} else {
 				result.Err = model.NewAppError("SqlChannelStore.Save", "We couldn't save the channel", "id="+channel.Id+", "+err.Error())
 			}
@@ -119,7 +119,7 @@ func (s SqlChannelStore) Update(channel *model.Channel) StoreChannel {
 			if strings.Contains(err.Error(), "Duplicate entry") && strings.Contains(err.Error(), "for key 'Name'") {
 				dupChannel := model.Channel{}
 				s.GetReplica().SelectOne(&dupChannel, "SELECT * FROM Channels WHERE TeamId=? AND Name=? AND DeleteAt > 0", channel.TeamId, channel.Name)
-				if (dupChannel.DeleteAt > 0) {
+				if dupChannel.DeleteAt > 0 {
 					result.Err = model.NewAppError("SqlChannelStore.Update", "A channel with that name was previously created", "id="+channel.Id+", "+err.Error())
 				} else {
 					result.Err = model.NewAppError("SqlChannelStore.Update", "A channel with that name already exists", "id="+channel.Id+", "+err.Error())
@@ -358,7 +358,7 @@ func (s SqlChannelStore) GetExtraMembers(channelId string, limit int) StoreChann
 		result := StoreResult{}
 
 		var members []model.ExtraMember
-		_, err := s.GetReplica().Select(&members, "SELECT Id, FullName, Email, ChannelMembers.Roles, Username FROM ChannelMembers, Users WHERE ChannelMembers.UserId = Users.Id AND ChannelId = ? LIMIT ?", channelId, limit)
+		_, err := s.GetReplica().Select(&members, "SELECT Id, Nickname, Email, ChannelMembers.Roles, Username FROM ChannelMembers, Users WHERE ChannelMembers.UserId = Users.Id AND ChannelId = ? LIMIT ?", channelId, limit)
 		if err != nil {
 			result.Err = model.NewAppError("SqlChannelStore.GetExtraMembers", "We couldn't get the extra info for channel members", "channel_id="+channelId+", "+err.Error())
 		} else {

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -200,13 +200,13 @@ func TestChannelMemberStore(t *testing.T) {
 	u1 := model.User{}
 	u1.TeamId = model.NewId()
 	u1.Email = model.NewId()
-	u1.FullName = model.NewId()
+	u1.Nickname = model.NewId()
 	Must(store.User().Save(&u1))
 
 	u2 := model.User{}
 	u2.TeamId = model.NewId()
 	u2.Email = model.NewId()
-	u2.FullName = model.NewId()
+	u2.Nickname = model.NewId()
 	Must(store.User().Save(&u2))
 
 	o1 := model.ChannelMember{}

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -25,7 +25,7 @@ func NewSqlUserStore(sqlStore *SqlStore) UserStore {
 		table.ColMap("Password").SetMaxSize(128)
 		table.ColMap("AuthData").SetMaxSize(128)
 		table.ColMap("Email").SetMaxSize(128)
-		table.ColMap("FullName").SetMaxSize(64)
+		table.ColMap("Nickname").SetMaxSize(64)
 		table.ColMap("Roles").SetMaxSize(64)
 		table.ColMap("Props").SetMaxSize(4000)
 		table.ColMap("NotifyProps").SetMaxSize(2000)
@@ -36,9 +36,14 @@ func NewSqlUserStore(sqlStore *SqlStore) UserStore {
 	return us
 }
 
-func (s SqlUserStore) UpgradeSchemaIfNeeded() {
-	s.CreateColumnIfNotExists("Users","LastPictureUpdate", "LastPasswordUpdate", "bigint(20)", "0")
+func (us SqlUserStore) UpgradeSchemaIfNeeded() {
+	us.CreateColumnIfNotExists("Users", "LastPictureUpdate", "LastPasswordUpdate", "bigint(20)", "0")
+
+	// migrating the FullName column to Nickname for MM-825
+	us.RenameColumnIfExists("Users", "FullName", "Nickname", "varchar(64)")
 }
+
+//func (ss SqlStore) CreateColumnIfNotExists(tableName string, columnName string, afterName string, colType string, defaultValue string) bool {
 
 func (us SqlUserStore) CreateIndexesIfNotExists() {
 	us.CreateIndexIfNotExists("idx_team_id", "Users", "TeamId")

--- a/web/react/components/channel_header.jsx
+++ b/web/react/components/channel_header.jsx
@@ -153,7 +153,7 @@ module.exports = React.createClass({
         if (isDirect) {
             if (this.state.users.length > 1) {
                 var contact = this.state.users[((this.state.users[0].id === currentId) ? 1 : 0)];
-                channelTitle = <UserProfile userId={contact.id} overwriteName={contact.full_name || contact.username} />;
+                channelTitle = <UserProfile userId={contact.id} overwriteName={contact.nickname || contact.username} />;
             }
         }
 

--- a/web/react/components/member_list_team.jsx
+++ b/web/react/components/member_list_team.jsx
@@ -85,8 +85,8 @@ var MemberListTeamItem = React.createClass({
         return (
             <div className="row member-div">
                 <img className="post-profile-img pull-left" src={"/api/v1/users/" + user.id + "/image?time=" + timestamp} height="36" width="36" />
-                <span className="member-name">{user.full_name.trim() ? user.full_name : user.username}</span>
-                <span className="member-email">{user.full_name.trim() ? user.username : email}</span>
+                <span className="member-name">{user.nickname.trim() ? user.nickname : user.username}</span>
+                <span className="member-email">{user.nickname.trim() ? user.username : email}</span>
                 <div className="dropdown member-drop">
                     <a href="#" className="dropdown-toggle theme" type="button" id="channel_header_dropdown" data-toggle="dropdown" aria-expanded="true">
                         <span>{currentRoles}  </span>

--- a/web/react/components/member_list_team.jsx
+++ b/web/react/components/member_list_team.jsx
@@ -85,8 +85,8 @@ var MemberListTeamItem = React.createClass({
         return (
             <div className="row member-div">
                 <img className="post-profile-img pull-left" src={"/api/v1/users/" + user.id + "/image?time=" + timestamp} height="36" width="36" />
-                <span className="member-name">{user.nickname.trim() ? user.nickname : user.username}</span>
-                <span className="member-email">{user.nickname.trim() ? user.username : email}</span>
+                <span className="member-name">{utils.getDisplayName(user)}</span>
+                <span className="member-email">{email}</span>
                 <div className="dropdown member-drop">
                     <a href="#" className="dropdown-toggle theme" type="button" id="channel_header_dropdown" data-toggle="dropdown" aria-expanded="true">
                         <span>{currentRoles}  </span>

--- a/web/react/components/mention_list.jsx
+++ b/web/react/components/mention_list.jsx
@@ -165,14 +165,14 @@ module.exports = React.createClass({
 
         var all = {};
         all.username = "all";
-        all.full_name = "";
+        all.nickname = "";
         all.secondary_text = "Notifies everyone in the team";
         all.id = "allmention";
         users.push(all);
 
         var channel = {};
         channel.username = "channel";
-        channel.full_name = "";
+        channel.nickname = "";
         channel.secondary_text = "Notifies everyone in the channel";
         channel.id = "channelmention";
         users.push(channel);
@@ -189,11 +189,11 @@ module.exports = React.createClass({
             if (this.alreadyMentioned(users[i].username)) continue;
 
             var firstName = "", lastName = "";
-            if (users[i].full_name.length > 0) {
-                var splitName = users[i].full_name.split(' ');
+            if (users[i].nickname.length > 0) {
+                var splitName = users[i].nickname.split(' ');
                 firstName = splitName[0].toLowerCase();
                 lastName = splitName.length > 1 ? splitName[splitName.length-1].toLowerCase() : "";
-                users[i].secondary_text = users[i].full_name;
+                users[i].secondary_text = users[i].nickname;
             }
 
             if (firstName.lastIndexOf(mentionText,0) === 0

--- a/web/react/components/mention_list.jsx
+++ b/web/react/components/mention_list.jsx
@@ -188,21 +188,13 @@ module.exports = React.createClass({
         for (var i = 0; i < users.length && index < MAX_ITEMS_IN_LIST; i++) {
             if (this.alreadyMentioned(users[i].username)) continue;
 
-            var firstName = "", lastName = "";
-            if (users[i].nickname.length > 0) {
-                var splitName = users[i].nickname.split(' ');
-                firstName = splitName[0].toLowerCase();
-                lastName = splitName.length > 1 ? splitName[splitName.length-1].toLowerCase() : "";
-                users[i].secondary_text = users[i].nickname;
-            }
-
-            if (firstName.lastIndexOf(mentionText,0) === 0
-                    || lastName.lastIndexOf(mentionText,0) === 0 || users[i].username.lastIndexOf(mentionText,0) === 0) {
+            if (users[i].first_name.lastIndexOf(mentionText,0) === 0
+                    || users[i].last_name.lastIndexOf(mentionText,0) === 0 || users[i].username.lastIndexOf(mentionText,0) === 0) {
                 mentions[index] = (
                     <Mention
                         ref={'mention' + index}
                         username={users[i].username}
-                        secondary_text={users[i].secondary_text}
+                        secondary_text={users[i].first_name + " " + users[i].last_name}
                         id={users[i].id}
                         listId={index}
                         isFocused={this.state.selectedMention === index ? "mentions-focus" : ""}

--- a/web/react/components/post_list.jsx
+++ b/web/react/components/post_list.jsx
@@ -305,7 +305,7 @@ module.exports = React.createClass({
                 var teammate = utils.getDirectTeammate(channel.id)
 
                 if (teammate) {
-                    var teammate_name = teammate.full_name.length > 0 ? teammate.full_name : teammate.username;
+                    var teammate_name = teammate.nickname.length > 0 ? teammate.nickname : teammate.username;
                     more_messages = (
                         <div className="channel-intro">
                             <div className="post-profile-img__container channel-intro-img">

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -131,7 +131,7 @@ function getStateFromStores() {
         var channel = ChannelStore.getByName(channelName);
 
         if (channel != null) {
-            channel.display_name = teammate.nickname.trim() != "" ? teammate.nickname : teammate.username;
+            channel.display_name = utils.getDisplayName(teammate);
             channel.teammate_username = teammate.username;
 
             channel.status = UserStore.getStatus(teammate.id);
@@ -150,7 +150,7 @@ function getStateFromStores() {
             var tempChannel = {};
             tempChannel.fake = true;
             tempChannel.name = channelName;
-            tempChannel.display_name = teammate.nickname.trim() != "" ? teammate.nickname : teammate.username;
+            tempChannel.display_name = utils.getDisplayName(teammate);
             tempChannel.status = UserStore.getStatus(teammate.id);
             tempChannel.last_post_at = 0;
             readDirectChannels.push(tempChannel);

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -131,7 +131,7 @@ function getStateFromStores() {
         var channel = ChannelStore.getByName(channelName);
 
         if (channel != null) {
-            channel.display_name = teammate.full_name.trim() != "" ? teammate.full_name : teammate.username;
+            channel.display_name = teammate.nickname.trim() != "" ? teammate.nickname : teammate.username;
             channel.teammate_username = teammate.username;
 
             channel.status = UserStore.getStatus(teammate.id);
@@ -150,7 +150,7 @@ function getStateFromStores() {
             var tempChannel = {};
             tempChannel.fake = true;
             tempChannel.name = channelName;
-            tempChannel.display_name = teammate.full_name.trim() != "" ? teammate.full_name : teammate.username;
+            tempChannel.display_name = teammate.nickname.trim() != "" ? teammate.nickname : teammate.username;
             tempChannel.status = UserStore.getStatus(teammate.id);
             tempChannel.last_post_at = 0;
             readDirectChannels.push(tempChannel);

--- a/web/react/components/user_settings.jsx
+++ b/web/react/components/user_settings.jsx
@@ -752,6 +752,21 @@ var GeneralTab = React.createClass({
 
         this.submitUser(user);
     },
+    submitNickname: function(e) {
+        e.preventDefault();
+
+        var user = UserStore.getCurrentUser();
+        var nickname = this.state.nickname.trim();
+
+        if (user.nickname === nickname) {
+            this.setState({client_error: "You must submit a new nickname"})
+            return;
+        }
+
+        user.nickname = nickname;
+
+        this.submitUser(user);
+    },
     submitName: function(e) {
         e.preventDefault();
 
@@ -839,6 +854,9 @@ var GeneralTab = React.createClass({
     updateLastName: function(e) {
         this.setState({ last_name: e.target.value});
     },
+    updateNickname: function(e) {
+        this.setState({nickname: e.target.value});
+    },
     updateEmail: function(e) {
         this.setState({ email: e.target.value});
     },
@@ -865,7 +883,7 @@ var GeneralTab = React.createClass({
         var firstName = splitStr.shift();
         var lastName = splitStr.join(' ');
 
-        return { username: user.username, first_name: firstName, last_name: lastName,
+        return { username: user.username, first_name: firstName, last_name: lastName, nickname: user.nickname,
                  email: user.email, picture: null };
     },
     render: function() {
@@ -915,6 +933,39 @@ var GeneralTab = React.createClass({
                     title="Name"
                     describe={UserStore.getCurrentUser().nickname}
                     updateSection={function(){self.updateSection("name");}}
+                />
+            );
+        }
+
+        var nicknameSection;
+        if (this.props.activeSection === 'nickname') {
+            var inputs = [];
+
+            inputs.push(
+                <div className="form-group">
+                    <label className="col-sm-5 control-label">{utils.isMobile() ? "": "Nickname"}</label>
+                    <div className="col-sm-7">
+                        <input className="form-control" type="text" onChange={this.updateNickname} value={this.state.nickname}/>
+                    </div>
+                </div>
+            );
+
+            nicknameSection = (
+                <SettingItemMax
+                    title="Nickname"
+                    inputs={inputs}
+                    submit={this.submitNickname}
+                    server_error={server_error}
+                    client_error={client_error}
+                    updateSection={function(e){self.updateSection("");e.preventDefault();}}
+                />
+            );
+        } else {
+            nicknameSection = (
+                <SettingItemMin
+                    title="Nickname"
+                    describe={UserStore.getCurrentUser().nickname}
+                    updateSection={function(){self.updateSection("nickname");}}
                 />
             );
         }
@@ -1025,6 +1076,8 @@ var GeneralTab = React.createClass({
                     {nameSection}
                     <div className="divider-light"/>
                     {usernameSection}
+                    <div className="divider-light"/>
+                    {nicknameSection}
                     <div className="divider-light"/>
                     {emailSection}
                     <div className="divider-light"/>

--- a/web/react/components/user_settings.jsx
+++ b/web/react/components/user_settings.jsx
@@ -156,6 +156,8 @@ var NotificationsTab = React.createClass({
 
         var self = this;
 
+        var user = this.props.user;
+
         var desktopSection;
         if (this.props.activeSection === 'desktop') {
             var notifyActive = [false, false, false];
@@ -314,20 +316,14 @@ var NotificationsTab = React.createClass({
 
         var keysSection;
         if (this.props.activeSection === 'keys') {
-            var user = this.props.user;
-            var first_name = "";
-            if (user.nickname.length > 0) {
-                first_name = user.nickname.split(' ')[0];
-            }
-
             var inputs = [];
 
-            if (first_name != "") {
+            if (user.first_name) {
                 inputs.push(
                     <div>
                         <div className="checkbox">
                             <label>
-                                <input type="checkbox" checked={this.state.first_name_key} onChange={function(e){self.updateFirstNameKey(e.target.checked);}}>{'Your case sensitive first name "' + first_name + '"'}</input>
+                                <input type="checkbox" checked={this.state.first_name_key} onChange={function(e){self.updateFirstNameKey(e.target.checked);}}>{'Your case sensitive first name "' + user.first_name + '"'}</input>
                             </label>
                         </div>
                     </div>
@@ -396,14 +392,9 @@ var NotificationsTab = React.createClass({
             );
         } else {
             var keys = [];
-            if (this.state.first_name_key) {
-                var first_name = "";
-                var user = this.props.user;
-                if (user.nickname.length > 0) first_name = user.nickname.split(' ')[0];
-                if (first_name != "") keys.push(first_name);
-            }
-            if (this.state.username_key) keys.push(this.props.user.username);
-            if (this.state.mention_key) keys.push('@'+this.props.user.username);
+            if (this.state.first_name_key) keys.push(user.first_name);
+            if (this.state.username_key) keys.push(user.username);
+            if (this.state.mention_key) keys.push('@'+user.username);
             if (this.state.all_key) keys.push('@all');
             if (this.state.channel_key) keys.push('@channel');
             if (this.state.custom_keys.length > 0) keys = keys.concat(this.state.custom_keys.split(','));

--- a/web/react/components/user_settings.jsx
+++ b/web/react/components/user_settings.jsx
@@ -774,14 +774,13 @@ var GeneralTab = React.createClass({
         var firstName = this.state.first_name.trim();
         var lastName = this.state.last_name.trim();
 
-        var fullName = firstName + ' ' + lastName;
-
-        if (user.nickname === fullName) {
-            this.setState({client_error: "You must submit a new name"})
+        if (user.first_name === firstName && user.last_name === lastName) {
+            this.setState({client_error: "You must submit a new first or last name"})
             return;
         }
 
-        user.nickname = fullName;
+        user.first_name = firstName;
+        user.last_name = lastName;
 
         this.submitUser(user);
     },
@@ -879,11 +878,7 @@ var GeneralTab = React.createClass({
     getInitialState: function() {
         var user = this.props.user;
 
-        var splitStr = user.nickname.split(' ');
-        var firstName = splitStr.shift();
-        var lastName = splitStr.join(' ');
-
-        return { username: user.username, first_name: firstName, last_name: lastName, nickname: user.nickname,
+        return { username: user.username, first_name: user.first_name, last_name: user.last_name, nickname: user.nickname,
                  email: user.email, picture: null };
     },
     render: function() {
@@ -919,7 +914,7 @@ var GeneralTab = React.createClass({
 
             nameSection = (
                 <SettingItemMax
-                    title="Name"
+                    title="Full Name"
                     inputs={inputs}
                     submit={this.submitName}
                     server_error={server_error}
@@ -928,10 +923,20 @@ var GeneralTab = React.createClass({
                 />
             );
         } else {
+            var full_name = "";
+
+            if (user.first_name && user.last_name) {
+                full_name = user.first_name + " " + user.last_name;
+            } else if (user.first_name) {
+                full_name = user.first_name;
+            } else if (user.last_name) {
+                full_name = user.last_name;
+            }
+
             nameSection = (
                 <SettingItemMin
-                    title="Name"
-                    describe={UserStore.getCurrentUser().nickname}
+                    title="Full Name"
+                    describe={full_name}
                     updateSection={function(){self.updateSection("name");}}
                 />
             );

--- a/web/react/components/user_settings.jsx
+++ b/web/react/components/user_settings.jsx
@@ -316,8 +316,8 @@ var NotificationsTab = React.createClass({
         if (this.props.activeSection === 'keys') {
             var user = this.props.user;
             var first_name = "";
-            if (user.full_name.length > 0) {
-                first_name = user.full_name.split(' ')[0];
+            if (user.nickname.length > 0) {
+                first_name = user.nickname.split(' ')[0];
             }
 
             var inputs = [];
@@ -399,7 +399,7 @@ var NotificationsTab = React.createClass({
             if (this.state.first_name_key) {
                 var first_name = "";
                 var user = this.props.user;
-                if (user.full_name.length > 0) first_name = user.full_name.split(' ')[0];
+                if (user.nickname.length > 0) first_name = user.nickname.split(' ')[0];
                 if (first_name != "") keys.push(first_name);
             }
             if (this.state.username_key) keys.push(this.props.user.username);
@@ -761,12 +761,12 @@ var GeneralTab = React.createClass({
 
         var fullName = firstName + ' ' + lastName;
 
-        if (user.full_name === fullName) {
+        if (user.nickname === fullName) {
             this.setState({client_error: "You must submit a new name"})
             return;
         }
 
-        user.full_name = fullName;
+        user.nickname = fullName;
 
         this.submitUser(user);
     },
@@ -861,7 +861,7 @@ var GeneralTab = React.createClass({
     getInitialState: function() {
         var user = this.props.user;
 
-        var splitStr = user.full_name.split(' ');
+        var splitStr = user.nickname.split(' ');
         var firstName = splitStr.shift();
         var lastName = splitStr.join(' ');
 
@@ -913,7 +913,7 @@ var GeneralTab = React.createClass({
             nameSection = (
                 <SettingItemMin
                     title="Name"
-                    describe={UserStore.getCurrentUser().full_name}
+                    describe={UserStore.getCurrentUser().nickname}
                     updateSection={function(){self.updateSection("name");}}
                 />
             );

--- a/web/react/stores/user_store.jsx
+++ b/web/react/stores/user_store.jsx
@@ -180,11 +180,7 @@ var UserStore = assign({}, EventEmitter.prototype, {
     if (user && user.notify_props && user.notify_props.mention_keys) {
       var keys = user.notify_props.mention_keys.split(',');
 
-      if (user.nickname.length > 0 && user.notify_props.first_name === "true") {
-        var first = user.nickname.split(' ')[0];
-        if (first.length > 0) keys.push(first);
-      }
-
+      if (user.first_name && user.notify_props.first_name === "true") keys.push(user.first_name);
       if (user.notify_props.all === "true") keys.push('@all');
       if (user.notify_props.channel === "true") keys.push('@channel');
 

--- a/web/react/stores/user_store.jsx
+++ b/web/react/stores/user_store.jsx
@@ -177,17 +177,15 @@ var UserStore = assign({}, EventEmitter.prototype, {
   },
   getCurrentMentionKeys: function() {
     var user = this.getCurrentUser();
-    if (user && user.notify_props && user.notify_props.mention_keys) {
-      var keys = user.notify_props.mention_keys.split(',');
 
-      if (user.first_name && user.notify_props.first_name === "true") keys.push(user.first_name);
-      if (user.notify_props.all === "true") keys.push('@all');
-      if (user.notify_props.channel === "true") keys.push('@channel');
+    var keys = [];
 
-      return keys;
-    } else {
-      return [];
-    }
+    if (user.notify_props && user.notify_props.mention_keys) keys = keys.concat(user.notify_props.mention_keys.split(','));
+    if (user.first_name && user.notify_props.first_name === "true") keys.push(user.first_name);
+    if (user.notify_props.all === "true") keys.push('@all');
+    if (user.notify_props.channel === "true") keys.push('@channel');
+
+    return keys;
   },
   getLastVersion: function() {
     return BrowserStore.getItem("last_version", '');

--- a/web/react/stores/user_store.jsx
+++ b/web/react/stores/user_store.jsx
@@ -180,8 +180,8 @@ var UserStore = assign({}, EventEmitter.prototype, {
     if (user && user.notify_props && user.notify_props.mention_keys) {
       var keys = user.notify_props.mention_keys.split(',');
 
-      if (user.full_name.length > 0 && user.notify_props.first_name === "true") {
-        var first = user.full_name.split(' ')[0];
+      if (user.nickname.length > 0 && user.notify_props.first_name === "true") {
+        var first = user.nickname.split(' ')[0];
         if (first.length > 0) keys.push(first);
       }
 

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -796,7 +796,6 @@ module.exports.getHomeLink = function() {
 	return window.location.protocol + "//" + parts.join(".");
 }
 
-
 module.exports.changeColor =function(col, amt) {
 
     var usePound = false;
@@ -824,5 +823,12 @@ module.exports.changeColor =function(col, amt) {
     else if (g < 0) g = 0;
 
     return (usePound?"#":"") + String("000000" + (g | (b << 8) | (r << 16)).toString(16)).slice(-6);
+};
 
+module.exports.getDisplayName = function(user) {
+    if (user.nickname && user.nickname.trim().length > 0) {
+        return user.nickname;
+    } else {
+        return user.username;
+    }
 };

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -825,10 +825,28 @@ module.exports.changeColor =function(col, amt) {
     return (usePound?"#":"") + String("000000" + (g | (b << 8) | (r << 16)).toString(16)).slice(-6);
 };
 
+module.exports.getFullName = function(user) {
+    if (user.first_name && user.last_name) {
+        return user.first_name + " " + user.last_name;
+    } else if (user.first_name) {
+        return user.first_name;
+    } else if (user.last_name) {
+        return user.last_name;
+    } else {
+        return "";
+    }
+};
+
 module.exports.getDisplayName = function(user) {
     if (user.nickname && user.nickname.trim().length > 0) {
         return user.nickname;
     } else {
-        return user.username;
+        var fullName = module.exports.getFullName(user);
+
+        if (fullName) {
+            return fullName;
+        } else {
+            return user.username;
+        }
     }
 };

--- a/web/templates/head.html
+++ b/web/templates/head.html
@@ -59,7 +59,7 @@
             var user = window.UserStore.getCurrentUser(true);
             if (user) {
               analytics.identify(user.id, {
-                  name: user.full_name,
+                  name: user.nickname,
                   email: user.email,
                   createdAt: user.create_at,
                   username: user.username,

--- a/web/web.go
+++ b/web/web.go
@@ -303,8 +303,8 @@ func getChannel(c *api.Context, w http.ResponseWriter, r *http.Request) {
 
 			//api.Handle404(w, r)
 			//Bad channel urls just redirect to the town-square for now
-			
-			http.Redirect(w,r,"/channels/town-square", http.StatusFound)
+
+			http.Redirect(w, r, "/channels/town-square", http.StatusFound)
 			return
 		}
 	}
@@ -351,7 +351,7 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			user := result.Data.(*model.User)
-			api.FireAndForgetVerifyEmail(user.Id, strings.Split(user.FullName, " ")[0], user.Email, domain, c.TeamUrl)
+			api.FireAndForgetVerifyEmail(user.Id, strings.Split(user.Nickname, " ")[0], user.Email, domain, c.TeamUrl)
 			http.Redirect(w, r, "/", http.StatusFound)
 			return
 		}

--- a/web/web.go
+++ b/web/web.go
@@ -351,7 +351,7 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			user := result.Data.(*model.User)
-			api.FireAndForgetVerifyEmail(user.Id, strings.Split(user.Nickname, " ")[0], user.Email, domain, c.TeamUrl)
+			api.FireAndForgetVerifyEmail(user.Id, user.FirstName, user.Email, domain, c.TeamUrl)
 			http.Redirect(w, r, "/", http.StatusFound)
 			return
 		}


### PR DESCRIPTION
Changes made:
1) Renamed all existing references to the FullName field to Nickname
2) Added FirstName and LastName fields, populated from the previous FullName if possible, and use them wherever it makes sense
3) Added GetDisplayName helper function to be more consistent how we're referring to users in the UI. Currently, this is to use the nickname if possible and fall back to the username if that's not available.

Since the first two commits (for 1 above) are a bunch of find and replaces, it may be easier to review this on a commit by commit basis since they're fairly self-contained.