### PR TITLE
PLT-379 Removed smilies that start with a semicolon

### DIFF
--- a/web/react/utils/emoticons.jsx
+++ b/web/react/utils/emoticons.jsx
@@ -5,15 +5,14 @@ const emoticonPatterns = {
     smile: /:-?\)/g, // :)
     open_mouth: /:o/gi, // :o
     scream: /:-o/gi, // :-o
-    smirk: /[:;]-?]/g, // :]
-    grinning: /[:;]-?d/gi, // :D
+    smirk: /:-?]/g, // :]
+    grinning: /:-?d/gi, // :D
     stuck_out_tongue_closed_eyes: /x-d/gi, // x-d
-    stuck_out_tongue_winking_eye: /[:;]-?p/gi, // ;p
+    stuck_out_tongue_winking_eye: /:-?p/gi, // :p
     rage: /:-?[\[@]/g, // :@
     frowning: /:-?\(/g, // :(
     sob: /:['’]-?\(|:&#x27;\(/g, // :`(
     kissing_heart: /:-?\*/g, // :*
-    wink: /;-?\)/g, // ;)
     pensive: /:-?\//g, // :/
     confounded: /:-?s/gi, // :s
     flushed: /:-?\|/g, // :|


### PR DESCRIPTION
Unfortunately, there's no way to do a regex lookbehind in javascript to make sure we're not taking part of an html entity as the start of a smiley. There's definitely other ways to get around this, but there's some other bugs I'd like to get to for 0.8.0 that are more important than winky faces.