### PR TITLE
PLT-39 Clicking "Resend email" on the verification page now confirms email was sent

### DIFF
--- a/web/react/components/email_verify.jsx
+++ b/web/react/components/email_verify.jsx
@@ -10,12 +10,14 @@ export default class EmailVerify extends React.Component {
         this.state = {};
     }
     handleResend() {
-        window.location.href = window.location.href + '&resend=true';
+        const newAddress = window.location.href.replace('?resend_success=true', '').replace('&resend_success=true', '');
+        window.location.href = newAddress + '&resend=true';
     }
     render() {
         var title = '';
         var body = '';
         var resend = '';
+        let resendConfirm = '';
         if (this.props.isVerified === 'true') {
             title = global.window.config.SiteName + ' Email Verified';
             body = <p>Your email has been verified! Click <a href={this.props.teamURL + '?email=' + this.props.userEmail}>here</a> to log in.</p>;
@@ -30,6 +32,9 @@ export default class EmailVerify extends React.Component {
                     Resend Email
                 </button>
             );
+            if (window.location.href.indexOf('resend_success=true') > -1) {
+                resendConfirm = <div><br /><p className='alert alert-success'><i className='fa fa-check'></i>{' Verification email sent.'}</p></div>;
+            }
         }
 
         return (
@@ -41,6 +46,7 @@ export default class EmailVerify extends React.Component {
                     <div className='panel-body'>
                         {body}
                         {resend}
+                        {resendConfirm}
                     </div>
                 </div>
             </div>

--- a/web/react/components/email_verify.jsx
+++ b/web/react/components/email_verify.jsx
@@ -10,14 +10,14 @@ export default class EmailVerify extends React.Component {
         this.state = {};
     }
     handleResend() {
-        const newAddress = window.location.href.replace('?resend_success=true', '').replace('&resend_success=true', '');
+        const newAddress = window.location.href.replace('&resend_success=true', '');
         window.location.href = newAddress + '&resend=true';
     }
     render() {
         var title = '';
         var body = '';
         var resend = '';
-        let resendConfirm = '';
+        var resendConfirm = '';
         if (this.props.isVerified === 'true') {
             title = global.window.config.SiteName + ' Email Verified';
             body = <p>Your email has been verified! Click <a href={this.props.teamURL + '?email=' + this.props.userEmail}>here</a> to log in.</p>;
@@ -32,7 +32,7 @@ export default class EmailVerify extends React.Component {
                     Resend Email
                 </button>
             );
-            if (window.location.href.indexOf('resend_success=true') > -1) {
+            if (this.props.resendSuccess) {
                 resendConfirm = <div><br /><p className='alert alert-success'><i className='fa fa-check'></i>{' Verification email sent.'}</p></div>;
             }
         }
@@ -57,10 +57,12 @@ export default class EmailVerify extends React.Component {
 EmailVerify.defaultProps = {
     isVerified: 'false',
     teamURL: '',
-    userEmail: ''
+    userEmail: '',
+    resendSuccess: 'false'
 };
 EmailVerify.propTypes = {
     isVerified: React.PropTypes.string,
     teamURL: React.PropTypes.string,
-    userEmail: React.PropTypes.string
+    userEmail: React.PropTypes.string,
+    resendSuccess: React.PropTypes.string
 };

--- a/web/react/pages/verify.jsx
+++ b/web/react/pages/verify.jsx
@@ -9,6 +9,7 @@ global.window.setupVerifyPage = function setupVerifyPage(props) {
             isVerified={props.IsVerified}
             teamURL={props.TeamURL}
             userEmail={props.UserEmail}
+            resendSuccess={props.ResendSuccess}
         />,
         document.getElementById('verify')
     );

--- a/web/web.go
+++ b/web/web.go
@@ -375,7 +375,10 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		} else {
 			user := result.Data.(*model.User)
 			api.FireAndForgetVerifyEmail(user.Id, user.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
-			http.Redirect(w, r, "/", http.StatusFound)
+
+			newAddress := strings.Replace(r.URL.String(), "?resend=true", "?resend_success=true", -1)
+			newAddress = strings.Replace(newAddress, "&resend=true", "&resend_success=true", -1)
+			http.Redirect(w, r, newAddress, http.StatusFound)
 			return
 		}
 	}

--- a/web/web.go
+++ b/web/web.go
@@ -355,6 +355,7 @@ func getChannel(c *api.Context, w http.ResponseWriter, r *http.Request) {
 
 func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	resend := r.URL.Query().Get("resend")
+	resendSuccess := r.URL.Query().Get("resend_success")
 	name := r.URL.Query().Get("teamname")
 	email := r.URL.Query().Get("email")
 	hashedId := r.URL.Query().Get("hid")
@@ -376,8 +377,7 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			user := result.Data.(*model.User)
 			api.FireAndForgetVerifyEmail(user.Id, user.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
 
-			newAddress := strings.Replace(r.URL.String(), "?resend=true", "?resend_success=true", -1)
-			newAddress = strings.Replace(newAddress, "&resend=true", "&resend_success=true", -1)
+			newAddress := strings.Replace(r.URL.String(), "&resend=true", "&resend_success=true", -1)
 			http.Redirect(w, r, newAddress, http.StatusFound)
 			return
 		}
@@ -403,6 +403,7 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	page.Props["IsVerified"] = isVerified
 	page.Props["TeamURL"] = c.GetTeamURLFromTeam(team)
 	page.Props["UserEmail"] = email
+	page.Props["ResendSuccess"] = resendSuccess
 	page.Render(c, w)
 }
 


### PR DESCRIPTION
Previously it just redirected you to where you were logged in on another account, or back to the splash screen if you weren't.  Now you stay on the page with a green toast informing you that the verification email has been sent.

The second url parameter `resend_success` is used so that if the user refreshes the page with the parameter there it doesn't re-resend the email.