### PR TITLE
Fixed 'X is typing...' messages being malformed when sent to the server

### DIFF
--- a/web/react/components/create_post.jsx
+++ b/web/react/components/create_post.jsx
@@ -127,7 +127,7 @@ module.exports = React.createClass({
 
         var t = Date.now();
         if ((t - this.lastTime) > 5000) {
-            SocketStore.sendMessage({channelId: this.state.channelId, action: 'typing', props: {'parent_id': ''}, state: {}});
+            SocketStore.sendMessage({channel_id: this.state.channelId, action: 'typing', props: {'parent_id': ''}, state: {}});
             this.lastTime = t;
         }
     },


### PR DESCRIPTION
I accidentally renamed channel_id to channelId in a message sent back to the server so the server wasn't able to unmarshall the message correctly.