### PR TITLE
Multiple fixes for IE10 & Edge browsers primarily due to aggressive ajax call caching on the browser

### DIFF
--- a/web/react/components/post.jsx
+++ b/web/react/components/post.jsx
@@ -102,7 +102,7 @@ module.exports = React.createClass({
             currentUserCss = "current--user";
         }
 
-        var timestamp = UserStore.getCurrentUser().update_at;
+        var timestamp = UserStore.getProfile(post.user_id).update_at;
 
         return (
             <div>

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -252,6 +252,7 @@ module.exports.revokeSession = function(altId, success, error) {
 
 module.exports.getSessions = function(userId, success, error) {
     $.ajax({
+        cache: false,
         url: '/api/v1/users/' + userId + '/sessions',
         dataType: 'json',
         contentType: 'application/json',
@@ -789,6 +790,7 @@ module.exports.removeChannelMember = function(id, data, success, error) {
 
 module.exports.getProfiles = function(success, error) {
     $.ajax({
+        cache: false,
         url: '/api/v1/users/profiles',
         dataType: 'json',
         contentType: 'application/json',

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -282,6 +282,7 @@ module.exports.getMeSynchronous = function(success, error) {
     var currentUser = null;
     $.ajax({
         async: false,
+        cache: false,
         url: '/api/v1/users/me',
         dataType: 'json',
         contentType: 'application/json',
@@ -293,12 +294,9 @@ module.exports.getMeSynchronous = function(success, error) {
             }
         },
         error: function onError(xhr, status, err) {
-            var ieChecker = window.navigator.userAgent; // This and the condition below is used to check specifically for browsers IE10 & 11 to suppress a 200 'OK' error from appearing on login
-            if (xhr.status !== 200 || !(ieChecker.indexOf('Trident/7.0') > 0 || ieChecker.indexOf('Trident/6.0') > 0)) {
-                if (error) {
-                    var e = handleError('getMeSynchronous', xhr, status, err);
-                    error(e);
-                }
+            if (error) {
+                var e = handleError('getMeSynchronous', xhr, status, err);
+                error(e);
             }
         }
     });

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -565,6 +565,7 @@ module.exports.updateLastViewedAt = function(channelId, success, error) {
 
 function getChannels(success, error) {
     $.ajax({
+        cache: false,
         url: '/api/v1/channels/',
         dataType: 'json',
         type: 'GET',
@@ -580,6 +581,7 @@ module.exports.getChannels = getChannels;
 
 module.exports.getChannel = function(id, success, error) {
     $.ajax({
+        cache: false,
         url: '/api/v1/channels/' + id + '/',
         dataType: 'json',
         type: 'GET',
@@ -609,6 +611,7 @@ module.exports.getMoreChannels = function(success, error) {
 
 function getChannelCounts(success, error) {
     $.ajax({
+        cache: false,
         url: '/api/v1/channels/counts',
         dataType: 'json',
         type: 'GET',
@@ -652,6 +655,7 @@ module.exports.executeCommand = function(channelId, command, suggest, success, e
 
 module.exports.getPosts = function(channelId, offset, limit, success, error, complete) {
     $.ajax({
+        cache: false,
         url: '/api/v1/channels/' + channelId + '/posts/' + offset + '/' + limit,
         dataType: 'json',
         type: 'GET',
@@ -667,6 +671,7 @@ module.exports.getPosts = function(channelId, offset, limit, success, error, com
 
 module.exports.getPost = function(channelId, postId, success, error) {
     $.ajax({
+        cache: false,
         url: '/api/v1/channels/' + channelId + '/post/' + postId,
         dataType: 'json',
         type: 'GET',


### PR DESCRIPTION
This PR bundles a bunch of fixes for issues that had similar causes and were easier to test together including the following:

MM-1933:  Fixes issue with logout button in active sessions not working properly in IE10 (ajax call caching issue).

MM-1934: Fixes issue with profile images not updating next to the posts of other users without a full refresh (believe this may have actually been an issue across all browsers, but was originally reported as an IE10 only issue)

MM-1921:  Blue bar displayed reporting error code 200 on successful login on the Edge browser (also removed suppression of similar error on IE10 & 11 due to solving the root of the issue there as well; ajax call caching issue)

MM-1935: Posts mentioning other users made on IE10 did not properly notify mentioned users on other browsers (was unable to reproduce it consistently, but preventing caching of certain calls seems to have solved the issue)

There were some other issues reported with IE10 I was unable to reproduce but I went ahead and added cache prevention to potential problem ajax calls that should reduce or stop them from occurring (from talking with @jwilander and my own research there should be no performance decrease due to preventing ajax call caching client side, we already attempt to do this in many places server side but IE10 seems to not listen to those for the most part).