### PR TITLE
Added slight delay to TestEchoCommand to account for race condition

### DIFF
--- a/api/command_test.go
+++ b/api/command_test.go
@@ -6,6 +6,7 @@ package api
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
@@ -175,6 +176,8 @@ func TestEchoCommand(t *testing.T) {
 	if r1.Response != model.RESP_EXECUTED {
 		t.Fatal("Echo command failed to execute")
 	}
+
+	time.Sleep(100 * time.Millisecond)
 
 	p1 := Client.Must(Client.GetPosts(channel1.Id, 0, 2, "")).Data.(*model.PostList)
 	if len(p1.Order) != 1 {


### PR DESCRIPTION
Fixes an issue with a test case that was failing occasionally (or constantly in my case). The test creates a post via an echo command and then checks if it exists, but the echo command runs asynchronously so the post wasn't always made by the time it was expected it to be.