### PR TITLE
PLT-17 Added Markdown support to the text formatter

### DIFF
--- a/web/react/components/post_body.jsx
+++ b/web/react/components/post_body.jsx
@@ -154,7 +154,7 @@ export default class PostBody extends React.Component {
         return (
             <div className='post-body'>
                 {comment}
-                <p
+                <div
                     key={`${post.id}_message`}
                     id={`${post.id}_message`}
                     className={postClass}
@@ -164,7 +164,7 @@ export default class PostBody extends React.Component {
                         onClick={TextFormatting.handleClick}
                         dangerouslySetInnerHTML={{__html: TextFormatting.formatText(this.state.message)}}
                     />
-                </p>
+                </div>
                 {fileAttachmentHolder}
                 {embed}
             </div>

--- a/web/react/package.json
+++ b/web/react/package.json
@@ -9,7 +9,8 @@
     "object-assign": "3.0.0",
     "react-zeroclipboard-mixin": "0.1.0",
     "twemoji": "1.4.1",
-    "babel-runtime": "5.8.24"
+    "babel-runtime": "5.8.24",
+    "marked": "0.3.5"
   },
   "devDependencies": {
     "browserify": "11.0.1",

--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -1,0 +1,14 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+const marked = require('marked');
+
+export class MattermostMarkdownRenderer extends marked.Renderer {
+    link(href, title, text) {
+        if (href.lastIndexOf('http', 0) !== 0) {
+            href = `http://${href}`;
+        }
+
+        return super.link(href, title, text);
+    }
+}

--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -5,10 +5,12 @@ const marked = require('marked');
 
 export class MattermostMarkdownRenderer extends marked.Renderer {
     link(href, title, text) {
-        if (href.lastIndexOf('http', 0) !== 0) {
-            href = `http://${href}`;
+        let outHref = href;
+
+        if (outHref.lastIndexOf('http', 0) !== 0) {
+            outHref = `http://${outHref}`;
         }
 
-        return super.link(href, title, text);
+        return super.link(outHref, title, text);
     }
 }

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -63,7 +63,7 @@ function autolinkUrls(text, tokens) {
         }
 
         const index = tokens.size;
-        const alias = `__MM_LINK${index}__`;
+        const alias = `MM_LINK${index}`;
 
         tokens.set(alias, {
             value: `<a class='theme' target='_blank' href='${url}'>${linkText}</a>`,
@@ -93,7 +93,7 @@ function autolinkAtMentions(text, tokens) {
         const usernameLower = username.toLowerCase();
         if (Constants.SPECIAL_MENTIONS.indexOf(usernameLower) !== -1 || UserStore.getProfileByUsername(usernameLower)) {
             const index = tokens.size;
-            const alias = `__MM_ATMENTION${index}__`;
+            const alias = `MM_ATMENTION${index}`;
 
             tokens.set(alias, {
                 value: `<a class='mention-link' href='#' data-mention='${usernameLower}'>${mention}</a>`,
@@ -121,7 +121,7 @@ function highlightCurrentMentions(text, tokens) {
     for (const [alias, token] of tokens) {
         if (mentionKeys.indexOf(token.originalText) !== -1) {
             const index = tokens.size + newTokens.size;
-            const newAlias = `__MM_SELFMENTION${index}__`;
+            const newAlias = `MM_SELFMENTION${index}`;
 
             newTokens.set(newAlias, {
                 value: `<span class='mention-highlight'>${alias}</span>`,
@@ -140,7 +140,7 @@ function highlightCurrentMentions(text, tokens) {
     // look for self mentions in the text
     function replaceCurrentMentionWithToken(fullMatch, prefix, mention) {
         const index = tokens.size;
-        const alias = `__MM_SELFMENTION${index}__`;
+        const alias = `MM_SELFMENTION${index}`;
 
         tokens.set(alias, {
             value: `<span class='mention-highlight'>${mention}</span>`,
@@ -164,7 +164,7 @@ function autolinkHashtags(text, tokens) {
     for (const [alias, token] of tokens) {
         if (token.originalText.lastIndexOf('#', 0) === 0) {
             const index = tokens.size + newTokens.size;
-            const newAlias = `__MM_HASHTAG${index}__`;
+            const newAlias = `MM_HASHTAG${index}`;
 
             newTokens.set(newAlias, {
                 value: `<a class='mention-link' href='#' data-hashtag='${token.originalText}'>${token.originalText}</a>`,
@@ -183,7 +183,7 @@ function autolinkHashtags(text, tokens) {
     // look for hashtags in the text
     function replaceHashtagWithToken(fullMatch, prefix, hashtag) {
         const index = tokens.size;
-        const alias = `__MM_HASHTAG${index}__`;
+        const alias = `MM_HASHTAG${index}`;
 
         tokens.set(alias, {
             value: `<a class='mention-link' href='#' data-hashtag='${hashtag}'>${hashtag}</a>`,
@@ -203,7 +203,7 @@ function highlightSearchTerm(text, tokens, searchTerm) {
     for (const [alias, token] of tokens) {
         if (token.originalText === searchTerm) {
             const index = tokens.size + newTokens.size;
-            const newAlias = `__MM_SEARCHTERM${index}__`;
+            const newAlias = `MM_SEARCHTERM${index}`;
 
             newTokens.set(newAlias, {
                 value: `<span class='search-highlight'>${alias}</span>`,
@@ -221,7 +221,7 @@ function highlightSearchTerm(text, tokens, searchTerm) {
 
     function replaceSearchTermWithToken(fullMatch, prefix, word) {
         const index = tokens.size;
-        const alias = `__MM_SEARCHTERM${index}__`;
+        const alias = `MM_SEARCHTERM${index}`;
 
         tokens.set(alias, {
             value: `<span class='search-highlight'>${word}</span>`,

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -33,7 +33,9 @@ export function formatText(text, options = {}) {
     output = replaceTokens(output, tokens);
 
     // replace newlines with html line breaks
-    output = replaceNewlines(output, options.singleline);
+    if (options.singleline) {
+        output = replaceNewlines(output);
+    }
 
     return output;
 }
@@ -246,11 +248,7 @@ function replaceTokens(text, tokens) {
     return output;
 }
 
-function replaceNewlines(text, singleline) {
-    if (!singleline) {
-        return text.replace(/\n/g, '<br />');
-    }
-
+function replaceNewlines(text) {
     return text.replace(/\n/g, ' ');
 }
 

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -21,7 +21,14 @@ export function formatText(text, options = {}) {
     // TODO remove me
     options.markdown = true;
 
-    let output = sanitizeHtml(text);
+    // wait until marked can sanitize the html so that we don't break markdown block quotes
+    let output;
+    if (!options.markdown) {
+        output = sanitizeHtml(text);
+    } else {
+        output = text;
+    }
+
     const tokens = new Map();
 
     // replace important words and phrases with tokens
@@ -40,7 +47,10 @@ export function formatText(text, options = {}) {
     // perform markdown parsing while we have an html-free input string
     if (options.markdown) {
         console.log('output before marked ' + output);
-        output = marked(output, {renderer: markdownRenderer});
+        output = marked(output, {
+            renderer: markdownRenderer,
+            sanitize: true
+        });
         console.log('output after marked ' + output);
     }
 

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -3,12 +3,13 @@
 
 const Autolinker = require('autolinker');
 const Constants = require('./constants.jsx');
+const Markdown = require('./markdown.jsx');
 const UserStore = require('../stores/user_store.jsx');
 const Utils = require('./utils.jsx');
 
 const marked = require('marked');
 
-const markdownRenderer = new marked.Renderer();
+const markdownRenderer = new Markdown.MattermostMarkdownRenderer();
 
 // Performs formatting of user posts including highlighting mentions and search terms and converting urls, hashtags, and
 // @mentions to links by taking a user's message and returning a string of formatted html. Also takes a number of options

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -6,6 +6,10 @@ const Constants = require('./constants.jsx');
 const UserStore = require('../stores/user_store.jsx');
 const Utils = require('./utils.jsx');
 
+const marked = require('marked');
+
+const markdownRenderer = new marked.Renderer();
+
 // Performs formatting of user posts including highlighting mentions and search terms and converting urls, hashtags, and
 // @mentions to links by taking a user's message and returning a string of formatted html. Also takes a number of options
 // as part of the second parameter:
@@ -28,6 +32,11 @@ export function formatText(text, options = {}) {
     if (!('mentionHighlight' in options) || options.mentionHighlight) {
         output = highlightCurrentMentions(output, tokens);
     }
+
+    // perform markdown parsing while we have an html-free input string
+    console.log('output before marked ' + output);
+    output = marked(output, {renderer: markdownRenderer});
+    console.log('output after marked ' + output);
 
     // reinsert tokens with formatted versions of the important words and phrases
     output = replaceTokens(output, tokens);

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -17,9 +17,11 @@ const markdownRenderer = new Markdown.MattermostMarkdownRenderer();
 // - searchTerm - If specified, this word is highlighted in the resulting html. Defaults to nothing.
 // - mentionHighlight - Specifies whether or not to highlight mentions of the current user. Defaults to true.
 // - singleline - Specifies whether or not to remove newlines. Defaults to false.
+// - markdown - Enables markdown parsing. Defaults to true.
 export function formatText(text, options = {}) {
-    // TODO remove me
-    options.markdown = true;
+    if (!('markdown' in options)) {
+        options.markdown = true;
+    }
 
     // wait until marked can sanitize the html so that we don't break markdown block quotes
     let output;
@@ -46,12 +48,10 @@ export function formatText(text, options = {}) {
 
     // perform markdown parsing while we have an html-free input string
     if (options.markdown) {
-        console.log('output before marked ' + output);
         output = marked(output, {
             renderer: markdownRenderer,
             sanitize: true
         });
-        console.log('output after marked ' + output);
     }
 
     // reinsert tokens with formatted versions of the important words and phrases


### PR DESCRIPTION
Might still need some additional styling for some lesser used features such as tables and horizontal lines, but otherwise works for all of the [basic markdown](https://help.github.com/articles/markdown-basics/) and [Github Flavoured Markdown](https://help.github.com/articles/github-flavored-markdown/) features.