### PR TITLE
MM-1356 Changing team URLs from team.domain.com to domain.com/team

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -16,10 +16,10 @@ var ServerTemplates *template.Template
 
 type ServerTemplatePage Page
 
-func NewServerTemplatePage(templateName, teamUrl string) *ServerTemplatePage {
+func NewServerTemplatePage(templateName, teamURL string) *ServerTemplatePage {
 	props := make(map[string]string)
 	props["AnalyticsUrl"] = utils.Cfg.ServiceSettings.AnalyticsUrl
-	return &ServerTemplatePage{TemplateName: templateName, SiteName: utils.Cfg.ServiceSettings.SiteName, FeedbackEmail: utils.Cfg.EmailSettings.FeedbackEmail, TeamUrl: teamUrl, Props: props}
+	return &ServerTemplatePage{TemplateName: templateName, SiteName: utils.Cfg.ServiceSettings.SiteName, FeedbackEmail: utils.Cfg.EmailSettings.FeedbackEmail, TeamURL: teamURL, Props: props}
 }
 
 func (me *ServerTemplatePage) Render() string {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,12 +24,12 @@ func Setup() {
 func SetupBenchmark() (*model.Team, *model.User, *model.Channel) {
 	Setup()
 
-	team := &model.Team{Name: "Benchmark Team", Domain: "z-z-" + model.NewId() + "a", Email: "benchmark@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Benchmark Team", Name: "z-z-" + model.NewId() + "a", Email: "benchmark@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "benchmark@test.com", Nickname: "Mr. Benchmarker", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 	channel := &model.Channel{DisplayName: "Benchmark Channel", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel = Client.Must(Client.CreateChannel(channel)).Data.(*model.Channel)
 

--- a/api/auto_constants.go
+++ b/api/auto_constants.go
@@ -12,8 +12,8 @@ const (
 	USER_PASSWORD              = "passwd"
 	CHANNEL_TYPE               = model.CHANNEL_OPEN
 	FUZZ_USER_EMAIL_PREFIX_LEN = 10
-	BTEST_TEAM_NAME            = "TestTeam"
-	BTEST_TEAM_DOMAIN_NAME     = "z-z-testdomaina"
+	BTEST_TEAM_DISPLAY_NAME            = "TestTeam"
+	BTEST_TEAM_NAME          = "z-z-testdomaina"
 	BTEST_TEAM_EMAIL           = "test@nowhere.com"
 	BTEST_TEAM_TYPE            = model.TEAM_OPEN
 	BTEST_USER_NAME            = "Mr. Testing Tester"

--- a/api/auto_teams.go
+++ b/api/auto_teams.go
@@ -39,22 +39,22 @@ func NewAutoTeamCreator(client *model.Client) *AutoTeamCreator {
 
 func (cfg *AutoTeamCreator) createRandomTeam() (*model.Team, bool) {
 	var teamEmail string
+	var teamDisplayName string
 	var teamName string
-	var teamDomain string
 	if cfg.Fuzzy {
 		teamEmail = utils.FuzzEmail()
+		teamDisplayName = utils.FuzzName()
 		teamName = utils.FuzzName()
-		teamDomain = utils.FuzzName()
 	} else {
 		teamEmail = utils.RandomEmail(cfg.EmailLength, cfg.EmailCharset)
-		teamName = utils.RandomName(cfg.NameLength, cfg.NameCharset)
-		teamDomain = utils.RandomName(cfg.NameLength, cfg.NameCharset) + model.NewId()
+		teamDisplayName = utils.RandomName(cfg.NameLength, cfg.NameCharset)
+		teamName = utils.RandomName(cfg.NameLength, cfg.NameCharset) + model.NewId()
 	}
 	team := &model.Team{
-		Name:   teamName,
-		Domain: teamDomain,
-		Email:  teamEmail,
-		Type:   model.TEAM_OPEN,
+		DisplayName: teamDisplayName,
+		Name:       teamName,
+		Email:       teamEmail,
+		Type:        model.TEAM_OPEN,
 	}
 
 	result, err := cfg.client.CreateTeam(team)

--- a/api/auto_users.go
+++ b/api/auto_users.go
@@ -33,9 +33,9 @@ func NewAutoUserCreator(client *model.Client, teamID string) *AutoUserCreator {
 
 // Basic test team and user so you always know one
 func CreateBasicUser(client *model.Client) *model.AppError {
-	result, _ := client.FindTeamByDomain(BTEST_TEAM_DOMAIN_NAME, true)
+	result, _ := client.FindTeamByName(BTEST_TEAM_NAME, true)
 	if result.Data.(bool) == false {
-		newteam := &model.Team{Name: BTEST_TEAM_NAME, Domain: BTEST_TEAM_DOMAIN_NAME, Email: BTEST_TEAM_EMAIL, Type: BTEST_TEAM_TYPE}
+		newteam := &model.Team{DisplayName: BTEST_TEAM_DISPLAY_NAME, Name: BTEST_TEAM_NAME, Email: BTEST_TEAM_EMAIL, Type: BTEST_TEAM_TYPE}
 		result, err := client.CreateTeam(newteam)
 		if err != nil {
 			return err

--- a/api/channel_benchmark_test.go
+++ b/api/channel_benchmark_test.go
@@ -141,7 +141,7 @@ func BenchmarkJoinChannel(b *testing.B) {
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "random@test.com", Nickname: "That Guy", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	// Benchmark Start
 	b.ResetTimer()

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -14,17 +14,17 @@ import (
 func TestCreateChannel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	team2 := &model.Team{Name: "Name Team 2", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team2 := &model.Team{DisplayName: "Name Team 2", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	channel := model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	rchannel, err := Client.CreateChannel(&channel)
@@ -94,7 +94,7 @@ func TestCreateChannel(t *testing.T) {
 func TestCreateDirectChannel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -105,7 +105,7 @@ func TestCreateDirectChannel(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	data := make(map[string]string)
 	data["user_id"] = user2.Id
@@ -149,7 +149,7 @@ func TestCreateDirectChannel(t *testing.T) {
 func TestUpdateChannel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	userTeamAdmin := &model.User{TeamId: team.Id, Email: team.Email, Nickname: "Corey Hulen", Password: "pwd"}
@@ -165,7 +165,7 @@ func TestUpdateChannel(t *testing.T) {
 	store.Must(Srv.Store.User().VerifyEmail(userStd.Id))
 	userStd.Roles = ""
 
-	Client.LoginByEmail(team.Domain, userChannelAdmin.Email, "pwd")
+	Client.LoginByEmail(team.Name, userChannelAdmin.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -184,7 +184,7 @@ func TestUpdateChannel(t *testing.T) {
 		t.Fatal("Channel admin failed to skip displayName")
 	}
 
-	Client.LoginByEmail(team.Domain, userTeamAdmin.Email, "pwd")
+	Client.LoginByEmail(team.Name, userTeamAdmin.Email, "pwd")
 
 	desc = "b" + model.NewId() + "b"
 	upChannel1 = &model.Channel{Id: channel1.Id, Description: desc}
@@ -210,7 +210,7 @@ func TestUpdateChannel(t *testing.T) {
 		}
 	}
 
-	Client.LoginByEmail(team.Domain, userStd.Email, "pwd")
+	Client.LoginByEmail(team.Name, userStd.Email, "pwd")
 
 	if _, err := Client.UpdateChannel(upChannel1); err == nil {
 		t.Fatal("Standard User should have failed to update")
@@ -220,14 +220,14 @@ func TestUpdateChannel(t *testing.T) {
 func TestUpdateChannelDesc(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -270,7 +270,7 @@ func TestUpdateChannelDesc(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
 	data["channel_id"] = channel1.Id
 	data["channel_description"] = "new desc"
@@ -282,14 +282,14 @@ func TestUpdateChannelDesc(t *testing.T) {
 func TestGetChannel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -324,14 +324,14 @@ func TestGetChannel(t *testing.T) {
 func TestGetMoreChannel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -343,7 +343,7 @@ func TestGetMoreChannel(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
 	rget := Client.Must(Client.GetMoreChannels(""))
 	data := rget.Data.(*model.ChannelList)
@@ -368,14 +368,14 @@ func TestGetMoreChannel(t *testing.T) {
 func TestJoinChannel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -387,7 +387,7 @@ func TestJoinChannel(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
 	Client.Must(Client.JoinChannel(channel1.Id))
 
@@ -402,7 +402,7 @@ func TestJoinChannel(t *testing.T) {
 	user3 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 
-	Client.LoginByEmail(team.Domain, user3.Email, "pwd")
+	Client.LoginByEmail(team.Name, user3.Email, "pwd")
 
 	if _, err := Client.JoinChannel(rchannel.Id); err == nil {
 		t.Fatal("shoudn't be able to join direct channel")
@@ -412,14 +412,14 @@ func TestJoinChannel(t *testing.T) {
 func TestLeaveChannel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -431,7 +431,7 @@ func TestLeaveChannel(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
 	Client.Must(Client.JoinChannel(channel1.Id))
 
@@ -461,7 +461,7 @@ func TestLeaveChannel(t *testing.T) {
 func TestDeleteChannel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	userTeamAdmin := &model.User{TeamId: team.Id, Email: team.Email, Nickname: "Corey Hulen", Password: "pwd"}
@@ -472,14 +472,14 @@ func TestDeleteChannel(t *testing.T) {
 	userChannelAdmin = Client.Must(Client.CreateUser(userChannelAdmin, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userChannelAdmin.Id))
 
-	Client.LoginByEmail(team.Domain, userChannelAdmin.Email, "pwd")
+	Client.LoginByEmail(team.Name, userChannelAdmin.Email, "pwd")
 
 	channelMadeByCA := &model.Channel{DisplayName: "C Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channelMadeByCA = Client.Must(Client.CreateChannel(channelMadeByCA)).Data.(*model.Channel)
 
 	Client.AddChannelMember(channelMadeByCA.Id, userTeamAdmin.Id)
 
-	Client.LoginByEmail(team.Domain, userTeamAdmin.Email, "pwd")
+	Client.LoginByEmail(team.Name, userTeamAdmin.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -504,7 +504,7 @@ func TestDeleteChannel(t *testing.T) {
 	userStd = Client.Must(Client.CreateUser(userStd, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userStd.Id))
 
-	Client.LoginByEmail(team.Domain, userStd.Email, "pwd")
+	Client.LoginByEmail(team.Name, userStd.Email, "pwd")
 
 	if _, err := Client.JoinChannel(channel1.Id); err == nil {
 		t.Fatal("should have failed to join deleted channel")
@@ -531,14 +531,14 @@ func TestDeleteChannel(t *testing.T) {
 func TestGetChannelExtraInfo(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -552,14 +552,14 @@ func TestGetChannelExtraInfo(t *testing.T) {
 func TestAddChannelMember(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -591,13 +591,13 @@ func TestAddChannelMember(t *testing.T) {
 	channel2 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel2 = Client.Must(Client.CreateChannel(channel2)).Data.(*model.Channel)
 
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
 	if _, err := Client.AddChannelMember(channel2.Id, user2.Id); err == nil {
 		t.Fatal("Should have errored, user not in channel")
 	}
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	Client.Must(Client.DeleteChannel(channel2.Id))
 
@@ -610,7 +610,7 @@ func TestAddChannelMember(t *testing.T) {
 func TestRemoveChannelMember(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	userTeamAdmin := &model.User{TeamId: team.Id, Email: team.Email, Nickname: "Corey Hulen", Password: "pwd"}
@@ -621,14 +621,14 @@ func TestRemoveChannelMember(t *testing.T) {
 	userChannelAdmin = Client.Must(Client.CreateUser(userChannelAdmin, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(userChannelAdmin.Id))
 
-	Client.LoginByEmail(team.Domain, userChannelAdmin.Email, "pwd")
+	Client.LoginByEmail(team.Name, userChannelAdmin.Email, "pwd")
 
 	channelMadeByCA := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channelMadeByCA = Client.Must(Client.CreateChannel(channelMadeByCA)).Data.(*model.Channel)
 
 	Client.Must(Client.AddChannelMember(channelMadeByCA.Id, userTeamAdmin.Id))
 
-	Client.LoginByEmail(team.Domain, userTeamAdmin.Email, "pwd")
+	Client.LoginByEmail(team.Name, userTeamAdmin.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -660,13 +660,13 @@ func TestRemoveChannelMember(t *testing.T) {
 	channel2 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel2 = Client.Must(Client.CreateChannel(channel2)).Data.(*model.Channel)
 
-	Client.LoginByEmail(team.Domain, userStd.Email, "pwd")
+	Client.LoginByEmail(team.Name, userStd.Email, "pwd")
 
 	if _, err := Client.RemoveChannelMember(channel2.Id, userStd.Id); err == nil {
 		t.Fatal("Should have errored, user not channel admin")
 	}
 
-	Client.LoginByEmail(team.Domain, userTeamAdmin.Email, "pwd")
+	Client.LoginByEmail(team.Name, userTeamAdmin.Email, "pwd")
 	Client.Must(Client.AddChannelMember(channel2.Id, userStd.Id))
 
 	Client.Must(Client.DeleteChannel(channel2.Id))
@@ -680,14 +680,14 @@ func TestRemoveChannelMember(t *testing.T) {
 func TestUpdateNotifyLevel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -749,7 +749,7 @@ func TestUpdateNotifyLevel(t *testing.T) {
 	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
 	data["channel_id"] = channel1.Id
 	data["user_id"] = user2.Id
@@ -762,14 +762,14 @@ func TestUpdateNotifyLevel(t *testing.T) {
 func TestFuzzyChannel(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	// Strings that should pass as acceptable channel names
 	var fuzzyStringsPass = []string{

--- a/api/command.go
+++ b/api/command.go
@@ -321,14 +321,14 @@ func loadTestSetupCommand(c *Context, command *model.Command) bool {
 				numPosts, _ = strconv.Atoi(tokens[numArgs+2])
 			}
 		}
-		client := model.NewClient(c.TeamUrl + "/api/v1")
+		client := model.NewClient(c.GetSiteURL() + "/api/v1")
 
 		if doTeams {
 			if err := CreateBasicUser(client); err != nil {
 				l4g.Error("Failed to create testing enviroment")
 				return true
 			}
-			client.LoginByEmail(BTEST_TEAM_DOMAIN_NAME, BTEST_USER_EMAIL, BTEST_USER_PASSWORD)
+			client.LoginByEmail(BTEST_TEAM_NAME, BTEST_USER_EMAIL, BTEST_USER_PASSWORD)
 			enviroment, err := CreateTestEnviromentWithTeams(
 				client,
 				utils.Range{numTeams, numTeams},
@@ -342,7 +342,7 @@ func loadTestSetupCommand(c *Context, command *model.Command) bool {
 			} else {
 				l4g.Info("Testing enviroment created")
 				for i := 0; i < len(enviroment.Teams); i++ {
-					l4g.Info("Team Created: " + enviroment.Teams[i].Domain)
+					l4g.Info("Team Created: " + enviroment.Teams[i].Name)
 					l4g.Info("\t User to login: " + enviroment.Enviroments[i].Users[0].Email + ", " + USER_PASSWORD)
 				}
 			}
@@ -381,7 +381,7 @@ func loadTestUsersCommand(c *Context, command *model.Command) bool {
 		if err == false {
 			usersr = utils.Range{10, 15}
 		}
-		client := model.NewClient(c.TeamUrl + "/api/v1")
+		client := model.NewClient(c.GetSiteURL() + "/api/v1")
 		userCreator := NewAutoUserCreator(client, c.Session.TeamId)
 		userCreator.Fuzzy = doFuzz
 		userCreator.CreateTestUsers(usersr)
@@ -411,7 +411,7 @@ func loadTestChannelsCommand(c *Context, command *model.Command) bool {
 		if err == false {
 			channelsr = utils.Range{20, 30}
 		}
-		client := model.NewClient(c.TeamUrl + "/api/v1")
+		client := model.NewClient(c.GetSiteURL() + "/api/v1")
 		client.MockSession(c.Session.Id)
 		channelCreator := NewAutoChannelCreator(client, c.Session.TeamId)
 		channelCreator.Fuzzy = doFuzz
@@ -463,7 +463,7 @@ func loadTestPostsCommand(c *Context, command *model.Command) bool {
 			}
 		}
 
-		client := model.NewClient(c.TeamUrl + "/api/v1")
+		client := model.NewClient(c.GetSiteURL() + "/api/v1")
 		client.MockSession(c.Session.Id)
 		testPoster := NewAutoPostCreator(client, command.ChannelId)
 		testPoster.Fuzzy = doFuzz

--- a/api/command_test.go
+++ b/api/command_test.go
@@ -12,14 +12,14 @@ import (
 func TestSuggestRootCommands(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	if _, err := Client.Command("", "", true); err == nil {
 		t.Fatal("Should fail")
@@ -55,14 +55,14 @@ func TestSuggestRootCommands(t *testing.T) {
 func TestLogoutCommands(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	rs1 := Client.Must(Client.Command("", "/logout", false)).Data.(*model.Command)
 	if rs1.GotoLocation != "/logout" {
@@ -73,14 +73,14 @@ func TestLogoutCommands(t *testing.T) {
 func TestJoinCommands(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "AA", Name: "aa" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)

--- a/api/context.go
+++ b/api/context.go
@@ -17,12 +17,14 @@ import (
 var sessionCache *utils.Cache = utils.NewLru(model.SESSION_CACHE_SIZE)
 
 type Context struct {
-	Session   model.Session
-	RequestId string
-	IpAddress string
-	TeamUrl   string
-	Path      string
-	Err       *model.AppError
+	Session      model.Session
+	RequestId    string
+	IpAddress    string
+	Path         string
+	Err          *model.AppError
+	teamURLValid bool
+	teamURL      string
+	siteURL      string
 }
 
 type Page struct {
@@ -30,32 +32,36 @@ type Page struct {
 	Title         string
 	SiteName      string
 	FeedbackEmail string
-	TeamUrl       string
+	TeamURL       string
 	Props         map[string]string
 }
 
 func ApiAppHandler(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &handler{h, false, false, true, false}
+	return &handler{h, false, false, true, false, false}
 }
 
 func AppHandler(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &handler{h, false, false, false, false}
+	return &handler{h, false, false, false, false, false}
+}
+
+func AppHandlerIndependent(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
+	return &handler{h, false, false, false, false, true}
 }
 
 func ApiUserRequired(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &handler{h, true, false, true, true}
+	return &handler{h, true, false, true, true, false}
 }
 
 func ApiUserRequiredActivity(h func(*Context, http.ResponseWriter, *http.Request), isUserActivity bool) http.Handler {
-	return &handler{h, true, false, true, isUserActivity}
+	return &handler{h, true, false, true, isUserActivity, false}
 }
 
 func UserRequired(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &handler{h, true, false, false, false}
+	return &handler{h, true, false, false, false, false}
 }
 
 func ApiAdminSystemRequired(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &handler{h, true, true, true, false}
+	return &handler{h, true, true, true, false, false}
 }
 
 type handler struct {
@@ -64,6 +70,7 @@ type handler struct {
 	requireSystemAdmin bool
 	isApi              bool
 	isUserActivity     bool
+	isTeamIndependent  bool
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -73,7 +80,6 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c := &Context{}
 	c.RequestId = model.NewId()
 	c.IpAddress = GetIpAddress(r)
-	c.Path = r.URL.Path
 
 	protocol := "http"
 
@@ -90,7 +96,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	c.TeamUrl = protocol + "://" + r.Host
+	c.setSiteURL(protocol + "://" + r.Host)
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.RequestId)
 	w.Header().Set(model.HEADER_VERSION_ID, utils.Cfg.ServiceSettings.Version)
@@ -135,6 +141,15 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if h.isApi || h.isTeamIndependent {
+		c.setTeamURL(c.GetSiteURL(), false)
+		c.Path = r.URL.Path
+	} else {
+		splitURL := strings.Split(r.URL.Path, "/")
+		c.setTeamURL(protocol+"://"+r.Host+"/"+splitURL[1], true)
+		c.Path = "/" + strings.Join(splitURL[2:], "/")
+	}
+
 	if c.Err == nil && h.requireUser {
 		c.UserRequired()
 	}
@@ -165,7 +180,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(c.Err.ToJson()))
 		} else {
 			if c.Err.StatusCode == http.StatusUnauthorized {
-				http.Redirect(w, r, "/?redirect="+url.QueryEscape(r.URL.Path), http.StatusTemporaryRedirect)
+				http.Redirect(w, r, c.GetTeamURL()+"/?redirect="+url.QueryEscape(r.URL.Path), http.StatusTemporaryRedirect)
 			} else {
 				RenderWebError(c.Err, w, r)
 			}
@@ -297,6 +312,39 @@ func (c *Context) SetInvalidParam(where string, name string) {
 
 func (c *Context) SetUnknownError(where string, details string) {
 	c.Err = model.NewAppError(where, "An unknown error has occured. Please contact support.", details)
+}
+
+func (c *Context) setTeamURL(url string, valid bool) {
+	c.teamURL = url
+	c.teamURLValid = valid
+}
+
+func (c *Context) setTeamURLFromSession() {
+	if result := <-Srv.Store.Team().Get(c.Session.TeamId); result.Err == nil {
+		c.setTeamURL(c.GetSiteURL()+"/"+result.Data.(*model.Team).Name, true)
+	}
+}
+
+func (c *Context) setSiteURL(url string) {
+	c.siteURL = url
+}
+
+func (c *Context) GetTeamURLFromTeam(team *model.Team) string {
+	return c.GetSiteURL() + "/" + team.Name
+}
+
+func (c *Context) GetTeamURL() string {
+	if !c.teamURLValid {
+		c.setTeamURLFromSession()
+		if !c.teamURLValid {
+			l4g.Debug("TeamURL accessed when not valid. Team URL should not be used in api functions or those that are team independent")
+		}
+	}
+	return c.teamURL
+}
+
+func (c *Context) GetSiteURL() string {
+	return c.siteURL
 }
 
 func GetIpAddress(r *http.Request) string {

--- a/api/file.go
+++ b/api/file.go
@@ -13,9 +13,9 @@ import (
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 	"github.com/nfnt/resize"
+	_ "golang.org/x/image/bmp"
 	"image"
 	_ "image/gif"
-	_ "golang.org/x/image/bmp"
 	"image/jpeg"
 	"io"
 	"net/http"
@@ -115,7 +115,7 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		fileUrl := c.TeamUrl + "/api/v1/files/get/" + channelId + "/" + c.Session.UserId + "/" + uid + "/" + url.QueryEscape(files[i].Filename)
+		fileUrl := c.GetSiteURL() + "/api/v1/files/get/" + channelId + "/" + c.Session.UserId + "/" + uid + "/" + url.QueryEscape(files[i].Filename)
 		resStruct.Filenames = append(resStruct.Filenames, fileUrl)
 	}
 
@@ -363,7 +363,7 @@ func getPublicLink(c *Context, w http.ResponseWriter, r *http.Request) {
 	data := model.MapToJson(newProps)
 	hash := model.HashPassword(fmt.Sprintf("%v:%v", data, utils.Cfg.ServiceSettings.PublicLinkSalt))
 
-	url := fmt.Sprintf("%s/api/v1/files/%s/%s/%s/%s?d=%s&h=%s&t=%s", c.TeamUrl, getType, channelId, userId, filename, url.QueryEscape(data), url.QueryEscape(hash), c.Session.TeamId)
+	url := fmt.Sprintf("%s/api/v1/files/%s/%s/%s/%s?d=%s&h=%s&t=%s", c.GetSiteURL(), getType, channelId, userId, filename, url.QueryEscape(data), url.QueryEscape(hash), c.Session.TeamId)
 
 	if !c.HasPermissionsToChannel(cchan, "getPublicLink") {
 		return

--- a/api/file_test.go
+++ b/api/file_test.go
@@ -24,14 +24,14 @@ import (
 func TestUploadFile(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -111,14 +111,14 @@ func TestUploadFile(t *testing.T) {
 func TestGetFile(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -173,7 +173,7 @@ func TestGetFile(t *testing.T) {
 			t.Fatal("file get failed")
 		}
 
-		team2 := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+		team2 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 		team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
 		user2 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -187,7 +187,7 @@ func TestGetFile(t *testing.T) {
 		data := model.MapToJson(newProps)
 		hash := model.HashPassword(fmt.Sprintf("%v:%v", data, utils.Cfg.ServiceSettings.PublicLinkSalt))
 
-		Client.LoginByEmail(team2.Domain, user2.Email, "pwd")
+		Client.LoginByEmail(team2.Name, user2.Email, "pwd")
 
 		if _, downErr := Client.GetFile(filenames[0]+"?d="+url.QueryEscape(data)+"&h="+url.QueryEscape(hash)+"&t="+team.Id, true); downErr != nil {
 			t.Fatal(downErr)
@@ -258,7 +258,7 @@ func TestGetFile(t *testing.T) {
 func TestGetPublicLink(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -269,7 +269,7 @@ func TestGetPublicLink(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -344,7 +344,7 @@ func TestGetPublicLink(t *testing.T) {
 			t.Fatal("Should have errored - bad file path")
 		}
 
-		Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+		Client.LoginByEmail(team.Name, user2.Email, "pwd")
 		data["filename"] = filenames[0]
 		if _, err := Client.GetPublicLink(data); err == nil {
 			t.Fatal("should have errored, user not member of channel")

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -15,10 +15,10 @@ import (
 func TestCreatePost(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	team2 := &model.Team{Name: "Name Team 2", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team2 := &model.Team{DisplayName: "Name Team 2", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -29,7 +29,7 @@ func TestCreatePost(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -96,7 +96,7 @@ func TestCreatePost(t *testing.T) {
 		t.Fatal("Should have been forbidden")
 	}
 
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 	post7 := &model.Post{ChannelId: channel1.Id, Message: "a" + model.NewId() + "a"}
 	_, err = Client.CreatePost(post7)
 	if err.StatusCode != http.StatusForbidden {
@@ -107,7 +107,7 @@ func TestCreatePost(t *testing.T) {
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user3.Id))
 
-	Client.LoginByEmail(team2.Domain, user3.Email, "pwd")
+	Client.LoginByEmail(team2.Name, user3.Email, "pwd")
 
 	channel3 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team2.Id}
 	channel3 = Client.Must(Client.CreateChannel(channel3)).Data.(*model.Channel)
@@ -126,10 +126,10 @@ func TestCreatePost(t *testing.T) {
 func TestCreateValetPost(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	team2 := &model.Team{Name: "Name Team 2", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team2 := &model.Team{DisplayName: "Name Team 2", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -140,7 +140,7 @@ func TestCreateValetPost(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -181,7 +181,7 @@ func TestCreateValetPost(t *testing.T) {
 			t.Fatal("Should have been forbidden")
 		}
 
-		Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+		Client.LoginByEmail(team.Name, user2.Email, "pwd")
 		post5 := &model.Post{ChannelId: channel1.Id, Message: "a" + model.NewId() + "a"}
 		_, err = Client.CreateValetPost(post5)
 		if err != nil {
@@ -192,7 +192,7 @@ func TestCreateValetPost(t *testing.T) {
 		user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 		store.Must(Srv.Store.User().VerifyEmail(user3.Id))
 
-		Client.LoginByEmail(team2.Domain, user3.Email, "pwd")
+		Client.LoginByEmail(team2.Name, user3.Email, "pwd")
 
 		channel3 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team2.Id}
 		channel3 = Client.Must(Client.CreateChannel(channel3)).Data.(*model.Channel)
@@ -218,10 +218,10 @@ func TestCreateValetPost(t *testing.T) {
 func TestUpdatePost(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	team2 := &model.Team{Name: "Name Team 2", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team2 := &model.Team{DisplayName: "Name Team 2", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -232,7 +232,7 @@ func TestUpdatePost(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -289,14 +289,14 @@ func TestUpdatePost(t *testing.T) {
 func TestGetPosts(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "TestGetPosts", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -354,14 +354,14 @@ func TestGetPosts(t *testing.T) {
 func TestSearchPosts(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "TestGetPosts", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -400,14 +400,14 @@ func TestSearchPosts(t *testing.T) {
 func TestSearchHashtagPosts(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "TestGetPosts", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -431,14 +431,14 @@ func TestSearchHashtagPosts(t *testing.T) {
 func TestGetPostsCache(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "TestGetPosts", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -480,7 +480,7 @@ func TestGetPostsCache(t *testing.T) {
 func TestDeletePosts(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	userAdmin := &model.User{TeamId: team.Id, Email: team.Email, Nickname: "Corey Hulen", Password: "pwd"}
@@ -491,7 +491,7 @@ func TestDeletePosts(t *testing.T) {
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "TestGetPosts", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -532,7 +532,7 @@ func TestDeletePosts(t *testing.T) {
 	post4 := &model.Post{ChannelId: channel1.Id, Message: "a" + model.NewId() + "a"}
 	post4 = Client.Must(Client.CreatePost(post4)).Data.(*model.Post)
 
-	Client.LoginByEmail(team.Domain, userAdmin.Email, "pwd")
+	Client.LoginByEmail(team.Name, userAdmin.Email, "pwd")
 
 	Client.Must(Client.DeletePost(channel1.Id, post4.Id))
 }
@@ -540,14 +540,14 @@ func TestDeletePosts(t *testing.T) {
 func TestEmailMention(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: "corey@test.com", Nickname: "Bob Bobby", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "TestGetPosts", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -562,14 +562,14 @@ func TestEmailMention(t *testing.T) {
 func TestFuzzyPosts(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)

--- a/api/sharding.go
+++ b/api/sharding.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api
+
+/*
+func createSubDomain(subDomain string, target string) {
+
+	if utils.Cfg.AWSSettings.Route53AccessKeyId == "" {
+		return
+	}
+
+	creds := aws.Creds(utils.Cfg.AWSSettings.Route53AccessKeyId, utils.Cfg.AWSSettings.Route53SecretAccessKey, "")
+	r53 := route53.New(aws.DefaultConfig.Merge(&aws.Config{Credentials: creds, Region: utils.Cfg.AWSSettings.Route53Region}))
+
+	rr := route53.ResourceRecord{
+		Value: aws.String(target),
+	}
+
+	rrs := make([]*route53.ResourceRecord, 1)
+	rrs[0] = &rr
+
+	change := route53.Change{
+		Action: aws.String("CREATE"),
+		ResourceRecordSet: &route53.ResourceRecordSet{
+			Name:            aws.String(fmt.Sprintf("%v.%v", subDomain, utils.Cfg.ServiceSettings.Domain)),
+			TTL:             aws.Long(300),
+			Type:            aws.String("CNAME"),
+			ResourceRecords: rrs,
+		},
+	}
+
+	changes := make([]*route53.Change, 1)
+	changes[0] = &change
+
+	r53req := &route53.ChangeResourceRecordSetsInput{
+		HostedZoneID: aws.String(utils.Cfg.AWSSettings.Route53ZoneId),
+		ChangeBatch: &route53.ChangeBatch{
+			Changes: changes,
+		},
+	}
+
+	if _, err := r53.ChangeResourceRecordSets(r53req); err != nil {
+		l4g.Error("erro in createSubDomain domain=%v err=%v", subDomain, err)
+		return
+	}
+}
+
+func doesSubDomainExist(subDomain string) bool {
+
+	// if it's configured for testing then skip this step
+	if utils.Cfg.AWSSettings.Route53AccessKeyId == "" {
+		return false
+	}
+
+	creds := aws.Creds(utils.Cfg.AWSSettings.Route53AccessKeyId, utils.Cfg.AWSSettings.Route53SecretAccessKey, "")
+	r53 := route53.New(aws.DefaultConfig.Merge(&aws.Config{Credentials: creds, Region: utils.Cfg.AWSSettings.Route53Region}))
+
+	r53req := &route53.ListResourceRecordSetsInput{
+		HostedZoneID:    aws.String(utils.Cfg.AWSSettings.Route53ZoneId),
+		MaxItems:        aws.String("1"),
+		StartRecordName: aws.String(fmt.Sprintf("%v.%v.", subDomain, utils.Cfg.ServiceSettings.Domain)),
+	}
+
+	if result, err := r53.ListResourceRecordSets(r53req); err != nil {
+		l4g.Error("error in doesSubDomainExist domain=%v err=%v", subDomain, err)
+		return true
+	} else {
+
+		for _, v := range result.ResourceRecordSets {
+			if v.Name != nil && *v.Name == fmt.Sprintf("%v.%v.", subDomain, utils.Cfg.ServiceSettings.Domain) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+*/

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -32,7 +32,7 @@ func TestCreateFromSignupTeam(t *testing.T) {
 	data := model.MapToJson(props)
 	hash := model.HashPassword(fmt.Sprintf("%v:%v", data, utils.Cfg.ServiceSettings.InviteSalt))
 
-	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	user := model.User{Email: props["email"], Nickname: "Corey Hulen", Password: "hello"}
 
 	ts := model.TeamSignup{Team: team, User: user, Invites: []string{"corey@test.com"}, Data: data, Hash: hash}
@@ -42,7 +42,7 @@ func TestCreateFromSignupTeam(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if rts.Data.(*model.TeamSignup).Team.Name != team.Name {
+	if rts.Data.(*model.TeamSignup).Team.DisplayName != team.DisplayName {
 		t.Fatal("full name didn't match")
 	}
 
@@ -71,7 +71,7 @@ func TestCreateFromSignupTeam(t *testing.T) {
 func TestCreateTeam(t *testing.T) {
 	Setup()
 
-	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, err := Client.CreateTeam(&team)
 	if err != nil {
 		t.Fatal(err)
@@ -81,14 +81,14 @@ func TestCreateTeam(t *testing.T) {
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	c1 := Client.Must(Client.GetChannels("")).Data.(*model.ChannelList)
 	if len(c1.Channels) != 2 {
 		t.Fatal("default channels not created")
 	}
 
-	if rteam.Data.(*model.Team).Name != team.Name {
+	if rteam.Data.(*model.Team).DisplayName != team.DisplayName {
 		t.Fatal("full name didn't match")
 	}
 
@@ -111,7 +111,7 @@ func TestCreateTeam(t *testing.T) {
 func TestFindTeamByEmail(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -122,7 +122,7 @@ func TestFindTeamByEmail(t *testing.T) {
 		t.Fatal(err)
 	} else {
 		domains := r1.Data.([]string)
-		if domains[0] != team.Domain {
+		if domains[0] != team.Name {
 			t.Fatal(domains)
 		}
 	}
@@ -139,14 +139,14 @@ XXXXXX investigate and fix failing test
 func TestFindTeamByDomain(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	if r1, err := Client.FindTeamByDomain(team.Domain, false); err != nil {
+	if r1, err := Client.FindTeamByDomain(team.Name, false); err != nil {
 		t.Fatal(err)
 	} else {
 		val := r1.Data.(bool)
@@ -155,7 +155,7 @@ func TestFindTeamByDomain(t *testing.T) {
 		}
 	}
 
-	if r1, err := Client.FindTeamByDomain(team.Domain, true); err != nil {
+	if r1, err := Client.FindTeamByDomain(team.Name, true); err != nil {
 		t.Fatal(err)
 	} else {
 		val := r1.Data.(bool)
@@ -179,7 +179,7 @@ func TestFindTeamByDomain(t *testing.T) {
 func TestFindTeamByEmailSend(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -203,14 +203,14 @@ func TestFindTeamByEmailSend(t *testing.T) {
 func TestInviteMembers(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user.Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	invite := make(map[string]string)
 	invite["email"] = model.NewId() + "corey@test.com"
@@ -229,10 +229,10 @@ func TestInviteMembers(t *testing.T) {
 	}
 }
 
-func TestUpdateTeamName(t *testing.T) {
+func TestUpdateTeamDisplayName(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -243,40 +243,40 @@ func TestUpdateTeamName(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
 	data := make(map[string]string)
 	data["new_name"] = "NewName"
-	if _, err := Client.UpdateTeamName(data); err == nil {
+	if _, err := Client.UpdateTeamDisplayName(data); err == nil {
 		t.Fatal("Should have errored, not admin")
 	}
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	data["new_name"] = ""
-	if _, err := Client.UpdateTeamName(data); err == nil {
+	if _, err := Client.UpdateTeamDisplayName(data); err == nil {
 		t.Fatal("Should have errored, empty name")
 	}
 
 	data["new_name"] = "NewName"
-	if _, err := Client.UpdateTeamName(data); err != nil {
+	if _, err := Client.UpdateTeamDisplayName(data); err != nil {
 		t.Fatal(err)
 	}
 	// No GET team web service, so hard to confirm here that team name updated
 
 	data["team_id"] = "junk"
-	if _, err := Client.UpdateTeamName(data); err == nil {
+	if _, err := Client.UpdateTeamDisplayName(data); err == nil {
 		t.Fatal("Should have errored, junk team id")
 	}
 
 	data["team_id"] = "12345678901234567890123456"
-	if _, err := Client.UpdateTeamName(data); err == nil {
+	if _, err := Client.UpdateTeamDisplayName(data); err == nil {
 		t.Fatal("Should have errored, bad team id")
 	}
 
 	data["team_id"] = team.Id
 	data["new_name"] = "NewNameAgain"
-	if _, err := Client.UpdateTeamName(data); err != nil {
+	if _, err := Client.UpdateTeamDisplayName(data); err != nil {
 		t.Fatal(err)
 	}
 	// No GET team web service, so hard to confirm here that team name updated
@@ -285,17 +285,17 @@ func TestUpdateTeamName(t *testing.T) {
 func TestFuzzyTeamCreate(t *testing.T) {
 
 	for i := 0; i < len(utils.FUZZY_STRINGS_NAMES) || i < len(utils.FUZZY_STRINGS_EMAILS); i++ {
-		testName := "Name"
+		testDisplayName := "Name"
 		testEmail := "test@nowhere.com"
 
 		if i < len(utils.FUZZY_STRINGS_NAMES) {
-			testName = utils.FUZZY_STRINGS_NAMES[i]
+			testDisplayName = utils.FUZZY_STRINGS_NAMES[i]
 		}
 		if i < len(utils.FUZZY_STRINGS_EMAILS) {
 			testEmail = utils.FUZZY_STRINGS_EMAILS[i]
 		}
 
-		team := model.Team{Name: testName, Domain: "z-z-" + model.NewId() + "a", Email: testEmail, Type: model.TEAM_OPEN}
+		team := model.Team{DisplayName: testDisplayName, Name: "z-z-" + model.NewId() + "a", Email: testEmail, Type: model.TEAM_OPEN}
 
 		_, err := Client.CreateTeam(&team)
 		if err != nil {
@@ -307,22 +307,22 @@ func TestFuzzyTeamCreate(t *testing.T) {
 func TestGetMyTeam(t *testing.T) {
 	Setup()
 
-	team := model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 
 	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	ruser, _ := Client.CreateUser(&user, "")
 	store.Must(Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
-	Client.LoginByEmail(team.Domain, user.Email, user.Password)
+	Client.LoginByEmail(team.Name, user.Email, user.Password)
 
 	if result, err := Client.GetMyTeam(""); err != nil {
 		t.Fatal("Failed to get user")
 	} else {
-		if result.Data.(*model.Team).Name != team.Name {
+		if result.Data.(*model.Team).DisplayName != team.DisplayName {
 			t.Fatal("team names did not match")
 		}
-		if result.Data.(*model.Team).Domain != team.Domain {
+		if result.Data.(*model.Team).Name != team.Name {
 			t.Fatal("team domains did not match")
 		}
 		if result.Data.(*model.Team).Type != team.Type {
@@ -334,7 +334,7 @@ func TestGetMyTeam(t *testing.T) {
 func TestUpdateValetFeature(t *testing.T) {
 	Setup()
 
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user := &model.User{TeamId: team.Id, Email: "test@nowhere.com", Nickname: "Corey Hulen", Password: "pwd"}
@@ -345,14 +345,14 @@ func TestUpdateValetFeature(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	team2 := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team2 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
 	user3 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user3.Id))
 
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
 	data := make(map[string]string)
 	data["allow_valet"] = "true"
@@ -360,7 +360,7 @@ func TestUpdateValetFeature(t *testing.T) {
 		t.Fatal("Should have errored, not admin")
 	}
 
-	Client.LoginByEmail(team.Domain, user.Email, "pwd")
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
 	data["allow_valet"] = ""
 	if _, err := Client.UpdateValetFeature(data); err == nil {
@@ -398,7 +398,7 @@ func TestUpdateValetFeature(t *testing.T) {
 		t.Fatal("Should have errored - allow valet property not updated")
 	}
 
-	Client.LoginByEmail(team2.Domain, user3.Email, "pwd")
+	Client.LoginByEmail(team2.Name, user3.Email, "pwd")
 
 	data["team_id"] = team.Id
 	data["allow_valet"] = "true"

--- a/api/templates/email_change_body.html
+++ b/api/templates/email_change_body.html
@@ -9,7 +9,7 @@
                         <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 20px 30px 10px; text-align:left;">
-                                    <img src="{{.TeamUrl}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
+                                    <img src="{{.TeamURL}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
                                 </td>
                             </tr>
                             <tr>
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">You updated your email</h2>
-                                                <p>You updated your email for {{.Props.TeamName}} on {{ .TeamUrl }}<br> If this change wasn't initiated by you, please reply to this email and let us know.</p>
+                                                <p>You updated your email for {{.Props.TeamDisplayName}} on {{ .TeamURL }}<br> If this change wasn't initiated by you, please reply to this email and let us know.</p>
                                             </td>
                                         </tr>
                                         <tr>
@@ -34,7 +34,7 @@
                             <tr>
                                 <td style="text-align: center;color: #AAA; font-size: 13px; padding-bottom: 10px;">
                                     <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.TeamUrl}}/static/images/circles.png" alt="">
+                                        <img width="65" src="{{.TeamURL}}/static/images/circles.png" alt="">
                                     </p>
                                     <p style="padding: 0 50px;">
                                         (c) 2015 SpinPunch, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>

--- a/api/templates/email_change_subject.html
+++ b/api/templates/email_change_subject.html
@@ -1,1 +1,1 @@
-{{define "email_change_subject"}}You updated your email for {{.Props.TeamName}} on {{ .Props.Domain }}{{end}}
+{{define "email_change_subject"}}You updated your email for {{.Props.TeamDisplayName}} on {{ .Props.Domain }}{{end}}

--- a/api/templates/find_teams_body.html
+++ b/api/templates/find_teams_body.html
@@ -9,7 +9,7 @@
                         <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 20px 30px 10px; text-align:left;">
-                                    <img src="{{.TeamUrl}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
+                                    <img src="{{.TeamURL}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
                                 </td>
                             </tr>
                             <tr>
@@ -42,7 +42,7 @@
                             <tr>
                                 <td style="text-align: center;color: #AAA; font-size: 13px; padding-bottom: 10px;">
                                     <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.TeamUrl}}/static/images/circles.png" alt="">
+                                        <img width="65" src="{{.TeamURL}}/static/images/circles.png" alt="">
                                     </p>
                                     <p style="padding: 0 50px;">
                                         (c) 2015 SpinPunch, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>

--- a/api/templates/invite_body.html
+++ b/api/templates/invite_body.html
@@ -9,7 +9,7 @@
                         <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 20px 30px 10px; text-align:left;">
-                                    <img src="{{.TeamUrl}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
+                                    <img src="{{.TeamURL}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
                                 </td>
                             </tr>
                             <tr>
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">You've been invited</h2>
-                                                <p>{{.Props.TeamName}} started using {{.SiteName}}.<br> The team {{.Props.SenderStatus}} <strong>{{.Props.SenderName}}</strong>, has invited you to join <strong>{{.Props.TeamName}}</strong>.</p>
+                                                <p>{{.Props.TeamDisplayName}} started using {{.SiteName}}.<br> The team {{.Props.SenderStatus}} <strong>{{.Props.SenderName}}</strong>, has invited you to join <strong>{{.Props.TeamDisplayName}}</strong>.</p>
                                                 <p style="margin: 20px 0 15px">
                                                     <a href="{{.Props.Link}}" style="background: #2389D7; border-radius: 3px; color: #fff; border: none; outline: none; min-width: 200px; padding: 15px 25px; font-size: 14px; font-family: inherit; cursor: pointer; -webkit-appearance: none;text-decoration: none;">Join Team</a>
                                                 </p>
@@ -37,7 +37,7 @@
                             <tr>
                                 <td style="text-align: center;color: #AAA; font-size: 13px; padding-bottom: 10px;">
                                     <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.TeamUrl}}/static/images/circles.png" alt="">
+                                        <img width="65" src="{{.TeamURL}}/static/images/circles.png" alt="">
                                     </p>
                                     <p style="padding: 0 50px;">
                                         (c) 2015 SpinPunch, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>

--- a/api/templates/invite_subject.html
+++ b/api/templates/invite_subject.html
@@ -1,1 +1,1 @@
-{{define "invite_subject"}}{{ .Props.SenderName }} invited you to join {{ .Props.TeamName }} Team on {{.SiteName}}{{end}}
+{{define "invite_subject"}}{{ .Props.SenderName }} invited you to join {{ .Props.TeamDisplayName }} Team on {{.SiteName}}{{end}}

--- a/api/templates/password_change_body.html
+++ b/api/templates/password_change_body.html
@@ -9,7 +9,7 @@
                         <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 20px 30px 10px; text-align:left;">
-                                    <img src="{{.TeamUrl}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
+                                    <img src="{{.TeamURL}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
                                 </td>
                             </tr>
                             <tr>
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">You updated your password</h2>
-                                                <p>You updated your password for {{.Props.TeamName}} on {{ .TeamUrl }} by {{.Props.Method}}.<br> If this change wasn't initiated by you, please reply to this email and let us know.</p>
+                                                <p>You updated your password for {{.Props.TeamDisplayName}} on {{ .TeamURL }} by {{.Props.Method}}.<br> If this change wasn't initiated by you, please reply to this email and let us know.</p>
                                             </td>
                                         </tr>
                                         <tr>
@@ -34,7 +34,7 @@
                             <tr>
                                 <td style="text-align: center;color: #AAA; font-size: 13px; padding-bottom: 10px;">
                                     <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.TeamUrl}}/static/images/circles.png" alt="">
+                                        <img width="65" src="{{.TeamURL}}/static/images/circles.png" alt="">
                                     </p>
                                     <p style="padding: 0 50px;">
                                         (c) 2015 SpinPunch, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>

--- a/api/templates/password_change_subject.html
+++ b/api/templates/password_change_subject.html
@@ -1,1 +1,1 @@
-{{define "password_change_subject"}}You updated your password for {{.Props.TeamName}} on {{ .SiteName }}{{end}}
+{{define "password_change_subject"}}You updated your password for {{.Props.TeamDisplayName}} on {{ .SiteName }}{{end}}

--- a/api/templates/post_body.html
+++ b/api/templates/post_body.html
@@ -9,7 +9,7 @@
                         <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 20px 30px 10px; text-align:left;">
-                                    <img src="{{.TeamUrl}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
+                                    <img src="{{.TeamURL}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
                                 </td>
                             </tr>
                             <tr>
@@ -37,7 +37,7 @@
                             <tr>
                                 <td style="text-align: center;color: #AAA; font-size: 13px; padding-bottom: 10px;">
                                     <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.TeamUrl}}/static/images/circles.png" alt="">
+                                        <img width="65" src="{{.TeamURL}}/static/images/circles.png" alt="">
                                     </p>
                                     <p style="padding: 0 50px;">
                                         (c) 2015 SpinPunch, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>

--- a/api/templates/post_subject.html
+++ b/api/templates/post_subject.html
@@ -1,1 +1,1 @@
-{{define "post_subject"}}[{{.Props.TeamName}} {{.SiteName}}] {{.Props.SubjectText}} for {{.Props.Month}} {{.Props.Day}}, {{.Props.Year}}{{end}}
+{{define "post_subject"}}[{{.Props.TeamDisplayName}} {{.SiteName}}] {{.Props.SubjectText}} for {{.Props.Month}} {{.Props.Day}}, {{.Props.Year}}{{end}}

--- a/api/templates/reset_body.html
+++ b/api/templates/reset_body.html
@@ -9,7 +9,7 @@
                         <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 20px 30px 10px; text-align:left;">
-                                    <img src="{{.TeamUrl}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
+                                    <img src="{{.TeamURL}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
                                 </td>
                             </tr>
                             <tr>
@@ -37,7 +37,7 @@
                             <tr>
                                 <td style="text-align: center;color: #AAA; font-size: 13px; padding-bottom: 10px;">
                                     <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.TeamUrl}}/static/images/circles.png" alt="">
+                                        <img width="65" src="{{.TeamURL}}/static/images/circles.png" alt="">
                                     </p>
                                     <p style="padding: 0 50px;">
                                         (c) 2015 SpinPunch, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>

--- a/api/templates/signup_team_body.html
+++ b/api/templates/signup_team_body.html
@@ -9,7 +9,7 @@
                         <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 20px 30px 10px; text-align:left;">
-                                    <img src="{{.TeamUrl}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
+                                    <img src="{{.TeamURL}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
                                 </td>
                             </tr>
                             <tr>
@@ -40,7 +40,7 @@
                             <tr>
                                 <td style="text-align: center;color: #AAA; font-size: 13px; padding-bottom: 10px;">
                                     <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.TeamUrl}}/static/images/circles.png" alt="">
+                                        <img width="65" src="{{.TeamURL}}/static/images/circles.png" alt="">
                                     </p>
                                     <p style="padding: 0 50px;">
                                         (c) 2015 SpinPunch, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>

--- a/api/templates/verify_body.html
+++ b/api/templates/verify_body.html
@@ -9,7 +9,7 @@
                         <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 20px 30px 10px; text-align:left;">
-                                    <img src="{{.TeamUrl}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
+                                    <img src="{{.TeamURL}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
                                 </td>
                             </tr>
                             <tr>
@@ -37,7 +37,7 @@
                             <tr>
                                 <td style="text-align: center;color: #AAA; font-size: 13px; padding-bottom: 10px;">
                                     <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.TeamUrl}}/static/images/circles.png" alt="">
+                                        <img width="65" src="{{.TeamURL}}/static/images/circles.png" alt="">
                                     </p>
                                     <p style="padding: 0 50px;">
                                         (c) 2015 SpinPunch, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>

--- a/api/templates/verify_subject.html
+++ b/api/templates/verify_subject.html
@@ -1,1 +1,1 @@
-{{define "verify_subject"}}[{{ .Props.TeamName }} {{ .SiteName }}] Email Verification{{end}}
+{{define "verify_subject"}}[{{ .Props.TeamDisplayName }} {{ .SiteName }}] Email Verification{{end}}

--- a/api/templates/welcome_body.html
+++ b/api/templates/welcome_body.html
@@ -9,7 +9,7 @@
                         <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 20px 30px 10px; text-align:left;">
-                                    <img src="{{.TeamUrl}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
+                                    <img src="{{.TeamURL}}/static/images/{{.SiteName}}-logodark.png" width="130px" style="opacity: 0.5" alt="">
                                 </td>
                             </tr>
                             <tr>
@@ -17,8 +17,8 @@
                                     <table border="0" cellpadding="0" cellspacing="0" style="padding: 20px 50px 0; text-align: center; margin: 0 auto">
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
-                                                <h2 style="font-weight: normal; margin-top: 10px;">You joined the {{.Props.TeamName}} team at {{.SiteName}}!</h2>
-                                                <p>Please let me know if you have any questions.<br>Enjoy your stay at <a href="{{.TeamUrl}}">{{.SiteName}}</a>.</p>
+                                                <h2 style="font-weight: normal; margin-top: 10px;">You joined the {{.Props.TeamDisplayName}} team at {{.SiteName}}!</h2>
+                                                <p>Please let me know if you have any questions.<br>Enjoy your stay at <a href="{{.TeamURL}}">{{.SiteName}}</a>.</p>
                                             </td>
                                         </tr>
                                         <tr>
@@ -34,7 +34,7 @@
                             <tr>
                                 <td style="text-align: center;color: #AAA; font-size: 13px; padding-bottom: 10px;">
                                     <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.TeamUrl}}/static/images/circles.png" alt="">
+                                        <img width="65" src="{{.TeamURL}}/static/images/circles.png" alt="">
                                     </p>
                                     <p style="padding: 0 50px;">
                                         (c) 2015 SpinPunch, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>

--- a/api/web_socket_test.go
+++ b/api/web_socket_test.go
@@ -17,13 +17,13 @@ func TestSocket(t *testing.T) {
 	Setup()
 
 	url := "ws://localhost:" + utils.Cfg.ServiceSettings.Port + "/api/v1/websocket"
-	team := &model.Team{Name: "Name", Domain: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
-	Client.LoginByEmail(team.Domain, user1.Email, "pwd")
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
 	channel1 := &model.Channel{DisplayName: "Test Web Scoket 1", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
@@ -42,7 +42,7 @@ func TestSocket(t *testing.T) {
 	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
-	Client.LoginByEmail(team.Domain, user2.Email, "pwd")
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
 	header2 := http.Header{}
 	header2.Set(model.HEADER_AUTH, "BEARER "+Client.AuthToken)

--- a/config/config.json
+++ b/config/config.json
@@ -9,7 +9,6 @@
     },
     "ServiceSettings": {
         "SiteName": "Mattermost",
-        "Domain": "xxxxxxmustbefilledin.com",
         "Mode" : "dev",
 		"AllowTesting" : false,
         "UseSSL": false,
@@ -35,11 +34,7 @@
         "S3AccessKeyId": "",
         "S3SecretAccessKey": "",
         "S3Bucket": "",
-        "S3Region": "",
-        "Route53AccessKeyId": "",
-        "Route53SecretAccessKey": "",
-        "Route53ZoneId": "",
-        "Route53Region": ""
+        "S3Region": ""
     },
     "ImageSettings": {
         "ThumbnailWidth": 200,

--- a/config/config_docker.json
+++ b/config/config_docker.json
@@ -9,7 +9,6 @@
     },
     "ServiceSettings": {
         "SiteName": "Mattermost",
-        "Domain": "",
         "Mode" : "dev",
 		"AllowTesting" : false,
         "UseSSL": false,
@@ -35,11 +34,7 @@
         "S3AccessKeyId": "",
         "S3SecretAccessKey": "",
         "S3Bucket": "",
-        "S3Region": "",
-        "Route53AccessKeyId": "",
-        "Route53SecretAccessKey": "",
-        "Route53ZoneId": "",
-        "Route53Region": ""
+        "S3Region": ""
     },
     "ImageSettings": {
         "ThumbnailWidth": 200,

--- a/manualtesting/manual_testing.go
+++ b/manualtesting/manual_testing.go
@@ -57,17 +57,17 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 
 	// Check for username parameter and create a user if present
 	username, ok1 := params["username"]
-	teamname, ok2 := params["teamname"]
+	teamDisplayName, ok2 := params["teamname"]
 	var teamID string
 	var userID string
 	if ok1 && ok2 {
 		l4g.Info("Creating user and team")
 		// Create team for testing
 		team := &model.Team{
-			Name:   teamname[0],
-			Domain: utils.RandomName(utils.Range{20, 20}, utils.LOWERCASE),
-			Email:  utils.RandomEmail(utils.Range{20, 20}, utils.LOWERCASE),
-			Type:   model.TEAM_OPEN,
+			DisplayName: teamDisplayName[0],
+			Name:       utils.RandomName(utils.Range{20, 20}, utils.LOWERCASE),
+			Email:       utils.RandomEmail(utils.Range{20, 20}, utils.LOWERCASE),
+			Type:        model.TEAM_OPEN,
 		}
 
 		if result := <-api.Srv.Store.Team().Save(team); result.Err != nil {

--- a/model/client.go
+++ b/model/client.go
@@ -98,10 +98,10 @@ func (c *Client) Must(result *Result, err *AppError) *Result {
 	return result
 }
 
-func (c *Client) SignupTeam(email string, name string) (*Result, *AppError) {
+func (c *Client) SignupTeam(email string, displayName string) (*Result, *AppError) {
 	m := make(map[string]string)
 	m["email"] = email
-	m["name"] = name
+	m["display_name"] = displayName
 	if r, err := c.DoPost("/teams/signup", MapToJson(m)); err != nil {
 		return nil, err
 	} else {
@@ -128,11 +128,11 @@ func (c *Client) CreateTeam(team *Team) (*Result, *AppError) {
 	}
 }
 
-func (c *Client) FindTeamByDomain(domain string, allServers bool) (*Result, *AppError) {
+func (c *Client) FindTeamByName(name string, allServers bool) (*Result, *AppError) {
 	m := make(map[string]string)
-	m["domain"] = domain
+	m["name"] = name
 	m["all"] = fmt.Sprintf("%v", allServers)
-	if r, err := c.DoPost("/teams/find_team_by_domain", MapToJson(m)); err != nil {
+	if r, err := c.DoPost("/teams/find_team_by_name", MapToJson(m)); err != nil {
 		return nil, err
 	} else {
 		val := false
@@ -177,7 +177,7 @@ func (c *Client) InviteMembers(invites *Invites) (*Result, *AppError) {
 	}
 }
 
-func (c *Client) UpdateTeamName(data map[string]string) (*Result, *AppError) {
+func (c *Client) UpdateTeamDisplayName(data map[string]string) (*Result, *AppError) {
 	if r, err := c.DoPost("/teams/update_name", MapToJson(data)); err != nil {
 		return nil, err
 	} else {
@@ -247,17 +247,17 @@ func (c *Client) LoginById(id string, password string) (*Result, *AppError) {
 	return c.login(m)
 }
 
-func (c *Client) LoginByEmail(domain string, email string, password string) (*Result, *AppError) {
+func (c *Client) LoginByEmail(name string, email string, password string) (*Result, *AppError) {
 	m := make(map[string]string)
-	m["domain"] = domain
+	m["name"] = name
 	m["email"] = email
 	m["password"] = password
 	return c.login(m)
 }
 
-func (c *Client) LoginByEmailWithDevice(domain string, email string, password string, deviceId string) (*Result, *AppError) {
+func (c *Client) LoginByEmailWithDevice(name string, email string, password string, deviceId string) (*Result, *AppError) {
 	m := make(map[string]string)
-	m["domain"] = domain
+	m["name"] = name
 	m["email"] = email
 	m["password"] = password
 	m["device_id"] = deviceId

--- a/model/team.go
+++ b/model/team.go
@@ -18,8 +18,8 @@ type Team struct {
 	CreateAt       int64  `json:"create_at"`
 	UpdateAt       int64  `json:"update_at"`
 	DeleteAt       int64  `json:"delete_at"`
+	DisplayName    string `json:"display_name"`
 	Name           string `json:"name"`
-	Domain         string `json:"domain"`
 	Email          string `json:"email"`
 	Type           string `json:"type"`
 	CompanyName    string `json:"company_name"`
@@ -97,20 +97,20 @@ func (o *Team) IsValid() *AppError {
 		return NewAppError("Team.IsValid", "Invalid email", "id="+o.Id)
 	}
 
-	if len(o.Name) > 64 {
+	if len(o.DisplayName) > 64 {
 		return NewAppError("Team.IsValid", "Invalid name", "id="+o.Id)
 	}
 
-	if len(o.Domain) > 64 {
-		return NewAppError("Team.IsValid", "Invalid domain", "id="+o.Id)
+	if len(o.Name) > 64 {
+		return NewAppError("Team.IsValid", "Invalid URL Identifier", "id="+o.Id)
 	}
 
-	if IsReservedDomain(o.Domain) {
+	if IsReservedTeamName(o.Name) {
 		return NewAppError("Team.IsValid", "This URL is unavailable. Please try another.", "id="+o.Id)
 	}
 
-	if !IsValidDomain(o.Domain) {
-		return NewAppError("Team.IsValid", "Domain must be 4 or more lowercase alphanumeric characters", "id="+o.Id)
+	if !IsValidTeamName(o.Name) {
+		return NewAppError("Team.IsValid", "Name must be 4 or more lowercase alphanumeric characters", "id="+o.Id)
 	}
 
 	if !(o.Type == TEAM_OPEN || o.Type == TEAM_INVITE) {

--- a/model/team_signup_test.go
+++ b/model/team_signup_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTeamSignupJson(t *testing.T) {
-	team := Team{Id: NewId(), Name: NewId()}
+	team := Team{Id: NewId(), DisplayName: NewId()}
 	o := TeamSignup{Team: team, Data: "data"}
 	json := o.ToJson()
 	ro := TeamSignupFromJson(strings.NewReader(json))

--- a/model/team_test.go
+++ b/model/team_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTeamJson(t *testing.T) {
-	o := Team{Id: NewId(), Name: NewId()}
+	o := Team{Id: NewId(), DisplayName: NewId()}
 	json := o.ToJson()
 	ro := TeamFromJson(strings.NewReader(json))
 
@@ -46,18 +46,18 @@ func TestTeamIsValid(t *testing.T) {
 	}
 
 	o.Email = "corey@hulen.com"
-	o.Name = strings.Repeat("01234567890", 20)
+	o.DisplayName = strings.Repeat("01234567890", 20)
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
 	}
 
-	o.Name = "1234"
-	o.Domain = "ZZZZZZZ"
+	o.DisplayName = "1234"
+	o.Name = "ZZZZZZZ"
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
 	}
 
-	o.Domain = "zzzzz"
+	o.Name = "zzzzz"
 	o.Type = TEAM_OPEN
 	if err := o.IsValid(); err != nil {
 		t.Fatal(err)
@@ -65,12 +65,12 @@ func TestTeamIsValid(t *testing.T) {
 }
 
 func TestTeamPreSave(t *testing.T) {
-	o := Team{Name: "test"}
+	o := Team{DisplayName: "test"}
 	o.PreSave()
 	o.Etag()
 }
 
 func TestTeamPreUpdate(t *testing.T) {
-	o := Team{Name: "test"}
+	o := Team{DisplayName: "test"}
 	o.PreUpdate()
 }

--- a/model/utils.go
+++ b/model/utils.go
@@ -148,7 +148,7 @@ func IsValidEmail(email string) bool {
 	return false
 }
 
-var reservedDomains = []string{
+var reservedName = []string{
 	"www",
 	"web",
 	"admin",
@@ -168,10 +168,10 @@ var reservedDomains = []string{
 	"api",
 }
 
-func IsReservedDomain(s string) bool {
+func IsReservedTeamName(s string) bool {
 	s = strings.ToLower(s)
 
-	for _, value := range reservedDomains {
+	for _, value := range reservedName {
 		if strings.Index(s, value) == 0 {
 			return true
 		}
@@ -180,7 +180,7 @@ func IsReservedDomain(s string) bool {
 	return false
 }
 
-func IsValidDomain(s string) bool {
+func IsValidTeamName(s string) bool {
 
 	if !IsValidAlphaNum(s) {
 		return false

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -83,9 +83,9 @@ var domains = []struct {
 	{"test", true},
 }
 
-func TestValidDomain(t *testing.T) {
+func TestValidTeamName(t *testing.T) {
 	for _, v := range domains {
-		if IsValidDomain(v.value) != v.expected {
+		if IsValidTeamName(v.value) != v.expected {
 			t.Errorf("expect %v as %v", v.value, v.expected)
 		}
 	}
@@ -102,9 +102,9 @@ var tReservedDomains = []struct {
 	{"spin-punch-admin", false},
 }
 
-func TestReservedDomain(t *testing.T) {
+func TestReservedTeamName(t *testing.T) {
 	for _, v := range tReservedDomains {
-		if IsReservedDomain(v.value) != v.expected {
+		if IsReservedTeamName(v.value) != v.expected {
 			t.Errorf("expect %v as %v", v.value, v.expected)
 		}
 	}

--- a/store/sql_team_store_test.go
+++ b/store/sql_team_store_test.go
@@ -13,8 +13,8 @@ func TestTeamStoreSave(t *testing.T) {
 	Setup()
 
 	o1 := model.Team{}
-	o1.Name = "Name"
-	o1.Domain = "a" + model.NewId() + "b"
+	o1.DisplayName = "DisplayName"
+	o1.Name = "a" + model.NewId() + "b"
 	o1.Email = model.NewId() + "@nowhere.com"
 	o1.Type = model.TEAM_OPEN
 
@@ -36,8 +36,8 @@ func TestTeamStoreUpdate(t *testing.T) {
 	Setup()
 
 	o1 := model.Team{}
-	o1.Name = "Name"
-	o1.Domain = "a" + model.NewId() + "b"
+	o1.DisplayName = "DisplayName"
+	o1.Name = "a" + model.NewId() + "b"
 	o1.Email = model.NewId() + "@nowhere.com"
 	o1.Type = model.TEAM_OPEN
 	if err := (<-store.Team().Save(&o1)).Err; err != nil {
@@ -61,25 +61,25 @@ func TestTeamStoreUpdate(t *testing.T) {
 	}
 }
 
-func TestTeamStoreUpdateName(t *testing.T) {
+func TestTeamStoreUpdateDisplayName(t *testing.T) {
 	Setup()
 
 	o1 := &model.Team{}
-	o1.Name = "Name"
-	o1.Domain = "a" + model.NewId() + "b"
+	o1.DisplayName = "Display Name"
+	o1.Name = "a" + model.NewId() + "b"
 	o1.Email = model.NewId() + "@nowhere.com"
 	o1.Type = model.TEAM_OPEN
 	o1 = (<-store.Team().Save(o1)).Data.(*model.Team)
 
-	newName := "NewName"
+	newDisplayName := "NewDisplayName"
 
-	if err := (<-store.Team().UpdateName(newName, o1.Id)).Err; err != nil {
+	if err := (<-store.Team().UpdateDisplayName(newDisplayName, o1.Id)).Err; err != nil {
 		t.Fatal(err)
 	}
 
 	ro1 := (<-store.Team().Get(o1.Id)).Data.(*model.Team)
-	if ro1.Name != newName {
-		t.Fatal("Name not updated")
+	if ro1.DisplayName != newDisplayName {
+		t.Fatal("DisplayName not updated")
 	}
 }
 
@@ -87,8 +87,8 @@ func TestTeamStoreGet(t *testing.T) {
 	Setup()
 
 	o1 := model.Team{}
-	o1.Name = "Name"
-	o1.Domain = "a" + model.NewId() + "b"
+	o1.DisplayName = "DisplayName"
+	o1.Name = "a" + model.NewId() + "b"
 	o1.Email = model.NewId() + "@nowhere.com"
 	o1.Type = model.TEAM_OPEN
 	Must(store.Team().Save(&o1))
@@ -106,12 +106,12 @@ func TestTeamStoreGet(t *testing.T) {
 	}
 }
 
-func TestTeamStoreGetByDomain(t *testing.T) {
+func TestTeamStoreGetByName(t *testing.T) {
 	Setup()
 
 	o1 := model.Team{}
-	o1.Name = "Name"
-	o1.Domain = "a" + model.NewId() + "b"
+	o1.DisplayName = "DisplayName"
+	o1.Name = "a" + model.NewId() + "b"
 	o1.Email = model.NewId() + "@nowhere.com"
 	o1.Type = model.TEAM_OPEN
 
@@ -119,7 +119,7 @@ func TestTeamStoreGetByDomain(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if r1 := <-store.Team().GetByDomain(o1.Domain); r1.Err != nil {
+	if r1 := <-store.Team().GetByName(o1.Name); r1.Err != nil {
 		t.Fatal(r1.Err)
 	} else {
 		if r1.Data.(*model.Team).ToJson() != o1.ToJson() {
@@ -127,7 +127,7 @@ func TestTeamStoreGetByDomain(t *testing.T) {
 		}
 	}
 
-	if err := (<-store.Team().GetByDomain("")).Err; err == nil {
+	if err := (<-store.Team().GetByName("")).Err; err == nil {
 		t.Fatal("Missing id should have failed")
 	}
 }
@@ -136,8 +136,8 @@ func TestTeamStoreGetForEmail(t *testing.T) {
 	Setup()
 
 	o1 := model.Team{}
-	o1.Name = "Name"
-	o1.Domain = "a" + model.NewId() + "b"
+	o1.DisplayName = "DisplayName"
+	o1.Name = "a" + model.NewId() + "b"
 	o1.Email = model.NewId() + "@nowhere.com"
 	o1.Type = model.TEAM_OPEN
 	Must(store.Team().Save(&o1))

--- a/store/store.go
+++ b/store/store.go
@@ -36,9 +36,9 @@ type Store interface {
 type TeamStore interface {
 	Save(team *model.Team) StoreChannel
 	Update(team *model.Team) StoreChannel
-	UpdateName(name string, teamId string) StoreChannel
+	UpdateDisplayName(name string, teamId string) StoreChannel
 	Get(id string) StoreChannel
-	GetByDomain(domain string) StoreChannel
+	GetByName(name string) StoreChannel
 	GetTeamsForEmail(domain string) StoreChannel
 }
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -19,13 +19,11 @@ const (
 
 type ServiceSettings struct {
 	SiteName       string
-	Domain         string
 	Mode           string
 	AllowTesting   bool
 	UseSSL         bool
 	Port           string
 	Version        string
-	Shards         map[string]string
 	InviteSalt     string
 	PublicLinkSalt string
 	ResetSalt      string
@@ -52,14 +50,10 @@ type LogSettings struct {
 }
 
 type AWSSettings struct {
-	S3AccessKeyId          string
-	S3SecretAccessKey      string
-	S3Bucket               string
-	S3Region               string
-	Route53AccessKeyId     string
-	Route53SecretAccessKey string
-	Route53ZoneId          string
-	Route53Region          string
+	S3AccessKeyId     string
+	S3SecretAccessKey string
+	S3Bucket          string
+	S3Region          string
 }
 
 type ImageSettings struct {
@@ -213,18 +207,10 @@ func LoadConfig(fileName string) {
 		panic("Error decoding configuration " + err.Error())
 	}
 
-	// Grabs the domain from enviroment variable if not in configuration
-	if config.ServiceSettings.Domain == "" {
-		config.ServiceSettings.Domain = os.Getenv("MATTERMOST_DOMAIN")
-		// If the enviroment variable is not set, use a default
-		if config.ServiceSettings.Domain == "" {
-			config.ServiceSettings.Domain = "localhost"
-		}
-	}
-
 	// Check for a valid email for feedback, if not then do feedback@domain
 	if _, err := mail.ParseAddress(config.EmailSettings.FeedbackEmail); err != nil {
-		config.EmailSettings.FeedbackEmail = "feedback@" + config.ServiceSettings.Domain
+		config.EmailSettings.FeedbackEmail = "feedback@localhost"
+		l4g.Error("Misconfigured feedback email setting: %s", config.EmailSettings.FeedbackEmail)
 	}
 
 	configureLog(config.LogSettings)

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -4,24 +4,9 @@
 package utils
 
 import (
-	"os"
 	"testing"
 )
 
 func TestConfig(t *testing.T) {
 	LoadConfig("config.json")
-}
-
-func TestEnvOverride(t *testing.T) {
-	os.Setenv("MATTERMOST_DOMAIN", "testdomain.com")
-
-	LoadConfig("config_docker.json")
-	if Cfg.ServiceSettings.Domain != "testdomain.com" {
-		t.Fail()
-	}
-
-	LoadConfig("config.json")
-	if Cfg.ServiceSettings.Domain == "testdomain.com" {
-		t.Fail()
-	}
 }

--- a/web/react/components/delete_channel_modal.jsx
+++ b/web/react/components/delete_channel_modal.jsx
@@ -12,7 +12,7 @@ module.exports = React.createClass({
         Client.deleteChannel(this.state.channel_id,
             function(data) {
                 AsyncClient.getChannels(true);
-                window.location.href = '/channels/town-square';
+                window.location.href = '/';
             }.bind(this),
             function(err) {
                 AsyncClient.dispatchError(err, "handleDelete");

--- a/web/react/components/login.jsx
+++ b/web/react/components/login.jsx
@@ -1,102 +1,21 @@
 // Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-
-
-
 var utils = require('../utils/utils.jsx');
 var client = require('../utils/client.jsx');
 var UserStore = require('../stores/user_store.jsx');
+var TeamStore = require('../stores/team_store.jsx');
 var BrowserStore = require('../stores/browser_store.jsx');
-
-
-var FindTeamDomain = React.createClass({
-    handleSubmit: function(e) {
-        e.preventDefault();
-        var state = { }
-
-        var domain = this.refs.domain.getDOMNode().value.trim();
-        if (!domain) {
-            state.server_error = "A domain is required"
-            this.setState(state);
-            return;
-        }
-
-        if (!BrowserStore.isLocalStorageSupported()) {
-            state.server_error = "This service requires local storage to be enabled. Please enable it or exit private browsing.";
-            this.setState(state);
-            return;
-        }
-
-        state.server_error = "";
-        this.setState(state);
-
-        client.findTeamByDomain(domain,
-            function(data) {
-                console.log(data);
-                if (data) {
-                    window.location.href = window.location.protocol + "//" + domain + "." + utils.getDomainWithOutSub();
-                }
-                else {
-                    this.state.server_error = "We couldn't find your " + strings.Team + ".";
-                    this.setState(this.state);
-                }
-            }.bind(this),
-            function(err) {
-                this.state.server_error = err.message;
-                this.setState(this.state);
-            }.bind(this)
-        );
-    },
-    getInitialState: function() {
-        return { };
-    },
-    render: function() {
-        var server_error = this.state.server_error ? <label className="control-label">{this.state.server_error}</label> : null;
-
-        return (
-            <div className="signup-team__container">
-                <div>
-                    <span className="signup-team__name">{ config.SiteName }</span>
-                    <br/>
-                    <span className="signup-team__subdomain">Enter your {strings.Team}'s domain.</span>
-                    <br/>
-                    <br/>
-                </div>
-                <form onSubmit={this.handleSubmit}>
-                    <div className={server_error ? 'form-group has-error' : 'form-group'}>
-                        { server_error }
-                        <input type="text" className="form-control" name="domain" ref="domain" placeholder="team domain" />
-                    </div>
-                    <div className="form-group">
-                        <button type="submit" className="btn btn-primary">Continue</button>
-                    </div>
-                    <div>
-                        <span>Don't remember your {strings.Team}'s domain? <a href="/find_team">Find it here</a></span>
-                    </div>
-                    <br/>
-                    <br/>
-                    <br/>
-                    <br/>
-                    <br/>
-                    <br/>
-                    <div>
-                        <span>{"Want to create your own " + strings.Team + "?"} <a href={utils.getHomeLink()} className="signup-team-login">Sign up now</a></span>
-                    </div>
-                </form>
-            </div>
-        );
-    }
-});
+var Constants = require('../utils/constants.jsx');
 
 module.exports = React.createClass({
     handleSubmit: function(e) {
         e.preventDefault();
         var state = { }
 
-        var domain = this.refs.domain.getDOMNode().value.trim();
-        if (!domain) {
-            state.server_error = "A domain is required"
+        var name = this.props.teamName
+        if (!name) {
+            state.server_error = "Bad team name"
             this.setState(state);
             return;
         }
@@ -124,23 +43,22 @@ module.exports = React.createClass({
         state.server_error = "";
         this.setState(state);
 
-        client.loginByEmail(domain, email, password,
+        client.loginByEmail(name, email, password,
             function(data) {
-                UserStore.setLastDomain(domain);
-                UserStore.setLastEmail(email);
                 UserStore.setCurrentUser(data);
+                UserStore.setLastEmail(email);
 
                 var redirect = utils.getUrlParameter("redirect");
                 if (redirect) {
-                    window.location.href = decodeURI(redirect);
+                    window.location.pathname = decodeURI(redirect);
                 } else {
-                    window.location.href = '/channels/town-square';
+                    window.location.pathname = '/' + name + '/channels/town-square';
                 }
 
             }.bind(this),
             function(err) {
                 if (err.message == "Login failed because email address has not been verified") {
-                    window.location.href = '/verify?domain=' + encodeURIComponent(domain) + '&email=' + encodeURIComponent(email);
+                    window.location.href = '/verify_email?name=' + encodeURIComponent(name) + '&email=' + encodeURIComponent(email);
                     return;
                 }
                 state.server_error = err.message;
@@ -161,35 +79,35 @@ module.exports = React.createClass({
             priorEmail = decodeURIComponent(emailParam);
         }
 
-        var subDomainClass = "form-control hidden";
-        var subDomain = utils.getSubDomain();
+        var teamDisplayName = this.props.teamDisplayName;
+        var teamName = this.props.teamName;
 
-        if (utils.isTestDomain()) {
-            subDomainClass = "form-control";
-            subDomain = UserStore.getLastDomain();
-        } else if (subDomain == "") {
-            return (<FindTeamDomain />);
+        var focusEmail = false;
+        var focusPassword = false;
+        if (priorEmail != "") {
+            focusPassword = true;
+        } else {
+            focusEmail = true;
         }
 
         return (
             <div className="signup-team__container">
                 <div>
-                    <span className="signup-team__name">{ subDomain }</span>
+                    <span className="signup-team__name">{ teamDisplayName }</span>
                     <br/>
-                    <span className="signup-team__subdomain">{ utils.getDomainWithOutSub() }</span>
+                    <span className="signup-team__subdomain">/{ teamName }/</span>
                     <br/>
                     <br/>
                 </div>
                 <form onSubmit={this.handleSubmit}>
                     <div className={server_error ? 'form-group has-error' : 'form-group'}>
                         { server_error }
-                        <input type="text" className={subDomainClass} name="domain" defaultValue={subDomain} ref="domain" placeholder="Domain" />
                     </div>
                     <div className={server_error ? 'form-group has-error' : 'form-group'}>
-                        <input type="email" className="form-control" name="email" defaultValue={priorEmail}  ref="email" placeholder="Email" />
+                        <input autoFocus={focusEmail} type="email" className="form-control" name="email" defaultValue={priorEmail}  ref="email" placeholder="Email" />
                     </div>
                     <div className={server_error ? 'form-group has-error' : 'form-group'}>
-                        <input type="password" className="form-control" name="password" ref="password" placeholder="Password" />
+                        <input autoFocus={focusPassword} type="password" className="form-control" name="password" ref="password" placeholder="Password" />
                     </div>
                     <div className="form-group">
                         <button type="submit" className="btn btn-primary">Sign in</button>
@@ -198,10 +116,10 @@ module.exports = React.createClass({
                         <span><a href="/find_team">{"Find other " + strings.TeamPlural}</a></span>
                     </div>
                     <div className="form-group">
-                        <a href="/reset_password">I forgot my password</a>
+                        <a href={"/" + teamName + "/reset_password"}>I forgot my password</a>
                     </div>
                     <div className="external-link">
-                        <span>{"Want to create your own " + strings.Team + "?"} <a href={utils.getHomeLink()} className="signup-team-login">Sign up now</a></span>
+                        <span>{"Want to create your own " + strings.Team + "?"} <a href="/" className="signup-team-login">Sign up now</a></span>
                     </div>
                 </form>
             </div>

--- a/web/react/components/msg_typing.jsx
+++ b/web/react/components/msg_typing.jsx
@@ -51,7 +51,7 @@ module.exports = React.createClass({
     },
     render: function() {
         return (
-        	<span className="msg-typing">{ this.state.text }</span>
+            <span className="msg-typing">{ this.state.text }</span>
         );
     }
 });

--- a/web/react/components/new_channel.jsx
+++ b/web/react/components/new_channel.jsx
@@ -6,6 +6,8 @@ var utils = require('../utils/utils.jsx');
 var client = require('../utils/client.jsx');
 var asyncClient = require('../utils/async_client.jsx');
 var UserStore = require('../stores/user_store.jsx');
+var TeamStore = require('../stores/team_store.jsx');
+var Constants = require('../utils/constants.jsx');
 
 module.exports = React.createClass({
     handleSubmit: function(e) {
@@ -60,13 +62,13 @@ module.exports = React.createClass({
 
         var self = this;
         client.createChannel(channel,
-            function(data) {
+            function() {
                 this.refs.display_name.getDOMNode().value = "";
                 this.refs.channel_name.getDOMNode().value = "";
                 this.refs.channel_desc.getDOMNode().value = "";
 
                 $(self.refs.modal.getDOMNode()).modal('hide');
-                window.location.href = "/channels/" + channel.name;
+                window.location = TeamStore.getCurrentTeamUrl() + "/channels/" + channel.name;
                 asyncClient.getChannels(true);
             }.bind(this),
             function(err) {

--- a/web/react/components/password_reset.jsx
+++ b/web/react/components/password_reset.jsx
@@ -10,13 +10,6 @@ SendResetPasswordLink = React.createClass({
         e.preventDefault();
         var state = {};
 
-        var domain = this.refs.domain.getDOMNode().value.trim();
-        if (!domain) {
-            state.error = "A domain is required"
-            this.setState(state);
-            return;
-        }
-
         var email = this.refs.email.getDOMNode().value.trim();
         if (!email) {
             state.error = "Please enter a valid email address."
@@ -29,17 +22,17 @@ SendResetPasswordLink = React.createClass({
 
         data = {};
         data['email'] = email;
-        data['domain'] = domain;
+        data['name'] = this.props.teamName;
 
         client.sendPasswordReset(data,
-            function(data) {
-                this.setState({ error: null, update_text: <p>A password reset link has been sent to <b>{email}</b> for your <b>{this.props.teamName}</b> team on {config.SiteName}.com.</p>, more_update_text: "Please check your inbox." });
-                $(this.refs.reset_form.getDOMNode()).hide();
-            }.bind(this),
-            function(err) {
-                this.setState({ error: err.message, update_text: null, more_update_text: null });
-            }.bind(this)
-        );
+             function(data) {
+                 this.setState({ error: null, update_text: <p>A password reset link has been sent to <b>{email}</b> for your <b>{this.props.teamDisplayName}</b> team on {window.location.hostname}.</p>, more_update_text: "Please check your inbox." });
+                 $(this.refs.reset_form.getDOMNode()).hide();
+             }.bind(this),
+             function(err) {
+                 this.setState({ error: err.message, update_text: null, more_update_text: null });
+             }.bind(this)
+            );
     },
     getInitialState: function() {
         return {};
@@ -48,24 +41,13 @@ SendResetPasswordLink = React.createClass({
         var update_text = this.state.update_text ? <div className="reset-form alert alert-success">{this.state.update_text}{this.state.more_update_text}</div> : null;
         var error = this.state.error ? <div className="form-group has-error"><label className="control-label">{this.state.error}</label></div> : null;
 
-        var subDomain = utils.getSubDomain();
-        var subDomainClass = "form-control hidden";
-
-        if (subDomain == "") {
-            subDomain = UserStore.getLastDomain();
-            subDomainClass = "form-control";
-        }
-
         return (
             <div className="col-sm-12">
                 <div className="signup-team__container">
                     <h3>Password Reset</h3>
                     { update_text }
                     <form onSubmit={this.handleSendLink} ref="reset_form">
-                        <p>{"To reset your password, enter the email address you used to sign up for " + this.props.teamName + "."}</p>
-                        <div className="form-group">
-                            <input type="text" className={subDomainClass} name="domain" defaultValue={subDomain} ref="domain" placeholder="Domain" />
-                        </div>
+                        <p>{"To reset your password, enter the email address you used to sign up for " + this.props.teamDisplayName + "."}</p>
                         <div className={error ? 'form-group has-error' : 'form-group'}>
                             <input type="text" className="form-control" name="email" ref="email" placeholder="Email" />
                         </div>
@@ -83,13 +65,6 @@ ResetPassword = React.createClass({
         e.preventDefault();
         var state = {};
 
-        var domain = this.refs.domain.getDOMNode().value.trim();
-        if (!domain) {
-            state.error = "A domain is required"
-            this.setState(state);
-            return;
-        }
-
         var password = this.refs.password.getDOMNode().value.trim();
         if (!password || password.length < 5) {
             state.error = "Please enter at least 5 characters."
@@ -104,41 +79,30 @@ ResetPassword = React.createClass({
         data['new_password'] = password;
         data['hash'] = this.props.hash;
         data['data'] = this.props.data;
-        data['domain'] = domain;
+        data['name'] = this.props.teamName;
 
         client.resetPassword(data,
-            function(data) {
-                this.setState({ error: null, update_text: "Your password has been updated successfully." });
-            }.bind(this),
-            function(err) {
-                this.setState({ error: err.message, update_text: null });
-            }.bind(this)
-        );
+             function(data) {
+                 this.setState({ error: null, update_text: "Your password has been updated successfully." });
+             }.bind(this),
+             function(err) {
+                 this.setState({ error: err.message, update_text: null });
+             }.bind(this)
+            );
     },
     getInitialState: function() {
         return {};
     },
     render: function() {
-        var update_text = this.state.update_text ? <div className="form-group"><br/><label className="control-label reset-form">{this.state.update_text} Click <a href="/login">here</a> to log in.</label></div> : null;
+        var update_text = this.state.update_text ? <div className="form-group"><br/><label className="control-label reset-form">{this.state.update_text} Click <a href={"/" + this.props.teamName + "/login"}>here</a> to log in.</label></div> : null;
         var error = this.state.error ? <div className="form-group has-error"><label className="control-label">{this.state.error}</label></div> : null;
-
-        var subDomain = this.props.domain != "" ? this.props.domain : utils.getSubDomain();
-        var subDomainClass = "form-control hidden";
-
-        if (subDomain == "") {
-            subDomain = UserStore.getLastDomain();
-            subDomainClass = "form-control";
-        }
 
         return (
             <div className="col-sm-12">
                 <div className="signup-team__container">
                     <h3>Password Reset</h3>
                     <form onSubmit={this.handlePasswordReset}>
-                        <p>{"Enter a new password for your " + this.props.teamName + " " + config.SiteName + " account."}</p>
-                        <div className="form-group">
-                            <input type="text" className={subDomainClass} name="domain" defaultValue={subDomain} ref="domain" placeholder="Domain" />
-                        </div>
+                        <p>{"Enter a new password for your " + this.props.teamDisplayName + " " + config.SiteName + " account."}</p>
                         <div className={error ? 'form-group has-error' : 'form-group'}>
                             <input type="password" className="form-control" name="password" ref="password" placeholder="Password" />
                         </div>
@@ -161,14 +125,15 @@ module.exports = React.createClass({
         if (this.props.isReset === "false") {
             return (
                 <SendResetPasswordLink
+                    teamDisplayName={this.props.teamDisplayName}
                     teamName={this.props.teamName}
                 />
             );
         } else {
             return (
                 <ResetPassword
+                    teamDisplayName={this.props.teamDisplayName}
                     teamName={this.props.teamName}
-                    domain={this.props.domain}
                     hash={this.props.hash}
                     data={this.props.data}
                 />

--- a/web/react/components/rename_channel_modal.jsx
+++ b/web/react/components/rename_channel_modal.jsx
@@ -6,6 +6,8 @@ var utils = require('../utils/utils.jsx');
 var Client = require('../utils/client.jsx');
 var AsyncClient = require('../utils/async_client.jsx');
 var ChannelStore = require('../stores/channel_store.jsx');
+var TeamStore = require('../stores/team_store.jsx');
+var Constants = require('../utils/constants.jsx');
 
 module.exports = React.createClass({
     handleSubmit: function(e) {
@@ -60,12 +62,12 @@ module.exports = React.createClass({
             return;
 
         Client.updateChannel(channel,
-            function(data) {
+            function(data, text, req) {
                 this.refs.display_name.getDOMNode().value = "";
                 this.refs.channel_name.getDOMNode().value = "";
 
                 $('#' + this.props.modalId).modal('hide');
-                window.location.href = '/channels/' + this.state.channel_name;
+                window.location.href = TeamStore.getCurrentTeamUrl() + '/channels/' + this.state.channel_name;
                 AsyncClient.getChannels(true);
             }.bind(this),
             function(err) {

--- a/web/react/components/rename_team_modal.jsx
+++ b/web/react/components/rename_team_modal.jsx
@@ -24,13 +24,13 @@ module.exports = React.createClass({
         if (!valid)
             return;
 
-        if (this.props.teamName === name)
+        if (this.props.teamDisplayName === name)
             return;
 
         var data = {};
         data["new_name"] = name;
 
-        Client.updateTeamName(data,
+        Client.updateTeamDisplayName(data,
             function(data) {
                 $('#rename_team_link').modal('hide');
                 window.location.reload();
@@ -47,11 +47,11 @@ module.exports = React.createClass({
     componentDidMount: function() {
         var self = this;
         $(this.refs.modal.getDOMNode()).on('hidden.bs.modal', function(e) {
-            self.setState({ name: self.props.teamName });
+            self.setState({ name: self.props.teamDisplayName });
         });
     },
     getInitialState: function() {
-        return { name: this.props.teamName };
+        return { name: this.props.teamDisplayName };
     },
     render: function() {
 

--- a/web/react/components/sidebar_header.jsx
+++ b/web/react/components/sidebar_header.jsx
@@ -61,19 +61,15 @@ var NavbarDropdown = React.createClass({
 
         var teams = [];
 
+        teams.push(<li className="divider" key="div"></li>);
         if (this.state.teams.length > 1) {
             for (var i = 0; i < this.state.teams.length; i++) {
-                var domain = this.state.teams[i];
+                var teamName = this.state.teams[i];
 
-                if (domain == utils.getSubDomain())
-                    continue;
-
-                if (teams.length == 0)
-                    teams.push(<li className="divider" key="div"></li>);
-
-                teams.push(<li key={ domain }><a href={window.location.protocol + "//" + domain + "." + utils.getDomainWithOutSub() }>Switch to { domain }</a></li>);
+                teams.push(<li key={ teamName }><a href={window.location.origin + "/" + teamName }>Switch to { teamName }</a></li>);
             }
         }
+        teams.push(<li><a href={window.location.origin + "/signup_team" }>Create a New Team</a></li>);
 
         return (
             <ul className="nav navbar-nav navbar-right">
@@ -110,19 +106,21 @@ module.exports = React.createClass({
     },
 
     render: function() {
-        var me = UserStore.getCurrentUser();
-
+        var teamDisplayName = this.props.teamDisplayName ? this.props.teamDisplayName : config.SiteName;
+        var me = UserStore.getCurrentUser()
         if (!me) {
             return null;
         }
 
         return (
             <div className="team__header theme">
-                <img className="user__picture" src={"/api/v1/users/" + me.id + "/image?time=" + me.update_at} />
-                <div className="header__info">
-                    <div className="user__name">{'@' + me.username}</div>
-                    <a className="team__name" href="/channels/town-square">{this.props.teamName}</a>
-                </div>
+                <a className="settings_link" href="#" data-toggle="modal" data-target="#user_settings1">
+                    <img className="user__picture" src={"/api/v1/users/" + me.id + "/image?time=" + me.update_at} />
+                    <div className="header__info">
+                        <div className="user__name">{ '@' + me.username}</div>
+                        <div className="team__name">{ teamDisplayName }</div>
+                    </div>
+                </a>
                 <NavbarDropdown teamType={this.props.teamType} />
             </div>
         );

--- a/web/react/components/sidebar_right_menu.jsx
+++ b/web/react/components/sidebar_right_menu.jsx
@@ -49,12 +49,12 @@ module.exports = React.createClass({
         }
 
         var siteName = config.SiteName != null ? config.SiteName : "";
-        var teamName = this.props.teamName ? this.props.teamName : siteName;
+        var teamDisplayName = this.props.teamDisplayName ? this.props.teamDisplayName : siteName;
 
         return (
             <div>
                 <div className="team__header theme">
-                    <a className="team__name" href="/channels/town-square">{ teamName }</a>
+                    <a className="team__name" href="/channels/town-square">{ teamDisplayName }</a>
                 </div>
 
                 <div className="nav-pills__container">

--- a/web/react/components/signup_team.jsx
+++ b/web/react/components/signup_team.jsx
@@ -20,8 +20,8 @@ module.exports = React.createClass({
             state.email_error = "";
         }
 
-        team.name = this.refs.name.getDOMNode().value.trim();
-        if (!team.name) {
+        team.display_name = this.refs.name.getDOMNode().value.trim();
+        if (!team.display_name) {
             state.name_error = "This field is required";
             state.inValid = true;
         }
@@ -34,7 +34,7 @@ module.exports = React.createClass({
             return;
         }
 
-        client.signupTeam(team.email, team.name,
+        client.signupTeam(team.email, team.display_name,
             function(data) {
                 if (data["follow_link"]) {
                     window.location.href = data["follow_link"];
@@ -61,7 +61,7 @@ module.exports = React.createClass({
         return (
             <form role="form" onSubmit={this.handleSubmit}>
                 <div className={ email_error ? "form-group has-error" : "form-group" }>
-                    <input type="email" ref="email" className="form-control" placeholder="Email Address" maxLength="128" />
+                    <input autoFocus={true} type="email" ref="email" className="form-control" placeholder="Email Address" maxLength="128" />
                     { email_error }
                 </div>
                 <div className={ name_error ? "form-group has-error" : "form-group" }>
@@ -70,6 +70,9 @@ module.exports = React.createClass({
                 </div>
                 { server_error }
                 <button className="btn btn-md btn-primary" type="submit">Sign up for Free</button>
+                <div className="form-group form-group--small">
+                    <span><a href="/find_team">{"Find my " + strings.Team}</a></span>
+                </div>
             </form>
         );
     }

--- a/web/react/components/signup_team_complete.jsx
+++ b/web/react/components/signup_team_complete.jsx
@@ -15,7 +15,7 @@ WelcomePage = React.createClass({
             return;
         }
         e.preventDefault();
-        this.props.state.wizard = "team_name";
+        this.props.state.wizard = "team_display_name";
         this.props.updateParent(this.props.state);
     },
     handleDiffEmail: function (e) {
@@ -57,6 +57,17 @@ WelcomePage = React.createClass({
     getInitialState: function() {
         return { use_diff: false };
     },
+    handleKeyPress: function(event) {
+        if (event.keyCode == 13) {
+            this.submitNext(event);
+        }
+    },
+    componentWillMount: function() {
+        document.addEventListener("keyup", this.handleKeyPress, false);
+    },
+    componentWillUnmount: function() {
+        document.removeEventListener("keyup", this.handleKeyPress, false);
+    },
     render: function() {
 
         client.track('signup', 'signup_team_01_welcome');
@@ -77,7 +88,7 @@ WelcomePage = React.createClass({
                     <span className="black">{ this.props.state.team.email }</span><br />
                 </p>
                 <div className="form-group">
-                    <button className="btn-primary btn form-group" onClick={this.submitNext}><i className="glyphicon glyphicon-ok"></i>Yes, this address is correct</button>
+                    <button className="btn-primary btn form-group" type="submit" onClick={this.submitNext}><i className="glyphicon glyphicon-ok"></i>Yes, this address is correct</button>
                     { storage_error }
                 </div>
                 <hr />
@@ -92,15 +103,15 @@ WelcomePage = React.createClass({
                         { email_error }
                     </div>
                     { server_error }
-                    <button className="btn btn-md btn-primary" onClick={this.handleDiffSubmit} type="submit">Use this instead</button>
+                    <button className="btn btn-md btn-primary" type="button" onClick={this.handleDiffSubmit} type="submit">Use this instead</button>
                 </div>
-                <button onClick={this.handleDiffEmail} className={ this.state.use_diff ? "btn-default btn hidden" : "btn-default btn" }>Use a different address</button>
+                <button type="button" onClick={this.handleDiffEmail} className={ this.state.use_diff ? "btn-default btn hidden" : "btn-default btn" }>Use a different address</button>
             </div>
         );
     }
 });
 
-TeamNamePage = React.createClass({
+TeamDisplayNamePage = React.createClass({
     submitBack: function (e) {
         e.preventDefault();
         this.props.state.wizard = "welcome";
@@ -109,18 +120,23 @@ TeamNamePage = React.createClass({
     submitNext: function (e) {
         e.preventDefault();
 
-        var name = this.refs.name.getDOMNode().value.trim();
-        if (!name) {
+        var display_name = this.refs.name.getDOMNode().value.trim();
+        if (!display_name) {
             this.setState({name_error: "This field is required"});
             return;
         }
 
         this.props.state.wizard = "team_url";
-        this.props.state.team.name = name;
+        this.props.state.team.display_name = display_name;
         this.props.updateParent(this.props.state);
     },
     getInitialState: function() {
         return {  };
+    },
+    handleFocus: function(e) {
+        e.preventDefault();
+
+        e.currentTarget.select();
     },
     render: function() {
 
@@ -130,29 +146,31 @@ TeamNamePage = React.createClass({
 
         return (
             <div>
+                <form>
                 <img className="signup-team-logo" src="/static/images/logo.png" />
 
                 <h2>{utils.toTitleCase(strings.Team) + " Name"}</h2>
                 <div className={ name_error ? "form-group has-error" : "form-group" }>
                 <div className="row">
                     <div className="col-sm-9">
-                        <input type="text" ref="name" className="form-control" placeholder="" maxLength="128" defaultValue={this.props.state.team.name} />
+                        <input type="text" ref="name" className="form-control" placeholder="" maxLength="128" defaultValue={this.props.state.team.display_name} autoFocus={true} onFocus={this.handleFocus} />
                     </div>
                 </div>
                 { name_error }
                 </div>
                 <p>{"Your " + strings.Team + " name shows in menus and headings. It may include the name of your " + strings.Company + ", but it's not required."}</p>
-                <button className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
-                <button className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button>
+                <button type="button" className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
+                <button type="submit" className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button>
+            </form>
             </div>
         );
     }
 });
 
-TeamUrlPage = React.createClass({
+TeamURLPage = React.createClass({
     submitBack: function (e) {
         e.preventDefault();
-        this.props.state.wizard = "team_name";
+        this.props.state.wizard = "team_display_name";
         this.props.updateParent(this.props.state);
     },
     submitNext: function (e) {
@@ -172,18 +190,18 @@ TeamUrlPage = React.createClass({
             return;
         }
         else if (cleaned_name.length <= 3 || cleaned_name.length > 15) {
-            this.setState({name_error: "Domain must be 4 or more characters up to a maximum of 15"})
+            this.setState({name_error: "Name must be 4 or more characters up to a maximum of 15"})
             return;
         }
 
-        for (var index = 0; index < constants.RESERVED_DOMAINS.length; index++) {
-            if (cleaned_name.indexOf(constants.RESERVED_DOMAINS[index]) == 0) {
-                this.setState({name_error: "This Team URL name is unavailable"})
+        for (var index = 0; index < constants.RESERVED_TEAM_NAMES.length; index++) {
+            if (cleaned_name.indexOf(constants.RESERVED_TEAM_NAMES[index]) == 0) {
+                this.setState({name_error: "This team name is unavailable"})
                 return;
             }
         }
 
-        client.findTeamByDomain(name,
+        client.findTeamByName(name,
             function(data) {
                 if (!data) {
                     if (config.AllowSignupDomainsWizard) {
@@ -193,7 +211,7 @@ TeamUrlPage = React.createClass({
                         this.props.state.team.type = 'O';
                     }
 
-                    this.props.state.team.domain = name;
+                    this.props.state.team.name = name;
                     this.props.updateParent(this.props.state);
                 }
                 else {
@@ -210,6 +228,11 @@ TeamUrlPage = React.createClass({
     getInitialState: function() {
         return { };
     },
+    handleFocus: function(e) {
+        e.preventDefault();
+
+        e.currentTarget.select();
+    },
     render: function() {
 
         client.track('signup', 'signup_team_03_url');
@@ -218,14 +241,15 @@ TeamUrlPage = React.createClass({
 
         return (
             <div>
+                <form>
                 <img className="signup-team-logo" src="/static/images/logo.png" />
                 <h2>{utils.toTitleCase(strings.Team) + " URL"}</h2>
                 <div className={ name_error ? "form-group has-error" : "form-group" }>
                <div className="row">
                     <div className="col-sm-9">
                         <div className="input-group">
-                            <input type="text" ref="name" className="form-control text-right" placeholder="" maxLength="128" defaultValue={this.props.state.team.domain} />
-                            <span className="input-group-addon">.{ utils.getDomainWithOutSub() }</span>
+                            <span className="input-group-addon">{ window.location.origin + "/" }</span>
+                            <input type="text" ref="name" className="form-control" placeholder="" maxLength="128" defaultValue={this.props.state.team.name} autoFocus={true} onFocus={this.handleFocus}/>
                         </div>
                     </div>
                 </div>
@@ -233,8 +257,9 @@ TeamUrlPage = React.createClass({
                 </div>
                 <p className="black">{"Pick something short and memorable for your " + strings.Team + "'s web address."}</p>
                 <p>{"Your " + strings.Team + " URL can only contain lowercase letters, numbers and dashes. Also, it needs to start with a letter and cannot end in a dash."}</p>
-                <button className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
-                <button className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button>
+                <button type="button" className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
+                <button type="submit" className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button>
+            </form>
             </div>
         );
     }
@@ -291,6 +316,7 @@ AllowedDomainsPage = React.createClass({
 
         return (
             <div>
+                <form>
                 <img className="signup-team-logo" src="/static/images/logo.png" />
                 <h2>Email Domain</h2>
                 <p>
@@ -303,7 +329,7 @@ AllowedDomainsPage = React.createClass({
                     <div className="col-sm-9">
                         <div className="input-group">
                             <span className="input-group-addon">@</span>
-                            <input type="text" ref="name" className="form-control" placeholder="" maxLength="128" defaultValue={this.props.state.team.allowed_domains} />
+                            <input type="text" ref="name" className="form-control" placeholder="" maxLength="128" defaultValue={this.props.state.team.allowed_domains} autoFocus={true} onFocus={this.handleFocus}/>
                         </div>
                     </div>
                 </div>
@@ -313,8 +339,9 @@ AllowedDomainsPage = React.createClass({
                 <p>
                 <div className="checkbox"><label><input type="checkbox" ref="open_network" defaultChecked={this.props.state.team.type == 'O'} /> Allow anyone to signup to this domain without an invitation.</label></div>
                 </p>
-                <button className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
-                <button className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button>
+                <button type="button" className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
+                <button type="submit" className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button>
+            </form>
             </div>
         );
     }
@@ -356,7 +383,7 @@ EmailItem = React.createClass({
 
         return (
             <div className={ email_error ? "form-group has-error" : "form-group" }>
-                <input type="email" ref="email" className="form-control" placeholder="Email Address" defaultValue={this.props.email} maxLength="128" />
+                <input autoFocus={this.props.focus} type="email" ref="email" className="form-control" placeholder="Email Address" defaultValue={this.props.email} maxLength="128" />
                 { email_error }
             </div>
         );
@@ -424,16 +451,22 @@ SendInivtesPage = React.createClass({
         var emails = [];
 
         for (var i = 0; i < this.props.state.invites.length; i++) {
-            emails.push(<EmailItem key={i} ref={'email_' + i} email={this.props.state.invites[i]} />);
+            if (i == 0) {
+                emails.push(<EmailItem focus={true} key={i} ref={'email_' + i} email={this.props.state.invites[i]} />);
+            } else {
+                emails.push(<EmailItem focus={false} key={i} ref={'email_' + i} email={this.props.state.invites[i]} />);
+            }
         }
 
         return (
             <div>
+                <form>
                 <img className="signup-team-logo" src="/static/images/logo.png" />
                 <h2>Send Invitations</h2>
                 { emails }
-                <div className="form-group"><button className="btn-default btn" onClick={this.submitAddInvite}>Add Invitation</button></div>
-                <div className="form btn-default-group"><button className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;<button className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button></div>
+                <div className="form-group"><button type="button" className="btn-default btn" onClick={this.submitAddInvite}>Add Invitation</button></div>
+                <div className="form btn-default-group"><button type="button" className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;<button type="submit" className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button></div>
+            </form>
                 <p>{"If you'd prefer, you can send invitations after you finish setting up the "+ strings.Team + "."}</p>
                 <div><a href="#" onClick={this.submitSkip}>Skip this step</a></div>
             </div>
@@ -477,20 +510,22 @@ UsernamePage = React.createClass({
 
         return (
             <div>
+                <form>
                 <img className="signup-team-logo" src="/static/images/logo.png" />
                 <h2>Choose a username</h2>
                 <div className={ name_error ? "form-group has-error" : "form-group" }>
                 <div className="row">
                     <div className="col-sm-9">
-                        <input type="text" ref="name" className="form-control" placeholder="" defaultValue={this.props.state.user.username} maxLength="128" />
+                        <input autoFocus={true} type="text" ref="name" className="form-control" placeholder="" defaultValue={this.props.state.user.username} maxLength="128" />
                     </div>
                 </div>
                 { name_error }
                 </div>
                 <p>{"Pick something " + strings.Team + "mates will recognize. Your username is how you will appear to others."}</p>
                 <p>It can be made of lowercase letters and numbers.</p>
-                <button className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
-                <button className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button>
+                <button type="button" className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
+                <button type="submit" className="btn-primary btn" onClick={this.submitNext}>Next<i className="glyphicon glyphicon-chevron-right"></i></button>
+            </form>
             </div>
         );
     }
@@ -531,18 +566,11 @@ PasswordPage = React.createClass({
                     props.state.wizard = "finished";
                     props.updateParent(props.state, true);
 
-                    if (utils.isTestDomain()) {
-                        UserStore.setLastDomain(teamSignup.team.domain);
-                        UserStore.setLastEmail(teamSignup.team.email);
-                        window.location.href = window.location.protocol  + '//' + utils.getDomainWithOutSub() + '/login?email=' + encodeURIComponent(teamSignup.team.email);
-                    }
-                    else {
-                        window.location.href = window.location.protocol + '//' + teamSignup.team.domain + '.' + utils.getDomainWithOutSub() + '/login?email=' + encodeURIComponent(teamSignup.team.email);
-                    }
+                    window.location.href = window.location.origin + '/' + props.state.team.name + '/login?email=' + encodeURIComponent(teamSignup.team.email);
 
                     // client.loginByEmail(teamSignup.team.domain, teamSignup.team.email, teamSignup.user.password,
                     //     function(data) {
-                    //         UserStore.setLastDomain(teamSignup.team.domain);
+                    //         TeamStore.setLastName(teamSignup.team.domain);
                     //         UserStore.setLastEmail(teamSignup.team.email);
                     //         UserStore.setCurrentUser(data);
                     //         window.location.href = '/channels/town-square';
@@ -570,13 +598,14 @@ PasswordPage = React.createClass({
 
         return (
             <div>
+                <form>
                 <img className="signup-team-logo" src="/static/images/logo.png" />
                 <h2>Choose a password</h2>
                 <p>You'll use your email address ({this.props.state.team.email}) and password to log into {config.SiteName}.</p>
                 <div className={ name_error ? "form-group has-error" : "form-group" }>
                 <div className="row">
                     <div className="col-sm-9">
-                        <input type="password" ref="password" className="form-control" placeholder="" maxLength="128" />
+                        <input autoFocus={true} type="password" ref="password" className="form-control" placeholder="" maxLength="128" />
                     </div>
                 </div>
                     { name_error }
@@ -585,10 +614,11 @@ PasswordPage = React.createClass({
                     <label><input type="checkbox" ref="email_service" /> It's ok to send me occassional email with updates about the {config.SiteName} service.</label>
                 </div>
                 <div className="form-group">
-                    <button className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
-                    <button className="btn-primary btn" id="finish-button" data-loading-text={"<span class='glyphicon glyphicon-refresh glyphicon-refresh-animate'></span> Creating "+strings.Team+"..."} onClick={this.submitNext}>Finish</button>
+                    <button type="button" className="btn btn-default" onClick={this.submitBack}><i className="glyphicon glyphicon-chevron-left"></i> Back</button>&nbsp;
+                    <button type="submit" className="btn-primary btn" id="finish-button" data-loading-text={"<span class='glyphicon glyphicon-refresh glyphicon-refresh-animate'></span> Creating "+strings.Team+"..."} onClick={this.submitNext}>Finish</button>
                 </div>
                 <p>By proceeding to create your account and use { config.SiteName }, you agree to our <a href={ config.TermsLink }>Terms of Service</a> and <a href={ config.PrivacyLink }>Privacy Policy</a>. If you do not agree, you cannot use {config.SiteName}.</p>
+            </form>
             </div>
         );
     }
@@ -610,9 +640,9 @@ module.exports = React.createClass({
             props.wizard = "welcome";
             props.team = {};
             props.team.email = this.props.email;
-            props.team.name = this.props.name;
+            props.team.display_name = this.props.name;
             props.team.company_name = this.props.name;
-            props.team.domain = utils.cleanUpUrlable(this.props.name);
+            props.team.name = utils.cleanUpUrlable(this.props.name);
             props.team.allowed_domains = "";
             props.invites = [];
             props.invites.push("");
@@ -630,12 +660,12 @@ module.exports = React.createClass({
             return <WelcomePage state={this.state} updateParent={this.updateParent} />
         }
 
-        if (this.state.wizard == "team_name") {
-            return <TeamNamePage state={this.state} updateParent={this.updateParent} />
+        if (this.state.wizard == "team_display_name") {
+            return <TeamDisplayNamePage state={this.state} updateParent={this.updateParent} />
         }
 
         if (this.state.wizard == "team_url") {
-            return <TeamUrlPage state={this.state} updateParent={this.updateParent} />
+            return <TeamURLPage state={this.state} updateParent={this.updateParent} />
         }
 
         if (this.state.wizard == "allowed_domains") {

--- a/web/react/components/signup_user_complete.jsx
+++ b/web/react/components/signup_user_complete.jsx
@@ -48,16 +48,17 @@ module.exports = React.createClass({
 
                 client.loginByEmail(this.props.domain, this.state.user.email, this.state.user.password,
                     function(data) {
-                        UserStore.setLastDomain(this.props.domain);
                         UserStore.setLastEmail(this.state.user.email);
                         UserStore.setCurrentUser(data);
                         if (this.props.hash > 0)
+                        {
                             BrowserStore.setGlobalItem(this.props.hash, JSON.stringify({wizard: "finished"}));
-                        window.location.href = '/channels/town-square';
+                        }
+                        window.location.href = '/';
                     }.bind(this),
                     function(err) {
                         if (err.message == "Login failed because email address has not been verified") {
-                            window.location.href = "/verify?email="+ encodeURIComponent(this.state.user.email) + "&domain=" + encodeURIComponent(this.props.domain);
+                            window.location.href = "/verify_email?email="+ encodeURIComponent(this.state.user.email) + "&domain=" + encodeURIComponent(this.props.domain);
                         } else {
                             this.state.server_error = err.message;
                             this.setState(this.state);

--- a/web/react/components/team_members.jsx
+++ b/web/react/components/team_members.jsx
@@ -57,7 +57,7 @@ module.exports = React.createClass({
                   <div className="modal-content">
                     <div className="modal-header">
                       <button type="button" className="close" data-dismiss="modal" aria-label="Close" data-reactid=".5.0.0.0.0"><span aria-hidden="true" data-reactid=".5.0.0.0.0.0">×</span></button>
-                      <h4 className="modal-title" id="myModalLabel">{this.props.teamName + " Members"}</h4>
+                      <h4 className="modal-title" id="myModalLabel">{this.props.teamDisplayName + " Members"}</h4>
                     </div>
                     <div ref="modalBody" className="modal-body">
                         <div className="channel-settings">

--- a/web/react/pages/channel.jsx
+++ b/web/react/pages/channel.jsx
@@ -61,17 +61,17 @@ global.window.setup_channel_page = function(team_name, team_type, team_id, chann
     );
 
     React.render(
-        <Navbar teamName={team_name} />,
+        <Navbar teamDisplayName={team_name} />,
         document.getElementById('navbar')
     );
 
     React.render(
-        <Sidebar teamName={team_name} teamType={team_type} />,
+        <Sidebar teamDisplayName={team_name} teamType={team_type} />,
         document.getElementById('sidebar-left')
     );
 
     React.render(
-        <RenameTeamModal teamName={team_name} />,
+        <RenameTeamModal teamDisplayName={team_name} />,
         document.getElementById('rename_team_modal')
     );
 
@@ -91,7 +91,7 @@ global.window.setup_channel_page = function(team_name, team_type, team_id, chann
     );
 
     React.render(
-        <TeamMembersModal teamName={team_name} />,
+        <TeamMembersModal teamDisplayName={team_name} />,
         document.getElementById('team_members_modal')
     );
 
@@ -186,7 +186,7 @@ global.window.setup_channel_page = function(team_name, team_type, team_id, chann
     );
 
     React.render(
-        <SidebarRightMenu teamName={team_name} teamType={team_type} />,
+        <SidebarRightMenu teamDisplayName={team_name} teamType={team_type} />,
         document.getElementById('sidebar-menu')
     );
 

--- a/web/react/pages/home.jsx
+++ b/web/react/pages/home.jsx
@@ -2,13 +2,14 @@
 // See License.txt for license information.
 
 var ChannelStore = require('../stores/channel_store.jsx');
+var TeamStore = require('../stores/team_store.jsx');
 var Constants = require('../utils/constants.jsx');
 
-global.window.setup_home_page = function() {
+global.window.setup_home_page = function(teamURL) {
     var last = ChannelStore.getLastVisitedName();
     if (last == null || last.length === 0) {
-        window.location.replace("/channels/" + Constants.DEFAULT_CHANNEL);
+        window.location = teamURL + "/channels/" + Constants.DEFAULT_CHANNEL;
     } else {
-        window.location.replace("/channels/" + last);
+        window.location = teamURL + "/channels/" + last;
     }
 }

--- a/web/react/pages/login.jsx
+++ b/web/react/pages/login.jsx
@@ -3,9 +3,9 @@
 
 var Login = require('../components/login.jsx');
 
-global.window.setup_login_page = function() {
+global.window.setup_login_page = function(teamDisplayName, teamName) {
     React.render(
-        <Login />,
+        <Login teamDisplayName={teamDisplayName} teamName={teamName}/>,
         document.getElementById('login')
     );
 };

--- a/web/react/pages/password_reset.jsx
+++ b/web/react/pages/password_reset.jsx
@@ -3,13 +3,13 @@
 
 var PasswordReset = require('../components/password_reset.jsx');
 
-global.window.setup_password_reset_page = function(is_reset, team_name, domain, hash, data) {
+global.window.setup_password_reset_page = function(is_reset, team_display_name, team_name, hash, data) {
 
     React.render(
         <PasswordReset
             isReset={is_reset}
+            teamDisplayName={team_display_name}
             teamName={team_name}
-            domain={domain}
             hash={hash}
             data={data}
         />,

--- a/web/react/pages/signup_team_complete.jsx
+++ b/web/react/pages/signup_team_complete.jsx
@@ -5,7 +5,7 @@ var SignupTeamComplete =require('../components/signup_team_complete.jsx');
 
 global.window.setup_signup_team_complete_page = function(email, name, data, hash) {
     React.render(
-        <SignupTeamComplete name={name} email={email} hash={hash} data={data} />,
+        <SignupTeamComplete name={name} email={email} hash={hash} data={data}/>,
         document.getElementById('signup-team-complete')
     );
 };

--- a/web/react/stores/browser_store.jsx
+++ b/web/react/stores/browser_store.jsx
@@ -8,7 +8,7 @@ function getPrefix() {
 }
 
 // Also change model/utils.go ETAG_ROOT_VERSION
-var BROWSER_STORE_VERSION = '.3';
+var BROWSER_STORE_VERSION = '.4';
 
 module.exports = {
     _initialized: false,

--- a/web/react/stores/post_store.jsx
+++ b/web/react/stores/post_store.jsx
@@ -151,12 +151,12 @@ var PostStore = assign({}, EventEmitter.prototype, {
     return BrowserStore.getItem("draft_" + channel_id + "_" + user_id);
   },
   clearDraftUploads: function() {
-	BrowserStore.actionOnItemsWithPrefix("draft_", function (key, value) {
-	  if (value) {
-		value.uploadsInProgress = 0;
-		BrowserStore.setItem(key, value);
-	  }
-	});
+      BrowserStore.actionOnItemsWithPrefix("draft_", function (key, value) {
+          if (value) {
+              value.uploadsInProgress = 0;
+              BrowserStore.setItem(key, value);
+          }
+      });
   }
 });
 

--- a/web/react/stores/team_store.jsx
+++ b/web/react/stores/team_store.jsx
@@ -57,10 +57,13 @@ var TeamStore = assign({}, EventEmitter.prototype, {
     else
       return null;
   },
+  getCurrentTeamUrl: function() {
+      return window.location.origin + "/" + this.getCurrent().name;
+  },
   storeTeam: function(team) {
-    var teams = this._getTeams();
-    teams[team.id] = team;
-    this._storeTeams(teams);
+      var teams = this._getTeams();
+      teams[team.id] = team;
+      this._storeTeams(teams);
   },
   _storeTeams: function(teams) {
     BrowserStore.setItem("user_teams", teams);

--- a/web/react/stores/user_store.jsx
+++ b/web/react/stores/user_store.jsx
@@ -67,9 +67,18 @@ var UserStore = assign({}, EventEmitter.prototype, {
   },
   setCurrentId: function(id) {
      this._current_id = id;
+     if (id == null) {
+         BrowserStore.removeGlobalItem("current_user_id");
+     } else {
+         BrowserStore.setGlobalItem("current_user_id", id);
+     }
   },
   getCurrentId: function(skipFetch) {
-      var current_id = this._current_id;
+    var current_id = this._current_id;
+
+    if (current_id == null) {
+        current_id = BrowserStore.getGlobalItem("current_user_id");
+    }
 
     // this is a speical case to force fetch the
     // current user if it's missing
@@ -92,17 +101,11 @@ var UserStore = assign({}, EventEmitter.prototype, {
     return this._getProfiles()[this.getCurrentId()];
   },
   setCurrentUser: function(user) {
-    this.saveProfile(user);
     this.setCurrentId(user.id);
-  },
-  getLastDomain: function() {
-	return BrowserStore.getItem("last_domain", '');
-  },
-  setLastDomain: function(domain) {
-    BrowserStore.setItem("last_domain", domain);
+    this.saveProfile(user);
   },
   getLastEmail: function() {
-	return BrowserStore.getItem("last_email", '');
+      return BrowserStore.getItem("last_email", '');
   },
   setLastEmail: function(email) {
     BrowserStore.setItem("last_email", email);
@@ -144,18 +147,18 @@ var UserStore = assign({}, EventEmitter.prototype, {
     this._storeProfiles(ps);
   },
   _storeProfiles: function(profiles) {
-    BrowserStore.setGlobalItem("profiles", profiles);
+    BrowserStore.setItem("profiles", profiles);
     var profileUsernameMap = {};
     for (var id in profiles) {
         profileUsernameMap[profiles[id].username] = profiles[id];
     }
-    BrowserStore.setGlobalItem("profileUsernameMap", profileUsernameMap);
+    BrowserStore.setItem("profileUsernameMap", profileUsernameMap);
   },
   _getProfiles: function() {
-    return BrowserStore.getGlobalItem("profiles", {});
+    return BrowserStore.getItem("profiles", {});
   },
   _getProfilesUsernameMap: function() {
-    return BrowserStore.getGlobalItem("profileUsernameMap", {});
+    return BrowserStore.getItem("profileUsernameMap", {});
   },
   setSessions: function(sessions) {
     BrowserStore.setItem("sessions", sessions);

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -54,7 +54,7 @@ module.exports = {
   DEFAULT_CHANNEL: 'town-square',
   OFFTOPIC_CHANNEL: 'off-topic',
   POST_CHUNK_SIZE: 60,
-  RESERVED_DOMAINS: [
+  RESERVED_TEAM_NAMES: [
     "www",
     "web",
     "admin",

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -16,10 +16,10 @@ module.exports.isEmail = function(email) {
 };
 
 module.exports.cleanUpUrlable = function(input) {
-	var cleaned = input.trim().replace(/-/g, ' ').replace(/[^\w\s]/gi, '').toLowerCase().replace(/\s/g, '-');
-	cleaned = cleaned.replace(/^\-+/, '');
-	cleaned = cleaned.replace(/\-+$/, '');
-	return cleaned;
+    var cleaned = input.trim().replace(/-/g, ' ').replace(/[^\w\s]/gi, '').toLowerCase().replace(/\s/g, '-');
+    cleaned = cleaned.replace(/^\-+/, '');
+    cleaned = cleaned.replace(/\-+$/, '');
+    return cleaned;
 };
 
 
@@ -114,7 +114,7 @@ module.exports.notifyMe = function(title, body, channel) {
           if (channel) {
               module.exports.switchChannel(channel);
           } else {
-              window.location.href = "/channels/town-square";
+              window.location.href = "/";
           }
         };
         setTimeout(function(){
@@ -708,8 +708,8 @@ module.exports.switchChannel = function(channel, teammate_name) {
       id: channel.id
     });
 
-    var domain = window.location.href.split('/channels')[0];
-    history.replaceState('data', '', domain + '/channels/' + channel.name);
+    var teamURL = window.location.href.split('/channels')[0];
+    history.replaceState('data', '', teamURL + '/channels/' + channel.name);
 
     if (channel.type === 'D' && teammate_name) {
         document.title = teammate_name + " " + document.title.substring(document.title.lastIndexOf("-"));
@@ -783,18 +783,6 @@ Image.prototype.load = function(url, progressCallback) {
 };
 
 Image.prototype.completedPercentage = 0;
-
-module.exports.getHomeLink = function() {
-	if (config.HomeLink != "") {
-		return config.HomeLink;
-	}
-	var parts = window.location.host.split(".");
-	if (parts.length <= 1) {
-		return window.location.protocol + "//" + window.location.host;
-	}
-	parts[0] = "www";
-	return window.location.protocol + "//" + parts.join(".");
-}
 
 module.exports.changeColor =function(col, amt) {
 

--- a/web/sass-files/sass/partials/_headers.scss
+++ b/web/sass-files/sass/partials/_headers.scss
@@ -98,6 +98,9 @@
 				fill: #fff;
 			}
 		}
+		.settings__link a:hover, a:visited, a:link, a:active {
+			text-decoration: none;
+		}
 		.user__picture {
 			width: 36px;
 			height: 36px;

--- a/web/sass-files/sass/partials/_signup.scss
+++ b/web/sass-files/sass/partials/_signup.scss
@@ -6,7 +6,7 @@
 }
 .signup-team__container {
     padding: 100px 0px 50px 0px;
-    max-width: 340px;
+    max-width: 600px;
     margin: 0 auto;
     font-size: 1.1em;
     position: relative;

--- a/web/templates/channel.html
+++ b/web/templates/channel.html
@@ -46,7 +46,7 @@
   <div id="direct_channel_modal"></div>
   <div id="channel_info_modal"></div>
 <script>
-window.setup_channel_page('{{ .Props.TeamName }}', '{{ .Props.TeamType }}', '{{ .Props.TeamId }}', '{{ .Props.ChannelName }}', '{{ .Props.ChannelId }}');
+window.setup_channel_page('{{ .Props.TeamDisplayName }}', '{{ .Props.TeamType }}', '{{ .Props.TeamId }}', '{{ .Props.ChannelName }}', '{{ .Props.ChannelId }}');
 </script>
 </body>
 </html>

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -17,7 +17,7 @@
     </div>
   </div>
   <script>
-  window.setup_home_page();
+	window.setup_home_page({{.Props.TeamURL}});
   </script>
 </body>
 </html>

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -7,7 +7,7 @@
 		<div class="inner__wrap">
 			<div class="row content">
 				<div class="signup-header">
-					{{.Props.TeamName}}
+					{{.Props.TeamDisplayName}}
 				</div>
 				<div class="col-sm-12">
 						<div id="login"></div>
@@ -20,7 +20,7 @@
 		</div>
 	</div>
 	<script>
-		window.setup_login_page();
+window.setup_login_page({{.Props.TeamDisplayName}}, {{.Props.TeamName}});
 	</script>
 </body>
 </html>

--- a/web/templates/password_reset.html
+++ b/web/templates/password_reset.html
@@ -9,7 +9,7 @@
 		</div>
 	</div>
 	<script>
-		window.setup_password_reset_page('{{ .Props.IsReset }}', '{{ .Props.TeamName }}', '{{ .Props.Domain }}', '{{ .Props.Hash }}', '{{ .Props.Data }}');
+		window.setup_password_reset_page('{{ .Props.IsReset }}', '{{ .Props.TeamDisplayName }}', '{{ .Props.TeamName }}', '{{ .Props.Hash }}', '{{ .Props.Data }}');
 	</script>
 </body>
 </html>

--- a/web/templates/signup_team.html
+++ b/web/templates/signup_team.html
@@ -12,7 +12,6 @@
                         <h2>All team communication in one place, searchable and accessible anywhere</h2>
                         <h4 class="text--light">{{ .SiteName }} is free for an unlimited time, for unlimited users </h4 class="text--light">
                         <div id="signup-team"></div>
-                        <a class="signup-team-login" href="/login">or Sign In</a>
                     </div>
                 </div>
                 <div class="footer-push"></div>
@@ -23,7 +22,7 @@
         </div>
     </div>
     <script>
-    window.setup_signup_team_page();
+window.setup_signup_team_page();
     </script>
 </body>
 </html>

--- a/web/templates/signup_team_complete.html
+++ b/web/templates/signup_team_complete.html
@@ -19,7 +19,7 @@
         </div>
     </div>
     <script>
-    window.setup_signup_team_complete_page('{{.Props.Email}}', '{{.Props.Name}}', '{{.Props.Data}}', '{{.Props.Hash}}');
+window.setup_signup_team_complete_page('{{.Props.Email}}', '{{.Props.DisplayName}}', '{{.Props.Data}}', '{{.Props.Hash}}');
     </script>
 </body>
 </html>

--- a/web/templates/signup_team_confirm.html
+++ b/web/templates/signup_team_confirm.html
@@ -8,7 +8,6 @@
             <div class="row content">
                 <div class="col-sm-12">
                     <div class="signup-team__container">
-                        <p>Did you mean to sign-in rather than sign up? Sign in <a href="/login">here</a>. </p>
                         <h3>Sign up Complete</h3>
                         <p>Please check your email: {{ .Props.Email }}<br>
                         You email contains a link to set up your team</p>

--- a/web/templates/signup_user_complete.html
+++ b/web/templates/signup_user_complete.html
@@ -19,7 +19,7 @@
         </div>
     </div>
     <script>
-    window.setup_signup_user_complete_page('{{.Props.Email}}', '{{.Props.TeamDomain}}', '{{.Props.TeamName}}', '{{.Props.TeamId}}', '{{.Props.Data}}', '{{.Props.Hash}}');
+    window.setup_signup_user_complete_page('{{.Props.Email}}', '{{.Props.TeamName}}', '{{.Props.TeamDisplayName}}', '{{.Props.TeamId}}', '{{.Props.Data}}', '{{.Props.Hash}}');
     </script>
 </body>
 </html>

--- a/web/web.go
+++ b/web/web.go
@@ -42,25 +42,28 @@ func (me *HtmlTemplatePage) Render(c *api.Context, w http.ResponseWriter) {
 func InitWeb() {
 	l4g.Debug("Initializing web routes")
 
+	mainrouter := api.Srv.Router
+
 	staticDir := utils.FindDir("web/static")
 	l4g.Debug("Using static directory at %v", staticDir)
-	api.Srv.Router.PathPrefix("/static/").Handler(http.StripPrefix("/static/",
-		http.FileServer(http.Dir(staticDir))))
+	mainrouter.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(staticDir))))
 
-	api.Srv.Router.Handle("/", api.AppHandler(root)).Methods("GET")
-	api.Srv.Router.Handle("/login", api.AppHandler(login)).Methods("GET")
-	api.Srv.Router.Handle("/signup_team_confirm/", api.AppHandler(signupTeamConfirm)).Methods("GET")
-	api.Srv.Router.Handle("/signup_team_complete/", api.AppHandler(signupTeamComplete)).Methods("GET")
-	api.Srv.Router.Handle("/signup_user_complete/", api.AppHandler(signupUserComplete)).Methods("GET")
+	mainrouter.Handle("/", api.AppHandlerIndependent(root)).Methods("GET")
+	mainrouter.Handle("/{team:[A-Za-z0-9-]+(__)?[A-Za-z0-9-]+}", api.AppHandler(login)).Methods("GET")
+	mainrouter.Handle("/{team:[A-Za-z0-9-]+(__)?[A-Za-z0-9-]+}/", api.AppHandler(login)).Methods("GET")
+	mainrouter.Handle("/{team:[A-Za-z0-9-]+(__)?[A-Za-z0-9-]+}/login", api.AppHandler(login)).Methods("GET")
+	mainrouter.Handle("/{team:[A-Za-z0-9-]+(__)?[A-Za-z0-9-]+}/logout", api.AppHandler(logout)).Methods("GET")
+	mainrouter.Handle("/{team:[A-Za-z0-9-]+(__)?[A-Za-z0-9-]+}/reset_password", api.AppHandler(resetPassword)).Methods("GET")
+	// Bug in gorilla.mux pervents us from using regex here.
+	mainrouter.Handle("/{team}/channels/{channelname}", api.UserRequired(getChannel)).Methods("GET")
 
-	api.Srv.Router.Handle("/logout", api.AppHandler(logout)).Methods("GET")
-
-	api.Srv.Router.Handle("/verify", api.AppHandler(verifyEmail)).Methods("GET")
-	api.Srv.Router.Handle("/find_team", api.AppHandler(findTeam)).Methods("GET")
-	api.Srv.Router.Handle("/reset_password", api.AppHandler(resetPassword)).Methods("GET")
-
-	csr := api.Srv.Router.PathPrefix("/channels").Subrouter()
-	csr.Handle("/{name:[A-Za-z0-9-]+(__)?[A-Za-z0-9-]+}", api.UserRequired(getChannel)).Methods("GET")
+	// Anything added here must have an _ in it so it does not conflict with team names
+	mainrouter.Handle("/signup_team_complete/", api.AppHandlerIndependent(signupTeamComplete)).Methods("GET")
+	mainrouter.Handle("/signup_user_complete/", api.AppHandlerIndependent(signupUserComplete)).Methods("GET")
+	mainrouter.Handle("/signup_team_confirm/", api.AppHandlerIndependent(signupTeamConfirm)).Methods("GET")
+	mainrouter.Handle("/verify_email", api.AppHandlerIndependent(verifyEmail)).Methods("GET")
+	mainrouter.Handle("/find_team", api.AppHandlerIndependent(findTeam)).Methods("GET")
+	mainrouter.Handle("/signup_team", api.AppHandlerIndependent(signup)).Methods("GET")
 
 	watchAndParseTemplates()
 }
@@ -128,46 +131,53 @@ func root(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(c.Session.UserId) == 0 {
-		if api.IsTestDomain(r) || strings.Index(r.Host, "www") == 0 || strings.Index(r.Host, "beta") == 0 || strings.Index(r.Host, "ci") == 0 {
-			page := NewHtmlTemplatePage("signup_team", "Signup")
-			page.Render(c, w)
-		} else {
-			login(c, w, r)
-		}
+		page := NewHtmlTemplatePage("signup_team", "Signup")
+		page.Render(c, w)
 	} else {
 		page := NewHtmlTemplatePage("home", "Home")
+		page.Props["TeamURL"] = c.GetTeamURL()
 		page.Render(c, w)
 	}
+}
+
+func signup(c *api.Context, w http.ResponseWriter, r *http.Request) {
+
+	if !CheckBrowserCompatability(c, r) {
+		return
+	}
+
+	page := NewHtmlTemplatePage("signup_team", "Signup")
+	page.Render(c, w)
 }
 
 func login(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	if !CheckBrowserCompatability(c, r) {
 		return
 	}
+	params := mux.Vars(r)
+	teamName := params["team"]
 
-	teamName := "Beta"
-	teamDomain := ""
-	siteDomain := "." + utils.Cfg.ServiceSettings.Domain
-
-	if utils.Cfg.ServiceSettings.Mode == utils.MODE_DEV {
-		teamDomain = "developer"
-	} else if utils.Cfg.ServiceSettings.Mode == utils.MODE_BETA {
-		teamDomain = "beta"
+	var team *model.Team
+	if tResult := <-api.Srv.Store.Team().GetByName(teamName); tResult.Err != nil {
+		l4g.Error("Couldn't find team name=%v, teamURL=%v, err=%v", teamName, c.GetTeamURL(), tResult.Err.Message)
+		// This should probably do somthing nicer
+		http.Redirect(w, r, "http://"+r.Host, http.StatusTemporaryRedirect)
+		return
 	} else {
-		teamDomain, siteDomain = model.GetSubDomain(c.TeamUrl)
-		siteDomain = "." + siteDomain + ".com"
+		team = tResult.Data.(*model.Team)
+	}
 
-		if tResult := <-api.Srv.Store.Team().GetByDomain(teamDomain); tResult.Err != nil {
-			l4g.Error("Couldn't find team teamDomain=%v, siteDomain=%v, teamUrl=%v, err=%v", teamDomain, siteDomain, c.TeamUrl, tResult.Err.Message)
-		} else {
-			teamName = tResult.Data.(*model.Team).Name
-		}
+	// If we are already logged into this team then go to home
+	if len(c.Session.UserId) != 0 && c.Session.TeamId == team.Id {
+		page := NewHtmlTemplatePage("home", "Home")
+		page.Props["TeamURL"] = c.GetTeamURL()
+		page.Render(c, w)
+		return
 	}
 
 	page := NewHtmlTemplatePage("login", "Login")
+	page.Props["TeamDisplayName"] = team.DisplayName
 	page.Props["TeamName"] = teamName
-	page.Props["TeamDomain"] = teamDomain
-	page.Props["SiteDomain"] = siteDomain
 	page.Render(c, w)
 }
 
@@ -198,7 +208,7 @@ func signupTeamComplete(c *api.Context, w http.ResponseWriter, r *http.Request) 
 
 	page := NewHtmlTemplatePage("signup_team_complete", "Complete Team Sign Up")
 	page.Props["Email"] = props["email"]
-	page.Props["Name"] = props["name"]
+	page.Props["DisplayName"] = props["display_name"]
 	page.Props["Data"] = data
 	page.Props["Hash"] = hash
 	page.Render(c, w)
@@ -225,8 +235,8 @@ func signupUserComplete(c *api.Context, w http.ResponseWriter, r *http.Request) 
 			}
 
 			props["email"] = ""
+			props["display_name"] = team.DisplayName
 			props["name"] = team.Name
-			props["domain"] = team.Domain
 			props["id"] = team.Id
 			data = model.MapToJson(props)
 			hash = ""
@@ -249,8 +259,8 @@ func signupUserComplete(c *api.Context, w http.ResponseWriter, r *http.Request) 
 
 	page := NewHtmlTemplatePage("signup_user_complete", "Complete User Sign Up")
 	page.Props["Email"] = props["email"]
+	page.Props["TeamDisplayName"] = props["display_name"]
 	page.Props["TeamName"] = props["name"]
-	page.Props["TeamDomain"] = props["domain"]
 	page.Props["TeamId"] = props["id"]
 	page.Props["Data"] = data
 	page.Props["Hash"] = hash
@@ -259,12 +269,12 @@ func signupUserComplete(c *api.Context, w http.ResponseWriter, r *http.Request) 
 
 func logout(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	api.Logout(c, w, r)
-	http.Redirect(w, r, "/", http.StatusFound)
+	http.Redirect(w, r, c.GetTeamURL(), http.StatusFound)
 }
 
 func getChannel(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	name := params["name"]
+	name := params["channelname"]
 
 	var channelId string
 	if result := <-api.Srv.Store.Channel().CheckPermissionsToByName(c.Session.TeamId, name, c.Session.UserId); result.Err != nil {
@@ -304,7 +314,7 @@ func getChannel(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			//api.Handle404(w, r)
 			//Bad channel urls just redirect to the town-square for now
 
-			http.Redirect(w, r, "/channels/town-square", http.StatusFound)
+			http.Redirect(w, r, c.GetTeamURL()+"/channels/town-square", http.StatusFound)
 			return
 		}
 	}
@@ -319,8 +329,8 @@ func getChannel(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	page := NewHtmlTemplatePage("channel", "")
-	page.Title = name + " - " + team.Name + " " + page.SiteName
-	page.Props["TeamName"] = team.Name
+	page.Title = name + " - " + team.DisplayName + " " + page.SiteName
+	page.Props["TeamDisplayName"] = team.DisplayName
 	page.Props["TeamType"] = team.Type
 	page.Props["TeamId"] = team.Id
 	page.Props["ChannelName"] = name
@@ -331,7 +341,7 @@ func getChannel(c *api.Context, w http.ResponseWriter, r *http.Request) {
 
 func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	resend := r.URL.Query().Get("resend")
-	domain := r.URL.Query().Get("domain")
+	name := r.URL.Query().Get("name")
 	email := r.URL.Query().Get("email")
 	hashedId := r.URL.Query().Get("hid")
 	userId := r.URL.Query().Get("uid")
@@ -339,7 +349,7 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	if resend == "true" {
 
 		teamId := ""
-		if result := <-api.Srv.Store.Team().GetByDomain(domain); result.Err != nil {
+		if result := <-api.Srv.Store.Team().GetByName(name); result.Err != nil {
 			c.Err = result.Err
 			return
 		} else {
@@ -351,7 +361,7 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			user := result.Data.(*model.User)
-			api.FireAndForgetVerifyEmail(user.Id, user.FirstName, user.Email, domain, c.TeamUrl)
+			api.FireAndForgetVerifyEmail(user.Id, strings.Split(user.Nickname, " ")[0], user.Email, name, c.GetTeamURL())
 			http.Redirect(w, r, "/", http.StatusFound)
 			return
 		}
@@ -387,6 +397,8 @@ func resetPassword(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	isResetLink := true
 	hash := r.URL.Query().Get("h")
 	data := r.URL.Query().Get("d")
+	params := mux.Vars(r)
+	teamName := params["team"]
 
 	if len(hash) == 0 || len(data) == 0 {
 		isResetLink = false
@@ -405,30 +417,25 @@ func resetPassword(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	teamName := "Developer/Beta"
-	domain := ""
-	if utils.Cfg.ServiceSettings.Mode != utils.MODE_DEV {
-		domain, _ = model.GetSubDomain(c.TeamUrl)
+	teamDisplayName := "Developer/Beta"
+	var team *model.Team
+	if tResult := <-api.Srv.Store.Team().GetByName(teamName); tResult.Err != nil {
+		c.Err = tResult.Err
+		return
+	} else {
+		team = tResult.Data.(*model.Team)
+	}
 
-		var team *model.Team
-		if tResult := <-api.Srv.Store.Team().GetByDomain(domain); tResult.Err != nil {
-			c.Err = tResult.Err
-			return
-		} else {
-			team = tResult.Data.(*model.Team)
-		}
-
-		if team != nil {
-			teamName = team.Name
-		}
+	if team != nil {
+		teamDisplayName = team.DisplayName
 	}
 
 	page := NewHtmlTemplatePage("password_reset", "")
 	page.Title = "Reset Password - " + page.SiteName
-	page.Props["TeamName"] = teamName
+	page.Props["TeamDisplayName"] = teamDisplayName
 	page.Props["Hash"] = hash
 	page.Props["Data"] = data
-	page.Props["Domain"] = domain
+	page.Props["TeamName"] = teamName
 	page.Props["IsReset"] = strconv.FormatBool(isResetLink)
 	page.Render(c, w)
 }


### PR DESCRIPTION
### Main Changes
This pull request changes how URLs in Mattermost operate. 

Team URLs are now of the form domain.com/team/*

The Domain column in the Team table has been renamed to URLId to better reflect its purpose. A column has also been added to the sessions table. Therefore when transitioning *all sessions should be expired*. (or else you will be redirected incorrectly) The transition has been tested, but backups are suggested. 

A response header of X-Team-URL has been added to make it easier and more consistent for the client to get the url in some instances. Not all instances use this new method. This could be a future improvement. 

The signup flow has also been modified:
- When accessing domain.com for the first time, your will be presented with a signup a team page. Future visits with a valid session with automatically redirect you to your team. 
- To sign up additional teams an option has been added to the settings menu where additional teams eventually show up. 
- @asaadmahmoodspin I had to change the width of the signup flow pages because there was not enough horizontal room on the TeamURL page. You might want to take a look at that. 

Code relating to sharding and the subdomain way of organizing teams has mostly been removed. I moved that code to sharding.go, but we can remove it if we don't want it. (it would still be in the git history)

### Additional Changes
- This also fixes MM-1576, clicking on the profile picture now opens the settings menu. 
- Signup flow items now autofocus.
- Signup flow now accepts enter to move to next screen. :tada: 

### Testing
There will be bugs. I would be especially careful of the signup flow. Check for any buttons that redirect improperly. If there is anywhere you click and don't end up where you expected (or end up in town square) report a bug. 