### PR TITLE
PLT-198 Fix unit tests on Go 1.5.1

### DIFF
--- a/utils/textgeneration.go
+++ b/utils/textgeneration.go
@@ -141,17 +141,14 @@ var FUZZY_STRINGS_NAMES = []string{
 // Strings that should pass as acceptable emails
 var FUZZY_STRINGS_EMAILS = []string{
 	"sue@thatmightbe",
-	"sue@thatmightbe.",
 	"sue@thatmightbe.c",
 	"sue@thatmightbe.co",
 	"su+san@thatmightbe.com",
-	"a@b.中国",
 	"1@2.am",
 	"a@b.co.uk",
 	"a@b.cancerresearch",
 	"su+s+an@thatmightbe.com",
 	"per.iod@thatmightbe.com",
-	"per..iods@thatmightbe.com",
 }
 
 // Lovely giberish for all to use

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -36,9 +36,14 @@ func TearDown() {
 func TestStatic(t *testing.T) {
 	Setup()
 
-	resp, _ := http.Get(URL + "/static/images/favicon.ico")
+	// add a short delay to make sure the server is ready to receive requests
+	time.Sleep(1 * time.Second)
 
-	if resp.StatusCode != http.StatusOK {
+	resp, err := http.Get(URL + "/static/images/favicon.ico")
+
+	if err != nil {
+		t.Fatalf("got error while trying to get static files %v", err)
+	} else if resp.StatusCode != http.StatusOK {
 		t.Fatalf("couldn't get static files %v", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
Makes two changes to the unit tests:
1) Removes some email addresses that are now considered invalid by Go. The first and third one are definitely invalid, but the second one seems to be legal from what I can tell since 中国 is a legal TLD according to [Wikipedia](https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#Internationalized_country_code_top-level_domains) so we may need to find a different way to determine valid email addresses.
2) Adds a short delay to one of the web tests. I'm not sure if this was just due to using a different environment to test Go 1.5.1 or if it's due to something in their code being faster, but there was a race condition causing the server to reject the request if it was received too early.