### PR TITLE
MM-1626 Changes the subject line for emails sent regarding notifications

### DIFF
--- a/api/templates/post_subject.html
+++ b/api/templates/post_subject.html
@@ -1,1 +1,1 @@
-{{define "post_subject"}}[{{.Props.TeamDisplayName}} {{.SiteName}}] {{.Props.SubjectText}} for {{.Props.Month}} {{.Props.Day}}, {{.Props.Year}}{{end}}
+{{define "post_subject"}}[{{.SiteName}}] {{.Props.TeamDisplayName}} Team Notifications for {{.Props.Month}} {{.Props.Day}}, {{.Props.Year}}{{end}}


### PR DESCRIPTION
Changes the subject line for emails sent regarding mentions and other team notifications. This is meant to prevent notification emails from different teams from combining into a single email thread.