### PR TITLE
MM-1682 Allow files without file extensions to be attached to messages

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -33,7 +33,7 @@ func InitFile(r *mux.Router) {
 
 	sr := r.PathPrefix("/files").Subrouter()
 	sr.Handle("/upload", ApiUserRequired(uploadFile)).Methods("POST")
-	sr.Handle("/get/{channel_id:[A-Za-z0-9]+}/{user_id:[A-Za-z0-9]+}/{filename:([A-Za-z0-9]+/)?.+\\.[A-Za-z0-9]{3,}}", ApiAppHandler(getFile)).Methods("GET")
+	sr.Handle("/get/{channel_id:[A-Za-z0-9]+}/{user_id:[A-Za-z0-9]+}/{filename:([A-Za-z0-9]+/)?.+(\\.[A-Za-z0-9]{3,})?}", ApiAppHandler(getFile)).Methods("GET")
 	sr.Handle("/get_public_link", ApiUserRequired(getPublicLink)).Methods("POST")
 }
 

--- a/model/utils.go
+++ b/model/utils.go
@@ -319,6 +319,6 @@ func ClearMentionTags(post string) string {
 }
 
 var UrlRegex = regexp.MustCompile(`^((?:[a-z]+:\/\/)?(?:(?:[a-z0-9\-]+\.)+(?:[a-z]{2}|aero|arpa|biz|com|coop|edu|gov|info|int|jobs|mil|museum|name|nato|net|org|pro|travel|local|internal))(:[0-9]{1,5})?(?:\/[a-z0-9_\-\.~]+)*(\/([a-z0-9_\-\.]*)(?:\?[a-z0-9+_~\-\.%=&amp;]*)?)?(?:#[a-zA-Z0-9!$&'()*+.=-_~:@/?]*)?)(?:\s+|$)$`)
-var PartialUrlRegex = regexp.MustCompile(`/([A-Za-z0-9]{26})/([A-Za-z0-9]{26})/((?:[A-Za-z0-9]{26})?.+(\.[A-Za-z0-9]{3,})?)`)
+var PartialUrlRegex = regexp.MustCompile(`/([A-Za-z0-9]{26})/([A-Za-z0-9]{26})/((?:[A-Za-z0-9]{26})?.+(?:\.[A-Za-z0-9]{3,})?)`)
 
 var SplitRunes = map[rune]bool{',': true, ' ': true, '.': true, '!': true, '?': true, ':': true, ';': true, '\n': true, '<': true, '>': true, '(': true, ')': true, '{': true, '}': true, '[': true, ']': true, '+': true, '/': true, '\\': true}

--- a/model/utils.go
+++ b/model/utils.go
@@ -319,6 +319,6 @@ func ClearMentionTags(post string) string {
 }
 
 var UrlRegex = regexp.MustCompile(`^((?:[a-z]+:\/\/)?(?:(?:[a-z0-9\-]+\.)+(?:[a-z]{2}|aero|arpa|biz|com|coop|edu|gov|info|int|jobs|mil|museum|name|nato|net|org|pro|travel|local|internal))(:[0-9]{1,5})?(?:\/[a-z0-9_\-\.~]+)*(\/([a-z0-9_\-\.]*)(?:\?[a-z0-9+_~\-\.%=&amp;]*)?)?(?:#[a-zA-Z0-9!$&'()*+.=-_~:@/?]*)?)(?:\s+|$)$`)
-var PartialUrlRegex = regexp.MustCompile(`/([A-Za-z0-9]{26})/([A-Za-z0-9]{26})/((?:[A-Za-z0-9]{26})?.+\.[A-Za-z0-9]{3,})`)
+var PartialUrlRegex = regexp.MustCompile(`/([A-Za-z0-9]{26})/([A-Za-z0-9]{26})/((?:[A-Za-z0-9]{26})?.+(\.[A-Za-z0-9]{3,})?)`)
 
 var SplitRunes = map[rune]bool{',': true, ' ': true, '.': true, '!': true, '?': true, ':': true, ';': true, '\n': true, '<': true, '>': true, '(': true, ')': true, '{': true, '}': true, '[': true, ']': true, '+': true, '/': true, '\\': true}

--- a/web/react/components/post_body.jsx
+++ b/web/react/components/post_body.jsx
@@ -126,7 +126,7 @@ module.exports = React.createClass({
                 } else if (i < Constants.MAX_DISPLAY_FILES) {
                     postFiles.push(
                         <div className="post-image__column custom-file" key={fileInfo.name+i}>
-                            <a href={fileInfo.path+"."+fileInfo.ext} download={fileInfo.name+"."+fileInfo.ext}>
+                            <a href={fileInfo.path + (fileInfo.ext ? "." + fileInfo.ext : "")} download={fileInfo.name + (fileInfo.ext ? "." + fileInfo.ext : "")}>
                                 <div className={"file-icon "+utils.getIconClassName(type)}/>
                             </a>
                         </div>

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -546,10 +546,13 @@ module.exports.getIconClassName = function(fileType) {
 
 module.exports.splitFileLocation = function(fileLocation) {
     var fileSplit = fileLocation.split('.');
-    if (fileSplit.length < 2) return {};
 
-    var ext = fileSplit[fileSplit.length-1];
-    fileSplit.splice(fileSplit.length-1,1)
+    var ext = "";
+    if (fileSplit.length > 1) {
+        ext = fileSplit[fileSplit.length - 1];
+        fileSplit.splice(fileSplit.length - 1, 1);
+    }
+
     var filePath = fileSplit.join('.');
     var filename = filePath.split('/')[filePath.split('/').length-1];
 


### PR DESCRIPTION
Currently, there's three things that prevent you from attaching files with no extension to a post:
1) The code in api/post.go rejects the file because it doesn't match its regex (which expects a file extension)
2) The code in api/file.go doesn't map urls for file/get for paths without file extensions
3) The code to display file thumbnails below a post skips files without extensions