### PR TITLE
Renaming "Handle" to "Channel URL" or "URL"

### DIFF
--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -57,7 +57,7 @@ func TestCreateChannel(t *testing.T) {
 
 	rchannel.Data.(*model.Channel).Id = ""
 	if _, err := Client.CreateChannel(rchannel.Data.(*model.Channel)); err != nil {
-		if err.Message != "A channel with that handle already exists" {
+		if err.Message != "A channel with that URL already exists" {
 			t.Fatal(err)
 		}
 	}
@@ -68,7 +68,7 @@ func TestCreateChannel(t *testing.T) {
 
 	Client.DeleteChannel(savedId)
 	if _, err := Client.CreateChannel(rchannel.Data.(*model.Channel)); err != nil {
-		if err.Message != "A channel with that handle was previously created" {
+		if err.Message != "A channel with that URL was previously created" {
 			t.Fatal(err)
 		}
 	}

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -85,9 +85,9 @@ func (s SqlChannelStore) Save(channel *model.Channel) StoreChannel {
 				dupChannel := model.Channel{}
 				s.GetReplica().SelectOne(&dupChannel, "SELECT * FROM Channels WHERE TeamId = :TeamId AND Name = :Name AND DeleteAt > 0", map[string]interface{}{"TeamId": channel.TeamId, "Name": channel.Name})
 				if dupChannel.DeleteAt > 0 {
-					result.Err = model.NewAppError("SqlChannelStore.Update", "A channel with that handle was previously created", "id="+channel.Id+", "+err.Error())
+					result.Err = model.NewAppError("SqlChannelStore.Update", "A channel with that URL was previously created", "id="+channel.Id+", "+err.Error())
 				} else {
-					result.Err = model.NewAppError("SqlChannelStore.Update", "A channel with that handle already exists", "id="+channel.Id+", "+err.Error())
+					result.Err = model.NewAppError("SqlChannelStore.Update", "A channel with that URL already exists", "id="+channel.Id+", "+err.Error())
 				}
 			} else {
 				result.Err = model.NewAppError("SqlChannelStore.Save", "We couldn't save the channel", "id="+channel.Id+", "+err.Error())


### PR DESCRIPTION
When we renamed "Handle" to "Channel URL" in the create channel dialog we missed some other spots where the word "Handle" was used. Changing those here. 

