### PR TITLE
MM-1582 Allow all channel members to perform channel administrator actions

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -182,14 +182,7 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		oldChannel := cresult.Data.(*model.Channel)
-		channelMember := cmcresult.Data.(model.ChannelMember)
 		if !c.HasPermissionsToTeam(oldChannel.TeamId, "updateChannel") {
-			return
-		}
-
-		if !strings.Contains(channelMember.Roles, model.CHANNEL_ROLE_ADMIN) && !strings.Contains(c.Session.Roles, model.ROLE_ADMIN) {
-			c.Err = model.NewAppError("updateChannel", "You do not have the appropriate permissions", "")
-			c.Err.StatusCode = http.StatusForbidden
 			return
 		}
 
@@ -486,15 +479,8 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		channel := cresult.Data.(*model.Channel)
 		user := uresult.Data.(*model.User)
-		channelMember := scmresult.Data.(model.ChannelMember)
 
 		if !c.HasPermissionsToTeam(channel.TeamId, "deleteChannel") {
-			return
-		}
-
-		if !strings.Contains(channelMember.Roles, model.CHANNEL_ROLE_ADMIN) && !strings.Contains(c.Session.Roles, model.ROLE_ADMIN) {
-			c.Err = model.NewAppError("deleteChannel", "You do not have the appropriate permissions", "")
-			c.Err.StatusCode = http.StatusForbidden
 			return
 		}
 
