### PR TITLE
MM-1184 Updating dockerfiles for latest master and osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,10 +245,8 @@ dist: install
 
 	tar -C dist -czf $(DIST_PATH).tar.gz mattermost
 
-docker-build: stop dist
-	cp $(DIST_PATH).tar.gz docker/dev
-	cd docker/dev && docker build -t ${DOCKERNAME} .
-	rm docker/dev/mattermost.tar.gz
+docker-build: stop
+	docker build -t ${DOCKERNAME} -f docker/local/Dockerfile .
 
 docker-run: docker-build
 	docker run --name ${DOCKER_CONTAINER_NAME} -d --publish 8065:80 ${DOCKERNAME}

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -13,8 +13,6 @@ ENV MYSQL_DATABASE=mattermost_test
 
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-RUN apt-get update && apt-get install -y perl --no-install-recommends && rm -rf /var/lib/apt/lists/*
-
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5
 
 ENV MYSQL_MAJOR 5.6
@@ -24,7 +22,7 @@ RUN echo "deb http://repo.mysql.com/apt/debian/ wheezy mysql-${MYSQL_MAJOR}" > /
 
 RUN apt-get update \
 	&& export DEBIAN_FRONTEND=noninteractive \
-	&& apt-get -y install mysql-server \
+	&& apt-get -y install perl wget mysql-server \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql
 
@@ -36,7 +34,8 @@ VOLUME /var/lib/mysql
 WORKDIR /mattermost
 
 # Copy over files
-ADD mattermost.tar.gz /
+RUN wget --no-check-certificate https://s3.amazonaws.com/mattermost-travis-master/mattermost.tar.gz
+RUN tar -zxvf mattermost.tar.gz --strip-components=1 && rm mattermost.tar.gz
 ADD config_docker.json /
 ADD docker-entry.sh /
 

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -1,0 +1,84 @@
+# Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+# See License.txt for license information.
+FROM ubuntu:14.04
+
+# Install Dependancies
+RUN apt-get update && apt-get install -y build-essential
+RUN apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup | bash -
+RUN apt-get install -y nodejs
+RUN apt-get install -y ruby-full
+RUN gem install compass
+
+#
+# Install GO
+#
+
+RUN apt-get update && apt-get install -y \
+		gcc libc6-dev make git mercurial \
+		--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.4.2
+
+RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
+		| tar -v -C /usr/src -xz
+
+RUN cd /usr/src/go/src && ./make.bash --no-clean 2>&1
+
+ENV PATH /usr/src/go/bin:$PATH
+
+RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
+ENV GOPATH /go
+ENV PATH /go/bin:$PATH
+WORKDIR /go
+
+# ---------------------------------------------------------------------------------------------------------------------
+
+#
+# Install SQL
+#
+
+ENV MYSQL_ROOT_PASSWORD=mostest
+ENV MYSQL_USER=mmuser
+ENV MYSQL_PASSWORD=mostest
+ENV MYSQL_DATABASE=mattermost_test
+
+RUN groupadd -r mysql && useradd -r -g mysql mysql
+
+RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5
+
+ENV MYSQL_MAJOR 5.6
+ENV MYSQL_VERSION 5.6.25
+
+RUN echo "deb http://repo.mysql.com/apt/debian/ wheezy mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
+
+RUN apt-get update \
+	&& export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get -y install perl mysql-server \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql
+
+RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf
+
+VOLUME /var/lib/mysql
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Copy over files
+ADD . /go/src/github.com/mattermost/platform
+
+RUN go get github.com/tools/godep
+RUN cd /go/src/github.com/mattermost/platform/; godep go install
+RUN cd /go/src/github.com/mattermost/platform/web/react; npm install
+
+ADD /docker/local/config_docker.json /
+ADD /docker/local/docker-entry.sh /
+
+RUN chmod +x /docker-entry.sh
+ENTRYPOINT /docker-entry.sh
+
+# Create default storage directory
+RUN mkdir /mattermost-data/
+
+# Ports
+EXPOSE 80

--- a/docker/local/Dockerrun.aws.json
+++ b/docker/local/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "mattermost/platform:dev",
+    "Name": "YOUR_DEV_INSTANCE_HERE",
     "Update": "true"
   },
   "Ports": [

--- a/docker/local/config_docker.json
+++ b/docker/local/config_docker.json
@@ -1,0 +1,98 @@
+{
+    "LogSettings": {
+        "ConsoleEnable": true,
+        "ConsoleLevel": "INFO",
+        "FileEnable": true,
+        "FileLevel": "INFO",
+        "FileFormat": "",
+        "FileLocation": ""
+    },
+    "ServiceSettings": {
+        "SiteName": "Mattermost",
+        "Mode" : "dev",
+		"AllowTesting" : true,
+        "UseSSL": false,
+        "Port": "80",
+        "Version": "developer",
+        "Shards": {
+        },
+        "InviteSalt": "gxHVDcKUyP2y1eiyW8S8na1UYQAfq6J6",
+        "PublicLinkSalt": "TO3pTyXIZzwHiwyZgGql7lM7DG3zeId4",
+        "ResetSalt": "IPxFzSfnDFsNsRafZxz8NaYqFKhf9y2t",
+        "AnalyticsUrl": "",
+        "UseLocalStorage": true,
+        "StorageDirectory": "/mattermost/data/",
+        "AllowedLoginAttempts": 10
+    },
+    "SSOSettings": {
+        "gitlab": {
+            "Allow": false,
+            "Secret" : "",
+            "Id": "",
+            "AuthEndpoint": "",
+            "TokenEndpoint": "",
+            "UserApiEndpoint": ""
+        }
+    },
+    "SqlSettings": {
+        "DriverName": "mysql",
+        "DataSource": "mmuser:mostest@tcp(localhost:3306)/mattermost_test?charset=utf8mb4,utf8",
+        "DataSourceReplicas": ["mmuser:mostest@tcp(localhost:3306)/mattermost_test?charset=utf8mb4,utf8"],
+        "MaxIdleConns": 10,
+        "MaxOpenConns": 10,
+        "Trace": false,
+        "AtRestEncryptKey": "Ya0xMrybACJ3sZZVWQC7e31h5nSDWZFS"
+    },
+    "AWSSettings": {
+        "S3AccessKeyId": "",
+        "S3SecretAccessKey": "",
+        "S3Bucket": "",
+        "S3Region": ""
+    },
+    "ImageSettings": {
+        "ThumbnailWidth": 120,
+        "ThumbnailHeight": 100,
+        "PreviewWidth": 1024,
+        "PreviewHeight": 0,
+        "ProfileWidth": 128,
+        "ProfileHeight": 128,
+        "InitialFont": "luximbi.ttf"
+    },
+    "EmailSettings": {
+        "ByPassEmail" : true,
+        "SMTPUsername": "",
+        "SMTPPassword": "",
+        "SMTPServer": "",
+		"UseTLS": false,
+        "FeedbackEmail": "",
+        "FeedbackName": "",
+        "ApplePushServer": "",
+        "ApplePushCertPublic": "",
+        "ApplePushCertPrivate": ""
+    },
+    "RateLimitSettings": {
+        "UseRateLimiter": true,
+        "PerSec": 10,
+        "MemoryStoreSize": 10000,
+        "VaryByRemoteAddr": true,
+        "VaryByHeader": ""
+    },
+    "PrivacySettings": {
+        "ShowEmailAddress": true,
+        "ShowPhoneNumber": true,
+        "ShowSkypeId": true,
+        "ShowFullName": true
+    },
+    "TeamSettings": {
+        "MaxUsersPerTeam": 150,
+        "AllowPublicLink": true,
+        "AllowValetDefault": false,
+        "TermsLink": "/static/help/configure_links.html",
+        "PrivacyLink": "/static/help/configure_links.html",
+        "AboutLink": "/static/help/configure_links.html",
+        "HelpLink": "/static/help/configure_links.html",
+        "ReportProblemLink": "/static/help/configure_links.html",
+        "TourLink": "/static/help/configure_links.html",
+        "DefaultThemeColor": "#2389D7"
+    }
+}

--- a/docker/local/docker-entry.sh
+++ b/docker/local/docker-entry.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+# See License.txt for license information.
+
+mkdir -p web/static/js
+
+echo "127.0.0.1 dockerhost" >> /etc/hosts
+/etc/init.d/networking restart
+
+echo configuring mysql
+
+# SQL!!!
+set -e
+
+get_option () {
+	local section=$1
+	local option=$2
+	local default=$3
+	ret=$(my_print_defaults $section | grep '^--'${option}'=' | cut -d= -f2-)
+	[ -z $ret ] && ret=$default
+	echo $ret
+}
+
+
+# Get config
+DATADIR="$("mysqld" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
+SOCKET=$(get_option  mysqld socket "$DATADIR/mysql.sock")
+PIDFILE=$(get_option mysqld pid-file "/var/run/mysqld/mysqld.pid")
+
+if [ ! -d "$DATADIR/mysql" ]; then
+	if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ]; then
+		echo >&2 'error: database is uninitialized and MYSQL_ROOT_PASSWORD not set'
+		echo >&2 '  Did you forget to add -e MYSQL_ROOT_PASSWORD=... ?'
+		exit 1
+	fi
+
+	mkdir -p "$DATADIR"
+	chown -R mysql:mysql "$DATADIR"
+
+	echo 'Running mysql_install_db'
+	mysql_install_db --user=mysql --datadir="$DATADIR" --rpm --keep-my-cnf
+	echo 'Finished mysql_install_db'
+
+	mysqld --user=mysql --datadir="$DATADIR" --skip-networking &
+	for i in $(seq 30 -1 0); do
+		[ -S "$SOCKET" ] && break
+		echo 'MySQL init process in progress...'
+		sleep 1
+	done
+	if [ $i = 0 ]; then
+		echo >&2 'MySQL init process failed.'
+		exit 1
+	fi
+
+	# These statements _must_ be on individual lines, and _must_ end with
+	# semicolons (no line breaks or comments are permitted).
+	# TODO proper SQL escaping on ALL the things D:
+
+	tempSqlFile=$(mktemp /tmp/mysql-first-time.XXXXXX.sql)
+	cat > "$tempSqlFile" <<-EOSQL
+	-- What's done in this file shouldn't be replicated
+	--  or products like mysql-fabric won't work
+	SET @@SESSION.SQL_LOG_BIN=0;
+
+	DELETE FROM mysql.user ;
+	CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+	GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+	DROP DATABASE IF EXISTS test ;
+	EOSQL
+
+	if [ "$MYSQL_DATABASE" ]; then
+		echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$tempSqlFile"
+	fi
+
+	if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+		echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" >> "$tempSqlFile"
+
+		if [ "$MYSQL_DATABASE" ]; then
+			echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" >> "$tempSqlFile"
+		fi
+	fi
+
+	echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
+
+	mysql -uroot < "$tempSqlFile"
+
+	rm -f "$tempSqlFile"
+	kill $(cat $PIDFILE)
+	for i in $(seq 30 -1 0); do
+		[ -f "$PIDFILE" ] || break
+		echo 'MySQL init process in progress...'
+		sleep 1
+	done
+	if [ $i = 0 ]; then
+		echo >&2 'MySQL hangs during init process.'
+		exit 1
+	fi
+	echo 'MySQL init process done. Ready for start up.'
+fi
+
+chown -R mysql:mysql "$DATADIR"
+
+mysqld &
+
+sleep 5
+
+# ------------------------
+
+echo starting react processor   
+cd /go/src/github.com/mattermost/platform/web/react && npm start &
+
+echo starting go web server
+cd /go/src/github.com/mattermost/platform/; godep go run mattermost.go -config=/config_docker.json &
+
+echo starting compass watch
+cd /go/src/github.com/mattermost/platform/web/sass-files && compass watch


### PR DESCRIPTION
Updated dockerfiles to allow for a build from latest master. Will be `:dev` on dockerhub. 
Added dockerfiles for a local build that will work on non linux operating systems.

To run a local docker build you can use: `make docker-run`
To just build one you can use: `make docker-build`
To stop the running docker container: `make stop`
To specify the image and container names you can override the `DOCKERNAME` and `DOCKER_CONTAINER_NAME` variables. Example: `make DOCKERNAME=crspeller/testing docker-build`

This PR requires #363  

### Todo
- After this PR is submitted the `:dev` tag will be created on DockerHub. 