### PR TITLE
MM-1596 While in mobile mode notifications are no longer counted for channels set to 'quiet mode' that are not direct mentions

### DIFF
--- a/web/react/components/navbar.jsx
+++ b/web/react/components/navbar.jsx
@@ -28,7 +28,7 @@ function getCountsStateFromStores() {
         } else {
             if (channelMember.mention_count > 0) {
                 count += channelMember.mention_count;
-            } else if (channel.total_msg_count - channelMember.msg_count > 0) {
+            } else if (channelMember.notify_level !== "quiet" && channel.total_msg_count - channelMember.msg_count > 0) {
                 count += 1;
             }
         }


### PR DESCRIPTION
Removes the bug that was causing erroneous notifications to be counted in mobile mode in the navbar.