### PR TITLE
PLT-341 Added CSS classes to markdown headings, links, and tables

### DIFF
--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -9,10 +9,17 @@ export class MattermostMarkdownRenderer extends marked.Renderer {
     constructor(options, formattingOptions = {}) {
         super(options);
 
+        this.heading = this.heading.bind(this);
         this.text = this.text.bind(this);
 
         this.formattingOptions = formattingOptions;
     }
+
+    heading(text, level, raw) {
+        const id = `${this.options.headerPrefix}${raw.toLowerCase().replace(/[^\w]+/g, '-')}`;
+        return `<h${level} id="${id}" class="markdown__heading">${text}</h${level}>`;
+    }
+
     link(href, title, text) {
         let outHref = href;
 
@@ -20,13 +27,17 @@ export class MattermostMarkdownRenderer extends marked.Renderer {
             outHref = `http://${outHref}`;
         }
 
-        let output = '<a class="theme" href="' + outHref + '"';
+        let output = '<a class="theme markdown__link" href="' + outHref + '"';
         if (title) {
             output += ' title="' + title + '"';
         }
         output += '>' + text + '</a>';
 
         return output;
+    }
+
+    table(header, body) {
+        return `<table class="markdown__table"><thead>${header}</thead><tbody>${body}</tbody></table>`;
     }
 
     text(text) {


### PR DESCRIPTION
These are so that Asaad will be able to update the formatting of these elements to be a bit more pleasing.