### PR TITLE
PLT-165 Prevents users from signing up via a public link using a non-valid email address

### DIFF
--- a/web/react/components/signup_user_complete.jsx
+++ b/web/react/components/signup_user_complete.jsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-var utils = require('../utils/utils.jsx');
+var Utils = require('../utils/utils.jsx');
 var client = require('../utils/client.jsx');
 var UserStore = require('../stores/user_store.jsx');
 var BrowserStore = require('../stores/browser_store.jsx');
@@ -31,13 +31,26 @@ export default class SignupUserComplete extends React.Component {
     handleSubmit(e) {
         e.preventDefault();
 
+        const providedEmail = React.findDOMNode(this.refs.email).value.trim();
+        if (!providedEmail) {
+            this.setState({nameError: '', emailError: 'This field is required', passwordError: ''});
+            return;
+        }
+
+        if (!Utils.isEmail(providedEmail)) {
+            this.setState({nameError: '', emailError: 'Please enter a valid email address', passwordError: ''});
+            return;
+        }
+
+        this.state.user.email = providedEmail;
+
         this.state.user.username = React.findDOMNode(this.refs.name).value.trim().toLowerCase();
         if (!this.state.user.username) {
             this.setState({nameError: 'This field is required', emailError: '', passwordError: '', serverError: ''});
             return;
         }
 
-        var usernameError = utils.isValidUsername(this.state.user.username);
+        var usernameError = Utils.isValidUsername(this.state.user.username);
         if (usernameError === 'Cannot use a reserved word as a username.') {
             this.setState({nameError: 'This username is reserved, please choose a new one.', emailError: '', passwordError: '', serverError: ''});
             return;
@@ -48,12 +61,6 @@ export default class SignupUserComplete extends React.Component {
                 passwordError: '',
                 serverError: ''
             });
-            return;
-        }
-
-        this.state.user.email = React.findDOMNode(this.refs.email).value.trim();
-        if (!this.state.user.email) {
-            this.setState({nameError: '', emailError: 'This field is required', passwordError: ''});
             return;
         }
 


### PR DESCRIPTION
Adds a check for email validity client-side when joining a team using a public link.  @coreyhulen will add any necessary backend checks as per the ticket description.

Also moved logic so that the email field is error checked first, so that any user input errors are shown top to bottom.