### PR TITLE
Adding go 1.5.1 and postgress to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: go
 go:
 - 1.4.2
+- 1.5.1
+env:
+- TRAVIS_DB=mysql
+- TRAVIS_DB=postgres
 before_install:
 - gem install compass
 - sudo apt-get update -qq
@@ -24,6 +28,9 @@ before_script:
 - mysql -e "CREATE DATABASE IF NOT EXISTS mattermost_test ;" -uroot
 - mysql -e "CREATE USER 'mmuser'@'%' IDENTIFIED BY 'mostest' ;"  -uroot
 - mysql -e "GRANT ALL ON mattermost_test.* TO 'mmuser'@'%' ;" -uroot
+- psql -c "create database mattermost_test ;" -U postgres
+- psql -c "create user mmuser with password 'mostest' ;" -U postgres
+- psql -c 'grant all privileges on database "mattermost_test" to mmuser ;' -U postgres
 services:
 - redis-server
 addons:
@@ -38,6 +45,8 @@ deploy:
    on:
      repo: mattermost/platform
      tags: true
+     go: 1.4.2
+     condition: $TRAVIS_DB = mysql
 
  - provider: s3
    access_key_id: AKIAJCO3KJYEGWJIKDIQ
@@ -52,3 +61,5 @@ deploy:
    on:
      repo: mattermost/platform
      branch: master
+     go: 1.4.2
+     condition: $TRAVIS_DB = mysql

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ all: travis
 travis:
 	@echo building for travis
 
+	if [ "$(TRAVIS_DB)" = "postgres" ]; then \
+		sed -i'.bak' 's|mysql|postgres|g' config/config.json; \
+		sed -i'.bak' 's|mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8|postgres://mmuser:mostest@dockerhost:5432/mattermost_test?sslmode=disable\&connect_timeout=10|g' config/config.json; \
+	fi
+
 	rm -Rf $(DIST_ROOT)
 	@$(GO) clean $(GOFLAGS) -i ./...
 


### PR DESCRIPTION
- When travis builds it will now spin up 4 instances, one for each of the possible combinations of the go versions and databases. (check out the build on this PR!)