### PR TITLE
PLT-50 Allowing channel names with underscores. Allow import of more slack channel names. 

### DIFF
--- a/api/slackimport.go
+++ b/api/slackimport.go
@@ -50,6 +50,15 @@ func SlackConvertTimeStamp(ts string) int64 {
 	return timeStamp * 1000 // Convert to milliseconds
 }
 
+func SlackConvertChannelName(channelName string) string {
+	newName := strings.Trim(channelName, "_-")
+	if len(newName) == 1 {
+		return "slack-channel-" + newName
+	}
+
+	return newName
+}
+
 func SlackParseChannels(data io.Reader) []SlackChannel {
 	decoder := json.NewDecoder(data)
 
@@ -172,7 +181,7 @@ func SlackAddChannels(teamId string, slackchannels []SlackChannel, posts map[str
 			TeamId:      teamId,
 			Type:        model.CHANNEL_OPEN,
 			DisplayName: sChannel.Name,
-			Name:        sChannel.Name,
+			Name:        SlackConvertChannelName(sChannel.Name),
 			Description: sChannel.Topic["value"],
 		}
 		mChannel := ImportChannel(&newChannel)

--- a/model/utils.go
+++ b/model/utils.go
@@ -213,7 +213,7 @@ func IsValidChannelIdentifier(s string) bool {
 	return true
 }
 
-var validAlphaNum = regexp.MustCompile(`^[a-z0-9]+([a-z\-0-9]+|(__)?)[a-z0-9]+$`)
+var validAlphaNum = regexp.MustCompile(`^[a-z0-9]+([a-z\-\_0-9]+|(__)?)[a-z0-9]+$`)
 
 func IsValidAlphaNum(s string) bool {
 	match := validAlphaNum.MatchString(s)

--- a/web/react/components/team_import_tab.jsx
+++ b/web/react/components/team_import_tab.jsx
@@ -35,7 +35,7 @@ export default class TeamImportTab extends React.Component {
         var uploadHelpText = (
             <div>
                 <p>{'Slack does not allow you to export files, images, private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of text messages in your Slack team\'\s public channels.'}</p>
-                <p>{'The Slack import to Mattermost is in "Preview". Slack bot posts and channels with underscores do not yet import.'}</p>
+                <p>{'The Slack import to Mattermost is in "Preview". Slack bot posts do not yet import.'}</p>
             </div>
         );
 


### PR DESCRIPTION
- We now allow underscores in channel names (UI has not been changed in this PR, will change with upcoming new channel modal)
- Slack channels with beginning or trailing `-` or `_` will be imported with trailing characters removed. 
- Single character slack channel names are padded with `slack-channel-`