### PR TITLE
Fix getParentsPosts() query

### DIFF
--- a/api/post_test.go
+++ b/api/post_test.go
@@ -331,7 +331,7 @@ func TestGetPosts(t *testing.T) {
 		t.Fatal("wrong order")
 	}
 
-	if len(r1.Posts) != 4 {
+	if len(r1.Posts) != 2 { // 3a1 and 3; 3a1's parent already there
 		t.Fatal("wrong size")
 	}
 
@@ -345,7 +345,7 @@ func TestGetPosts(t *testing.T) {
 		t.Fatal("wrong order")
 	}
 
-	if len(r2.Posts) != 4 {
+	if len(r2.Posts) != 3 { // 2 and 1a1; + 1a1's parent
 		t.Log(r2.Posts)
 		t.Fatal("wrong size")
 	}

--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -343,9 +343,9 @@ func (s SqlPostStore) getParentsPosts(channelId string, offset int, limit int) S
 			    WHERE
 			        ChannelId = :ChannelId1
 			            AND DeleteAt = 0
-				    AND RootId <> ''
 			    ORDER BY CreateAt DESC
-			    LIMIT :Limit OFFSET :Offset) q3) q1 ON q1.RootId = q2.RootId
+			    LIMIT :Limit OFFSET :Offset) q3
+			    WHERE q3.RootId != '') q1 ON q1.RootId = q2.Id
 			WHERE
 			    ChannelId = :ChannelId2
 			        AND DeleteAt = 0

--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -343,6 +343,7 @@ func (s SqlPostStore) getParentsPosts(channelId string, offset int, limit int) S
 			    WHERE
 			        ChannelId = :ChannelId1
 			            AND DeleteAt = 0
+				    AND RootId <> ''
 			    ORDER BY CreateAt DESC
 			    LIMIT :Limit OFFSET :Offset) q3) q1 ON q1.RootId = q2.RootId
 			WHERE

--- a/store/sql_post_store_test.go
+++ b/store/sql_post_store_test.go
@@ -374,7 +374,7 @@ func TestPostStoreGetPostsWtihDetails(t *testing.T) {
 		t.Fatal("invalid order")
 	}
 
-	if len(r1.Posts) != 6 {
+	if len(r1.Posts) != 5 { //the last 4, + o1 (o3 and o2a's parent)
 		t.Fatal("wrong size")
 	}
 


### PR DESCRIPTION
DISREGARD this comment-
postgres DISTINCT includes empty/null columns - the getparentsposts query was essentially returning all posts (for postgres) with no rootId, assuming one post row within the limit/offset had an empty rootId