### PR TITLE
[Cosmetic Reformatting] UserSettingsGeneralTab (and a few minor changes to PostInfo)

### DIFF
--- a/web/react/components/post_info.jsx
+++ b/web/react/components/post_info.jsx
@@ -43,13 +43,16 @@ export default class PostInfo extends React.Component {
 
         if (isOwner) {
             dropdownContents.push(
-                <li role='presentation'>
+                <li
+                    key='editPost'
+                    role='presentation'
+                >
                     <a
                         href='#'
                         role='menuitem'
                         data-toggle='modal'
                         data-target='#edit_post'
-                        data-refoucsid="#post_textbox"
+                        data-refoucsid='#post_textbox'
                         data-title={type}
                         data-message={post.message}
                         data-postid={post.id}
@@ -64,7 +67,10 @@ export default class PostInfo extends React.Component {
 
         if (isOwner || isAdmin) {
             dropdownContents.push(
-                <li role='presentation'>
+                <li
+                    key='deletePost'
+                    role='presentation'
+                >
                     <a
                         href='#'
                         role='menuitem'
@@ -83,7 +89,10 @@ export default class PostInfo extends React.Component {
 
         if (this.props.allowReply === 'true') {
             dropdownContents.push(
-                <li role='presentation'>
+                <li
+                    key='replyLink'
+                    role='presentation'
+                >
                     <a
                         className='reply-link theme'
                         href='#'


### PR DESCRIPTION
Meant to go in during the cosmetic reformatting period.  Finishes the cosmetic reformatting of the user_settings_general.jsx file (except for two not camal case variable names part of the that are part of the 'user' object) along with fixing an issue where only certain client-side errors were being cleared upon section change, leaving server/email errors uncleared (e.g. your email has somehow already been taken while you're viewing your profile picture).  Also adds keys to the child elements in the render array of post_info.jsx as the warnings were bugging me.