### PR TITLE
PLT-194 Replaced quiet mode with an option for when to show a channel as unread

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -76,7 +76,7 @@ func CreateChannel(c *Context, channel *model.Channel, addMember bool) (*model.C
 
 		if addMember {
 			cm := &model.ChannelMember{ChannelId: sc.Id, UserId: c.Session.UserId,
-				Roles: model.CHANNEL_ROLE_ADMIN, NotifyLevel: model.CHANNEL_NOTIFY_ALL}
+				Roles: model.CHANNEL_ROLE_ADMIN, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT}
 
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				return nil, cmresult.Err
@@ -135,7 +135,7 @@ func CreateDirectChannel(c *Context, otherUserId string) (*model.Channel, *model
 		return nil, err
 	} else {
 		cm := &model.ChannelMember{ChannelId: sc.Id, UserId: otherUserId,
-			Roles: "", NotifyLevel: model.CHANNEL_NOTIFY_ALL}
+			Roles: "", NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT}
 
 		if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 			return nil, cmresult.Err
@@ -372,7 +372,7 @@ func JoinChannel(c *Context, channelId string, role string) {
 		}
 
 		if channel.Type == model.CHANNEL_OPEN {
-			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: c.Session.UserId, NotifyLevel: model.CHANNEL_NOTIFY_ALL, Roles: role}
+			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: c.Session.UserId, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, Roles: role}
 
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				c.Err = cmresult.Err
@@ -405,7 +405,7 @@ func JoinDefaultChannels(user *model.User, channelRole string) *model.AppError {
 	if result := <-Srv.Store.Channel().GetByName(user.TeamId, "town-square"); result.Err != nil {
 		err = result.Err
 	} else {
-		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, NotifyLevel: model.CHANNEL_NOTIFY_ALL, Roles: channelRole}
+		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, Roles: channelRole}
 		if cmResult := <-Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
 			err = cmResult.Err
 		}
@@ -414,7 +414,7 @@ func JoinDefaultChannels(user *model.User, channelRole string) *model.AppError {
 	if result := <-Srv.Store.Channel().GetByName(user.TeamId, "off-topic"); result.Err != nil {
 		err = result.Err
 	} else {
-		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, NotifyLevel: model.CHANNEL_NOTIFY_ALL, Roles: channelRole}
+		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, Roles: channelRole}
 		if cmResult := <-Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
 			err = cmResult.Err
 		}
@@ -694,7 +694,7 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		} else {
 			oUser := oresult.Data.(*model.User)
 
-			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: userId, NotifyLevel: model.CHANNEL_NOTIFY_ALL}
+			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: userId, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT}
 
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				l4g.Error("Failed to add member user_id=%v channel_id=%v err=%v", userId, id, cmresult.Err)

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -15,7 +15,6 @@ const (
 	CHANNEL_NOTIFY_ALL          = "all"
 	CHANNEL_NOTIFY_MENTION      = "mention"
 	CHANNEL_NOTIFY_NONE         = "none"
-	CHANNEL_NOTIFY_QUIET        = "quiet" // no longer used, should be considered functionally equivalent to CHANNEL_NOTIFY_NONE
 	CHANNEL_MARK_UNREAD_ALL     = "all"
 	CHANNEL_MARK_UNREAD_MENTION = "mention"
 )
