### PR TITLE
PLT-310 Wrapped comment messages in divs like posts in the center pane

### DIFF
--- a/web/react/components/rhs_comment.jsx
+++ b/web/react/components/rhs_comment.jsx
@@ -207,7 +207,7 @@ export default class RhsComment extends React.Component {
                     <div className='post-body'>
                         <p className={postClass}>
                             {loading}
-                            <span
+                            <div
                                 onClick={TextFormatting.handleClick}
                                 dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message)}}
                             />

--- a/web/react/components/rhs_root_post.jsx
+++ b/web/react/components/rhs_root_post.jsx
@@ -147,7 +147,7 @@ export default class RhsRootPost extends React.Component {
                         </li>
                     </ul>
                     <div className='post-body'>
-                        <p
+                        <div
                             onClick={TextFormatting.handleClick}
                             dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message)}}
                         />


### PR DESCRIPTION
Corrects some incorrect nesting of block html elements inside of spans which causes React's dangerouslySetInnerHTML to behave strangely.