### PR TITLE
MM-1494 Change image resizing for preview and thumbnail to use Lanczos interpolation and update nfnt/resize so that it works correctly

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -95,7 +95,7 @@
 		},
 		{
 			"ImportPath": "github.com/nfnt/resize",
-			"Rev": "f2d1b73023c55bdfb4fa2ed385d2bec95bce3692"
+			"Rev": "dc93e1b98c579d90ee2fa15c1fd6dac34f6e7899"
 		},
 		{
 			"ImportPath": "github.com/stretchr/objx",

--- a/Godeps/_workspace/src/github.com/nfnt/resize/converter.go
+++ b/Godeps/_workspace/src/github.com/nfnt/resize/converter.go
@@ -131,11 +131,11 @@ func resizeRGBA(in *image.RGBA, out *image.NRGBA, scale float64, coeffs []int16,
 
 					// reverse alpha-premultiplication.
 					if a != 0 {
-						r *= 0xffff
+						r *= 0xff
 						r /= a
-						g *= 0xffff
+						g *= 0xff
 						g /= a
-						b *= 0xffff
+						b *= 0xff
 						b /= a
 					}
 

--- a/Godeps/_workspace/src/github.com/nfnt/resize/resize.go
+++ b/Godeps/_workspace/src/github.com/nfnt/resize/resize.go
@@ -167,7 +167,7 @@ func Resize(width, height uint, img image.Image, interp InterpolationFunction) i
 		// accessing the YCbCr arrays in a tight loop is slow.
 		// converting the image to ycc increases performance by 2x.
 		temp := newYCC(image.Rect(0, 0, input.Bounds().Dy(), int(width)), input.SubsampleRatio)
-		result := newYCC(image.Rect(0, 0, int(width), int(height)), input.SubsampleRatio)
+		result := newYCC(image.Rect(0, 0, int(width), int(height)), image.YCbCrSubsampleRatio444)
 
 		coeffs, offset, filterLength := createWeights8(temp.Bounds().Dy(), taps, blur, scaleX, kernel)
 		in := imageYCbCrToYCC(input)
@@ -409,7 +409,7 @@ func resizeNearest(width, height uint, scaleX, scaleY float64, img image.Image, 
 		// accessing the YCbCr arrays in a tight loop is slow.
 		// converting the image to ycc increases performance by 2x.
 		temp := newYCC(image.Rect(0, 0, input.Bounds().Dy(), int(width)), input.SubsampleRatio)
-		result := newYCC(image.Rect(0, 0, int(width), int(height)), input.SubsampleRatio)
+		result := newYCC(image.Rect(0, 0, int(width), int(height)), image.YCbCrSubsampleRatio444)
 
 		coeffs, offset, filterLength := createWeightsNearest(temp.Bounds().Dy(), taps, blur, scaleX)
 		in := imageYCbCrToYCC(input)

--- a/Godeps/_workspace/src/github.com/nfnt/resize/resize_test.go
+++ b/Godeps/_workspace/src/github.com/nfnt/resize/resize_test.go
@@ -46,7 +46,7 @@ func Test_CorrectResize(t *testing.T) {
 	}
 }
 
-func Test_SameColor(t *testing.T) {
+func Test_SameColorWithRGBA(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 20, 20))
 	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
 		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
@@ -56,9 +56,99 @@ func Test_SameColor(t *testing.T) {
 	out := Resize(10, 10, img, Lanczos3)
 	for y := out.Bounds().Min.Y; y < out.Bounds().Max.Y; y++ {
 		for x := out.Bounds().Min.X; x < out.Bounds().Max.X; x++ {
-			color := img.At(x, y).(color.RGBA)
+			color := out.At(x, y).(color.NRGBA)
 			if color.R != 0x80 || color.G != 0x80 || color.B != 0x80 || color.A != 0xFF {
-				t.Fail()
+				t.Errorf("%+v", color)
+			}
+		}
+	}
+}
+
+func Test_SameColorWithNRGBA(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 20, 20))
+	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
+		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
+			img.SetNRGBA(x, y, color.NRGBA{0x80, 0x80, 0x80, 0xFF})
+		}
+	}
+	out := Resize(10, 10, img, Lanczos3)
+	for y := out.Bounds().Min.Y; y < out.Bounds().Max.Y; y++ {
+		for x := out.Bounds().Min.X; x < out.Bounds().Max.X; x++ {
+			color := out.At(x, y).(color.NRGBA)
+			if color.R != 0x80 || color.G != 0x80 || color.B != 0x80 || color.A != 0xFF {
+				t.Errorf("%+v", color)
+			}
+		}
+	}
+}
+
+func Test_SameColorWithRGBA64(t *testing.T) {
+	img := image.NewRGBA64(image.Rect(0, 0, 20, 20))
+	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
+		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
+			img.SetRGBA64(x, y, color.RGBA64{0x8000, 0x8000, 0x8000, 0xFFFF})
+		}
+	}
+	out := Resize(10, 10, img, Lanczos3)
+	for y := out.Bounds().Min.Y; y < out.Bounds().Max.Y; y++ {
+		for x := out.Bounds().Min.X; x < out.Bounds().Max.X; x++ {
+			color := out.At(x, y).(color.NRGBA64)
+			if color.R != 0x8000 || color.G != 0x8000 || color.B != 0x8000 || color.A != 0xFFFF {
+				t.Errorf("%+v", color)
+			}
+		}
+	}
+}
+
+func Test_SameColorWithNRGBA64(t *testing.T) {
+	img := image.NewNRGBA64(image.Rect(0, 0, 20, 20))
+	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
+		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
+			img.SetNRGBA64(x, y, color.NRGBA64{0x8000, 0x8000, 0x8000, 0xFFFF})
+		}
+	}
+	out := Resize(10, 10, img, Lanczos3)
+	for y := out.Bounds().Min.Y; y < out.Bounds().Max.Y; y++ {
+		for x := out.Bounds().Min.X; x < out.Bounds().Max.X; x++ {
+			color := out.At(x, y).(color.NRGBA64)
+			if color.R != 0x8000 || color.G != 0x8000 || color.B != 0x8000 || color.A != 0xFFFF {
+				t.Errorf("%+v", color)
+			}
+		}
+	}
+}
+
+func Test_SameColorWithGray(t *testing.T) {
+	img := image.NewGray(image.Rect(0, 0, 20, 20))
+	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
+		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
+			img.SetGray(x, y, color.Gray{0x80})
+		}
+	}
+	out := Resize(10, 10, img, Lanczos3)
+	for y := out.Bounds().Min.Y; y < out.Bounds().Max.Y; y++ {
+		for x := out.Bounds().Min.X; x < out.Bounds().Max.X; x++ {
+			color := out.At(x, y).(color.Gray)
+			if color.Y != 0x80 {
+				t.Errorf("%+v", color)
+			}
+		}
+	}
+}
+
+func Test_SameColorWithGray16(t *testing.T) {
+	img := image.NewGray16(image.Rect(0, 0, 20, 20))
+	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
+		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
+			img.SetGray16(x, y, color.Gray16{0x8000})
+		}
+	}
+	out := Resize(10, 10, img, Lanczos3)
+	for y := out.Bounds().Min.Y; y < out.Bounds().Max.Y; y++ {
+		for x := out.Bounds().Min.X; x < out.Bounds().Max.X; x++ {
+			color := out.At(x, y).(color.Gray16)
+			if color.Y != 0x8000 {
+				t.Errorf("%+v", color)
 			}
 		}
 	}

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOPATH ?= $(GOPATH:)
 GOFLAGS ?= $(GOFLAGS:)
 BUILD_NUMBER ?= $(BUILD_NUMBER:)
 
