### PR TITLE
Removing OAuth and webhooks changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,6 @@ Admin Console
 
 - (Preview) Ability to view server logs and change config settings
 
-Integrations
-
-- (Preview) Added API for incoming webhooks
-- (Preview) Added OAuth2 as a service provider to allow for more secure connection to external apps 
-
 ### Improvements
 
 Documentation


### PR DESCRIPTION
While OAuth2 and webhooks are in the codebase, the UI was only partly finished and we foresee enough time for testing before shipping Oct 2 so we're postponing these to the Oct 16 release.