### PR TITLE
PLT-367 Added a json response to the uploadProfileImage api call

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -821,6 +821,9 @@ func uploadProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	Srv.Store.User().UpdateLastPictureUpdate(c.Session.UserId)
 
 	c.LogAudit("")
+
+	// write something as the response since jQuery expects a json response
+	w.Write([]byte("true"))
 }
 
 func updateUser(c *Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is to prevent an "unexpected error 200" error message that was showing up when uploading a new profile picture that was due to jquery attempting to parse a "200 OK" response as json.