### PR TITLE
PLT-376 Fix account settings being scrolled to bottom when opened.

### DIFF
--- a/web/react/components/user_settings/user_settings_appearance.jsx
+++ b/web/react/components/user_settings/user_settings_appearance.jsx
@@ -81,6 +81,8 @@ export default class UserSettingsAppearance extends React.Component {
 
                 $('#user_settings').off('hidden.bs.modal', this.handleClose);
                 this.props.updateTab('general');
+                $('.ps-container.modal-body').scrollTop(0);
+                $('.ps-container.modal-body').perfectScrollbar('update');
                 $('#user_settings').modal('hide');
             },
             (err) => {


### PR DESCRIPTION
I know we're planning on totally yanking out perfect scrollbar but this is just for an intermediate bug fix.