### PR TITLE
[Performance Fix] Removes warning message when at the max character limit

### DIFF
--- a/web/react/components/create_comment.jsx
+++ b/web/react/components/create_comment.jsx
@@ -104,17 +104,14 @@ module.exports = React.createClass({
             this.lastTime = t;
         }
     },
-    handleUserInput: function(message) {
-        var messageText = utils.truncateText(message);
-        var newPostError = utils.checkMessageLengthError(messageText, this.state.postError, 'Comment length cannot exceed ' + Constants.MAX_POST_LEN + ' characters');
-
+    handleUserInput: function(messageText) {
         var draft = PostStore.getCommentDraft(this.props.rootId);
         draft.message = messageText;
         PostStore.storeCommentDraft(this.props.rootId, draft);
 
         $('.post-right__scroll').scrollTop($('.post-right__scroll')[0].scrollHeight);
         $('.post-right__scroll').perfectScrollbar('update');
-        this.setState({messageText: messageText, postError: newPostError});
+        this.setState({messageText: messageText});
     },
     handleUploadStart: function(clientIds, channelId) {
         var draft = PostStore.getCommentDraft(this.props.rootId);

--- a/web/react/components/create_post.jsx
+++ b/web/react/components/create_post.jsx
@@ -130,12 +130,9 @@ module.exports = React.createClass({
             this.lastTime = t;
         }
     },
-    handleUserInput: function(message) {
-        var messageText = utils.truncateText(message);
-        var newPostError = utils.checkMessageLengthError(messageText, this.state.postError, 'Message length cannot exceed ' + Constants.MAX_POST_LEN + ' characters');
-
+    handleUserInput: function(messageText) {
         this.resizePostHolder();
-        this.setState({messageText: messageText, postError: newPostError});
+        this.setState({messageText: messageText});
 
         var draft = PostStore.getCurrentDraft();
         draft['message'] = messageText;

--- a/web/react/components/edit_post_modal.jsx
+++ b/web/react/components/edit_post_modal.jsx
@@ -38,10 +38,8 @@ module.exports = React.createClass({
         $("#edit_post").modal('hide');
         $(this.state.refocusId).focus();
     },
-    handleEditInput: function(editText) {
-        var editMessage = utils.truncateText(editText);
-        var newError = utils.checkMessageLengthError(editMessage, this.state.error, 'New message length cannot exceed ' + Constants.MAX_POST_LEN + ' characters');
-        this.setState({editText: editMessage, error: newError});
+    handleEditInput: function(editMessage) {
+        this.setState({editText: editMessage});
     },
     handleEditKeyPress: function(e) {
         if (e.which == 13 && !e.shiftKey && !e.altKey) {

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1001,43 +1001,6 @@ module.exports.isBrowserEdge = function() {
     return window.naviagtor && navigator.userAgent && navigator.userAgent.toLowerCase().indexOf('edge') > -1;
 };
 
-// Gets text length consistent with maxlength property of textarea html tag
-module.exports.getLengthOfTextInTextarea = function(messageText) {
-    // Need to get length with carriage returns counting as two characters to match textbox maxlength behavior
-    // unless ie10/ie11/edge which already do
-
-    var len = messageText.length;
-    if (!module.exports.isBrowserIE() && !module.exports.isBrowserEdge()) {
-        len = messageText.replace(/\r(?!\n)|\n(?!\r)/g, '--').length;
-    }
-
-    return len;
-};
-
-module.exports.checkMessageLengthError = function(message, currentError, newError) {
-    var updatedError = currentError;
-    var len = module.exports.getLengthOfTextInTextarea(message);
-
-    if (!currentError && len >= Constants.MAX_POST_LEN) {
-        updatedError = newError;
-    } else if (currentError === newError && len < Constants.MAX_POST_LEN) {
-        updatedError = '';
-    }
-
-    return updatedError;
-};
-
-// Necessary due to issues with textarea max length and pasting newlines
-module.exports.truncateText = function(message) {
-    var lengthDifference = module.exports.getLengthOfTextInTextarea(message) - message.length;
-
-    if (lengthDifference > 0) {
-        return message.substring(0, Constants.MAX_POST_LEN - lengthDifference);
-    }
-
-    return message.substring(0, Constants.MAX_POST_LEN);
-};
-
 // Used to get the id of the other user from a DM channel
 module.exports.getUserIdFromChannelName = function(channel) {
     var ids = channel.name.split('__');


### PR DESCRIPTION
Helps reduce the performance impact, especially on mobile, when typing.  However this leaves in the maxlength check in the textbox that prevents the user from typing too much, along with some minor error clearing and formatting issues with the edit post modal, as well as the ie/edge check utils functions for future use.