### PR TITLE
MM-651 Added scroll bumperring and cut off overscroll on ios

### DIFF
--- a/web/react/components/post_list.jsx
+++ b/web/react/components/post_list.jsx
@@ -118,6 +118,22 @@ export default class PostList extends React.Component {
             }
         }.bind(this));
 
+        $(document).on('touchmove', function stopScrollBounce(e) {
+            e.preventDefault();
+        });
+
+        $('body').on('touchmove', '.post-list-holder-by-time', function stopTMBubble(e) {
+            e.stopPropagation();
+        });
+
+        $('body').on('touchstart', '.post-list-holder-by-time', function bumperScrolling(e) {
+            if (e.currentTarget.scrollTop === 0) {
+                e.currentTarget.scrollTop = 1;
+            } else if (e.currentTarget.scrollHeight === e.currentTarget.scrollTop + e.currentTarget.offsetHeight) {
+                e.currentTarget.scrollTop -= 1;
+            }
+        });
+
         postHolder.scroll(function scroll() {
             var position = postHolder.scrollTop() + postHolder.height() + 14;
             var bottom = postHolder[0].scrollHeight;


### PR DESCRIPTION
Fixes a problem in iOS that when you are scrolling the post_list, your touch gestures can be interpreted by the app as scrolling the whole document instead of the post_list. This sometimes leads to being able to scroll above/below the document, and scrolling on post_list not working. This fix intercepts all touch scrolling, and if it's from above the body, then it's canceled.