### PR TITLE
MM-1674 Replaced call to String.prototype.startsWith which only works in browsers that support ES6

### DIFF
--- a/web/react/components/create_post.jsx
+++ b/web/react/components/create_post.jsx
@@ -32,7 +32,7 @@ module.exports = React.createClass({
         post.message = this.state.messageText;
 
         // if this is a reply, trim off any carets from the beginning of a message
-        if (this.state.rootId && post.message.startsWith("^")) {
+        if (this.state.rootId && post.message[0] === "^") {
             post.message = post.message.replace(/^\^+\s*/g, "");
         }
 


### PR DESCRIPTION
This was used in ^ reply code which is why it broke ^ replies in certain browsers (most notably IE and Safari).