### PR TITLE
Change versioning to exact versions in package.json

### DIFF
--- a/web/react/package.json
+++ b/web/react/package.json
@@ -3,22 +3,22 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "autolinker": "^0.18.1",
-    "flux": "^2.1.1",
-    "keymirror": "^0.1.1",
-    "object-assign": "^3.0.0",
-    "react": "^0.13.3",
-    "react-zeroclipboard-mixin": "^0.1.0",
-    "twemoji": "^1.4.1"
+    "autolinker": "0.18.1",
+    "flux": "2.1.1",
+    "keymirror": "0.1.1",
+    "object-assign": "3.0.0",
+    "react": "0.13.3",
+    "react-zeroclipboard-mixin": "0.1.0",
+    "twemoji": "1.4.1"
   },
   "devDependencies": {
-    "browserify": "^11.0.1",
-    "envify": "^3.4.0",
-    "babelify": "^6.1.3",
-    "uglify-js": "^2.4.24",
-    "watchify": "^3.3.1",
-    "eslint": "^1.3.1",
-    "eslint-plugin-react": "^3.3.1"
+    "browserify": "11.0.1",
+    "envify": "3.4.0",
+    "babelify": "6.1.3",
+    "uglify-js": "2.4.24",
+    "watchify": "3.3.1",
+    "eslint": "1.3.1",
+    "eslint-plugin-react": "3.3.1"
   },
   "scripts": {
     "start": "watchify --extension=jsx -o ../static/js/bundle.js -v -d ./**/*.jsx",


### PR DESCRIPTION
Travis was failing because ESLint updated and our package.json allowed newer versions. 