### PR TITLE
MM-1628 The navbar is no longer completely obscured by the status bar in full screen safari on iOS

### DIFF
--- a/web/templates/head.html
+++ b/web/templates/head.html
@@ -7,7 +7,7 @@
 
     <!-- iOS add to homescreen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="{{ .Title }}">
     <meta name="application-name" content="{{ .Title }}">


### PR DESCRIPTION
Meant for 0.8.0.  I was only able to test iOS 8/9 using a simulator (and it seems like the iOS 9 uses the default no matter what) but this should solve the issue (if it exists) in iOS 7 as well.  Gives the status bar it's own section like it normally has instead of trying to overlay the status text on our site.