### PR TITLE
Updating MaxUsersPerTeam error msg

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -74,7 +74,7 @@ func (us SqlUserStore) Save(user *model.User) StoreChannel {
 			close(storeChannel)
 			return
 		} else if int(count) > utils.Cfg.TeamSettings.MaxUsersPerTeam {
-			result.Err = model.NewAppError("SqlUserStore.Save", "You've reached the limit of the number of allowed accounts.", "teamId="+user.TeamId)
+			result.Err = model.NewAppError("SqlUserStore.Save", "This team has reached the maxmium number of allowed accounts. Contact your systems administrator to set a higher limit.", "teamId="+user.TeamId)
 			storeChannel <- result
 			close(storeChannel)
 			return


### PR DESCRIPTION
This message is displayed to a person attempting to sign-up for a new team, and "You've reached the limit" phrasing is confusing because it refers to the team, not the person signing up for the team.