### PR TITLE
MM-2044 Removes ability to auto-scroll to new messages in ie10/11 to fix rendering issue

### DIFF
--- a/web/react/components/post_list.jsx
+++ b/web/react/components/post_list.jsx
@@ -511,9 +511,15 @@ export default class PostList extends React.Component {
 
             if (post.user_id !== userId && post.create_at > this.state.lastViewed && !renderedLastViewed) {
                 renderedLastViewed = true;
+
+                // Temporary fix to solve ie10/11 rendering issue
+                let newSeparatorId = '';
+                if (!utils.isBrowserIE()) {
+                    newSeparatorId = 'new_message';
+                }
                 postCtls.push(
                     <div
-                        id='new_message'
+                        id={newSeparatorId}
                         key='unviewed'
                         className='new-separator'
                     >


### PR DESCRIPTION
Probably should go in for 0.7.0 since this is a P1 issue (see bugs/issues discussion).  Removes the identifier from the new messages separator in ie10/11 to fix an issue where the LHS was not rendering in ie10/11.  Should only be a temporary fix as it removes the ability to auto-scroll to new messages in ie10/11.