### PR TITLE
MM-1763 update our postgresql index check to work with 9.2.4+ versions of postgresql

### DIFF
--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -224,7 +224,7 @@ func (ss SqlStore) CreateFullTextIndexIfNotExists(indexName string, tableName st
 func (ss SqlStore) createIndexIfNotExists(indexName string, tableName string, columnName string, fullText bool) {
 
 	if utils.Cfg.SqlSettings.DriverName == "postgres" {
-		_, err := ss.GetMaster().SelectStr("SELECT to_regclass($1)", indexName)
+		_, err := ss.GetMaster().SelectStr("SELECT $1::regclass", indexName)
 		// It should fail if the index does not exist
 		if err == nil {
 			return


### PR DESCRIPTION
For issue #263 

I installed PostgreSQL 9.2.4 locally, fixed the one issue, performed a smoke test and confirmed unit tests passed. This should hopefully be all we need to support PostgreSQL 9.2+. I also confirmed this still works with 9.4.