### PR TITLE
Mm 552 Enables email from a name instead of just an address

### DIFF
--- a/utils/mail.go
+++ b/utils/mail.go
@@ -83,7 +83,7 @@ func SendMail(to, subject, body string) *model.AppError {
 		return nil
 	}
 
-	fromMail := mail.Address{"", Cfg.EmailSettings.FeedbackEmail}
+	fromMail := mail.Address{Cfg.EmailSettings.FeedbackName, Cfg.EmailSettings.FeedbackEmail}
 	toMail := mail.Address{"", to}
 
 	headers := make(map[string]string)


### PR DESCRIPTION
When Mattermost dispatches an email, the receiver will see it as coming from whatever name is in the "FeedbackName" category on the config file.