### PR TITLE
MM-1494 Change image resizing for preview and thumbnail to use Lanczos interpolation

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -13,9 +13,9 @@ import (
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 	"github.com/nfnt/resize"
+	_ "golang.org/x/image/bmp"
 	"image"
 	_ "image/gif"
-	_ "golang.org/x/image/bmp"
 	"image/jpeg"
 	"io"
 	"net/http"
@@ -157,7 +157,7 @@ func fireAndForgetHandleImages(filenames []string, fileData [][]byte, teamId, ch
 				go func() {
 					var thumbnail image.Image
 					if imgConfig.Width > int(utils.Cfg.ImageSettings.ThumbnailWidth) {
-						thumbnail = resize.Resize(utils.Cfg.ImageSettings.ThumbnailWidth, utils.Cfg.ImageSettings.ThumbnailHeight, img, resize.NearestNeighbor)
+						thumbnail = resize.Resize(utils.Cfg.ImageSettings.ThumbnailWidth, utils.Cfg.ImageSettings.ThumbnailHeight, img, resize.Lanczos3)
 					} else {
 						thumbnail = img
 					}
@@ -182,7 +182,7 @@ func fireAndForgetHandleImages(filenames []string, fileData [][]byte, teamId, ch
 				go func() {
 					var preview image.Image
 					if imgConfig.Width > int(utils.Cfg.ImageSettings.PreviewWidth) {
-						preview = resize.Resize(utils.Cfg.ImageSettings.PreviewWidth, utils.Cfg.ImageSettings.PreviewHeight, img, resize.NearestNeighbor)
+						preview = resize.Resize(utils.Cfg.ImageSettings.PreviewWidth, utils.Cfg.ImageSettings.PreviewHeight, img, resize.Lanczos3)
 					} else {
 						preview = img
 					}


### PR DESCRIPTION
Makes text in images appear much clearer than with the existing nearest neighbour filtering.