### PR TITLE
PLT-256 Added headers to getFile api call to trigger IE/Edge to download the file instead of just opening it

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -85,8 +85,8 @@
 		},
 		{
 			"ImportPath": "github.com/mssola/user_agent",
-			"Comment": "v0.4.1-2-g35c7f18",
-			"Rev": "35c7f18f5261cc18c698a461053c119aebaf8542"
+			"Comment": "v0.4.1-4-ga163d6a",
+			"Rev": "a163d6a569f1cd264d2f8b2bf3c5d04ace5995eb"
 		},
 		{
 			"ImportPath": "github.com/nfnt/resize",

--- a/Godeps/_workspace/src/github.com/mssola/user_agent/.travis.yml
+++ b/Godeps/_workspace/src/github.com/mssola/user_agent/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.2
   - 1.3
   - 1.4
+  - 1.5
   - tip
 matrix:
   allow_failures:

--- a/Godeps/_workspace/src/github.com/mssola/user_agent/all_test.go
+++ b/Godeps/_workspace/src/github.com/mssola/user_agent/all_test.go
@@ -40,6 +40,10 @@ var uastrings = []struct {
 	{"IE11b32Win7b64MDDRJS", "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; MDDRJS; rv:11.0) like Gecko"},
 	{"IE11Compatibility", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.3; Trident/7.0)"},
 
+	// Microsoft Edge
+	{"EdgeDesktop", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240"},
+	{"EdgeMobile", "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; DEVICE INFO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.10240"},
+
 	// Gecko
 	{"FirefoxMac", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:2.0b8) Gecko/20100101 Firefox/4.0b8"},
 	{"FirefoxMacLoc", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13"},
@@ -128,6 +132,10 @@ var expected = []string{
 	"Mozilla:5.0 Platform:Windows OS:Windows 7 Browser:Internet Explorer-11.0 Engine:Trident Bot:false Mobile:false",
 	"Mozilla:5.0 Platform:Windows OS:Windows 7 Browser:Internet Explorer-11.0 Engine:Trident Bot:false Mobile:false",
 	"Mozilla:4.0 Platform:Windows OS:Windows 8.1 Browser:Internet Explorer-7.0 Engine:Trident Bot:false Mobile:false",
+
+	// Microsoft Edge
+	"Mozilla:5.0 Platform:Windows OS:Windows NT 10.0 Browser:Edge-12.10240 Engine:EdgeHTML Bot:false Mobile:false",
+	"Mozilla:5.0 Platform:Windows OS:Windows Phone 10.0 Browser:Edge-12.10240 Engine:EdgeHTML Bot:false Mobile:true",
 
 	// Gecko
 	"Mozilla:5.0 Platform:Macintosh OS:Intel Mac OS X 10.6 Browser:Firefox-4.0b8 Engine:Gecko-20100101 Bot:false Mobile:false",

--- a/Godeps/_workspace/src/github.com/mssola/user_agent/browser.go
+++ b/Godeps/_workspace/src/github.com/mssola/user_agent/browser.go
@@ -48,13 +48,21 @@ func (p *UserAgent) detectBrowser(sections []section) {
 		if slen > 2 {
 			p.browser.Version = sections[2].version
 			if engine.name == "AppleWebKit" {
-				if sections[slen-1].name == "OPR" {
+				switch sections[slen-1].name {
+				case "Edge":
+					p.browser.Name = "Edge"
+					p.browser.Version = sections[slen-1].version
+					p.browser.Engine = "EdgeHTML"
+					p.browser.EngineVersion = ""
+				case "OPR":
 					p.browser.Name = "Opera"
 					p.browser.Version = sections[slen-1].version
-				} else if sections[2].name == "Chrome" {
-					p.browser.Name = "Chrome"
-				} else {
-					p.browser.Name = "Safari"
+				default:
+					if sections[2].name == "Chrome" {
+						p.browser.Name = "Chrome"
+					} else {
+						p.browser.Name = "Safari"
+					}
 				}
 			} else if engine.name == "Gecko" {
 				name := sections[2].name

--- a/api/file.go
+++ b/api/file.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
+	"github.com/mssola/user_agent"
 	"github.com/nfnt/resize"
 	"github.com/rwcarlsen/goexif/exif"
 	_ "golang.org/x/image/bmp"
@@ -426,6 +427,19 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "max-age=2592000, public")
 	w.Header().Set("Content-Length", strconv.Itoa(len(f)))
 	w.Header().Set("Content-Type", mime.TypeByExtension(filepath.Ext(filename)))
+
+	// attach extra headers to trigger a download on IE and Edge
+	ua := user_agent.New(r.UserAgent())
+	bname, _ := ua.Browser()
+
+	if bname == "Edge" || bname == "Internet Explorer" {
+		// trim off anything before the final / so we just get the file's name
+		parts := strings.Split(filename, "/")
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", "attachment;filename=\""+parts[len(parts)-1]+"\"")
+	}
+
 	w.Write(f)
 }
 


### PR DESCRIPTION
IE and Edge don't respect the download attribute of an <a> tag so we need to set some header fields to get files to download properly.

Also updated the https://github.com/mssola/user_agent library so that it properly detects Edge.