### PR TITLE
Fix Google Fonts Mixed Content Violation

### DIFF
--- a/web/templates/head.html
+++ b/web/templates/head.html
@@ -27,7 +27,7 @@
 
     <link id="favicon" rel="icon" href="/static/images/favicon.ico" type="image/x-icon">
     <link rel="shortcut icon" href="/static/images/favicon.ico" type="image/x-icon">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="/static/css/styles.css">
 
     <script src="/static/js/perfect-scrollbar-0.6.3.jquery.js"></script>


### PR DESCRIPTION
Use HTTPS so fonts are not blocked when serving mattermost over SSL. Another alternative would be to use protocol-relative URLs, but all the surrounding code uses https, so I've used that for google fonts as well.