### PR TITLE
PLT-334 Restricted markdown output to only appear on one line when in singleline mode

### DIFF
--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -15,6 +15,14 @@ export class MattermostMarkdownRenderer extends marked.Renderer {
         this.formattingOptions = formattingOptions;
     }
 
+    br() {
+        if (this.formattingOptions.singleline) {
+            return ' ';
+        }
+
+        return super.br();
+    }
+
     heading(text, level, raw) {
         const id = `${this.options.headerPrefix}${raw.toLowerCase().replace(/[^\w]+/g, '-')}`;
         return `<h${level} id="${id}" class="markdown__heading">${text}</h${level}>`;
@@ -34,6 +42,14 @@ export class MattermostMarkdownRenderer extends marked.Renderer {
         output += '>' + text + '</a>';
 
         return output;
+    }
+
+    paragraph(text) {
+        if (this.formattingOptions.singleline) {
+            return `<p class="markdown__paragraph-inline">${text}</p>`;
+        }
+
+        return super.paragraph(text);
     }
 
     table(header, body) {

--- a/web/sass-files/sass/partials/_markdown.scss
+++ b/web/sass-files/sass/partials/_markdown.scss
@@ -1,6 +1,12 @@
 .markdown__heading {
 	font-weight: bold;
 }
+.markdown__paragraph-inline {
+    display: inline;
+    + .markdown__paragraph-inline {
+        margin-left: 4px;
+    }
+}
 .markdown__table {
 	background: #fff;
 	margin: 5px 0 10px;


### PR DESCRIPTION
I just learned about the "adjacent child" selector in CSS and how incredibly useful it can be in cases like this.