### PR TITLE
MM-1702 Adding etag to channel extra_info api call.

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -570,6 +570,11 @@ func getChannelExtraInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 		channel := cresult.Data.(*model.Channel)
 		member := cmresult.Data.(model.ChannelMember)
 		extraMembers := ecmresult.Data.([]model.ExtraMember)
+		extraEtag := channel.ExtraEtag()
+
+		if HandleEtag(extraEtag, w, r) {
+			return
+		}
 
 		if !c.HasPermissionsToTeam(channel.TeamId, "getChannelExtraInfo") {
 			return
@@ -586,6 +591,7 @@ func getChannelExtraInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		data := model.ChannelExtra{Id: channel.Id, Members: extraMembers}
+		w.Header().Set(model.HEADER_ETAG_SERVER, extraEtag)
 		w.Header().Set("Expires", "-1")
 		w.Write([]byte(data.ToJson()))
 	}
@@ -711,7 +717,7 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		message := model.NewMessage(c.Session.TeamId, "", userId, model.ACTION_USER_REMOVED)
-		message.Add("channel_id",id)
+		message.Add("channel_id", id)
 		message.Add("remover", c.Session.UserId)
 		PublishAndForget(message)
 

--- a/api/channel_benchmark_test.go
+++ b/api/channel_benchmark_test.go
@@ -189,7 +189,7 @@ func BenchmarkGetChannelExtraInfo(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := range channels {
-			Client.Must(Client.GetChannelExtraInfo(channels[j].Id))
+			Client.Must(Client.GetChannelExtraInfo(channels[j].Id, ""))
 		}
 	}
 }

--- a/model/channel.go
+++ b/model/channel.go
@@ -27,6 +27,7 @@ type Channel struct {
 	Description   string `json:"description"`
 	LastPostAt    int64  `json:"last_post_at"`
 	TotalMsgCount int64  `json:"total_msg_count"`
+	ExtraUpdateAt int64  `json:"extra_update_at"`
 }
 
 func (o *Channel) ToJson() string {
@@ -50,7 +51,11 @@ func ChannelFromJson(data io.Reader) *Channel {
 }
 
 func (o *Channel) Etag() string {
-	return Etag(o.Id, o.LastPostAt)
+	return Etag(o.Id, o.UpdateAt)
+}
+
+func (o *Channel) ExtraEtag() string {
+	return Etag(o.Id, o.ExtraUpdateAt)
 }
 
 func (o *Channel) IsValid() *AppError {
@@ -97,8 +102,13 @@ func (o *Channel) PreSave() {
 
 	o.CreateAt = GetMillis()
 	o.UpdateAt = o.CreateAt
+	o.ExtraUpdateAt = o.CreateAt
 }
 
 func (o *Channel) PreUpdate() {
 	o.UpdateAt = GetMillis()
+}
+
+func (o *Channel) ExtraUpdated() {
+	o.ExtraUpdateAt = GetMillis()
 }

--- a/model/client.go
+++ b/model/client.go
@@ -457,8 +457,8 @@ func (c *Client) UpdateLastViewedAt(channelId string) (*Result, *AppError) {
 	}
 }
 
-func (c *Client) GetChannelExtraInfo(id string) (*Result, *AppError) {
-	if r, err := c.DoGet("/channels/"+id+"/extra_info", "", ""); err != nil {
+func (c *Client) GetChannelExtraInfo(id string, etag string) (*Result, *AppError) {
+	if r, err := c.DoGet("/channels/"+id+"/extra_info", "", etag); err != nil {
 		return nil, err
 	} else {
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -197,6 +197,16 @@ func TestChannelStoreGetByName(t *testing.T) {
 func TestChannelMemberStore(t *testing.T) {
 	Setup()
 
+	c1 := model.Channel{}
+	c1.TeamId = model.NewId()
+	c1.DisplayName = "NameName"
+	c1.Name = "a" + model.NewId() + "b"
+	c1.Type = model.CHANNEL_OPEN
+	c1 = *Must(store.Channel().Save(&c1)).(*model.Channel)
+
+	c1t1 := (<-store.Channel().Get(c1.Id)).Data.(*model.Channel)
+	t1 := c1t1.ExtraUpdateAt
+
 	u1 := model.User{}
 	u1.TeamId = model.NewId()
 	u1.Email = model.NewId()
@@ -210,16 +220,23 @@ func TestChannelMemberStore(t *testing.T) {
 	Must(store.User().Save(&u2))
 
 	o1 := model.ChannelMember{}
-	o1.ChannelId = model.NewId()
+	o1.ChannelId = c1.Id
 	o1.UserId = u1.Id
 	o1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	Must(store.Channel().SaveMember(&o1))
 
 	o2 := model.ChannelMember{}
-	o2.ChannelId = o1.ChannelId
+	o2.ChannelId = c1.Id
 	o2.UserId = u2.Id
 	o2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	Must(store.Channel().SaveMember(&o2))
+
+	c1t2 := (<-store.Channel().Get(c1.Id)).Data.(*model.Channel)
+	t2 := c1t2.ExtraUpdateAt
+
+	if t2 <= t1 {
+		t.Fatal("Member update time incorrect")
+	}
 
 	members := (<-store.Channel().GetMembers(o1.ChannelId)).Data.([]model.ChannelMember)
 	if len(members) != 2 {
@@ -231,6 +248,13 @@ func TestChannelMemberStore(t *testing.T) {
 	members = (<-store.Channel().GetMembers(o1.ChannelId)).Data.([]model.ChannelMember)
 	if len(members) != 1 {
 		t.Fatal("should have removed 1 member")
+	}
+
+	c1t3 := (<-store.Channel().Get(c1.Id)).Data.(*model.Channel)
+	t3 := c1t3.ExtraUpdateAt
+
+	if t3 <= t2 || t3 <= t1 {
+		t.Fatal("Member update time incorrect on delete")
 	}
 
 	member := (<-store.Channel().GetMember(o1.ChannelId, o1.UserId)).Data.(model.ChannelMember)
@@ -245,6 +269,12 @@ func TestChannelMemberStore(t *testing.T) {
 
 	if err := (<-store.Channel().SaveMember(&o1)).Err; err == nil {
 		t.Fatal("Should have been a duplicate")
+	}
+
+	c1t4 := (<-store.Channel().Get(c1.Id)).Data.(*model.Channel)
+	t4 := c1t4.ExtraUpdateAt
+	if t4 != t3 {
+		t.Fatal("Should not update time upon failure")
 	}
 }
 


### PR DESCRIPTION
Adds etags to the channel extra_info call.

A new field is added to channel: ExtraUpdateAt. This keeps track of when members changes and hence the all of the extra info changes (because members are the only current extra info). This allows us to generate an etag. 