### PR TITLE
hotfix: removed vestigial perfect Scrollbar command

### DIFF
--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -289,7 +289,6 @@ function getYoutubeEmbed(link) {
         $('.video-uploader.' + youtubeId).html(metadata.channelTitle);
         $('.video-title.' + youtubeId).find('a').html(metadata.title);
         $('.post-list-holder-by-time').scrollTop($('.post-list-holder-by-time')[0].scrollHeight);
-        $('.post-list-holder-by-time').perfectScrollbar('update');
     }
 
     if (config.GoogleDeveloperKey) {


### PR DESCRIPTION
This is intended for 0.7.0, as it's a bug causing a console error. However, it doesn't seem incredibly breaking, so it may not be the end of the world if we don't get it in until 0.8.0