### PR TITLE
Update to latest community URLs

### DIFF
--- a/web/static/help/configure_links.html
+++ b/web/static/help/configure_links.html
@@ -15,9 +15,14 @@ Learn more, or download the source code from <a href=http://mattermost.com>http:
 <p>To take part in the community building Mattermost, please consider sharing comments, feature requests, votes, and contributions. If you like the project, please Tweet about us at <a href=https://twitter.com/mattermosthq>@mattermosthq</a>.</p>
 
 <p>Here's some links to get started:<br>
-<li><a href=http://bit.ly/1dHmQqX>Mattermost source code and install instructions</a></li>
-<li><a href=http://bit.ly/1JUDoZ3>Mattermost Feature Request and Voting Site</a> </li>
-<li><a href=http://bit.ly/1MH9HKa>Mattermost Issue Tracker for reporting bugs</a></li>
+<ul>
+	<li><a href="https://github.com/mattermost/platform">Follow Mattermost on Github</a></li>
+	<li><a href="http://forum.mattermost.org/">Ask us anything at http://forum.mattermost.org/</a></li>
+	<li><a href="http://www.mattermost.org/feature-requests/">Review the Mattermost feature list </a></li>
+	<li><a href="http://www.mattermost.org/download/">Download our source code and install instructions</a></li>
+	<li><a href="http://www.mattermost.org/feature-requests/">Share feature requests and upvotes</a></li>
+	<li><a href="http://www.mattermost.org/filing-issues/">File any bugs you find with our Issue tracking system</a></li>
+</ul>
 </p>
 </body>
 </html>


### PR DESCRIPTION
URLs in configure_links.html were out-of-date, this patch points people to the correct pages. 