### PR TITLE
HOTFIX for 0.7.0 - MM-2091 Fix bad user being set on team creation causing Manage Team modal to not work.

### DIFF
--- a/web/react/components/team_signup_password_page.jsx
+++ b/web/react/components/team_signup_password_page.jsx
@@ -41,7 +41,7 @@ module.exports = React.createClass({
                 client.loginByEmail(teamSignup.team.name, teamSignup.team.email, teamSignup.user.password,
                     function(data) {
                         UserStore.setLastEmail(teamSignup.team.email);
-                        UserStore.setCurrentUser(teamSignup.user);
+                        UserStore.setCurrentUser(data);
                         if (this.props.hash > 0) {
                             BrowserStore.setGlobalItem(this.props.hash, JSON.stringify({wizard: 'finished'}));
                         }


### PR DESCRIPTION
This is actually a security issue. The plaintext password was being saved to the browser local storage. Then the malformed (or incomplete) user object just happened to cause an error on the Manage Team modal.