### PR TITLE
MM-1498 Provide a replacement message for email notifications for posts only containing files

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/platform/store"
 	"github.com/mattermost/platform/utils"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -411,7 +412,12 @@ func fireAndForgetNotifications(post *model.Post, teamId, teamUrl string) {
 						filenames := make([]string, len(post.Filenames))
 						onlyImages := true
 						for i, filename := range post.Filenames {
-							filenames[i] = strings.Replace(filepath.Base(filename), "+", " ", -1)
+							var err error
+							if filenames[i], err = url.QueryUnescape(filepath.Base(filename)); err != nil {
+								// this should never error since filepath was escaped using url.QueryEscape
+								filenames[i] = filepath.Base(filename)
+							}
+
 							ext := filepath.Ext(filename)
 							onlyImages = onlyImages && model.IsFileExtImage(ext)
 						}

--- a/api/post.go
+++ b/api/post.go
@@ -405,8 +405,8 @@ func fireAndForgetNotifications(post *model.Post, teamId, teamUrl string) {
 					bodyPage.Props["PostMessage"] = model.ClearMentionTags(post.Message)
 					bodyPage.Props["TeamLink"] = teamUrl + "/channels/" + channel.Name
 
-					// attempt to fill in a message body based if the message has none
-					if len(strings.TrimSpace(bodyPage.Props["PostMessage"])) == 0 {
+					// attempt to fill in a message body if the post doesn't have any text
+					if len(strings.TrimSpace(bodyPage.Props["PostMessage"])) == 0 && len(post.Filenames) > 0 {
 						// extract the filenames from their paths and determine what type of files are attached
 						filenames := make([]string, len(post.Filenames))
 						onlyImages := true


### PR DESCRIPTION
As per spec, adds text to email notifications for posts which only contain file attachments and no text. These are of one of the following forms:
1) "Image: FILENAME sent" for a single image
2) "Images: FILENAME, FILENAME, etc sent" for multiple images
3) "File: FILENAME sent" for a single non-image file
4) "Files: FILENAME, FILENAME, etc sent" for multiple non-image or mixed files

Note for testing: Notifications for posts with no text are currently only sent for private messages.