### PR TITLE
MM-1915 Added white background to non-image file previews

### DIFF
--- a/web/react/components/view_image.jsx
+++ b/web/react/components/view_image.jsx
@@ -224,6 +224,7 @@ module.exports = React.createClass({
                         </div>
                     </div>
                 );
+                bgClass = 'white-bg';
 
                 // asynchronously request the actual size of this file
                 if (!(filename in this.state.fileSizes)) {

--- a/web/sass-files/sass/partials/_base.scss
+++ b/web/sass-files/sass/partials/_base.scss
@@ -124,3 +124,7 @@ div.theme {
 .black-bg {
   background-color: black !important;
 }
+
+.white-bg {
+  background-color: white !important;
+}


### PR DESCRIPTION
This fixes the issue of non-image file previews having an invisible background, making it hard to see the icon/file info.