### PR TITLE
PLT-159/MM-2074 Changed unread posts indicator to not be shown for the current channel

### DIFF
--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -315,10 +315,12 @@ export default class Sidebar extends React.Component {
         if (unread) {
             titleClass = 'unread-title';
 
-            if (!this.firstUnreadChannel) {
-                this.firstUnreadChannel = channel.name;
+            if (channel.id !== activeId) {
+                if (!this.firstUnreadChannel) {
+                    this.firstUnreadChannel = channel.name;
+                }
+                this.lastUnreadChannel = channel.name;
             }
-            this.lastUnreadChannel = channel.name;
         }
 
         var badge = null;


### PR DESCRIPTION
This is to fix the issue where the unread posts indicator hangs around sometimes and doesn't go away until you refresh the channel.