### PR TITLE
PLT-43 Fixes backspace navigating back a page.

### DIFF
--- a/web/react/components/channel_loader.jsx
+++ b/web/react/components/channel_loader.jsx
@@ -109,6 +109,13 @@ export default class ChannelLoader extends React.Component {
             $('.modal-body').css('overflow-y', 'auto');
             $('.modal-body').css('max-height', $(window).height() * 0.7);
         });
+
+        /* Prevent backspace from navigating back a page */
+        $(window).on('keydown.preventBackspace', (e) => {
+            if (e.which === 8 && !$(e.target).is('input, textarea')) {
+                e.preventDefault();
+            }
+        });
     }
     componentWillUnmount() {
         clearInterval(this.intervalId);
@@ -123,6 +130,8 @@ export default class ChannelLoader extends React.Component {
         $('body').off('mouseenter mouseleave', '.post.post--comment.same--root');
 
         $('.modal').off('show.bs.modal');
+
+        $(window).off('keydown.preventBackspace');
     }
     onSocketChange(msg) {
         if (msg && msg.user_id && msg.user_id !== UserStore.getCurrentId()) {

--- a/web/react/components/settings_sidebar.jsx
+++ b/web/react/components/settings_sidebar.jsx
@@ -7,7 +7,8 @@ export default class SettingsSidebar extends React.Component {
 
         this.handleClick = this.handleClick.bind(this);
     }
-    handleClick(tab) {
+    handleClick(tab, e) {
+        e.preventDefault();
         this.props.updateTab(tab.name);
         $('.settings-modal').addClass('display--content');
     }


### PR DESCRIPTION
I also prevented switching tabs in the account/team settings modal from adding a `#` to the address bar URL.