### PR TITLE
MM-1579 Added a date separator before the first post displayed in a channel

### DIFF
--- a/web/react/components/post_list.jsx
+++ b/web/react/components/post_list.jsx
@@ -311,7 +311,6 @@ module.exports = React.createClass({
             } else if (channel.type === 'D') {
                 var teammate = utils.getDirectTeammate(channel.id)
 
-
                 if (teammate) {
                     var teammate_name = teammate.nickname.length > 0 ? teammate.nickname : teammate.username;
                     more_messages = (
@@ -399,7 +398,7 @@ module.exports = React.createClass({
         var postCtls = [];
 
         if (posts) {
-            var previousPostDay = posts[order[order.length-1]] ? utils.getDateForUnixTicks(posts[order[order.length-1]].create_at): new Date();
+            var previousPostDay = new Date(0);
             var currentPostDay;
 
             for (var i = order.length-1; i >= 0; i--) {


### PR DESCRIPTION
This is to fix an issue where there is no date separator at the top of a channel (below the channel description) so you can't tell when the first posts were sent. As a bonus, it also adds a date separator below the "load more messages" bar so you can also see when those posts were sent.