### PR TITLE
MM-1625 Correct the appearance of the post menu on both desktop and mobile

### DIFF
--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -215,9 +215,6 @@ body.ios {
 				@include opacity(1);
 			}
 			.dropdown-toggle:after {
-				content: '...';
-			}
-			.dropdown-toggle:hover:after {
 				content: '[...]';
 			}
 		}

--- a/web/sass-files/sass/partials/_responsive.scss
+++ b/web/sass-files/sass/partials/_responsive.scss
@@ -239,6 +239,11 @@
         }
         &:hover {
             background: none;
+            .post-header .post-header-col.post-header__reply {
+                .dropdown-toggle:after {
+                    content: '...';
+                }
+            }
         }
         &.post--comment {
             &.other--root {
@@ -247,6 +252,11 @@
                 }
             }
         }
+		.post-header .post-header-col.post-header__reply {
+			.dropdown-toggle:after {
+				content: '...';
+			}
+		}
     }
     .signup-team__container {
         padding: 30px 0;


### PR DESCRIPTION
As per the ticket, this changes it so that:
On desktop:
1) The post menu is just labelled [...] regardless of whether or not the user is hovering over the actual link
On mobile/small screens:
1) The post menu is visible at all times since users can't hover on mobile devices
2) The post menu is labelled ... to make it less distracting

This has been tested to work on both desktop and mobile (via user agent/screen size spoofing on Chrome) in both the main post window and the sidebar.