### PR TITLE
MM-1700 don't pull all channel data all the time

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -24,7 +24,7 @@ func InitChannel(r *mux.Router) {
 	sr.Handle("/update", ApiUserRequired(updateChannel)).Methods("POST")
 	sr.Handle("/update_desc", ApiUserRequired(updateChannelDesc)).Methods("POST")
 	sr.Handle("/update_notify_level", ApiUserRequired(updateNotifyLevel)).Methods("POST")
-	sr.Handle("/{id:[A-Za-z0-9]+}/", ApiUserRequired(getChannel)).Methods("GET")
+	sr.Handle("/{id:[A-Za-z0-9]+}/", ApiUserRequiredActivity(getChannel, false)).Methods("GET")
 	sr.Handle("/{id:[A-Za-z0-9]+}/extra_info", ApiUserRequired(getChannelExtraInfo)).Methods("GET")
 	sr.Handle("/{id:[A-Za-z0-9]+}/join", ApiUserRequired(joinChannel)).Methods("POST")
 	sr.Handle("/{id:[A-Za-z0-9]+}/leave", ApiUserRequired(leaveChannel)).Methods("POST")

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -320,6 +320,27 @@ func TestGetChannel(t *testing.T) {
 	if _, err := Client.UpdateLastViewedAt(channel2.Id); err != nil {
 		t.Fatal(err)
 	}
+
+	if resp, err := Client.GetChannel(channel1.Id, ""); err != nil {
+		t.Fatal(err)
+	} else {
+		data := resp.Data.(*model.ChannelData)
+		if data.Channel.DisplayName != channel1.DisplayName {
+			t.Fatal("name didn't match")
+		}
+
+		// test etag caching
+		if cache_result, err := Client.GetChannel(channel1.Id, resp.Etag); err != nil {
+			t.Fatal(err)
+		} else if cache_result.Data.(*model.ChannelData) != nil {
+			t.Log(cache_result.Data)
+			t.Fatal("cache should be empty")
+		}
+	}
+
+	if _, err := Client.GetChannel("junk", ""); err == nil {
+		t.Fatal("should have failed - bad channel id")
+	}
 }
 
 func TestGetMoreChannel(t *testing.T) {

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -417,6 +417,13 @@ func TestGetChannelCounts(t *testing.T) {
 		if len(counts.UpdateTimes) != 4 {
 			t.Fatal("wrong number of channel update times")
 		}
+
+		if cache_result, err := Client.GetChannelCounts(result.Etag); err != nil {
+			t.Fatal(err)
+		} else if cache_result.Data.(*model.ChannelCounts) != nil {
+			t.Log(cache_result.Data)
+			t.Fatal("cache should be empty")
+		}
 	}
 
 }

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -387,6 +387,40 @@ func TestGetMoreChannel(t *testing.T) {
 	}
 }
 
+func TestGetChannelCounts(t *testing.T) {
+	Setup()
+
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
+
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(user.Id))
+
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
+
+	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
+
+	channel2 := &model.Channel{DisplayName: "B Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel2 = Client.Must(Client.CreateChannel(channel2)).Data.(*model.Channel)
+
+	if result, err := Client.GetChannelCounts(""); err != nil {
+		t.Fatal(err)
+	} else {
+		counts := result.Data.(*model.ChannelCounts)
+
+		if len(counts.Counts) != 4 {
+			t.Fatal("wrong number of channel counts")
+		}
+
+		if len(counts.UpdateTimes) != 4 {
+			t.Fatal("wrong number of channel update times")
+		}
+	}
+
+}
+
 func TestJoinChannel(t *testing.T) {
 	Setup()
 

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -422,7 +422,7 @@ func TestGetChannelCounts(t *testing.T) {
 			t.Fatal(err)
 		} else if cache_result.Data.(*model.ChannelCounts) != nil {
 			t.Log(cache_result.Data)
-			t.Fatal("cache should be empty")
+			t.Fatal("result data should be empty")
 		}
 	}
 

--- a/model/channel_count.go
+++ b/model/channel_count.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"io"
+	"strconv"
+)
+
+type ChannelCounts struct {
+	Counts map[string]int64 `json:"counts"`
+}
+
+func (o *ChannelCounts) Etag() string {
+	str := ""
+	for id, count := range o.Counts {
+		str += id + strconv.FormatInt(count, 10)
+	}
+
+	data := []byte(str)
+
+	return Etag(md5.Sum(data))
+}
+
+func (o *ChannelCounts) ToJson() string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func ChannelCountsFromJson(data io.Reader) *ChannelCounts {
+	decoder := json.NewDecoder(data)
+	var o ChannelCounts
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
+	} else {
+		return nil
+	}
+}

--- a/model/channel_count.go
+++ b/model/channel_count.go
@@ -6,7 +6,9 @@ package model
 import (
 	"crypto/md5"
 	"encoding/json"
+	"fmt"
 	"io"
+	"sort"
 	"strconv"
 )
 
