### PR TITLE
Clean installed Go dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,8 @@ clean:
 	rm -rf api/data/*
 	rm -rf logs/*
 
+	rm -rf Godeps/_workspace/pkg/
+
 
 run: install
 	mkdir -p web/static/js


### PR DESCRIPTION
If these are not cleaned it can cause problems when switching between different Go versions. Especially when downgrading Go.

I noticed this when I downgraded from 1.5.1 to 1.4.2 and started getting errors about Go versions.