### PR TITLE
MM-1654 Anti-clickjacking measures

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -100,8 +100,12 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.RequestId)
 	w.Header().Set(model.HEADER_VERSION_ID, utils.Cfg.ServiceSettings.Version)
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
+
+	// Instruct the browser not to display us in an iframe for anti-clickjacking
+	if !h.isApi {
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Content-Security-Policy", "frame-ancestors none")
+	}
 
 	sessionId := ""
 

--- a/api/context.go
+++ b/api/context.go
@@ -100,6 +100,8 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.RequestId)
 	w.Header().Set(model.HEADER_VERSION_ID, utils.Cfg.ServiceSettings.Version)
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	sessionId := ""
 

--- a/web/templates/head.html
+++ b/web/templates/head.html
@@ -36,6 +36,13 @@
 
     <script type="text/javascript" src="https://cloudfront.loggly.com/js/loggly.tracker.js" async></script>
     <script id="config" type="text/javascript" src="/static/config/config.js"></script>
+    <style id="antiClickjack">body{display:none !important;}</style>
+    <script type="text/javascript">
+        if (self === top) {
+            var blocker = document.getElementById("antiClickjack");
+            blocker.parentNode.removeChild(blocker);
+        }
+    </script>
     <script>
         if (config == null) {
             config = {};

--- a/web/web.go
+++ b/web/web.go
@@ -140,9 +140,6 @@ func root(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
-
 	if len(c.Session.UserId) == 0 {
 		page := NewHtmlTemplatePage("signup_team", "Signup")
 		page.Render(c, w)
@@ -158,9 +155,6 @@ func signup(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	if !CheckBrowserCompatability(c, r) {
 		return
 	}
-
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("signup_team", "Signup")
 	page.Render(c, w)
@@ -183,9 +177,6 @@ func login(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		team = tResult.Data.(*model.Team)
 	}
 
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
-
 	// If we are already logged into this team then go to home
 	if len(c.Session.UserId) != 0 && c.Session.TeamId == team.Id {
 		page := NewHtmlTemplatePage("home", "Home")
@@ -203,9 +194,6 @@ func login(c *api.Context, w http.ResponseWriter, r *http.Request) {
 
 func signupTeamConfirm(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	email := r.FormValue("email")
-
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("signup_team_confirm", "Signup Email Sent")
 	page.Props["Email"] = email
@@ -228,9 +216,6 @@ func signupTeamComplete(c *api.Context, w http.ResponseWriter, r *http.Request) 
 		c.Err = model.NewAppError("signupTeamComplete", "The signup link has expired", "")
 		return
 	}
-
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("signup_team_complete", "Complete Team Sign Up")
 	page.Props["Email"] = props["email"]
@@ -282,9 +267,6 @@ func signupUserComplete(c *api.Context, w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	}
-
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("signup_user_complete", "Complete User Sign Up")
 	page.Props["Email"] = props["email"]
@@ -358,9 +340,6 @@ func getChannel(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		team = tResult.Data.(*model.Team)
 	}
 
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
-
 	page := NewHtmlTemplatePage("channel", "")
 	page.Title = name + " - " + team.DisplayName + " " + page.SiteName
 	page.Props["TeamDisplayName"] = team.DisplayName
@@ -416,17 +395,12 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		isVerified = "false"
 	}
 
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
-
 	page := NewHtmlTemplatePage("verify", "Email Verified")
 	page.Props["IsVerified"] = isVerified
 	page.Render(c, w)
 }
 
 func findTeam(c *api.Context, w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 	page := NewHtmlTemplatePage("find_team", "Find Team")
 	page.Render(c, w)
 }
@@ -467,9 +441,6 @@ func resetPassword(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	if team != nil {
 		teamDisplayName = team.DisplayName
 	}
-
-	w.Header().Set("X-FRAME-OPTIONS", "DENY")
-	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("password_reset", "")
 	page.Title = "Reset Password - " + page.SiteName
@@ -579,9 +550,6 @@ func signupCompleteOAuth(c *api.Context, w http.ResponseWriter, r *http.Request)
 		}
 
 		user.TeamId = team.Id
-
-		w.Header().Set("X-FRAME-OPTIONS", "DENY")
-		w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 		page := NewHtmlTemplatePage("signup_user_oauth", "Complete User Sign Up")
 		page.Props["User"] = user.ToJson()

--- a/web/web.go
+++ b/web/web.go
@@ -140,6 +140,9 @@ func root(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
+
 	if len(c.Session.UserId) == 0 {
 		page := NewHtmlTemplatePage("signup_team", "Signup")
 		page.Render(c, w)
@@ -155,6 +158,9 @@ func signup(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	if !CheckBrowserCompatability(c, r) {
 		return
 	}
+
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("signup_team", "Signup")
 	page.Render(c, w)
@@ -177,6 +183,9 @@ func login(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		team = tResult.Data.(*model.Team)
 	}
 
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
+
 	// If we are already logged into this team then go to home
 	if len(c.Session.UserId) != 0 && c.Session.TeamId == team.Id {
 		page := NewHtmlTemplatePage("home", "Home")
@@ -194,6 +203,9 @@ func login(c *api.Context, w http.ResponseWriter, r *http.Request) {
 
 func signupTeamConfirm(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	email := r.FormValue("email")
+
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("signup_team_confirm", "Signup Email Sent")
 	page.Props["Email"] = email
@@ -216,6 +228,9 @@ func signupTeamComplete(c *api.Context, w http.ResponseWriter, r *http.Request) 
 		c.Err = model.NewAppError("signupTeamComplete", "The signup link has expired", "")
 		return
 	}
+
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("signup_team_complete", "Complete Team Sign Up")
 	page.Props["Email"] = props["email"]
@@ -267,6 +282,9 @@ func signupUserComplete(c *api.Context, w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	}
+
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("signup_user_complete", "Complete User Sign Up")
 	page.Props["Email"] = props["email"]
@@ -340,6 +358,9 @@ func getChannel(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		team = tResult.Data.(*model.Team)
 	}
 
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
+
 	page := NewHtmlTemplatePage("channel", "")
 	page.Title = name + " - " + team.DisplayName + " " + page.SiteName
 	page.Props["TeamDisplayName"] = team.DisplayName
@@ -395,12 +416,17 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		isVerified = "false"
 	}
 
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
+
 	page := NewHtmlTemplatePage("verify", "Email Verified")
 	page.Props["IsVerified"] = isVerified
 	page.Render(c, w)
 }
 
 func findTeam(c *api.Context, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 	page := NewHtmlTemplatePage("find_team", "Find Team")
 	page.Render(c, w)
 }
@@ -441,6 +467,9 @@ func resetPassword(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	if team != nil {
 		teamDisplayName = team.DisplayName
 	}
+
+	w.Header().Set("X-FRAME-OPTIONS", "DENY")
+	w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 	page := NewHtmlTemplatePage("password_reset", "")
 	page.Title = "Reset Password - " + page.SiteName
@@ -550,6 +579,9 @@ func signupCompleteOAuth(c *api.Context, w http.ResponseWriter, r *http.Request)
 		}
 
 		user.TeamId = team.Id
+
+		w.Header().Set("X-FRAME-OPTIONS", "DENY")
+		w.Header().Set("Content-Security-Policy", "frame-ancestors none")
 
 		page := NewHtmlTemplatePage("signup_user_oauth", "Complete User Sign Up")
 		page.Props["User"] = user.ToJson()


### PR DESCRIPTION
The 'x-frame-options' and 'content-security-policy' headers tell the browser not to allow the given page to be rendered in an iframe, the main method of executing clickjacks. In addition, the head template now has a kill switch that will display nothing even if the page renders inside of an iframe.