### PR TITLE
MM-1852 Fixed hashtag regex to only look for words starting with a #

### DIFF
--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -457,7 +457,7 @@ export function textToJsx(textin, options) {
     var inner = [];
 
     // Function specific regex
-    var hashRegex = /^href="#[^']+"|(#[A-Za-z]+[A-Za-z0-9_\-]*[A-Za-z0-9])$/g;
+    var hashRegex = /^href="#[^']+"|(^#[A-Za-z]+[A-Za-z0-9_\-]*[A-Za-z0-9])$/g;
 
     var implicitKeywords = UserStore.getCurrentMentionKeys();
 


### PR DESCRIPTION
This is to fix an issue where words with a # in the middle of them would be flagged as hashtags.