### PR TITLE
PLT-233 Removed click handler from RHS [...] menu

### DIFF
--- a/web/react/components/rhs_comment.jsx
+++ b/web/react/components/rhs_comment.jsx
@@ -114,14 +114,7 @@ export default class RhsComment extends React.Component {
         var ownerOptions;
         if (isOwner && post.state !== Constants.POST_FAILED && post.state !== Constants.POST_LOADING) {
             ownerOptions = (
-                <div
-                    className='dropdown'
-                    onClick={
-                        function scroll() {
-                            $('.post-list-holder-by-time').scrollTop($('.post-list-holder-by-time').scrollTop() + 50);
-                        }
-                    }
-                >
+                <div className='dropdown'>
                     <a
                         href='#'
                         className='dropdown-toggle theme'


### PR DESCRIPTION
Not sure why this was there in the first place since it only appears in comments in the RHS sidebar, but the jquery refers to an element in the center channel.