@@ -87,8 +86,7 @@ func IsChannelNotifyLevelValid(notifyLevel string) bool {
 	return notifyLevel == CHANNEL_NOTIFY_DEFAULT ||
 		notifyLevel == CHANNEL_NOTIFY_ALL ||
 		notifyLevel == CHANNEL_NOTIFY_MENTION ||
-		notifyLevel == CHANNEL_NOTIFY_NONE ||
-		notifyLevel == CHANNEL_NOTIFY_QUIET
+		notifyLevel == CHANNEL_NOTIFY_NONE
 }
 
 func IsChannelMarkUnreadLevelValid(markUnreadLevel string) bool {

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -10,23 +10,26 @@ import (
 )
 
 const (
-	CHANNEL_ROLE_ADMIN     = "admin"
-	CHANNEL_NOTIFY_DEFAULT = "default"
-	CHANNEL_NOTIFY_ALL     = "all"
-	CHANNEL_NOTIFY_MENTION = "mention"
-	CHANNEL_NOTIFY_NONE    = "none"
-	CHANNEL_NOTIFY_QUIET   = "quiet" // TODO deprecate me
+	CHANNEL_ROLE_ADMIN          = "admin"
+	CHANNEL_NOTIFY_DEFAULT      = "default"
+	CHANNEL_NOTIFY_ALL          = "all"
+	CHANNEL_NOTIFY_MENTION      = "mention"
+	CHANNEL_NOTIFY_NONE         = "none"
+	CHANNEL_NOTIFY_QUIET        = "quiet" // no longer used, should be considered functionally equivalent to CHANNEL_NOTIFY_NONE
+	CHANNEL_MARK_UNREAD_ALL     = "all"
+	CHANNEL_MARK_UNREAD_MENTION = "mention"
 )
 
 type ChannelMember struct {
-	ChannelId    string `json:"channel_id"`
-	UserId       string `json:"user_id"`
-	Roles        string `json:"roles"`
-	LastViewedAt int64  `json:"last_viewed_at"`
-	MsgCount     int64  `json:"msg_count"`
-	MentionCount int64  `json:"mention_count"`
-	NotifyLevel  string `json:"notify_level"`
-	LastUpdateAt int64  `json:"last_update_at"`
+	ChannelId       string `json:"channel_id"`
+	UserId          string `json:"user_id"`
+	Roles           string `json:"roles"`
+	LastViewedAt    int64  `json:"last_viewed_at"`
+	MsgCount        int64  `json:"msg_count"`
+	MentionCount    int64  `json:"mention_count"`
+	NotifyLevel     string `json:"notify_level"`
+	MarkUnreadLevel string `json:"mark_unread_level"`
+	LastUpdateAt    int64  `json:"last_update_at"`
 }
 
 func (o *ChannelMember) ToJson() string {
@@ -69,6 +72,10 @@ func (o *ChannelMember) IsValid() *AppError {
 		return NewAppError("ChannelMember.IsValid", "Invalid notify level", "notify_level="+o.NotifyLevel)
 	}
 
+	if len(o.MarkUnreadLevel) > 20 || !IsChannelMarkUnreadLevelValid(o.MarkUnreadLevel) {
+		return NewAppError("ChannelMember.IsValid", "Invalid mark unread level", "mark_unread_level="+o.MarkUnreadLevel)
+	}
+
 	return nil
 }
 
@@ -82,4 +89,8 @@ func IsChannelNotifyLevelValid(notifyLevel string) bool {
 		notifyLevel == CHANNEL_NOTIFY_MENTION ||
 		notifyLevel == CHANNEL_NOTIFY_NONE ||
 		notifyLevel == CHANNEL_NOTIFY_QUIET
+}
+
+func IsChannelMarkUnreadLevelValid(markUnreadLevel string) bool {
+	return markUnreadLevel == CHANNEL_MARK_UNREAD_ALL || markUnreadLevel == CHANNEL_MARK_UNREAD_MENTION
 }

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -11,10 +11,11 @@ import (
 
 const (
 	CHANNEL_ROLE_ADMIN     = "admin"
+	CHANNEL_NOTIFY_DEFAULT = "default"
 	CHANNEL_NOTIFY_ALL     = "all"
 	CHANNEL_NOTIFY_MENTION = "mention"
 	CHANNEL_NOTIFY_NONE    = "none"
-	CHANNEL_NOTIFY_QUIET   = "quiet"
+	CHANNEL_NOTIFY_QUIET   = "quiet" // TODO deprecate me
 )
 
 type ChannelMember struct {
@@ -76,5 +77,9 @@ func (o *ChannelMember) PreSave() {
 }
 
 func IsChannelNotifyLevelValid(notifyLevel string) bool {
-	return notifyLevel == CHANNEL_NOTIFY_ALL || notifyLevel == CHANNEL_NOTIFY_MENTION || notifyLevel == CHANNEL_NOTIFY_NONE || notifyLevel == CHANNEL_NOTIFY_QUIET
+	return notifyLevel == CHANNEL_NOTIFY_DEFAULT ||
+		notifyLevel == CHANNEL_NOTIFY_ALL ||
+		notifyLevel == CHANNEL_NOTIFY_MENTION ||
+		notifyLevel == CHANNEL_NOTIFY_NONE ||
+		notifyLevel == CHANNEL_NOTIFY_QUIET
 }

--- a/model/channel_member_test.go
+++ b/model/channel_member_test.go
@@ -32,6 +32,7 @@ func TestChannelMemberIsValid(t *testing.T) {
 
 	o.Roles = "missing"
 	o.NotifyLevel = CHANNEL_NOTIFY_ALL
+	o.MarkUnreadLevel = CHANNEL_MARK_UNREAD_ALL
 	o.UserId = NewId()
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
@@ -49,6 +50,16 @@ func TestChannelMemberIsValid(t *testing.T) {
 	}
 
 	o.NotifyLevel = CHANNEL_NOTIFY_ALL
+	if err := o.IsValid(); err != nil {
+		t.Fatal(err)
+	}
+
+	o.MarkUnreadLevel = "123456789012345678901"
+	if err := o.IsValid(); err == nil {
+		t.Fatal("should be invalid")
+	}
+
+	o.MarkUnreadLevel = CHANNEL_MARK_UNREAD_ALL
 	if err := o.IsValid(); err != nil {
 		t.Fatal(err)
 	}

--- a/model/client.go
+++ b/model/client.go
@@ -468,6 +468,15 @@ func (c *Client) UpdateNotifyLevel(data map[string]string) (*Result, *AppError) 
 	}
 }
 
+func (c *Client) UpdateMarkUnreadLevel(data map[string]string) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/channels/update_mark_unread_level", MapToJson(data)); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), MapFromJson(r.Body)}, nil
+	}
+}
+
 func (c *Client) GetChannels(etag string) (*Result, *AppError) {
 	if r, err := c.DoApiGet("/channels/", "", etag); err != nil {
 		return nil, err

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -136,12 +136,14 @@ func TestChannelStoreDelete(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o2.Id
 	m2.UserId = m1.UserId
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m2))
 
 	if r := <-store.Channel().Delete(o1.Id, model.GetMillis()); r.Err != nil {
@@ -223,12 +225,14 @@ func TestChannelMemberStore(t *testing.T) {
 	o1.ChannelId = c1.Id
 	o1.UserId = u1.Id
 	o1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	o1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&o1))
 
 	o2 := model.ChannelMember{}
 	o2.ChannelId = c1.Id
 	o2.UserId = u2.Id
 	o2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	o2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&o2))
 
 	c1t2 := (<-store.Channel().Get(c1.Id)).Data.(*model.Channel)
