### PR TITLE
MM-1758 partially fixed postgres search so that multiple search terms work

### DIFF
--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -401,7 +401,7 @@ func (s SqlPostStore) Search(teamId string, userId string, terms string, isHasht
 				            Id = ChannelId AND TeamId = $1
 				                AND UserId = $2
 				                AND DeleteAt = 0)
-				    AND %s @@  plainto_tsquery($3)
+				    AND %s @@  to_tsquery($3)
 				    ORDER BY CreateAt DESC
 				LIMIT 100`, searchType)
 

--- a/store/sql_post_store_test.go
+++ b/store/sql_post_store_test.go
@@ -483,4 +483,9 @@ func TestPostStoreSearch(t *testing.T) {
 	if len(r8.Order) != 0 {
 		t.Fatal("returned wrong serach result")
 	}
+
+	r9 := (<-store.Post().Search(teamId, userId, "mattermost jersey", false)).Data.(*model.PostList)
+	if len(r9.Order) != 2 {
+		t.Fatal("returned wrong search result")
+	}
 }


### PR DESCRIPTION
This will allow multiple words to be searched at once in PostgreSQL but doesn't fix the issue that certain 'stop words' (such as 'the' and 'all') are ignored in PostgreSQL searches.