### PR TITLE
MM-1610 Fixed issue with error message for uploading more than 5 files not appearing on OSX

### DIFF
--- a/web/react/components/create_comment.jsx
+++ b/web/react/components/create_comment.jsx
@@ -40,7 +40,7 @@ module.exports = React.createClass({
         post.parent_id = this.props.parentId;
         post.filenames = this.state.previews;
 
-        this.setState({ submitting: true });
+        this.setState({ submitting: true, limit_error: null });
 
         client.createPost(post, ChannelStore.getCurrent(),
             function(data) {

--- a/web/react/components/create_post.jsx
+++ b/web/react/components/create_post.jsx
@@ -45,7 +45,7 @@ module.exports = React.createClass({
             return;
         }
 
-        this.setState({ submitting: true });
+        this.setState({ submitting: true, limit_error: null });
 
         var user_id = UserStore.getCurrentId();
 

--- a/web/react/components/file_upload.jsx
+++ b/web/react/components/file_upload.jsx
@@ -15,7 +15,7 @@ module.exports = React.createClass({
         // This looks redundant, but must be done this way due to
         // setState being an asynchronous call
         var numFiles = 0;
-        for(var i = 0; i < files.length && i < Constants.MAX_UPLOAD_FILES; i++) {
+        for(var i = 0; i < files.length; i++) {
             if (files[i].size <= Constants.MAX_FILE_SIZE) {
                 numFiles++;
             }


### PR DESCRIPTION
The fact that the user was trying to upload more then five files was never reaching where the error checks occur unless the user "pastes" in the files (due to following a separate path in the code).  Since the number of files is checked within the "setUploads" function of create_post/create_comment anyway, the additional check before in file_upload is unnecessary.