### PR TITLE
PLT-164 Post drafts containing only files are now recognized properly

### DIFF
--- a/web/react/components/create_post.jsx
+++ b/web/react/components/create_post.jsx
@@ -23,6 +23,7 @@ export default class CreatePost extends React.Component {
 
         this.lastTime = 0;
 
+        this.getCurrentDraft = this.getCurrentDraft.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
         this.postMsgKeyPress = this.postMsgKeyPress.bind(this);
         this.handleUserInput = this.handleUserInput.bind(this);
@@ -36,29 +37,39 @@ export default class CreatePost extends React.Component {
 
         PostStore.clearDraftUploads();
 
-        const draft = PostStore.getCurrentDraft();
-        let previews = [];
-        let messageText = '';
-        let uploadsInProgress = [];
-        if (draft && (draft.message || (draft.previews && draft.previews.length))) {
-            previews = draft.previews;
-            messageText = draft.message;
-            uploadsInProgress = draft.uploadsInProgress;
-        }
+        const draft = this.getCurrentDraft();
 
         this.state = {
             channelId: ChannelStore.getCurrentId(),
-            messageText: messageText,
-            uploadsInProgress: uploadsInProgress,
-            previews: previews,
+            messageText: draft.messageText,
+            uploadsInProgress: draft.uploadsInProgress,
+            previews: draft.previews,
             submitting: false,
-            initialText: messageText
+            initialText: draft.messageText
         };
     }
     componentDidUpdate(prevProps, prevState) {
         if (prevState.previews.length !== this.state.previews.length) {
             this.resizePostHolder();
         }
+    }
+    getCurrentDraft() {
+        const draft = PostStore.getCurrentDraft();
+        const safeDraft = {previews: [], messageText: '', uploadsInProgress: []};
+
+        if (draft) {
+            if (draft.message) {
+                safeDraft.messageText = draft.message;
+            }
+            if (draft.previews) {
+                safeDraft.previews = draft.previews;
+            }
+            if (draft.uploadsInProgress) {
+                safeDraft.uploadsInProgress = draft.uploadsInProgress;
+            }
+        }
+
+        return safeDraft;
     }
     handleSubmit(e) {
         e.preventDefault();
@@ -253,18 +264,9 @@ export default class CreatePost extends React.Component {
     onChange() {
         const channelId = ChannelStore.getCurrentId();
         if (this.state.channelId !== channelId) {
-            let draft = PostStore.getCurrentDraft();
+            const draft = this.getCurrentDraft();
 
-            let previews = [];
-            let messageText = '';
-            let uploadsInProgress = [];
-            if (draft && (draft.message || (draft.previews && draft.previews.length))) {
-                previews = draft.previews;
-                messageText = draft.message;
-                uploadsInProgress = draft.uploadsInProgress;
-            }
-
-            this.setState({channelId: channelId, messageText: messageText, initialText: messageText, submitting: false, serverError: null, postError: null, previews: previews, uploadsInProgress: uploadsInProgress});
+            this.setState({channelId: channelId, messageText: draft.messageText, initialText: draft.messageText, submitting: false, serverError: null, postError: null, previews: draft.previews, uploadsInProgress: draft.uploadsInProgress});
         }
     }
     getFileCount(channelId) {

--- a/web/react/components/create_post.jsx
+++ b/web/react/components/create_post.jsx
@@ -40,7 +40,7 @@ export default class CreatePost extends React.Component {
         let previews = [];
         let messageText = '';
         let uploadsInProgress = [];
-        if (draft && draft.previews && draft.message) {
+        if (draft && (draft.message || (draft.previews && draft.previews.length))) {
             previews = draft.previews;
             messageText = draft.message;
             uploadsInProgress = draft.uploadsInProgress;
@@ -258,7 +258,7 @@ export default class CreatePost extends React.Component {
             let previews = [];
             let messageText = '';
             let uploadsInProgress = [];
-            if (draft && draft.previews && draft.message) {
+            if (draft && (draft.message || (draft.previews && draft.previews.length))) {
                 previews = draft.previews;
                 messageText = draft.message;
                 uploadsInProgress = draft.uploadsInProgress;

--- a/web/react/components/post_list_container.jsx
+++ b/web/react/components/post_list_container.jsx
@@ -49,6 +49,7 @@ export default class PostListContainer extends React.Component {
         for (let i = 0; i <= this.state.postLists.length - 1; i++) {
             postListCtls.push(
                 <PostList
+                    key={'postlistkey' + i}
                     channelId={postLists[i]}
                     isActive={postLists[i] === channelId}
                 />


### PR DESCRIPTION
Previously post drafts containing only files would not show the file previews or post the files unless another file was uploaded.  Each individual component of the returned draft is now checked for validity, rather than just the message portion, and are now used accordingly.

Also contains a minor fix for a react key warning that I noticed.