### PR TITLE
Update the /join command to use the correct redirect URL

### DIFF
--- a/api/command.go
+++ b/api/command.go
@@ -195,7 +195,7 @@ func joinCommand(c *Context, command *model.Command) bool {
 						return false
 					}
 
-					command.GotoLocation = "/channels/" + v.Name
+					command.GotoLocation = c.GetTeamURL() + "/channels/" + v.Name
 					command.Response = model.RESP_EXECUTED
 					return true
 				}

--- a/api/command_test.go
+++ b/api/command_test.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mattermost/platform/model"
@@ -126,12 +127,12 @@ func TestJoinCommands(t *testing.T) {
 	}
 
 	rs5 := Client.Must(Client.Command("", "/join "+channel2.Name, false)).Data.(*model.Command)
-	if rs5.GotoLocation != "/channels/"+channel2.Name {
+	if !strings.HasSuffix(rs5.GotoLocation, "/"+team.Name+"/channels/"+channel2.Name) {
 		t.Fatal("failed to join channel")
 	}
 
 	rs6 := Client.Must(Client.Command("", "/join "+channel3.Name, false)).Data.(*model.Command)
-	if rs6.GotoLocation == "/channels/"+channel3.Name {
+	if strings.HasSuffix(rs6.GotoLocation, "/"+team.Name+"/channels/"+channel3.Name) {
 		t.Fatal("should not have joined direct message channel")
 	}
 


### PR DESCRIPTION
Please see https://github.com/mattermost/platform/issues/842 for the related issue.  My concern is whether or not I should be using `GetTeamURL()` since it returns an absolute url where the redirect url was relative previously.