-ifeq ($(shell which godep), "")
+ifeq ($(shell which godep),)
 	GODEP=$(GOPATH)/bin/godep
 else
 	GODEP=godep

--- a/api/file.go
+++ b/api/file.go
@@ -13,9 +13,9 @@ import (
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 	"github.com/nfnt/resize"
+	_ "golang.org/x/image/bmp"
 	"image"
 	_ "image/gif"
-	_ "golang.org/x/image/bmp"
 	"image/jpeg"
 	"io"
 	"net/http"
@@ -157,7 +157,7 @@ func fireAndForgetHandleImages(filenames []string, fileData [][]byte, teamId, ch
 				go func() {
 					var thumbnail image.Image
 					if imgConfig.Width > int(utils.Cfg.ImageSettings.ThumbnailWidth) {
-						thumbnail = resize.Resize(utils.Cfg.ImageSettings.ThumbnailWidth, utils.Cfg.ImageSettings.ThumbnailHeight, img, resize.NearestNeighbor)
+						thumbnail = resize.Resize(utils.Cfg.ImageSettings.ThumbnailWidth, utils.Cfg.ImageSettings.ThumbnailHeight, img, resize.Lanczos3)
 					} else {
 						thumbnail = img
 					}
@@ -182,7 +182,7 @@ func fireAndForgetHandleImages(filenames []string, fileData [][]byte, teamId, ch
 				go func() {
 					var preview image.Image
 					if imgConfig.Width > int(utils.Cfg.ImageSettings.PreviewWidth) {
-						preview = resize.Resize(utils.Cfg.ImageSettings.PreviewWidth, utils.Cfg.ImageSettings.PreviewHeight, img, resize.NearestNeighbor)
+						preview = resize.Resize(utils.Cfg.ImageSettings.PreviewWidth, utils.Cfg.ImageSettings.PreviewHeight, img, resize.Lanczos3)
 					} else {
 						preview = img
 					}


### PR DESCRIPTION
Updates nfnt/resize to fix incorrect behaviour when rescaling images using anything other than nearest neighbour interpolation and then changes the file api to use Lanczos interpolation for rescaling. Also changes the Makefile to run go using godep so that it uses local versions of dependencies (in Godeps/_Workspace) instead of the ones stored in $(GOPATH)/src so that we can more easily update them.