### PR TITLE
Upon viewing a new comment, the RHS scrolls to the bottom of the comment thread

### DIFF
--- a/web/react/components/post_right.jsx
+++ b/web/react/components/post_right.jsx
@@ -294,6 +294,8 @@ module.exports = React.createClass({
         });
     },
     componentDidUpdate: function() {
+        $(".post-right__scroll").scrollTop($(".post-right__scroll")[0].scrollHeight);
+        $(".post-right__scroll").perfectScrollbar('update');
         this.resize();
     },
     componentWillUnmount: function() {


### PR DESCRIPTION
Fixes the bug where switching from a comment thread with more comments to one with less in the RHS makes it scroll below the bottom of the pane.