### PR TITLE
MM-1691/1692 Reset User settings tab on close

### DIFF
--- a/web/react/components/user_settings.jsx
+++ b/web/react/components/user_settings.jsx
@@ -102,6 +102,8 @@ var NotificationsTab = React.createClass({
         });
 
         this.setState(assign({},getNotificationsStateFromStores(),{server_error: null}));
+
+        this.props.updateTab('general');
     },
     componentDidMount: function() {
         UserStore.addChangeListener(this._onChange);
@@ -110,6 +112,7 @@ var NotificationsTab = React.createClass({
     componentWillUnmount: function() {
         UserStore.removeChangeListener(this._onChange);
         $('#user_settings1').off('hidden.bs.modal', this.handleClose);
+        this.props.updateSection('');
     },
     _onChange: function() {
         var newState = getNotificationsStateFromStores();
@@ -522,12 +525,14 @@ var SecurityTab = React.createClass({
             this.value = "";
         });
         this.setState({current_password: '', new_password: '', confirm_password: '', server_error: null, password_error: null});
+        this.props.updateTab('general');
     },
     componentDidMount: function() {
         $('#user_settings1').on('hidden.bs.modal', this.handleClose);
     },
     componentWillUnmount: function() {
         $('#user_settings1').off('hidden.bs.modal', this.handleClose);
+        this.props.updateSection('');
     },
     getInitialState: function() {
         return { current_password: '', new_password: '', confirm_password: '' };
@@ -790,6 +795,7 @@ var GeneralTab = React.createClass({
         });
 
         this.setState(assign({}, this.getInitialState(), {client_error: null, server_error: null, email_error: null}));
+        this.props.updateSection('');
     },
     componentDidMount: function() {
         $('#user_settings1').on('hidden.bs.modal', this.handleClose);
@@ -1042,6 +1048,7 @@ var AppearanceTab = React.createClass({
     },
     handleClose: function() {
         this.setState({server_error: null});
+        this.props.updateTab('general');
     },
     componentDidMount: function() {
         if (this.props.activeSection === "theme") {
@@ -1057,6 +1064,7 @@ var AppearanceTab = React.createClass({
     },
     componentWillUnmount: function() {
         $('#user_settings1').off('hidden.bs.modal', this.handleClose);
+        this.props.updateSection('');
     },
     getInitialState: function() {
         var user = UserStore.getCurrentUser();
@@ -1125,10 +1133,11 @@ var AppearanceTab = React.createClass({
                 </div>
             </div>
         );
-     }
+    }
 });
 
 module.exports = React.createClass({
+    displayName: 'UserSettings',
     componentDidMount: function() {
         UserStore.addChangeListener(this._onChange);
     },
@@ -1154,19 +1163,19 @@ module.exports = React.createClass({
         } else if (this.props.activeTab === 'security') {
             return (
                 <div>
-                    <SecurityTab user={this.state.user} activeSection={this.props.activeSection} updateSection={this.props.updateSection} />
+                    <SecurityTab user={this.state.user} activeSection={this.props.activeSection} updateSection={this.props.updateSection} updateTab={this.props.updateTab} />
                 </div>
             );
         } else if (this.props.activeTab === 'notifications') {
             return (
                 <div>
-                    <NotificationsTab user={this.state.user} activeSection={this.props.activeSection} updateSection={this.props.updateSection} />
+                    <NotificationsTab user={this.state.user} activeSection={this.props.activeSection} updateSection={this.props.updateSection} updateTab={this.props.updateTab} />
                 </div>
             );
         } else if (this.props.activeTab === 'appearance') {
             return (
                 <div>
-                    <AppearanceTab activeSection={this.props.activeSection} updateSection={this.props.updateSection} />
+                    <AppearanceTab activeSection={this.props.activeSection} updateSection={this.props.updateSection} updateTab={this.props.updateTab} />
                 </div>
             );
         } else {

--- a/web/react/components/user_settings_modal.jsx
+++ b/web/react/components/user_settings_modal.jsx
@@ -53,6 +53,7 @@ module.exports = React.createClass({
                                 activeTab={this.state.active_tab}
                                 activeSection={this.state.active_section}
                                 updateSection={this.updateSection}
+                                updateTab={this.updateTab}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
Both were closely enough related that they warranted one ticket. When the settings modal is closed, the state returns to general tab with nothing selected. We needed to pass down the controller function in order to guarantee synchronous behavior with other 'on-close' events 