@@ -292,6 +296,7 @@ func TestChannelStorePermissionsTo(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	count := (<-store.Channel().CheckPermissionsTo(o1.TeamId, o1.Id, m1.UserId)).Data.(int64)
@@ -372,18 +377,21 @@ func TestChannelStoreGetChannels(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
 	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m3.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m3))
 
 	cresult := <-store.Channel().GetChannels(o1.TeamId, m1.UserId)
@@ -415,18 +423,21 @@ func TestChannelStoreGetMoreChannels(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
 	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m3.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m3))
 
 	o3 := model.Channel{}
@@ -483,18 +494,21 @@ func TestChannelStoreGetChannelCounts(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
 	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m3.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m3))
 
 	cresult := <-store.Channel().GetChannelCounts(o1.TeamId, m1.UserId)
@@ -524,6 +538,7 @@ func TestChannelStoreUpdateLastViewedAt(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	err := (<-store.Channel().UpdateLastViewedAt(m1.ChannelId, m1.UserId)).Err
@@ -552,6 +567,7 @@ func TestChannelStoreIncrementMentionCount(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	err := (<-store.Channel().IncrementMentionCount(m1.ChannelId, m1.UserId)).Err

--- a/store/sql_post_store_test.go
+++ b/store/sql_post_store_test.go
@@ -485,6 +485,7 @@ func TestPostStoreSearch(t *testing.T) {
 	m1.ChannelId = c1.Id
 	m1.UserId = userId
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	c2 := &model.Channel{}

--- a/store/store.go
+++ b/store/store.go
@@ -72,6 +72,7 @@ type ChannelStore interface {
 	UpdateLastViewedAt(channelId string, userId string) StoreChannel
 	IncrementMentionCount(channelId string, userId string) StoreChannel
 	UpdateNotifyLevel(channelId string, userId string, notifyLevel string) StoreChannel
+	UpdateMarkUnreadLevel(channelId string, userId string, markUnreadLevel string) StoreChannel
 }
 
 type PostStore interface {

--- a/web/react/components/channel_notifications.jsx
+++ b/web/react/components/channel_notifications.jsx
@@ -81,6 +81,11 @@ export default class ChannelNotifications extends React.Component {
         var channelId = this.state.channelId;
         var notifyLevel = this.state.notifyLevel;
 
+        if (ChannelStore.getMember(channelId).notify_level === notifyLevel) {
+            this.updateSection('');
+            return;
+        }
+
         var data = {};
         data.channel_id = channelId;
         data.user_id = UserStore.getCurrentId();
@@ -243,6 +248,11 @@ export default class ChannelNotifications extends React.Component {
     handleSubmitMarkUnreadLevel() {
         const channelId = this.state.channelId;
         const markUnreadLevel = this.state.markUnreadLevel;
+
+        if (ChannelStore.getMember(channelId).mark_unread_level === markUnreadLevel) {
+            this.updateSection('');
+            return;
+        }
 
         const data = {
             channel_id: channelId,

--- a/web/react/components/channel_notifications.jsx
+++ b/web/react/components/channel_notifications.jsx
@@ -104,14 +104,28 @@ export default class ChannelNotifications extends React.Component {
     createDesktopSection(serverError) {
         var handleUpdateSection;
 
+        const user = UserStore.getCurrentUser();
+        const globalNotifyLevel = user.notify_props.desktop;
+
+        let globalNotifyLevelName;
+        if (globalNotifyLevel === 'all') {
+            globalNotifyLevelName = 'For all activity';
+        } else if (globalNotifyLevel === 'mention') {
+            globalNotifyLevelName = 'Only for mentions';
+        } else {
+            globalNotifyLevelName = 'Never';
+        }
+
         if (this.state.activeSection === 'desktop') {
-            var notifyActive = [false, false, false];
-            if (this.state.notifyLevel === 'mention') {
-                notifyActive[1] = true;
-            } else if (this.state.notifyLevel === 'all') {
+            var notifyActive = [false, false, false, false];
+            if (this.state.notifyLevel === 'default') {
                 notifyActive[0] = true;
-            } else {
+            } else if (this.state.notifyLevel === 'all') {
+                notifyActive[1] = true;
+            } else if (this.state.notifyLevel === 'mention') {
                 notifyActive[2] = true;
+            } else {
+                notifyActive[3] = true;
             }
 
             var inputs = [];
@@ -123,9 +137,9 @@ export default class ChannelNotifications extends React.Component {
                             <input
                                 type='radio'
                                 checked={notifyActive[0]}
-                                onChange={this.handleRadioClick.bind(this, 'all')}
+                                onChange={this.handleRadioClick.bind(this, 'default')}
                             >
-                                For all activity
+                                {`Global default (${globalNotifyLevelName})`}
                             </input>
                         </label>
                         <br/>
@@ -135,9 +149,9 @@ export default class ChannelNotifications extends React.Component {
                             <input
                                 type='radio'
                                 checked={notifyActive[1]}
-                                onChange={this.handleRadioClick.bind(this, 'mention')}
+                                onChange={this.handleRadioClick.bind(this, 'all')}
                             >
-                                Only for mentions
+                                {'For all activity'}
                             </input>
                         </label>
                         <br/>
@@ -147,9 +161,21 @@ export default class ChannelNotifications extends React.Component {
                             <input
                                 type='radio'
                                 checked={notifyActive[2]}
+                                onChange={this.handleRadioClick.bind(this, 'mention')}
+                            >
+                                {'Only for mentions'}
+                            </input>
+                        </label>
+                        <br/>
+                    </div>
+                    <div className='radio'>
+                        <label>
+                            <input
+                                type='radio'
+                                checked={notifyActive[3]}
                                 onChange={this.handleRadioClick.bind(this, 'none')}
                             >
-                                Never
+                                {'Never'}
                             </input>
                         </label>
                     </div>
@@ -162,24 +188,13 @@ export default class ChannelNotifications extends React.Component {
                 e.preventDefault();
             }.bind(this);
 
-            let curChannel = ChannelStore.get(this.state.channelId);
-            let extraInfo = (
+            const extraInfo = (
                 <span>
-                    These settings will override the global notification settings.
+                    {'Selecting an option other than "Default" will override the global notification settings.'}
                     <br/>
-                    Desktop notifications are available on Firefox, Safari, and Chrome.
+                    {'Desktop notifications are available on Firefox, Safari, and Chrome.'}
                 </span>
             );
-
-            if (curChannel && curChannel.display_name) {
-                extraInfo = (
-                    <span>
-                        These settings will override the global notification settings for the <b>{curChannel.display_name}</b> channel.
-                        <br/>
-                        Desktop notifications are available on Firefox, Safari, and Chrome.
-                    </span>
-                );
-            }
 
             return (
                 <SettingItemMax
@@ -194,7 +209,9 @@ export default class ChannelNotifications extends React.Component {
         }
 
         var describe;
-        if (this.state.notifyLevel === 'mention') {
+        if (this.state.notifyLevel === 'default') {
+            describe = `Global default (${globalNotifyLevelName})`;
+        } else if (this.state.notifyLevel === 'mention') {
             describe = 'Only for mentions';
         } else if (this.state.notifyLevel === 'all') {
             describe = 'For all activity';

--- a/web/react/components/notify_counts.jsx
+++ b/web/react/components/notify_counts.jsx
@@ -15,7 +15,7 @@ function getCountsStateFromStores() {
             count += channel.total_msg_count - channelMember.msg_count;
         } else if (channelMember.mention_count > 0) {
             count += channelMember.mention_count;
-        } else if (channelMember.notify_level !== 'quiet' && channel.total_msg_count - channelMember.msg_count > 0) {
+        } else if (channelMember.mark_unread_level !== 'mention' && channel.total_msg_count - channelMember.msg_count > 0) {
             count += 1;
         }
     });

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -329,7 +329,7 @@ export default class Sidebar extends React.Component {
         var unread = false;
         if (channelMember) {
             msgCount = channel.total_msg_count - channelMember.msg_count;
-            unread = (msgCount > 0 && channelMember.notify_level !== 'quiet') || channelMember.mention_count > 0;
+            unread = (msgCount > 0 && channelMember.mark_unread_level !== 'mention') || channelMember.mention_count > 0;
         }
 
         var titleClass = '';

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -200,13 +200,17 @@ export default class Sidebar extends React.Component {
                 }
                 var channel = ChannelStore.get(msg.channel_id);
 
-                var user = UserStore.getCurrentUser();
-                if (user.notify_props && ((user.notify_props.desktop === 'mention' && mentions.indexOf(user.id) === -1 && channel.type !== 'D') || user.notify_props.desktop === 'none')) {
-                    return;
+                const user = UserStore.getCurrentUser();
+                const member = ChannelStore.getMember(msg.channel_id);
+
+                var notifyLevel = member.notify_level;
+                if (notifyLevel === 'default') {
+                    notifyLevel = user.notify_props.desktop;
                 }
 
-                var member = ChannelStore.getMember(msg.channel_id);
-                if ((member.notify_level === 'mention' && mentions.indexOf(user.id) === -1) || member.notify_level === 'none' || member.notify_level === 'quiet') {
+                if (notifyLevel === 'none') {
+                    return;
+                } else if (notifyLevel === 'mention' && mentions.indexOf(user.id) === -1 && channel.type !== 'D') {
                     return;
                 }
 

--- a/web/react/components/user_settings/user_settings_notifications.jsx
+++ b/web/react/components/user_settings/user_settings_notifications.jsx
@@ -17,7 +17,7 @@ function getNotificationsStateFromStores() {
     if (user.notify_props && user.notify_props.desktop_sound) {
         sound = user.notify_props.desktop_sound;
     }
-    var desktop = 'all';
+    var desktop = 'default';
     if (user.notify_props && user.notify_props.desktop) {
         desktop = user.notify_props.desktop;
     }

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -152,21 +152,23 @@ export function getChannel(id) {
 }
 
 export function updateLastViewedAt() {
-    if (isCallInProgress('updateLastViewed')) {
+    const channelId = ChannelStore.getCurrentId();
+
+    if (channelId === null) {
         return;
     }
 
-    if (ChannelStore.getCurrentId() == null) {
+    if (isCallInProgress(`updateLastViewed${channelId}`)) {
         return;
     }
 
-    callTracker.updateLastViewed = utils.getTimestamp();
+    callTracker[`updateLastViewed${channelId}`] = utils.getTimestamp();
     client.updateLastViewedAt(
-        ChannelStore.getCurrentId(),
-        function updateLastViewedAtSuccess() {
+        channelId,
+        () => {
             callTracker.updateLastViewed = 0;
         },
-        function updateLastViewdAtFailure(err) {
+        (err) => {
             callTracker.updateLastViewed = 0;
             dispatchError(err, 'updateLastViewedAt');
         }

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -583,6 +583,21 @@ export function updateNotifyLevel(data, success, error) {
     });
 }
 
+export function updateMarkUnreadLevel(data, success, error) {
+    $.ajax({
+        url: '/api/v1/channels/update_mark_unread_level',
+        dataType: 'json',
+        contentType: 'application/json',
+        type: 'POST',
+        data: JSON.stringify(data),
+        success,
+        error: function onError(xhr, status, err) {
+            var e = handleError('updateMarkUnreadLevel', xhr, status, err);
+            error(e);
+        }
+    });
+}
+
 export function joinChannel(id, success, error) {
     $.ajax({
         url: '/api/v1/channels/' + id + '/join',


### PR DESCRIPTION
1) Adds a "default" notification level that uses the level set in user settings. This is the new default option for newly joined channels.
2) Removes Quiet Mode and replaces it with the "mark unread" level which tells when a channel should be shown as unread in the left sidebar.
3) Slightly changes how we detect multiple updateLastViewed api calls to allow multiple calls to go out at once for different channels.