### PR TITLE
MM-1183 Allow channel descriptions on 1-1 channels

### DIFF
--- a/web/react/components/channel_header.jsx
+++ b/web/react/components/channel_header.jsx
@@ -153,7 +153,7 @@ module.exports = React.createClass({
         if (isDirect) {
             if (this.state.users.length > 1) {
                 var contact = this.state.users[((this.state.users[0].id === currentId) ? 1 : 0)];
-                channelTitle = <UserProfile userId={contact.id} overwriteName={contact.nickname || contact.username} />;
+                channelTitle = contact.nickname || contact.username;
             }
         }
 
@@ -161,13 +161,13 @@ module.exports = React.createClass({
             <table className="channel-header alt">
                 <tr>
                     <th>
-                        { !isDirect ?
                         <div className="channel-header__info">
                             <div className="dropdown">
                                 <a href="#" className="dropdown-toggle theme" type="button" id="channel_header_dropdown" data-toggle="dropdown" aria-expanded="true">
                                     <strong className="heading">{channelTitle} </strong>
                                     <span className="glyphicon glyphicon-chevron-down header-dropdown__icon"></span>
                                 </a>
+                                { !isDirect ?
                                 <ul className="dropdown-menu" role="menu" aria-labelledby="channel_header_dropdown">
                                     <li role="presentation"><a role="menuitem" data-toggle="modal" data-target="#channel_info" data-channelid={channel.id} href="#">View Info</a></li>
                                     { !ChannelStore.isDefault(channel) ?
@@ -193,12 +193,14 @@ module.exports = React.createClass({
                                         : null
                                     }
                                 </ul>
+                                :
+                                <ul className="dropdown-menu" role="menu" aria-labelledby="channel_header_dropdown">
+                                    <li role="presentation"><a role="menuitem" href="#" data-toggle="modal" data-target="#edit_channel" data-desc={channel.description} data-title={channel.display_name} data-channelid={channel.id}>Set Channel Description...</a></li>
+                                </ul>
+                                }
                             </div>
                             <div data-toggle="popover" data-content={popoverContent} className="description">{description}</div>
                         </div>
-                    :
-                        <a href="#"><strong className="heading">{channelTitle}</strong></a>
-                    }
                     </th>
                     <th><PopoverListMembers members={this.state.users} channelId={channel.id} /></th>
                     <th className="search-bar__container"><NavbarSearchBox /></th>

--- a/web/react/components/post_list.jsx
+++ b/web/react/components/post_list.jsx
@@ -309,11 +309,14 @@ module.exports = React.createClass({
 
         var more_messages = <p className="beginning-messages-text">Beginning of Channel</p>;
 
+        var userStyle = { color: UserStore.getCurrentUser().props.theme }
+
         if (channel != null) {
             if (order.length > 0 && order.length % Constants.POST_CHUNK_SIZE === 0) {
                 more_messages = <a ref="loadmore" className="more-messages-text theme" href="#" onClick={this.getMorePosts}>Load more messages</a>;
             } else if (channel.type === 'D') {
                 var teammate = utils.getDirectTeammate(channel.id)
+
 
                 if (teammate) {
                     var teammate_name = teammate.nickname.length > 0 ? teammate.nickname : teammate.username;
@@ -329,6 +332,7 @@ module.exports = React.createClass({
                                 {"This is the start of your private message history with " + teammate_name + "." }<br/>
                                 {"Private messages and files shared here are not shown to people outside this area."}
                             </p>
+                            <a className="intro-links" href="#" style={userStyle} data-toggle="modal" data-target="#edit_channel" data-desc={channel.description} data-title={channel.display_name} data-channelid={channel.id}><i className="fa fa-pencil"></i>Set a description</a>
                         </div>
                     );
                 } else {
@@ -342,7 +346,6 @@ module.exports = React.createClass({
                 var ui_name = channel.display_name
                 var members = ChannelStore.getCurrentExtraInfo().members;
                 var creator_name = "";
-                var userStyle = { color: UserStore.getCurrentUser().props.theme }
 
                 for (var i = 0; i < members.length; i++) {
                     if (members[i].roles.indexOf('admin') > -1) {


### PR DESCRIPTION
If one wants to add a description or notes on a 1-1 channel, the capability had now been added. I removed the popover on the username as it was very annoying for the user to try and click the arrow and have it covered up by the popover.