@@ -687,15 +673,8 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		channel := cresult.Data.(*model.Channel)
-		channelMember := cmcresult.Data.(model.ChannelMember)
 
 		if !c.HasPermissionsToTeam(channel.TeamId, "removeChannelMember") {
-			return
-		}
-
-		if !strings.Contains(channelMember.Roles, model.CHANNEL_ROLE_ADMIN) && !strings.Contains(c.Session.Roles, model.ROLE_ADMIN) {
-			c.Err = model.NewAppError("updateChannel", "You do not have the appropriate permissions ", "")
-			c.Err.StatusCode = http.StatusForbidden
 			return
 		}
 

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -512,8 +512,8 @@ func TestDeleteChannel(t *testing.T) {
 
 	Client.Must(Client.JoinChannel(channel2.Id))
 
-	if _, err := Client.DeleteChannel(channel2.Id); err == nil {
-		t.Fatal("should have failed to delete channel you're not an admin of")
+	if _, err := Client.DeleteChannel(channel2.Id); err != nil {
+		t.Fatal("should have been able to delete channel you're not an admin of")
 	}
 
 	rget := Client.Must(Client.GetChannels(""))

--- a/web/react/components/channel_header.jsx
+++ b/web/react/components/channel_header.jsx
@@ -174,17 +174,17 @@ module.exports = React.createClass({
                                         <li role="presentation"><a role="menuitem" data-toggle="modal" data-target="#channel_invite" href="#">Add Members</a></li>
                                         : null
                                     }
-                                    { isAdmin && !ChannelStore.isDefault(channel) ?
+                                    { !ChannelStore.isDefault(channel) ?
                                         <li role="presentation"><a role="menuitem" data-toggle="modal" data-target="#channel_members" href="#">Manage Members</a></li>
                                         : null
                                     }
                                     <li role="presentation"><a role="menuitem" href="#" data-toggle="modal" data-target="#edit_channel" data-desc={channel.description} data-title={channel.display_name} data-channelid={channel.id}>Set Channel Description...</a></li>
                                     <li role="presentation"><a role="menuitem" href="#" data-toggle="modal" data-target="#channel_notifications" data-title={channel.display_name} data-channelid={channel.id}>Notification Preferences</a></li>
-                                    { isAdmin && !ChannelStore.isDefault(channel) ?
+                                    { !ChannelStore.isDefault(channel) ?
                                         <li role="presentation"><a role="menuitem" href="#" data-toggle="modal" data-target="#rename_channel" data-display={channel.display_name} data-name={channel.name} data-channelid={channel.id}>Rename Channel...</a></li>
                                         : null
                                     }
-                                    { isAdmin && !ChannelStore.isDefault(channel) ?
+                                    { !ChannelStore.isDefault(channel) ?
                                         <li role="presentation"><a role="menuitem" href="#" data-toggle="modal" data-target="#delete_channel" data-title={channel.display_name} data-channelid={channel.id}>Delete Channel...</a></li>
                                         : null
                                     }

--- a/web/react/components/channel_members.jsx
+++ b/web/react/components/channel_members.jsx
@@ -137,6 +137,7 @@ module.exports = React.createClass({
                                     memberList={this.state.member_list}
                                     isAdmin={isAdmin}
                                     handleRemove={this.handleRemove}
+                                    allAdminAccess={true}
                                 />
                                 : "" }
                             </div>

--- a/web/react/components/member_list.jsx
+++ b/web/react/components/member_list.jsx
@@ -25,6 +25,7 @@ module.exports = React.createClass({
                                 handleInvite={this.props.handleInvite}
                                 handleRemove={this.props.handleRemove}
                                 handleMakeAdmin={this.props.handleMakeAdmin}
+                                allAdminAccess={this.props.allAdminAccess}
                             />;
                 }, this)}
                 {message}

--- a/web/react/components/member_list_item.jsx
+++ b/web/react/components/member_list_item.jsx
@@ -30,7 +30,7 @@ module.exports = React.createClass({
             invite = <span className="member-role">Added</span>;
         } else if (this.props.handleInvite) {
             invite = <a onClick={this.handleInvite} className="btn btn-sm btn-primary member-invite"><i className="glyphicon glyphicon-envelope"/>  Add</a>;
-        } else if (isAdmin && !isMemberAdmin && (member.id != UserStore.getCurrentId())) {
+        } else if ((isAdmin || this.props.allAdminAccess) && !isMemberAdmin && (member.id != UserStore.getCurrentId())) {
             var self = this;
             invite = (
                         <div className="dropdown member-drop">

--- a/web/react/components/navbar.jsx
+++ b/web/react/components/navbar.jsx
@@ -301,17 +301,17 @@ module.exports = React.createClass({
                                             <li role="presentation"><a role="menuitem" data-toggle="modal" data-target="#channel_invite" href="#">Add Members</a></li>
                                             : null
                                         }
-                                        { isAdmin && !ChannelStore.isDefault(channel) ?
+                                        { !ChannelStore.isDefault(channel) ?
                                             <li role="presentation"><a role="menuitem" data-toggle="modal" data-target="#channel_members" href="#">Manage Members</a></li>
                                             : null
                                         }
                                         <li role="presentation"><a role="menuitem" href="#" data-toggle="modal" data-target="#edit_channel" data-desc={channel.description} data-title={channel.display_name} data-channelid={channel.id}>Set Channel Description...</a></li>
                                         <li role="presentation"><a role="menuitem" href="#" data-toggle="modal" data-target="#channel_notifications" data-title={channel.display_name} data-channelid={channel.id}>Notification Preferences</a></li>
-                                        { isAdmin && !ChannelStore.isDefault(channel) ?
+                                        { !ChannelStore.isDefault(channel) ?
                                             <li role="presentation"><a role="menuitem" href="#" data-toggle="modal" data-target="#rename_channel" data-display={channel.display_name} data-name={channel.name} data-channelid={channel.id}>Rename Channel...</a></li>
                                             : null
                                         }
-                                        { isAdmin && !ChannelStore.isDefault(channel) ?
+                                        { !ChannelStore.isDefault(channel) ?
                                             <li role="presentation"><a role="menuitem" href="#" data-toggle="modal" data-target="#delete_channel" data-title={channel.display_name} data-channelid={channel.id}>Delete Channel...</a></li>
                                             : null
                                         }


### PR DESCRIPTION
Removes checks against non-channel admins not being unable to manage members, rename the channel, and delete the channel.  Now the only restriction is that normal members cannot remove the channel admin from the channel.