### PR TITLE
Removed pointless attempt to verify a new user's username

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -71,10 +71,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !model.IsUsernameValid(user.Username) {
-		c.Err = model.NewAppError("createUser", "That username is invalid", "might be using a resrved username")
-		return
-	}
+	// the user's username is checked to be valid when they are saved to the database
 
 	user.EmailVerified = false
 

--- a/model/user.go
+++ b/model/user.go
@@ -335,11 +335,6 @@ func ComparePassword(hash string, password string) bool {
 	return err == nil
 }
 
-func IsUsernameValid(username string) bool {
-
-	return true
-}
-
 var validUsernameChars = regexp.MustCompile(`^[a-z0-9\.\-_]+$`)
 
 var restrictedUsernames = []string{


### PR DESCRIPTION
We had two functions to verify a new user's username: IsUsernameValid and IsValidUsername. IsUsernameValid did nothing so I removed it. The username is still correctly verified later in the process since we call User.IsValid before saving to the database which in turn calls IsValidUsername.