@@ -16,12 +18,19 @@ type ChannelCounts struct {
 }
 
 func (o *ChannelCounts) Etag() string {
+
+	ids := []string{}
+	for id, _ := range o.Counts {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
 	str := ""
-	for id, count := range o.Counts {
-		str += id + strconv.FormatInt(count, 10)
+	for _, id := range ids {
+		str += id + strconv.FormatInt(o.Counts[id], 10)
 	}
 
-	md5Counts := md5.Sum([]byte(str))
+	md5Counts := fmt.Sprintf("%x", md5.Sum([]byte(str)))
 
 	var update int64 = 0
 	for _, u := range o.UpdateTimes {

--- a/model/channel_count.go
+++ b/model/channel_count.go
@@ -11,7 +11,8 @@ import (
 )
 
 type ChannelCounts struct {
-	Counts map[string]int64 `json:"counts"`
+	Counts      map[string]int64 `json:"counts"`
+	UpdateTimes map[string]int64 `json:"update_times"`
 }
 
 func (o *ChannelCounts) Etag() string {
@@ -20,9 +21,16 @@ func (o *ChannelCounts) Etag() string {
 		str += id + strconv.FormatInt(count, 10)
 	}
 
-	data := []byte(str)
+	md5Counts := md5.Sum([]byte(str))
 
-	return Etag(md5.Sum(data))
+	var update int64 = 0
+	for _, u := range o.UpdateTimes {
+		if u > update {
+			update = u
+		}
+	}
+
+	return Etag(md5Counts, update)
 }
 
 func (o *ChannelCounts) ToJson() string {

--- a/model/channel_data.go
+++ b/model/channel_data.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type ChannelData struct {
+	Channel *Channel       `json:"channel"`
+	Member  *ChannelMember `json:"member"`
+}
+
+func (o *ChannelData) Etag() string {
+	var mt int64 = 0
+	if o.Member != nil {
+		mt = o.Member.LastUpdateAt
+	}
+
+	return Etag(o.Channel.Id, o.Channel.UpdateAt, o.Channel.LastPostAt, mt)
+}
+
+func (o *ChannelData) ToJson() string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func ChannelDataFromJson(data io.Reader) *ChannelData {
+	decoder := json.NewDecoder(data)
+	var o ChannelData
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
+	} else {
+		return nil
+	}
+}

--- a/model/client.go
+++ b/model/client.go
@@ -408,6 +408,15 @@ func (c *Client) GetMoreChannels(etag string) (*Result, *AppError) {
 	}
 }
 
+func (c *Client) GetChannelCounts(etag string) (*Result, *AppError) {
+	if r, err := c.DoGet("/channels/counts", "", etag); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), ChannelCountsFromJson(r.Body)}, nil
+	}
+}
+
 func (c *Client) JoinChannel(id string) (*Result, *AppError) {
 	if r, err := c.DoPost("/channels/"+id+"/join", ""); err != nil {
 		return nil, err

--- a/model/client.go
+++ b/model/client.go
@@ -390,6 +390,15 @@ func (c *Client) GetChannels(etag string) (*Result, *AppError) {
 	}
 }
 
+func (c *Client) GetChannel(id, etag string) (*Result, *AppError) {
+	if r, err := c.DoGet("/channels/"+id+"/", "", etag); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), ChannelDataFromJson(r.Body)}, nil
+	}
+}
+
 func (c *Client) GetMoreChannels(etag string) (*Result, *AppError) {
 	if r, err := c.DoGet("/channels/more", "", etag); err != nil {
 		return nil, err

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -281,9 +281,10 @@ func (s SqlChannelStore) GetMoreChannels(teamId string, userId string) StoreChan
 	return storeChannel
 }
 
-type channelIdWithCount struct {
+type channelIdWithCountandUpdateAt struct {
 	Id            string
 	TotalMsgCount int64
+	UpdateAt      int64
 }
 
 func (s SqlChannelStore) GetChannelCounts(teamId string, userId string) StoreChannel {
@@ -292,16 +293,17 @@ func (s SqlChannelStore) GetChannelCounts(teamId string, userId string) StoreCha
 	go func() {
 		result := StoreResult{}
 
-		var data []channelIdWithCount
-		_, err := s.GetReplica().Select(&data, "SELECT Id, TotalMsgCount FROM Channels WHERE Id IN (SELECT ChannelId FROM ChannelMembers WHERE UserId = :UserId) AND TeamId = :TeamId AND DeleteAt = 0 ORDER BY DisplayName", map[string]interface{}{"TeamId": teamId, "UserId": userId})
+		var data []channelIdWithCountandUpdateAt
+		_, err := s.GetReplica().Select(&data, "SELECT Id, TotalMsgCount, UpdateAt FROM Channels WHERE Id IN (SELECT ChannelId FROM ChannelMembers WHERE UserId = :UserId) AND TeamId = :TeamId AND DeleteAt = 0 ORDER BY DisplayName", map[string]interface{}{"TeamId": teamId, "UserId": userId})
 
 		if err != nil {
 			result.Err = model.NewAppError("SqlChannelStore.GetChannelCounts", "We couldn't get the channel counts", "teamId="+teamId+", userId="+userId+", err="+err.Error())
 		} else {
-			counts := &model.ChannelCounts{Counts: make(map[string]int64)}
+			counts := &model.ChannelCounts{Counts: make(map[string]int64), UpdateTimes: make(map[string]int64)}
 			for i := range data {
 				v := data[i]
 				counts.Counts[v.Id] = v.TotalMsgCount
+				counts.UpdateTimes[v.Id] = v.UpdateAt
 			}
 
 			result.Data = counts

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -281,7 +281,7 @@ func (s SqlChannelStore) GetMoreChannels(teamId string, userId string) StoreChan
 	return storeChannel
 }
 
-type channelIdWithCountandUpdateAt struct {
+type channelIdWithCountAndUpdateAt struct {
 	Id            string
 	TotalMsgCount int64
 	UpdateAt      int64
@@ -293,7 +293,7 @@ func (s SqlChannelStore) GetChannelCounts(teamId string, userId string) StoreCha
 	go func() {
 		result := StoreResult{}
 
-		var data []channelIdWithCountandUpdateAt
+		var data []channelIdWithCountAndUpdateAt
 		_, err := s.GetReplica().Select(&data, "SELECT Id, TotalMsgCount, UpdateAt FROM Channels WHERE Id IN (SELECT ChannelId FROM ChannelMembers WHERE UserId = :UserId) AND TeamId = :TeamId AND DeleteAt = 0 ORDER BY DisplayName", map[string]interface{}{"TeamId": teamId, "UserId": userId})
 
 		if err != nil {

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -462,6 +462,53 @@ func TestChannelStoreGetMoreChannels(t *testing.T) {
 	}
 }
 
+func TestChannelStoreGetChannelCounts(t *testing.T) {
+	Setup()
+
+	o2 := model.Channel{}
+	o2.TeamId = model.NewId()
+	o2.DisplayName = "Channel2"
+	o2.Name = "a" + model.NewId() + "b"
+	o2.Type = model.CHANNEL_OPEN
+	Must(store.Channel().Save(&o2))
+
+	o1 := model.Channel{}
+	o1.TeamId = model.NewId()
+	o1.DisplayName = "Channel1"
+	o1.Name = "a" + model.NewId() + "b"
+	o1.Type = model.CHANNEL_OPEN
+	Must(store.Channel().Save(&o1))
+
+	m1 := model.ChannelMember{}
+	m1.ChannelId = o1.Id
+	m1.UserId = model.NewId()
+	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	Must(store.Channel().SaveMember(&m1))
+
+	m2 := model.ChannelMember{}
+	m2.ChannelId = o1.Id
+	m2.UserId = model.NewId()
+	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	Must(store.Channel().SaveMember(&m2))
+
+	m3 := model.ChannelMember{}
+	m3.ChannelId = o2.Id
+	m3.UserId = model.NewId()
+	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	Must(store.Channel().SaveMember(&m3))
+
+	cresult := <-store.Channel().GetChannelCounts(o1.TeamId, m1.UserId)
+	counts := cresult.Data.(*model.ChannelCounts)
+
+	if len(counts.Counts) != 1 {
+		t.Fatal("wrong number of counts")
+	}
+
+	if len(counts.UpdateTimes) != 1 {
+		t.Fatal("wrong number of update times")
+	}
+}
+
 func TestChannelStoreUpdateLastViewedAt(t *testing.T) {
 	Setup()
 

--- a/store/store.go
+++ b/store/store.go
@@ -50,6 +50,7 @@ type ChannelStore interface {
 	GetByName(team_id string, domain string) StoreChannel
 	GetChannels(teamId string, userId string) StoreChannel
 	GetMoreChannels(teamId string, userId string) StoreChannel
+	GetChannelCounts(teamId string, userId string) StoreChannel
 
 	SaveMember(member *model.ChannelMember) StoreChannel
 	GetMembers(channelId string) StoreChannel

--- a/web/react/components/edit_channel_modal.jsx
+++ b/web/react/components/edit_channel_modal.jsx
@@ -14,7 +14,7 @@ module.exports = React.createClass({
         Client.updateChannelDesc(data,
             function(data) {
                 this.setState({ server_error: "" });
-                AsyncClient.getChannels(true);
+                AsyncClient.getChannel(this.state.channel_id);
                 $(this.refs.modal.getDOMNode()).modal('hide');
             }.bind(this),
             function(err) {

--- a/web/react/components/more_channels.jsx
+++ b/web/react/components/more_channels.jsx
@@ -1,34 +1,32 @@
 // Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-
 var utils = require('../utils/utils.jsx');
 var client = require('../utils/client.jsx');
 var asyncClient = require('../utils/async_client.jsx');
-var UserStore = require('../stores/user_store.jsx');
 var ChannelStore = require('../stores/channel_store.jsx');
 var LoadingScreen = require('./loading_screen.jsx');
 
 function getStateFromStores() {
-  return {
-    channels: ChannelStore.getMoreAll(),
-    server_error: null
-  };
+    return {
+        channels: ChannelStore.getMoreAll(),
+        serverError: null
+    };
 }
 
 module.exports = React.createClass({
-    displayName: "MoreChannelsModal",
+    displayName: 'MoreChannelsModal',
 
     componentDidMount: function() {
         ChannelStore.addMoreChangeListener(this._onChange);
-        $(this.refs.modal.getDOMNode()).on('shown.bs.modal', function (e) {
+        $(this.refs.modal.getDOMNode()).on('shown.bs.modal', function shown() {
             asyncClient.getMoreChannels(true);
         });
 
         var self = this;
-        $(this.refs.modal.getDOMNode()).on('show.bs.modal', function(e) {
+        $(this.refs.modal.getDOMNode()).on('show.bs.modal', function show(e) {
             var button = e.relatedTarget;
-            self.setState({ channel_type: $(button).attr('data-channeltype') });
+            self.setState({channelType: $(button).attr('data-channeltype')});
         });
     },
     componentWillUnmount: function() {
@@ -42,18 +40,17 @@ module.exports = React.createClass({
     },
     getInitialState: function() {
         var initState = getStateFromStores();
-        initState.channel_type = "";
+        initState.channelType = '';
         return initState;
     },
-    handleJoin: function(e) {
-        var self = this;
-        client.joinChannel(e,
-            function(data) {
-                $(self.refs.modal.getDOMNode()).modal('hide');
-                asyncClient.getChannels(true);
+    handleJoin: function(id) {
+        client.joinChannel(id,
+            function() {
+                $(this.refs.modal.getDOMNode()).modal('hide');
+                asyncClient.getChannel(id);
             }.bind(this),
             function(err) {
-                this.state.server_error = err.message;
+                this.state.serverError = err.message;
                 this.setState(this.state);
             }.bind(this)
         );
@@ -62,52 +59,66 @@ module.exports = React.createClass({
         $(this.refs.modal.getDOMNode()).modal('hide');
     },
     render: function() {
-        var server_error = this.state.server_error ? <div className='form-group has-error'><label className='control-label'>{ this.state.server_error }</label></div> : null;
+        var serverError;
+        if (this.state.serverError) {
+            serverError = <div className='form-group has-error'><label className='control-label'>{this.state.serverError}</label></div>;
+        }
+
         var outter = this;
         var moreChannels;
 
-        if (this.state.channels != null)
-            moreChannels = this.state.channels;
+        if (this.state.channels != null) {
+            var channels = this.state.channels;
+            if (!channels.loading) {
+                if (channels.length) {
+                    moreChannels = (
+                        <table className='more-channel-table table'>
+                            <tbody>
+                                {moreChannels.map(function cMap(channel) {
+                                    return (
+                                        <tr key={channel.id}>
+                                            <td>
+                                                <p className='more-channel-name'>{channel.display_name}</p>
+                                                <p className='more-channel-description'>{channel.description}</p>
+                                            </td>
+                                            <td className='td--action'><button onClick={outter.handleJoin.bind(outter, channel.id)} className='btn btn-primary'>Join</button></td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    );
+                } else {
+                    moreChannels = (
+                        <div className='no-channel-message'>
+                           <p className='primary-message'>No more channels to join</p>
+                           <p className='secondary-message'>Click 'Create New Channel' to make a new one</p>
+                        </div>
+                    );
+                }
+            } else {
+                moreChannels = <LoadingScreen />;
+            }
+        }
 
         return (
-            <div className="modal fade" id="more_channels" ref="modal" tabIndex="-1" role="dialog" aria-hidden="true">
-                <div className="modal-dialog">
-                    <div className="modal-content">
-                        <div className="modal-header">
-                            <button type="button" className="close" data-dismiss="modal">
-                                <span aria-hidden="true">&times;</span>
-                                <span className="sr-only">Close</span>
+            <div className='modal fade' id='more_channels' ref='modal' tabIndex='-1' role='dialog' aria-hidden='true'>
+                <div className='modal-dialog'>
+                    <div className='modal-content'>
+                        <div className='modal-header'>
+                            <button type='button' className='close' data-dismiss='modal'>
+                                <span aria-hidden='true'>&times;</span>
+                                <span className='sr-only'>Close</span>
                             </button>
-                            <h4 className="modal-title">More Channels</h4>
-                            <button data-toggle="modal" data-target="#new_channel" data-channeltype={this.state.channel_type} type="button" className="btn btn-primary channel-create-btn" onClick={this.handleNewChannel}>Create New Channel</button>
+                            <h4 className='modal-title'>More Channels</h4>
+                            <button data-toggle='modal' data-target='#new_channel' data-channeltype={this.state.channelType} type='button' className='btn btn-primary channel-create-btn' onClick={this.handleNewChannel}>Create New Channel</button>
                         </div>
-                        <div className="modal-body">
-                            {!moreChannels.loading ?
-                                (moreChannels.length ?
-                                    <table className="more-channel-table table">
-                                        <tbody>
-                                            {moreChannels.map(function(channel) {
-                                                return (
-                                                    <tr key={channel.id}>
-                                                        <td>
-                                                            <p className="more-channel-name">{channel.display_name}</p>
-                                                            <p className="more-channel-description">{channel.description}</p>
-                                                        </td>
-                                                        <td className="td--action"><button onClick={outter.handleJoin.bind(outter, channel.id)} className="btn btn-primary">Join</button></td>
-                                                    </tr>
-                                                )
-                                            })}
-                                        </tbody>
-                                    </table>
-                                    :   <div className="no-channel-message">
-                                            <p className="primary-message">No more channels to join</p>
-                                            <p className="secondary-message">Click 'Create New Channel' to make a new one</p>
-                                        </div>)
-                            :   <LoadingScreen /> }
-                            { server_error }
+                        <div className='modal-body'>
+                            {moreChannels}
+                            {serverError}
                         </div>
-                        <div className="modal-footer">
-                            <button type="button" className="btn btn-default" data-dismiss="modal">Close</button>
+                        <div className='modal-footer'>
+                            <button type='button' className='btn btn-default' data-dismiss='modal'>Close</button>
                         </div>
                     </div>
                 </div>

--- a/web/react/components/more_channels.jsx
+++ b/web/react/components/more_channels.jsx
@@ -74,7 +74,7 @@ module.exports = React.createClass({
                     moreChannels = (
                         <table className='more-channel-table table'>
                             <tbody>
-                                {moreChannels.map(function cMap(channel) {
+                                {channels.map(function cMap(channel) {
                                     return (
                                         <tr key={channel.id}>
                                             <td>

--- a/web/react/components/new_channel.jsx
+++ b/web/react/components/new_channel.jsx
@@ -55,16 +55,17 @@ module.exports = React.createClass({
         channel.description = this.refs.channel_desc.getDOMNode().value.trim();
         channel.type = this.state.channelType;
 
-        var self = this;
         client.createChannel(channel,
             function(data) {
+                $(this.refs.modal.getDOMNode()).modal('hide');
+
+                asyncClient.getChannel(data.id);
+                utils.updateTabTitle(channel.display_name);
+                utils.updateAddressBar(channel.name);
+
                 this.refs.display_name.getDOMNode().value = '';
                 this.refs.channel_name.getDOMNode().value = '';
                 this.refs.channel_desc.getDOMNode().value = '';
-
-                $(self.refs.modal.getDOMNode()).modal('hide');
-                window.location = TeamStore.getCurrentTeamUrl() + '/channels/' + channel.name;
-                asyncClient.getChannel(data.id);
             }.bind(this),
             function(err) {
                 state.serverError = err.message;

--- a/web/react/components/new_channel.jsx
+++ b/web/react/components/new_channel.jsx
@@ -60,8 +60,7 @@ module.exports = React.createClass({
                 $(this.refs.modal.getDOMNode()).modal('hide');
 
                 asyncClient.getChannel(data.id);
-                utils.updateTabTitle(channel.display_name);
-                utils.updateAddressBar(channel.name);
+                utils.switchChannel(data);
 
                 this.refs.display_name.getDOMNode().value = '';
                 this.refs.channel_name.getDOMNode().value = '';

--- a/web/react/components/new_channel.jsx
+++ b/web/react/components/new_channel.jsx
@@ -57,14 +57,14 @@ module.exports = React.createClass({
 
         var self = this;
         client.createChannel(channel,
-            function() {
+            function(data) {
                 this.refs.display_name.getDOMNode().value = '';
                 this.refs.channel_name.getDOMNode().value = '';
                 this.refs.channel_desc.getDOMNode().value = '';
 
                 $(self.refs.modal.getDOMNode()).modal('hide');
                 window.location = TeamStore.getCurrentTeamUrl() + '/channels/' + channel.name;
-                asyncClient.getChannels(true);
+                asyncClient.getChannel(data.id);
             }.bind(this),
             function(err) {
                 state.serverError = err.message;

--- a/web/react/components/rename_channel_modal.jsx
+++ b/web/react/components/rename_channel_modal.jsx
@@ -68,7 +68,7 @@ module.exports = React.createClass({
 
                 $('#' + this.props.modalId).modal('hide');
                 window.location.href = TeamStore.getCurrentTeamUrl() + '/channels/' + this.state.channel_name;
-                AsyncClient.getChannels(true);
+                AsyncClient.getChannel(channel.id);
             }.bind(this),
             function(err) {
                 state.server_error = err.message;

--- a/web/react/components/rename_channel_modal.jsx
+++ b/web/react/components/rename_channel_modal.jsx
@@ -63,12 +63,14 @@ module.exports = React.createClass({
 
         Client.updateChannel(channel,
             function(data, text, req) {
+                $(this.refs.modal.getDOMNode()).modal('hide');
+
+                AsyncClient.getChannel(channel.id);
+                utils.updateTabTitle(channel.display_name);
+                utils.updateAddressBar(channel.name);
+
                 this.refs.display_name.getDOMNode().value = "";
                 this.refs.channel_name.getDOMNode().value = "";
-
-                $('#' + this.props.modalId).modal('hide');
-                window.location.href = TeamStore.getCurrentTeamUrl() + '/channels/' + this.state.channel_name;
-                AsyncClient.getChannel(channel.id);
             }.bind(this),
             function(err) {
                 state.server_error = err.message;

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -284,7 +284,7 @@ module.exports = React.createClass({
     },
     render: function() {
         var members = this.state.members;
-        var activeId = this.state.active_id;
+        var activeId = this.state.activeId;
         var badgesActive = false;
 
         // keep track of the first and last unread channels so we can use them to set the unread indicators
@@ -296,7 +296,7 @@ module.exports = React.createClass({
             var channelMember = members[channel.id];
 
             var linkClass = '';
-            if (channel.id === self.state.active_id) {
+            if (channel.id === activeId) {
                 linkClass = 'active';
             }
 

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -157,9 +157,12 @@ module.exports = React.createClass({
     onSocketChange: function(msg) {
         if (msg.action === 'posted') {
             if (ChannelStore.getCurrentId() === msg.channel_id) {
-                if (window.isActive) AsyncClient.updateLastViewedAt();
+                if (window.isActive) {
+                    AsyncClient.updateLastViewedAt();
+                }
             } else {
-                AsyncClient.getChannel(msg.channel_id);
+                console.log('hit');
+                AsyncClient.getChannels();
             }
 
             if (UserStore.getCurrentId() !== msg.user_id) {
@@ -213,7 +216,7 @@ module.exports = React.createClass({
                     utils.ding();
                 }
             }
-        } else if (msg.action === "viewed") {
+        } else if (msg.action === 'viewed') {
             if (ChannelStore.getCurrentId() !== msg.channel_id && UserStore.getCurrentId() === msg.user_id) {
                 AsyncClient.getChannel(msg.channel_id);
             }

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -157,9 +157,9 @@ module.exports = React.createClass({
     onSocketChange: function(msg) {
         if (msg.action === 'posted') {
             if (ChannelStore.getCurrentId() === msg.channel_id) {
-                AsyncClient.getChannels(true, window.isActive);
+                if (window.isActive) AsyncClient.updateLastViewedAt();
             } else {
-                AsyncClient.getChannels(true);
+                AsyncClient.getChannel(msg.channel_id);
             }
 
             if (UserStore.getCurrentId() !== msg.user_id) {
@@ -213,13 +213,13 @@ module.exports = React.createClass({
                     utils.ding();
                 }
             }
-        } else if (msg.action === 'viewed') {
-            if (ChannelStore.getCurrentId() != msg.channel_id) {
-                AsyncClient.getChannels(true);
+        } else if (msg.action === "viewed") {
+            if (ChannelStore.getCurrentId() !== msg.channel_id && UserStore.getCurrentId() === msg.user_id) {
+                AsyncClient.getChannel(msg.channel_id);
             }
         } else if (msg.action === 'user_added') {
             if (UserStore.getCurrentId() === msg.user_id) {
-                AsyncClient.getChannels(true);
+                AsyncClient.getChannel(msg.channel_id);
             }
         } else if (msg.action === 'user_removed') {
             if (msg.user_id === UserStore.getCurrentId()) {

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -161,7 +161,6 @@ module.exports = React.createClass({
                     AsyncClient.updateLastViewedAt();
                 }
             } else {
-                console.log('hit');
                 AsyncClient.getChannels();
             }
 

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -102,7 +102,20 @@ function getStateFromStores() {
         }
         readDirectChannels = readDirectChannels.slice(index);
 
-        showDirectChannels.sort(function(a, b) {
+        showDirectChannels.sort(function directSort(a, b) {
+            if (a.display_name < b.display_name) {
+                return -1;
+            }
+            if (a.display_name > b.display_name) {
+                return 1;
+            }
+            return 0;
+        });
+    }
+
+    var channels = ChannelStore.getAll();
+    if (channels) {
+        channels.sort(function chanSort(a, b) {
             if (a.display_name < b.display_name) {
                 return -1;
             }
@@ -114,8 +127,8 @@ function getStateFromStores() {
     }
 
     return {
-        active_id: currentId,
-        channels: ChannelStore.getAll(),
+        activeId: currentId,
+        channels: channels,
         members: members,
         showDirectChannels: showDirectChannels,
         hideDirectChannels: readDirectChannels

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -113,22 +113,9 @@ function getStateFromStores() {
         });
     }
 
-    var channels = ChannelStore.getAll();
-    if (channels) {
-        channels.sort(function chanSort(a, b) {
-            if (a.display_name.toLowerCase() < b.display_name.toLowerCase()) {
-                return -1;
-            }
-            if (a.display_name.toLowerCase() > b.display_name.toLowerCase()) {
-                return 1;
-            }
-            return 0;
-        });
-    }
-
     return {
         activeId: currentId,
-        channels: channels,
+        channels: ChannelStore.getAll(),
         members: members,
         showDirectChannels: showDirectChannels,
         hideDirectChannels: readDirectChannels

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -116,10 +116,10 @@ function getStateFromStores() {
     var channels = ChannelStore.getAll();
     if (channels) {
         channels.sort(function chanSort(a, b) {
-            if (a.display_name < b.display_name) {
+            if (a.display_name.toLowerCase() < b.display_name.toLowerCase()) {
                 return -1;
             }
-            if (a.display_name > b.display_name) {
+            if (a.display_name.toLowerCase() > b.display_name.toLowerCase()) {
                 return 1;
             }
             return 0;

--- a/web/react/stores/channel_store.jsx
+++ b/web/react/stores/channel_store.jsx
@@ -10,247 +10,264 @@ var ActionTypes = Constants.ActionTypes;
 
 var BrowserStore = require('../stores/browser_store.jsx');
 
-
 var CHANGE_EVENT = 'change';
 var MORE_CHANGE_EVENT = 'change';
 var EXTRA_INFO_EVENT = 'extra_info';
 
 var ChannelStore = assign({}, EventEmitter.prototype, {
-    _current_id: null,
-  emitChange: function() {
-    this.emit(CHANGE_EVENT);
-  },
-  addChangeListener: function(callback) {
-    this.on(CHANGE_EVENT, callback);
-  },
-  removeChangeListener: function(callback) {
-    this.removeListener(CHANGE_EVENT, callback);
-  },
-  emitMoreChange: function() {
-    this.emit(MORE_CHANGE_EVENT);
-  },
-  addMoreChangeListener: function(callback) {
-    this.on(MORE_CHANGE_EVENT, callback);
-  },
-  removeMoreChangeListener: function(callback) {
-    this.removeListener(MORE_CHANGE_EVENT, callback);
-  },
-  emitExtraInfoChange: function() {
-    this.emit(EXTRA_INFO_EVENT);
-  },
-  addExtraInfoChangeListener: function(callback) {
-    this.on(EXTRA_INFO_EVENT, callback);
-  },
-  removeExtraInfoChangeListener: function(callback) {
-    this.removeListener(EXTRA_INFO_EVENT, callback);
-  },
-  findFirstBy: function(field, value) {
-    var channels = this._getChannels();
-    for (var i = 0; i < channels.length; i++) {
-      if (channels[i][field] == value) {
-        return channels[i];
-      }
-    }
+    _currentId: null,
+    emitChange: function() {
+        this.emit(CHANGE_EVENT);
+    },
+    addChangeListener: function(callback) {
+        this.on(CHANGE_EVENT, callback);
+    },
+    removeChangeListener: function(callback) {
+        this.removeListener(CHANGE_EVENT, callback);
+    },
+    emitMoreChange: function() {
+        this.emit(MORE_CHANGE_EVENT);
+    },
+    addMoreChangeListener: function(callback) {
+        this.on(MORE_CHANGE_EVENT, callback);
+    },
+    removeMoreChangeListener: function(callback) {
+        this.removeListener(MORE_CHANGE_EVENT, callback);
+    },
+    emitExtraInfoChange: function() {
+        this.emit(EXTRA_INFO_EVENT);
+    },
+    addExtraInfoChangeListener: function(callback) {
+        this.on(EXTRA_INFO_EVENT, callback);
+    },
+    removeExtraInfoChangeListener: function(callback) {
+        this.removeListener(EXTRA_INFO_EVENT, callback);
+    },
+    findFirstBy: function(field, value) {
+        var channels = this._getChannels();
+        for (var i = 0; i < channels.length; i++) {
+            if (channels[i][field] === value) {
+                return channels[i];
+            }
+        }
 
-    return null;
-  },
-  get: function(id) {
-    return this.findFirstBy('id', id);
-  },
-  getMember: function(id) {
-    return this.getAllMembers()[id];
-  },
-  getByName: function(name) {
-    return this.findFirstBy('name', name);
-  },
-  getAll: function() {
-    return this._getChannels();
-  },
-  getAllMembers: function() {
-    return this._getChannelMembers();
-  },
-  getMoreAll: function() {
-    return this._getMoreChannels();
-  },
-  setCurrentId: function(id) {
-      this._current_id = id;
-  },
-  setLastVisitedName: function(name) {
-    if (name == null)
-      BrowserStore.removeItem("last_visited_name");
-    else
-      BrowserStore.setItem("last_visited_name", name);
-  },
-  getLastVisitedName: function() {
-    return BrowserStore.getItem("last_visited_name");
-  },
-  resetCounts: function(id) {
-      var cm = this._getChannelMembers();
-      for (var cmid in cm) {
-          if (cm[cmid].channel_id == id) {
-              var c = this.get(id);
-              if (c) {
-                  cm[cmid].msg_count = this.get(id).total_msg_count;
-                  cm[cmid].mention_count = 0;
-              }
-              break;
-          }
-      }
-      this._storeChannelMembers(cm);
-  },
-  getCurrentId: function() {
-      return this._current_id;
-  },
-  getCurrent: function() {
-    var currentId = this.getCurrentId();
+        return null;
+    },
+    get: function(id) {
+        return this.findFirstBy('id', id);
+    },
+    getMember: function(id) {
+        return this.getAllMembers()[id];
+    },
+    getByName: function(name) {
+        return this.findFirstBy('name', name);
+    },
+    getAll: function() {
+        return this._getChannels();
+    },
+    getAllMembers: function() {
+        return this._getChannelMembers();
+    },
+    getMoreAll: function() {
+        return this._getMoreChannels();
+    },
+    setCurrentId: function(id) {
+        this._currentId = id;
+    },
+    setLastVisitedName: function(name) {
+        if (name == null) {
+            BrowserStore.removeItem('last_visited_name');
+        } else {
+            BrowserStore.setItem('last_visited_name', name);
+        }
+    },
+    getLastVisitedName: function() {
+        return BrowserStore.getItem('last_visited_name');
+    },
+    resetCounts: function(id) {
+        var cm = this._getChannelMembers();
+        for (var cmid in cm) {
+            if (cm[cmid].channel_id === id) {
+                var c = this.get(id);
+                if (c) {
+                    cm[cmid].msg_count = this.get(id).total_msg_count;
+                    cm[cmid].mention_count = 0;
+                }
+                break;
+            }
+        }
+        this._storeChannelMembers(cm);
+    },
+    getCurrentId: function() {
+        return this._currentId;
+    },
+    getCurrent: function() {
+        var currentId = this.getCurrentId();
 
-    if (currentId)
-      return this.get(currentId);
-    else
-      return null;
-  },
-  getCurrentMember: function() {
-    var currentId = ChannelStore.getCurrentId();
+        if (currentId) {
+            return this.get(currentId);
+        } else {
+            return null;
+        }
+    },
+    getCurrentMember: function() {
+        var currentId = ChannelStore.getCurrentId();
 
-    if (currentId)
-      return this.getAllMembers()[currentId];
-    else
-      return null;
-  },
-  setChannelMember: function(member) {
-    var members = this._getChannelMembers();
-    members[member.channel_id] = member;
-    this._storeChannelMembers(members);
-    this.emitChange();
-  },
-  getCurrentExtraInfo: function() {
-    var currentId = ChannelStore.getCurrentId();
-    var extra = null;
+        if (currentId) {
+            return this.getAllMembers()[currentId];
+        } else {
+            return null;
+        }
+    },
+    setChannelMember: function(member) {
+        var members = this._getChannelMembers();
+        members[member.channel_id] = member;
+        this._storeChannelMembers(members);
+        this.emitChange();
+    },
+    getCurrentExtraInfo: function() {
+        var currentId = ChannelStore.getCurrentId();
+        var extra = null;
 
-    if (currentId)
-      extra = this._getExtraInfos()[currentId];
+        if (currentId) {
+            extra = this._getExtraInfos()[currentId];
+        }
 
-    if (extra == null)
-      extra = {members: []};
+        if (extra == null) {
+            extra = {members: []};
+        }
 
-    return extra;
-  },
-  getExtraInfo: function(channel_id) {
-    var extra = null;
+        return extra;
+    },
+    getExtraInfo: function(channelId) {
+        var extra = null;
 
-    if (channel_id)
-      extra = this._getExtraInfos()[channel_id];
+        if (channelId) {
+            extra = this._getExtraInfos()[channelId];
+        }
 
-    if (extra == null)
-      extra = {members: []};
+        if (extra == null) {
+            extra = {members: []};
+        }
 
-    return extra;
-  },
-  _storeChannel: function(channel) {
-    var channels = this._getChannels();
-    var found;
+        return extra;
+    },
+    _storeChannel: function(channel) {
+        var channels = this._getChannels();
+        var found;
 
-    for (var i = 0; i < channels.length; i++) {
-      if (channels[i].id == channel.id) {
-        channels[i] = channel;
-        found = true;
-        break;
-      }
-    }
+        for (var i = 0; i < channels.length; i++) {
+            if (channels[i].id === channel.id) {
+                channels[i] = channel;
+                found = true;
+                break;
+            }
+        }
 
-    if (!found) {
-        channels.push(channel);
-        channels.sort(function(a,b) {
-          if (a.display_name < b.display_name) return -1;
-          if (a.display_name > b.display_name) return 1;
-          return 0;
+        if (!found) {
+            channels.push(channel);
+        }
+
+        channels.sort(function chanSort(a, b) {
+            if (a.display_name.toLowerCase() < b.display_name.toLowerCase()) {
+                return -1;
+            }
+            if (a.display_name.toLowerCase() > b.display_name.toLowerCase()) {
+                return 1;
+            }
+            return 0;
         });
-    }
-    this._storeChannels(channels);
-  },
-  _storeChannels: function(channels) {
-    BrowserStore.setItem("channels", channels);
-  },
-  _getChannels: function() {
-    return BrowserStore.getItem("channels", []);
-  },
-  _storeChannelMember: function(channelMember) {
-    var members = this._getChannelMembers();
-    members[channelMember.channel_id] = channelMember;
-    this._storeChannelMembers(members);
-  },
-  _storeChannelMembers: function(channelMembers) {
-    BrowserStore.setItem("channel_members", channelMembers);
-  },
-  _getChannelMembers: function() {
-    return BrowserStore.getItem("channel_members", {});
-  },
-  _storeMoreChannels: function(channels) {
-    BrowserStore.setItem("more_channels", channels);
-  },
-  _getMoreChannels: function() {
-    var channels = BrowserStore.getItem("more_channels");
 
-    if (channels == null) {
-        channels = {};
-        channels.loading = true;
-    }
+        this._storeChannels(channels);
+    },
+    _storeChannels: function(channels) {
+        BrowserStore.setItem('channels', channels);
+    },
+    _getChannels: function() {
+        return BrowserStore.getItem('channels', []);
+    },
+    _storeChannelMember: function(channelMember) {
+        var members = this._getChannelMembers();
+        members[channelMember.channel_id] = channelMember;
+        this._storeChannelMembers(members);
+    },
+    _storeChannelMembers: function(channelMembers) {
+        BrowserStore.setItem('channel_members', channelMembers);
+    },
+    _getChannelMembers: function() {
+        return BrowserStore.getItem('channel_members', {});
+    },
+    _storeMoreChannels: function(channels) {
+        BrowserStore.setItem('more_channels', channels);
+    },
+    _getMoreChannels: function() {
+        var channels = BrowserStore.getItem('more_channels');
 
-    return channels;
-  },
-  _storeExtraInfos: function(extraInfos) {
-    BrowserStore.setItem("extra_infos", extraInfos);
-  },
-  _getExtraInfos: function() {
-    return BrowserStore.getItem("extra_infos", {});
-  },
-  isDefault: function(channel) {
-    return channel.name == Constants.DEFAULT_CHANNEL;
-  }  
+        if (channels == null) {
+            channels = {};
+            channels.loading = true;
+        }
+
+        return channels;
+    },
+    _storeExtraInfos: function(extraInfos) {
+        BrowserStore.setItem('extra_infos', extraInfos);
+    },
+    _getExtraInfos: function() {
+        return BrowserStore.getItem('extra_infos', {});
+    },
+    isDefault: function(channel) {
+        return channel.name === Constants.DEFAULT_CHANNEL;
+    }
 });
 
 ChannelStore.dispatchToken = AppDispatcher.register(function(payload) {
-  var action = payload.action;
+    var action = payload.action;
+    var currentId;
 
-  switch(action.type) {
+    switch(action.type) {
 
-    case ActionTypes.CLICK_CHANNEL:
-      ChannelStore.setCurrentId(action.id);
-      ChannelStore.setLastVisitedName(action.name);
-      ChannelStore.resetCounts(action.id);
-      ChannelStore.emitChange();
-      break;
+        case ActionTypes.CLICK_CHANNEL:
+            ChannelStore.setCurrentId(action.id);
+            ChannelStore.setLastVisitedName(action.name);
+            ChannelStore.resetCounts(action.id);
+            ChannelStore.emitChange();
+            break;
 
-    case ActionTypes.RECIEVED_CHANNELS:
-      ChannelStore._storeChannels(action.channels);
-      ChannelStore._storeChannelMembers(action.members);
-      var currentId = ChannelStore.getCurrentId();
-      if (currentId) ChannelStore.resetCounts(currentId);
-      ChannelStore.emitChange();
-      break;
+        case ActionTypes.RECIEVED_CHANNELS:
+            ChannelStore._storeChannels(action.channels);
+            ChannelStore._storeChannelMembers(action.members);
+            currentId = ChannelStore.getCurrentId();
+            if (currentId) {
+                ChannelStore.resetCounts(currentId);
+            }
+            ChannelStore.emitChange();
+            break;
 
-    case ActionTypes.RECIEVED_CHANNEL:
-      ChannelStore._storeChannel(action.channel);
-      ChannelStore._storeChannelMember(action.member);
-      var currentId = ChannelStore.getCurrentId();
-      if (currentId) ChannelStore.resetCounts(currentId);
-      ChannelStore.emitChange();
-      break;
+        case ActionTypes.RECIEVED_CHANNEL:
+            ChannelStore._storeChannel(action.channel);
+            ChannelStore._storeChannelMember(action.member);
+            currentId = ChannelStore.getCurrentId();
+            if (currentId) {
+                ChannelStore.resetCounts(currentId);
+            }
+            ChannelStore.emitChange();
+            break;
 
-    case ActionTypes.RECIEVED_MORE_CHANNELS:
-      ChannelStore._storeMoreChannels(action.channels);
-      ChannelStore.emitMoreChange();
-      break;
+        case ActionTypes.RECIEVED_MORE_CHANNELS:
+            ChannelStore._storeMoreChannels(action.channels);
+            ChannelStore.emitMoreChange();
+            break;
 
-    case ActionTypes.RECIEVED_CHANNEL_EXTRA_INFO:
-      var extra_infos = ChannelStore._getExtraInfos();
-      extra_infos[action.extra_info.id] = action.extra_info;
-      ChannelStore._storeExtraInfos(extra_infos);
-      ChannelStore.emitExtraInfoChange();
-      break;
+        case ActionTypes.RECIEVED_CHANNEL_EXTRA_INFO:
+            var extraInfos = ChannelStore._getExtraInfos();
+            extraInfos[action.extra_info.id] = action.extra_info;
+            ChannelStore._storeExtraInfos(extraInfos);
+            ChannelStore.emitExtraInfoChange();
+            break;
 
-    default:
-  }
+        default:
+    }
 });
 
 module.exports = ChannelStore;

--- a/web/react/stores/channel_store.jsx
+++ b/web/react/stores/channel_store.jsx
@@ -15,7 +15,7 @@ var MORE_CHANGE_EVENT = 'change';
 var EXTRA_INFO_EVENT = 'extra_info';
 
 var ChannelStore = assign({}, EventEmitter.prototype, {
-    _currentId: null,
+    currentId: null,
     emitChange: function() {
         this.emit(CHANGE_EVENT);
     },
@@ -44,7 +44,7 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
         this.removeListener(EXTRA_INFO_EVENT, callback);
     },
     findFirstBy: function(field, value) {
-        var channels = this._getChannels();
+        var channels = this.pGetChannels();
         for (var i = 0; i < channels.length; i++) {
             if (channels[i][field] === value) {
                 return channels[i];
@@ -63,16 +63,16 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
         return this.findFirstBy('name', name);
     },
     getAll: function() {
-        return this._getChannels();
+        return this.pGetChannels();
     },
     getAllMembers: function() {
-        return this._getChannelMembers();
+        return this.pGetChannelMembers();
     },
     getMoreAll: function() {
-        return this._getMoreChannels();
+        return this.pGetMoreChannels();
     },
     setCurrentId: function(id) {
-        this._currentId = id;
+        this.currentId = id;
     },
     setLastVisitedName: function(name) {
         if (name == null) {
@@ -85,7 +85,7 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
         return BrowserStore.getItem('last_visited_name');
     },
     resetCounts: function(id) {
-        var cm = this._getChannelMembers();
+        var cm = this.pGetChannelMembers();
         for (var cmid in cm) {
             if (cm[cmid].channel_id === id) {
                 var c = this.get(id);
@@ -96,10 +96,10 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
                 break;
             }
         }
-        this._storeChannelMembers(cm);
+        this.pStoreChannelMembers(cm);
     },
     getCurrentId: function() {
-        return this._currentId;
+        return this.currentId;
     },
     getCurrent: function() {
         var currentId = this.getCurrentId();
@@ -120,9 +120,9 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
         }
     },
     setChannelMember: function(member) {
-        var members = this._getChannelMembers();
+        var members = this.pGetChannelMembers();
         members[member.channel_id] = member;
-        this._storeChannelMembers(members);
+        this.pStoreChannelMembers(members);
         this.emitChange();
     },
     getCurrentExtraInfo: function() {
@@ -130,7 +130,7 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
         var extra = null;
 
         if (currentId) {
-            extra = this._getExtraInfos()[currentId];
+            extra = this.pGetExtraInfos()[currentId];
         }
 
         if (extra == null) {
@@ -143,7 +143,7 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
         var extra = null;
 
         if (channelId) {
-            extra = this._getExtraInfos()[channelId];
+            extra = this.pGetExtraInfos()[channelId];
         }
 
         if (extra == null) {
@@ -152,8 +152,8 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
 
         return extra;
     },
-    _storeChannel: function(channel) {
-        var channels = this._getChannels();
+    pStoreChannel: function(channel) {
+        var channels = this.pGetChannels();
         var found;
 
         for (var i = 0; i < channels.length; i++) {
@@ -178,29 +178,29 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
             return 0;
         });
 
-        this._storeChannels(channels);
+        this.pStoreChannels(channels);
     },
-    _storeChannels: function(channels) {
+    pStoreChannels: function(channels) {
         BrowserStore.setItem('channels', channels);
     },
-    _getChannels: function() {
+    pGetChannels: function() {
         return BrowserStore.getItem('channels', []);
     },
-    _storeChannelMember: function(channelMember) {
-        var members = this._getChannelMembers();
+    pStoreChannelMember: function(channelMember) {
+        var members = this.pGetChannelMembers();
         members[channelMember.channel_id] = channelMember;
-        this._storeChannelMembers(members);
+        this.pStoreChannelMembers(members);
     },
-    _storeChannelMembers: function(channelMembers) {
+    pStoreChannelMembers: function(channelMembers) {
         BrowserStore.setItem('channel_members', channelMembers);
     },
-    _getChannelMembers: function() {
+    pGetChannelMembers: function() {
         return BrowserStore.getItem('channel_members', {});
     },
-    _storeMoreChannels: function(channels) {
+    pStoreMoreChannels: function(channels) {
         BrowserStore.setItem('more_channels', channels);
     },
-    _getMoreChannels: function() {
+    pGetMoreChannels: function() {
         var channels = BrowserStore.getItem('more_channels');
 
         if (channels == null) {
@@ -210,10 +210,10 @@ var ChannelStore = assign({}, EventEmitter.prototype, {
 
         return channels;
     },
-    _storeExtraInfos: function(extraInfos) {
+    pStoreExtraInfos: function(extraInfos) {
         BrowserStore.setItem('extra_infos', extraInfos);
     },
-    _getExtraInfos: function() {
+    pGetExtraInfos: function() {
         return BrowserStore.getItem('extra_infos', {});
     },
     isDefault: function(channel) {
@@ -235,8 +235,8 @@ ChannelStore.dispatchToken = AppDispatcher.register(function(payload) {
             break;
 
         case ActionTypes.RECIEVED_CHANNELS:
-            ChannelStore._storeChannels(action.channels);
-            ChannelStore._storeChannelMembers(action.members);
+            ChannelStore.pStoreChannels(action.channels);
+            ChannelStore.pStoreChannelMembers(action.members);
             currentId = ChannelStore.getCurrentId();
             if (currentId) {
                 ChannelStore.resetCounts(currentId);
@@ -245,8 +245,8 @@ ChannelStore.dispatchToken = AppDispatcher.register(function(payload) {
             break;
 
         case ActionTypes.RECIEVED_CHANNEL:
-            ChannelStore._storeChannel(action.channel);
-            ChannelStore._storeChannelMember(action.member);
+            ChannelStore.pStoreChannel(action.channel);
+            ChannelStore.pStoreChannelMember(action.member);
             currentId = ChannelStore.getCurrentId();
             if (currentId) {
                 ChannelStore.resetCounts(currentId);
@@ -255,14 +255,14 @@ ChannelStore.dispatchToken = AppDispatcher.register(function(payload) {
             break;
 
         case ActionTypes.RECIEVED_MORE_CHANNELS:
-            ChannelStore._storeMoreChannels(action.channels);
+            ChannelStore.pStoreMoreChannels(action.channels);
             ChannelStore.emitMoreChange();
             break;
 
         case ActionTypes.RECIEVED_CHANNEL_EXTRA_INFO:
-            var extraInfos = ChannelStore._getExtraInfos();
+            var extraInfos = ChannelStore.pGetExtraInfos();
             extraInfos[action.extra_info.id] = action.extra_info;
-            ChannelStore._storeExtraInfos(extraInfos);
+            ChannelStore.pStoreExtraInfos(extraInfos);
             ChannelStore.emitExtraInfoChange();
             break;
 

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -99,11 +99,13 @@ function getChannels(force, updateLastViewed, checkVersion) {
                 }
 
                 var countMap = data.counts;
+                var updateAtMap = data.update_times;
 
                 for (var id in countMap) {
-                    var chan = ChannelStore.get(id);
+                    var c = ChannelStore.get(id);
                     var count = countMap[id];
-                    if (!chan || chan.total_msg_count !== count) {
+                    var updateAt = updateAtMap[id];
+                    if (!c || c.total_msg_count !== count || updateAt > c.update_at) {
                         getChannel(id);
                     }
                 }

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -81,6 +81,30 @@ module.exports.getChannels = function(force, updateLastViewed, checkVersion) {
     }
 }
 
+module.exports.getChannel = function(id) {
+    if (isCallInProgress("getChannel"+id)) return;
+
+        callTracker["getChannel"+id] = utils.getTimestamp();
+        client.getChannel(id,
+            function(data, textStatus, xhr) {
+                callTracker["getChannel"+id] = 0;
+
+                if (xhr.status === 304 || !data) return;
+
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECIEVED_CHANNEL,
+                    channel: data.channel,
+                    member: data.member
+                });
+
+            },
+            function(err) {
+                callTracker["getChannel"+id] = 0;
+                dispatchError(err, "getChannel");
+            }
+        );
+}
+
 module.exports.updateLastViewedAt = function() {
     if (isCallInProgress("updateLastViewed")) return;
 

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -14,124 +14,169 @@ var ActionTypes = Constants.ActionTypes;
 // Used to track in progress async calls
 var callTracker = {};
 
-var dispatchError = function(err, method) {
+function dispatchError(err, method) {
     AppDispatcher.handleServerAction({
         type: ActionTypes.RECIEVED_ERROR,
         err: err,
         method: method
     });
-};
+}
+module.exports.dispatchError = dispatchError;
 
-var isCallInProgress = function(callName) {
-    if (!(callName in callTracker)) return false;
+function isCallInProgress(callName) {
+    if (!(callName in callTracker)) {
+        return false;
+    }
 
-    if (callTracker[callName] === 0) return false;
+    if (callTracker[callName] === 0) {
+        return false;
+    }
 
     if (utils.getTimestamp() - callTracker[callName] > 5000) {
-        console.log("AsyncClient call " + callName + " expired after more than 5 seconds");
+        console.log('AsyncClient call ' + callName + ' expired after more than 5 seconds');
         return false;
     }
 
     return true;
-};
+}
 
-module.exports.dispatchError = dispatchError;
+function getChannels(force, updateLastViewed, checkVersion) {
+    var channels = ChannelStore.getAll();
 
-module.exports.getChannels = function(force, updateLastViewed, checkVersion) {
-    if (isCallInProgress("getChannels")) return;
+    if (channels.length === 0 || force) {
+        if (isCallInProgress('getChannels')) {
+            return;
+        }
 
-    if (ChannelStore.getAll().length == 0 || force) {
-        callTracker["getChannels"] = utils.getTimestamp();
+        callTracker.getChannels = utils.getTimestamp();
+
         client.getChannels(
             function(data, textStatus, xhr) {
-                callTracker["getChannels"] = 0;
-
-                if (updateLastViewed && ChannelStore.getCurrentId() != null) {
-                    module.exports.updateLastViewedAt();
-                }
+                callTracker.getChannels = 0;
 
                 if (checkVersion) {
-                    var serverVersion = xhr.getResponseHeader("X-Version-ID");
+                    var serverVersion = xhr.getResponseHeader('X-Version-ID');
 
                     if (!UserStore.getLastVersion()) {
                         UserStore.setLastVersion(serverVersion);
                     }
 
-                    if (serverVersion != UserStore.getLastVersion()) {
+                    if (serverVersion !== UserStore.getLastVersion()) {
                         UserStore.setLastVersion(serverVersion);
                         window.location.href = window.location.href;
-                        console.log("Detected version update refreshing the page");
+                        console.log('Detected version update refreshing the page');
                     }
                 }
 
-                if (xhr.status === 304 || !data) return;
+                if (xhr.status === 304 || !data) {
+                    return;
+                }
 
                 AppDispatcher.handleServerAction({
                     type: ActionTypes.RECIEVED_CHANNELS,
                     channels: data.channels,
                     members: data.members
                 });
-
             },
             function(err) {
-                callTracker["getChannels"] = 0;
-                dispatchError(err, "getChannels");
+                callTracker.getChannels = 0;
+                dispatchError(err, 'getChannels');
+            }
+        );
+    } else {
+        if (isCallInProgress('getChannelCounts')) {
+            return;
+        }
+
+        callTracker.getChannelCounts = utils.getTimestamp();
+
+        client.getChannelCounts(
+            function(data, textStatus, xhr) {
+                callTracker.getChannelCounts = 0;
+
+                if (xhr.status === 304 || !data) {
+                    return;
+                }
+
+                var countMap = data.counts;
+
+                for (var id in countMap) {
+                    var chan = ChannelStore.get(id);
+                    var count = countMap[id];
+                    if (!chan || chan.total_msg_count !== count) {
+                        getChannel(id);
+                    }
+                }
+            },
+            function(err) {
+                callTracker.getChannelCounts = 0;
+                dispatchError(err, 'getChannelCounts');
             }
         );
     }
+
+    if (updateLastViewed && ChannelStore.getCurrentId() != null) {
+        module.exports.updateLastViewedAt();
+    }
 }
+module.exports.getChannels = getChannels;
 
-module.exports.getChannel = function(id) {
-    if (isCallInProgress("getChannel"+id)) return;
+function getChannel(id) {
+    if (isCallInProgress('getChannel' + id)) {
+        return;
+    }
 
-        callTracker["getChannel"+id] = utils.getTimestamp();
-        client.getChannel(id,
-            function(data, textStatus, xhr) {
-                callTracker["getChannel"+id] = 0;
+    callTracker['getChannel' + id] = utils.getTimestamp();
 
-                if (xhr.status === 304 || !data) return;
+    client.getChannel(id,
+        function(data, textStatus, xhr) {
+            callTracker['getChannel' + id] = 0;
 
-                AppDispatcher.handleServerAction({
-                    type: ActionTypes.RECIEVED_CHANNEL,
-                    channel: data.channel,
-                    member: data.member
-                });
-
-            },
-            function(err) {
-                callTracker["getChannel"+id] = 0;
-                dispatchError(err, "getChannel");
+            if (xhr.status === 304 || !data) {
+                return;
             }
-        );
+
+            AppDispatcher.handleServerAction({
+                type: ActionTypes.RECIEVED_CHANNEL,
+                channel: data.channel,
+                member: data.member
+            });
+        },
+        function(err) {
+            callTracker['getChannel' + id] = 0;
+            dispatchError(err, 'getChannel');
+        }
+    );
 }
+module.exports.getChannel = getChannel;
 
 module.exports.updateLastViewedAt = function() {
-    if (isCallInProgress("updateLastViewed")) return;
+    if (isCallInProgress('updateLastViewed')) return;
 
     if (ChannelStore.getCurrentId() == null) return;
 
-    callTracker["updateLastViewed"] = utils.getTimestamp();
+    callTracker['updateLastViewed'] = utils.getTimestamp();
     client.updateLastViewedAt(
         ChannelStore.getCurrentId(),
         function(data) {
-            callTracker["updateLastViewed"] = 0;
+            callTracker['updateLastViewed'] = 0;
         },
         function(err) {
-            callTracker["updateLastViewed"] = 0;
-            dispatchError(err, "updateLastViewedAt");
+            callTracker['updateLastViewed'] = 0;
+            dispatchError(err, 'updateLastViewedAt');
         }
     );
 }
 
 module.exports.getMoreChannels = function(force) {
-    if (isCallInProgress("getMoreChannels")) return;
+    if (isCallInProgress('getMoreChannels')) return;
 
     if (ChannelStore.getMoreAll().loading || force) {
 
-        callTracker["getMoreChannels"] = utils.getTimestamp();
+        callTracker['getMoreChannels'] = utils.getTimestamp();
         client.getMoreChannels(
             function(data, textStatus, xhr) {
-                callTracker["getMoreChannels"] = 0;
+                callTracker['getMoreChannels'] = 0;
 
                 if (xhr.status === 304 || !data) return;
 
@@ -142,8 +187,8 @@ module.exports.getMoreChannels = function(force) {
                 });
             },
             function(err) {
-                callTracker["getMoreChannels"] = 0;
-                dispatchError(err, "getMoreChannels");
+                callTracker['getMoreChannels'] = 0;
+                dispatchError(err, 'getMoreChannels');
             }
         );
     }
@@ -153,15 +198,15 @@ module.exports.getChannelExtraInfo = function(force) {
     var channelId = ChannelStore.getCurrentId();
 
     if (channelId != null) {
-        if (isCallInProgress("getChannelExtraInfo_"+channelId)) return;
+        if (isCallInProgress('getChannelExtraInfo_'+channelId)) return;
         var minMembers = ChannelStore.getCurrent() && ChannelStore.getCurrent().type === 'D' ? 1 : 0;
 
         if (ChannelStore.getCurrentExtraInfo().members.length <= minMembers || force) {
-            callTracker["getChannelExtraInfo_"+channelId] = utils.getTimestamp();
+            callTracker['getChannelExtraInfo_'+channelId] = utils.getTimestamp();
             client.getChannelExtraInfo(
                 channelId,
                 function(data, textStatus, xhr) {
-                    callTracker["getChannelExtraInfo_"+channelId] = 0;
+                    callTracker['getChannelExtraInfo_'+channelId] = 0;
 
                     if (xhr.status === 304 || !data) return;
 
@@ -171,8 +216,8 @@ module.exports.getChannelExtraInfo = function(force) {
                     });
                 },
                 function(err) {
-                    callTracker["getChannelExtraInfo_"+channelId] = 0;
-                    dispatchError(err, "getChannelExtraInfo");
+                    callTracker['getChannelExtraInfo_'+channelId] = 0;
+                    dispatchError(err, 'getChannelExtraInfo');
                 }
             );
         }
@@ -180,12 +225,12 @@ module.exports.getChannelExtraInfo = function(force) {
 }
 
 module.exports.getProfiles = function() {
-    if (isCallInProgress("getProfiles")) return;
+    if (isCallInProgress('getProfiles')) return;
 
-    callTracker["getProfiles"] = utils.getTimestamp();
+    callTracker['getProfiles'] = utils.getTimestamp();
     client.getProfiles(
         function(data, textStatus, xhr) {
-            callTracker["getProfiles"] = 0;
+            callTracker['getProfiles'] = 0;
 
             if (xhr.status === 304 || !data) return;
 
@@ -195,20 +240,20 @@ module.exports.getProfiles = function() {
             });
         },
         function(err) {
-            callTracker["getProfiles"] = 0;
-            dispatchError(err, "getProfiles");
+            callTracker['getProfiles'] = 0;
+            dispatchError(err, 'getProfiles');
         }
     );
 }
 
 module.exports.getSessions = function() {
-    if (isCallInProgress("getSessions")) return;
+    if (isCallInProgress('getSessions')) return;
 
-    callTracker["getSessions"] = utils.getTimestamp();
+    callTracker['getSessions'] = utils.getTimestamp();
     client.getSessions(
         UserStore.getCurrentId(),
         function(data, textStatus, xhr) {
-            callTracker["getSessions"] = 0;
+            callTracker['getSessions'] = 0;
 
             if (xhr.status === 304 || !data) return;
 
@@ -218,20 +263,20 @@ module.exports.getSessions = function() {
             });
         },
         function(err) {
-            callTracker["getSessions"] = 0;
-            dispatchError(err, "getSessions");
+            callTracker['getSessions'] = 0;
+            dispatchError(err, 'getSessions');
         }
     );
 }
 
 module.exports.getAudits = function() {
-    if (isCallInProgress("getAudits")) return;
+    if (isCallInProgress('getAudits')) return;
 
-    callTracker["getAudits"] = utils.getTimestamp();
+    callTracker['getAudits'] = utils.getTimestamp();
     client.getAudits(
         UserStore.getCurrentId(),
         function(data, textStatus, xhr) {
-            callTracker["getAudits"] = 0;
+            callTracker['getAudits'] = 0;
 
             if (xhr.status === 304 || !data) return;
 
@@ -241,22 +286,22 @@ module.exports.getAudits = function() {
             });
         },
         function(err) {
-            callTracker["getAudits"] = 0;
-            dispatchError(err, "getAudits");
+            callTracker['getAudits'] = 0;
+            dispatchError(err, 'getAudits');
         }
     );
 }
 
 module.exports.findTeams = function(email) {
-    if (isCallInProgress("findTeams_"+email)) return;
+    if (isCallInProgress('findTeams_'+email)) return;
 
     var user = UserStore.getCurrentUser();
     if (user) {
-        callTracker["findTeams_"+email] = utils.getTimestamp();
+        callTracker['findTeams_'+email] = utils.getTimestamp();
         client.findTeams(
             user.email,
             function(data, textStatus, xhr) {
-                callTracker["findTeams_"+email] = 0;
+                callTracker['findTeams_'+email] = 0;
 
                 if (xhr.status === 304 || !data) return;
 
@@ -266,21 +311,21 @@ module.exports.findTeams = function(email) {
                 });
             },
             function(err) {
-                callTracker["findTeams_"+email] = 0;
-                dispatchError(err, "findTeams");
+                callTracker['findTeams_'+email] = 0;
+                dispatchError(err, 'findTeams');
             }
         );
     }
 }
 
 module.exports.search = function(terms) {
-    if (isCallInProgress("search_"+String(terms))) return;
+    if (isCallInProgress('search_'+String(terms))) return;
 
-    callTracker["search_"+String(terms)] = utils.getTimestamp();
+    callTracker['search_'+String(terms)] = utils.getTimestamp();
     client.search(
         terms,
         function(data, textStatus, xhr) {
-            callTracker["search_"+String(terms)] = 0;
+            callTracker['search_'+String(terms)] = 0;
 
             if (xhr.status === 304 || !data) return;
 
@@ -290,8 +335,8 @@ module.exports.search = function(terms) {
             });
         },
         function(err) {
-            callTracker["search_"+String(terms)] = 0;
-            dispatchError(err, "search");
+            callTracker['search_'+String(terms)] = 0;
+            dispatchError(err, 'search');
         }
     );
 }
@@ -300,7 +345,7 @@ module.exports.getPosts = function(force, id, maxPosts) {
     if (PostStore.getCurrentPosts() == null || force) {
         var channelId = id ? id : ChannelStore.getCurrentId();
 
-        if (isCallInProgress("getPosts_"+channelId)) return;
+        if (isCallInProgress('getPosts_'+channelId)) return;
 
         var post_list = PostStore.getCurrentPosts();
 
@@ -315,7 +360,7 @@ module.exports.getPosts = function(force, id, maxPosts) {
         }
 
         if (channelId != null) {
-            callTracker["getPosts_"+channelId] = utils.getTimestamp();
+            callTracker['getPosts_'+channelId] = utils.getTimestamp();
             client.getPosts(
                 channelId,
                 0,
@@ -332,23 +377,25 @@ module.exports.getPosts = function(force, id, maxPosts) {
                     module.exports.getProfiles();
                 },
                 function(err) {
-                    dispatchError(err, "getPosts");
+                    dispatchError(err, 'getPosts');
                 },
                 function() {
-                    callTracker["getPosts_"+channelId] = 0;
+                    callTracker['getPosts_'+channelId] = 0;
                 }
             );
         }
     }
 }
 
-module.exports.getMe = function() {
-    if (isCallInProgress("getMe")) return;
+function getMe() {
+    if (isCallInProgress('getMe')) {
+        return;
+    }
 
-    callTracker["getMe"] = utils.getTimestamp();
+    callTracker.getMe = utils.getTimestamp();
     client.getMe(
         function(data, textStatus, xhr) {
-            callTracker["getMe"] = 0;
+            callTracker.getMe = 0;
 
             if (xhr.status === 304 || !data) return;
 
@@ -358,19 +405,20 @@ module.exports.getMe = function() {
             });
         },
         function(err) {
-            callTracker["getMe"] = 0;
-            dispatchError(err, "getMe");
+            callTracker.getMe = 0;
+            dispatchError(err, 'getMe');
         }
     );
 }
+module.exports.getMe = getMe;
 
 module.exports.getStatuses = function() {
-    if (isCallInProgress("getStatuses")) return;
+    if (isCallInProgress('getStatuses')) return;
 
-    callTracker["getStatuses"] = utils.getTimestamp();
+    callTracker['getStatuses'] = utils.getTimestamp();
     client.getStatuses(
         function(data, textStatus, xhr) {
-            callTracker["getStatuses"] = 0;
+            callTracker['getStatuses'] = 0;
 
             if (xhr.status === 304 || !data) return;
 
@@ -380,19 +428,19 @@ module.exports.getStatuses = function() {
             });
         },
         function(err) {
-            callTracker["getStatuses"] = 0;
-            dispatchError(err, "getStatuses");
+            callTracker['getStatuses'] = 0;
+            dispatchError(err, 'getStatuses');
         }
     );
 }
 
 module.exports.getMyTeam = function() {
-    if (isCallInProgress("getMyTeam")) return;
+    if (isCallInProgress('getMyTeam')) return;
 
-    callTracker["getMyTeam"] = utils.getTimestamp();
+    callTracker['getMyTeam'] = utils.getTimestamp();
     client.getMyTeam(
         function(data, textStatus, xhr) {
-            callTracker["getMyTeam"] = 0;
+            callTracker['getMyTeam'] = 0;
 
             if (xhr.status === 304 || !data) return;
 
@@ -402,8 +450,8 @@ module.exports.getMyTeam = function() {
             });
         },
         function(err) {
-            callTracker["getMyTeam"] = 0;
-            dispatchError(err, "getMyTeam");
+            callTracker['getMyTeam'] = 0;
+            dispatchError(err, 'getMyTeam');
         }
     );
 }

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -554,6 +554,21 @@ module.exports.getChannels = function(success, error) {
     });
 };
 
+module.exports.getChannel = function(id, success, error) {
+    $.ajax({
+        url: "/api/v1/channels/" + id + "/",
+        dataType: 'json',
+        type: 'GET',
+        success: success,
+        error: function(xhr, status, err) {
+            e = handleError("getChannel", xhr, status, err);
+            error(e);
+        }
+    });
+
+    module.exports.track('api', 'api_channel_get');
+};
+
 module.exports.getMoreChannels = function(success, error) {
     $.ajax({
         url: "/api/v1/channels/more",

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -540,19 +540,20 @@ module.exports.updateLastViewedAt = function(channelId, success, error) {
     });
 };
 
-module.exports.getChannels = function(success, error) {
+function getChannels(success, error) {
     $.ajax({
-        url: "/api/v1/channels/",
+        url: '/api/v1/channels/',
         dataType: 'json',
         type: 'GET',
         success: success,
         ifModified: true,
         error: function(xhr, status, err) {
-            e = handleError("getChannels", xhr, status, err);
+            var e = handleError('getChannels', xhr, status, err);
             error(e);
         }
     });
-};
+}
+module.exports.getChannels = getChannels;
 
 module.exports.getChannel = function(id, success, error) {
     $.ajax({
@@ -582,6 +583,21 @@ module.exports.getMoreChannels = function(success, error) {
         }
     });
 };
+
+function getChannelCounts(success, error) {
+    $.ajax({
+        url: '/api/v1/channels/counts',
+        dataType: 'json',
+        type: 'GET',
+        success: success,
+        ifModified: true,
+        error: function(xhr, status, err) {
+            var e = handleError('getChannelCounts', xhr, status, err);
+            error(e);
+        }
+    });
+}
+module.exports.getChannelCounts = getChannelCounts;
 
 module.exports.getChannelExtraInfo = function(id, success, error) {
     $.ajax({

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -10,6 +10,7 @@ module.exports = {
     CLICK_CHANNEL: null,
     CREATE_CHANNEL: null,
     RECIEVED_CHANNELS: null,
+    RECIEVED_CHANNEL: null,
     RECIEVED_MORE_CHANNELS: null,
     RECIEVED_CHANNEL_EXTRA_INFO: null,
 

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -732,20 +732,19 @@ module.exports.isValidUsername = function (name) {
     return error;
 }
 
-module.exports.switchChannel = function(channel, teammate_name) {
+function switchChannel(channel, teammateName) {
     AppDispatcher.handleViewAction({
       type: ActionTypes.CLICK_CHANNEL,
       name: channel.name,
       id: channel.id
     });
 
-    var teamURL = window.location.href.split('/channels')[0];
-    history.replaceState('data', '', teamURL + '/channels/' + channel.name);
+    updateAddressBar(channel.name);
 
-    if (channel.type === 'D' && teammate_name) {
-        document.title = teammate_name + " " + document.title.substring(document.title.lastIndexOf("-"));
+    if (channel.type === 'D' && teammateName) {
+        updateTabTitle(teammateName);
     } else {
-        document.title = channel.display_name + " " + document.title.substring(document.title.lastIndexOf("-"));
+        updateTabTitle(channel.display_name);
     }
 
     AsyncClient.getChannels(true, true, true);
@@ -759,6 +758,18 @@ module.exports.switchChannel = function(channel, teammate_name) {
 
     return false;
 }
+module.exports.switchChannel = switchChannel;
+
+function updateTabTitle(name) {
+    document.title = name + ' ' + document.title.substring(document.title.lastIndexOf('-'));
+}
+module.exports.updateTabTitle = updateTabTitle;
+
+function updateAddressBar(channelName) {
+    var teamURL = window.location.href.split('/channels')[0];
+    history.replaceState('data', '', teamURL + '/channels/' + channelName);
+}
+module.exports.updateAddressBar = updateAddressBar;
 
 module.exports.isMobile = function() {
   return screen.width <= 768;


### PR DESCRIPTION
This PR does a few things:
* Adds GetChannel api service to allow the client to pull a single channel at a time
* Adds GetChannelCounts api service to allow client to ask only for the message count and update time of the channels
* Updates client to use GetChannel over GetChannels where possible
* Updates GetChannel async call on client to only pull updated channels unless forced
* Reformat channel_store.jsx to more closely match style guide
* Update edit channel description, rename channel and create new channel modals to not refresh after submission

I know there are instances where missing function names don't match the style guide. That's on purpose, because I don't agree with the style guide and I don't want to add them in if it's going to change.