### PR TITLE
Fixes race condition

### DIFF
--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -4,7 +4,6 @@
 package store
 
 import (
-	"fmt"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 )
@@ -154,10 +153,17 @@ func (s SqlChannelStore) extraUpdated(channel *model.Channel) StoreChannel {
 
 		channel.ExtraUpdated()
 
-		if count, err := s.GetMaster().Update(channel); err != nil {
+		_, err := s.GetMaster().Exec(
+			`UPDATE
+				Channels
+			SET
+				ExtraUpdateAt = :Time
+			WHERE
+				Id = :Id`,
+			map[string]interface{}{"Id": channel.Id, "Time": channel.ExtraUpdateAt})
+
+		if err != nil {
 			result.Err = model.NewAppError("SqlChannelStore.extraUpdated", "Problem updating members last updated time", "id="+channel.Id+", "+err.Error())
-		} else if count != 1 {
-			result.Err = model.NewAppError("SqlChannelStore.extraUpdated", "Problem updating members last updated time", fmt.Sprintf("id=%v, count=%v", channel.Id, count))
 		}
 
 		storeChannel <- result


### PR DESCRIPTION

More a race condition in the unit test where create channel and save member are happening in the same millisecond (I think).