### PR TITLE
PLT-194 Changes to ChannelMember notification settings

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -23,7 +23,6 @@ func InitChannel(r *mux.Router) {
 	sr.Handle("/create_direct", ApiUserRequired(createDirectChannel)).Methods("POST")
 	sr.Handle("/update", ApiUserRequired(updateChannel)).Methods("POST")
 	sr.Handle("/update_desc", ApiUserRequired(updateChannelDesc)).Methods("POST")
-	sr.Handle("/update_notify_level", ApiUserRequired(updateNotifyLevel)).Methods("POST")
 	sr.Handle("/update_notify_props", ApiUserRequired(updateNotifyProps)).Methods("POST")
 	sr.Handle("/{id:[A-Za-z0-9]+}/", ApiUserRequiredActivity(getChannel, false)).Methods("GET")
 	sr.Handle("/{id:[A-Za-z0-9]+}/extra_info", ApiUserRequired(getChannelExtraInfo)).Methods("GET")
@@ -76,8 +75,8 @@ func CreateChannel(c *Context, channel *model.Channel, addMember bool) (*model.C
 		sc := result.Data.(*model.Channel)
 
 		if addMember {
-			cm := &model.ChannelMember{ChannelId: sc.Id, UserId: c.Session.UserId, Roles: model.CHANNEL_ROLE_ADMIN,
-				NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, NotifyProps: model.GetDefaultChannelNotifyProps()}
+			cm := &model.ChannelMember{ChannelId: sc.Id, UserId: c.Session.UserId,
+				Roles: model.CHANNEL_ROLE_ADMIN, NotifyProps: model.GetDefaultChannelNotifyProps()}
 
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				return nil, cmresult.Err
@@ -135,8 +134,7 @@ func CreateDirectChannel(c *Context, otherUserId string) (*model.Channel, *model
 	if sc, err := CreateChannel(c, channel, true); err != nil {
 		return nil, err
 	} else {
-		cm := &model.ChannelMember{ChannelId: sc.Id, UserId: otherUserId, Roles: "",
-			NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, NotifyProps: model.GetDefaultChannelNotifyProps()}
+		cm := &model.ChannelMember{ChannelId: sc.Id, UserId: otherUserId, Roles: "", NotifyProps: model.GetDefaultChannelNotifyProps()}
 
 		if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 			return nil, cmresult.Err
@@ -373,8 +371,8 @@ func JoinChannel(c *Context, channelId string, role string) {
 		}
 
 		if channel.Type == model.CHANNEL_OPEN {
-			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: c.Session.UserId, Roles: role,
-				NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, NotifyProps: model.GetDefaultChannelNotifyProps()}
+			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: c.Session.UserId,
+				Roles: role, NotifyProps: model.GetDefaultChannelNotifyProps()}
 
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				c.Err = cmresult.Err
@@ -407,8 +405,8 @@ func JoinDefaultChannels(user *model.User, channelRole string) *model.AppError {
 	if result := <-Srv.Store.Channel().GetByName(user.TeamId, "town-square"); result.Err != nil {
 		err = result.Err
 	} else {
-		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, Roles: channelRole,
-			NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, NotifyProps: model.GetDefaultChannelNotifyProps()}
+		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id,
+			Roles: channelRole, NotifyProps: model.GetDefaultChannelNotifyProps()}
 
 		if cmResult := <-Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
 			err = cmResult.Err
@@ -418,8 +416,8 @@ func JoinDefaultChannels(user *model.User, channelRole string) *model.AppError {
 	if result := <-Srv.Store.Channel().GetByName(user.TeamId, "off-topic"); result.Err != nil {
 		err = result.Err
 	} else {
-		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, Roles: channelRole,
-			NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, NotifyProps: model.GetDefaultChannelNotifyProps()}
+		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id,
+			Roles: channelRole, NotifyProps: model.GetDefaultChannelNotifyProps()}
 
 		if cmResult := <-Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
 			err = cmResult.Err
@@ -700,8 +698,7 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		} else {
 			oUser := oresult.Data.(*model.User)
 
-			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: userId,
-				NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, NotifyProps: model.GetDefaultChannelNotifyProps()}
+			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: userId, NotifyProps: model.GetDefaultChannelNotifyProps()}
 
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				l4g.Error("Failed to add member user_id=%v channel_id=%v err=%v", userId, id, cmresult.Err)
@@ -789,45 +786,6 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(model.MapToJson(result)))
 	}
 
-}
-
-// TODO remove me
-func updateNotifyLevel(c *Context, w http.ResponseWriter, r *http.Request) {
-	data := model.MapFromJson(r.Body)
-	userId := data["user_id"]
-	if len(userId) != 26 {
-		c.SetInvalidParam("updateNotifyLevel", "user_id")
-		return
-	}
-
-	channelId := data["channel_id"]
-	if len(channelId) != 26 {
-		c.SetInvalidParam("updateNotifyLevel", "channel_id")
-		return
-	}
-
-	notifyLevel := data["notify_level"]
-	if len(notifyLevel) == 0 || !model.IsChannelNotifyLevelValid(notifyLevel) {
-		c.SetInvalidParam("updateNotifyLevel", "notify_level")
-		return
-	}
-
-	cchan := Srv.Store.Channel().CheckPermissionsTo(c.Session.TeamId, channelId, c.Session.UserId)
-
-	if !c.HasPermissionsToUser(userId, "updateNotifyLevel") {
-		return
-	}
-
-	if !c.HasPermissionsToChannel(cchan, "updateNotifyLevel") {
-		return
-	}
-
-	if result := <-Srv.Store.Channel().UpdateNotifyLevel(channelId, userId, notifyLevel); result.Err != nil {
-		c.Err = result.Err
-		return
-	}
-
-	w.Write([]byte(model.MapToJson(data)))
 }
 
 func updateNotifyProps(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api/channel.go
+++ b/api/channel.go
@@ -76,7 +76,7 @@ func CreateChannel(c *Context, channel *model.Channel, addMember bool) (*model.C
 
 		if addMember {
 			cm := &model.ChannelMember{ChannelId: sc.Id, UserId: c.Session.UserId,
-				Roles: model.CHANNEL_ROLE_ADMIN, NotifyLevel: model.CHANNEL_NOTIFY_ALL}
+				Roles: model.CHANNEL_ROLE_ADMIN, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT}
 
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				return nil, cmresult.Err
@@ -135,7 +135,7 @@ func CreateDirectChannel(c *Context, otherUserId string) (*model.Channel, *model
 		return nil, err
 	} else {
 		cm := &model.ChannelMember{ChannelId: sc.Id, UserId: otherUserId,
-			Roles: "", NotifyLevel: model.CHANNEL_NOTIFY_ALL}
+			Roles: "", NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT}
 
 		if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 			return nil, cmresult.Err
@@ -372,7 +372,7 @@ func JoinChannel(c *Context, channelId string, role string) {
 		}
 
 		if channel.Type == model.CHANNEL_OPEN {
-			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: c.Session.UserId, NotifyLevel: model.CHANNEL_NOTIFY_ALL, Roles: role}
+			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: c.Session.UserId, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, Roles: role}
 
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				c.Err = cmresult.Err
@@ -405,7 +405,7 @@ func JoinDefaultChannels(user *model.User, channelRole string) *model.AppError {
 	if result := <-Srv.Store.Channel().GetByName(user.TeamId, "town-square"); result.Err != nil {
 		err = result.Err
 	} else {
-		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, NotifyLevel: model.CHANNEL_NOTIFY_ALL, Roles: channelRole}
+		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, Roles: channelRole}
 		if cmResult := <-Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
 			err = cmResult.Err
 		}
@@ -414,7 +414,7 @@ func JoinDefaultChannels(user *model.User, channelRole string) *model.AppError {
 	if result := <-Srv.Store.Channel().GetByName(user.TeamId, "off-topic"); result.Err != nil {
 		err = result.Err
 	} else {
-		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, NotifyLevel: model.CHANNEL_NOTIFY_ALL, Roles: channelRole}
+		cm := &model.ChannelMember{ChannelId: result.Data.(*model.Channel).Id, UserId: user.Id, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT, Roles: channelRole}
 		if cmResult := <-Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
 			err = cmResult.Err
 		}
@@ -694,7 +694,7 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		} else {
 			oUser := oresult.Data.(*model.User)
 
-			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: userId, NotifyLevel: model.CHANNEL_NOTIFY_ALL}
+			cm := &model.ChannelMember{ChannelId: channel.Id, UserId: userId, NotifyLevel: model.CHANNEL_NOTIFY_DEFAULT}
 
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				l4g.Error("Failed to add member user_id=%v channel_id=%v err=%v", userId, id, cmresult.Err)

--- a/api/channel_benchmark_test.go
+++ b/api/channel_benchmark_test.go
@@ -255,7 +255,7 @@ func BenchmarkRemoveChannelMember(b *testing.B) {
 	}
 }
 
-func BenchmarkUpdateNotifyLevel(b *testing.B) {
+func BenchmarkUpdateNotifyProps(b *testing.B) {
 	var (
 		NUM_CHANNELS_RANGE = utils.Range{NUM_CHANNELS, NUM_CHANNELS}
 	)
@@ -271,9 +271,10 @@ func BenchmarkUpdateNotifyLevel(b *testing.B) {
 
 	for i := range data {
 		newmap := map[string]string{
-			"channel_id":   channels[i].Id,
-			"user_id":      user.Id,
-			"notify_level": model.CHANNEL_NOTIFY_MENTION,
+			"channel_id":  channels[i].Id,
+			"user_id":     user.Id,
+			"desktop":     model.CHANNEL_NOTIFY_MENTION,
+			"mark_unread": model.CHANNEL_MARK_UNREAD_MENTION,
 		}
 		data[i] = newmap
 	}
@@ -282,7 +283,7 @@ func BenchmarkUpdateNotifyLevel(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := range channels {
-			Client.Must(Client.UpdateNotifyLevel(data[j]))
+			Client.Must(Client.UpdateNotifyProps(data[j]))
 		}
 	}
 }

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -803,88 +803,6 @@ func TestRemoveChannelMember(t *testing.T) {
 
 }
 
-func TestUpdateNotifyLevel(t *testing.T) {
-	Setup()
-
-	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
-	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
-
-	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
-	store.Must(Srv.Store.User().VerifyEmail(user.Id))
-
-	Client.LoginByEmail(team.Name, user.Email, "pwd")
-
-	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
-	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
-
-	data := make(map[string]string)
-	data["channel_id"] = channel1.Id
-	data["user_id"] = user.Id
-	data["notify_level"] = model.CHANNEL_NOTIFY_MENTION
-
-	timeBeforeUpdate := model.GetMillis()
-	time.Sleep(100 * time.Millisecond)
-
-	if _, err := Client.UpdateNotifyLevel(data); err != nil {
-		t.Fatal(err)
-	}
-
-	rget := Client.Must(Client.GetChannels(""))
-	rdata := rget.Data.(*model.ChannelList)
-	if len(rdata.Members) == 0 || rdata.Members[channel1.Id].NotifyLevel != data["notify_level"] {
-		t.Fatal("NotifyLevel did not update properly")
-	}
-
-	if rdata.Members[channel1.Id].LastUpdateAt <= timeBeforeUpdate {
-		t.Fatal("LastUpdateAt did not update")
-	}
-
-	data["user_id"] = "junk"
-	if _, err := Client.UpdateNotifyLevel(data); err == nil {
-		t.Fatal("Should have errored - bad user id")
-	}
-
-	data["user_id"] = "12345678901234567890123456"
-	if _, err := Client.UpdateNotifyLevel(data); err == nil {
-		t.Fatal("Should have errored - bad user id")
-	}
-
-	data["user_id"] = user.Id
-	data["channel_id"] = "junk"
-	if _, err := Client.UpdateNotifyLevel(data); err == nil {
-		t.Fatal("Should have errored - bad channel id")
-	}
-
-	data["channel_id"] = "12345678901234567890123456"
-	if _, err := Client.UpdateNotifyLevel(data); err == nil {
-		t.Fatal("Should have errored - bad channel id")
-	}
-
-	data["channel_id"] = channel1.Id
-	data["notify_level"] = ""
-	if _, err := Client.UpdateNotifyLevel(data); err == nil {
-		t.Fatal("Should have errored - empty notify level")
-	}
-
-	data["notify_level"] = "junk"
-	if _, err := Client.UpdateNotifyLevel(data); err == nil {
-		t.Fatal("Should have errored - bad notify level")
-	}
-
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
-
-	Client.LoginByEmail(team.Name, user2.Email, "pwd")
-
-	data["channel_id"] = channel1.Id
-	data["user_id"] = user2.Id
-	data["notify_level"] = model.CHANNEL_NOTIFY_MENTION
-	if _, err := Client.UpdateNotifyLevel(data); err == nil {
-		t.Fatal("Should have errored - user not in channel")
-	}
-}
-
 func TestUpdateNotifyProps(t *testing.T) {
 	Setup()
 
@@ -1002,7 +920,7 @@ func TestUpdateNotifyProps(t *testing.T) {
 	data["user_id"] = user2.Id
 	data["desktop"] = model.CHANNEL_NOTIFY_MENTION
 	data["mark_unread"] = model.CHANNEL_MARK_UNREAD_MENTION
-	if _, err := Client.UpdateNotifyLevel(data); err == nil {
+	if _, err := Client.UpdateNotifyProps(data); err == nil {
 		t.Fatal("Should have errored - user not in channel")
 	}
 }

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -15,7 +15,6 @@ const (
 	CHANNEL_NOTIFY_ALL          = "all"
 	CHANNEL_NOTIFY_MENTION      = "mention"
 	CHANNEL_NOTIFY_NONE         = "none"
-	CHANNEL_NOTIFY_QUIET        = "quiet" // no longer used, should be considered functionally equivalent to CHANNEL_NOTIFY_NONE
 	CHANNEL_MARK_UNREAD_ALL     = "all"
 	CHANNEL_MARK_UNREAD_MENTION = "mention"
 )
@@ -87,8 +86,7 @@ func IsChannelNotifyLevelValid(notifyLevel string) bool {
 	return notifyLevel == CHANNEL_NOTIFY_DEFAULT ||
 		notifyLevel == CHANNEL_NOTIFY_ALL ||
 		notifyLevel == CHANNEL_NOTIFY_MENTION ||
-		notifyLevel == CHANNEL_NOTIFY_NONE ||
-		notifyLevel == CHANNEL_NOTIFY_QUIET
+		notifyLevel == CHANNEL_NOTIFY_NONE
 }
 
 func IsChannelMarkUnreadLevelValid(markUnreadLevel string) bool {

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -10,23 +10,26 @@ import (
 )
 
 const (
-	CHANNEL_ROLE_ADMIN     = "admin"
-	CHANNEL_NOTIFY_DEFAULT = "default"
-	CHANNEL_NOTIFY_ALL     = "all"
-	CHANNEL_NOTIFY_MENTION = "mention"
-	CHANNEL_NOTIFY_NONE    = "none"
-	CHANNEL_NOTIFY_QUIET   = "quiet" // TODO deprecate me
+	CHANNEL_ROLE_ADMIN          = "admin"
+	CHANNEL_NOTIFY_DEFAULT      = "default"
+	CHANNEL_NOTIFY_ALL          = "all"
+	CHANNEL_NOTIFY_MENTION      = "mention"
+	CHANNEL_NOTIFY_NONE         = "none"
+	CHANNEL_NOTIFY_QUIET        = "quiet" // no longer used, should be considered functionally equivalent to CHANNEL_NOTIFY_NONE
+	CHANNEL_MARK_UNREAD_ALL     = "all"
+	CHANNEL_MARK_UNREAD_MENTION = "mention"
 )
 
 type ChannelMember struct {
-	ChannelId    string `json:"channel_id"`
-	UserId       string `json:"user_id"`
-	Roles        string `json:"roles"`
-	LastViewedAt int64  `json:"last_viewed_at"`
-	MsgCount     int64  `json:"msg_count"`
-	MentionCount int64  `json:"mention_count"`
-	NotifyLevel  string `json:"notify_level"`
-	LastUpdateAt int64  `json:"last_update_at"`
+	ChannelId       string `json:"channel_id"`
+	UserId          string `json:"user_id"`
+	Roles           string `json:"roles"`
+	LastViewedAt    int64  `json:"last_viewed_at"`
+	MsgCount        int64  `json:"msg_count"`
+	MentionCount    int64  `json:"mention_count"`
+	NotifyLevel     string `json:"notify_level"`
+	MarkUnreadLevel string `json:"mark_unread_level"`
+	LastUpdateAt    int64  `json:"last_update_at"`
 }
 
 func (o *ChannelMember) ToJson() string {
@@ -69,6 +72,10 @@ func (o *ChannelMember) IsValid() *AppError {
 		return NewAppError("ChannelMember.IsValid", "Invalid notify level", "notify_level="+o.NotifyLevel)
 	}
 
+	if len(o.MarkUnreadLevel) > 20 || !IsChannelMarkUnreadLevelValid(o.MarkUnreadLevel) {
+		return NewAppError("ChannelMember.IsValid", "Invalid mark unread level", "mark_unread_level="+o.MarkUnreadLevel)
+	}
+
 	return nil
 }
 
@@ -82,4 +89,8 @@ func IsChannelNotifyLevelValid(notifyLevel string) bool {
 		notifyLevel == CHANNEL_NOTIFY_MENTION ||
 		notifyLevel == CHANNEL_NOTIFY_NONE ||
 		notifyLevel == CHANNEL_NOTIFY_QUIET
+}
+
+func IsChannelMarkUnreadLevelValid(markUnreadLevel string) bool {
+	return markUnreadLevel == CHANNEL_MARK_UNREAD_ALL || markUnreadLevel == CHANNEL_MARK_UNREAD_MENTION
 }

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -27,7 +27,6 @@ type ChannelMember struct {
 	MsgCount     int64     `json:"msg_count"`
 	MentionCount int64     `json:"mention_count"`
 	NotifyProps  StringMap `json:"notify_props"`
-	NotifyLevel  string    `json:"notify_level"`
 	LastUpdateAt int64     `json:"last_update_at"`
 }
 
@@ -67,8 +66,9 @@ func (o *ChannelMember) IsValid() *AppError {
 		}
 	}
 
-	if len(o.NotifyLevel) > 20 || !IsChannelNotifyLevelValid(o.NotifyLevel) {
-		return NewAppError("ChannelMember.IsValid", "Invalid notify level", "notify_level="+o.NotifyLevel)
+	notifyLevel := o.NotifyProps["desktop"]
+	if len(notifyLevel) > 20 || !IsChannelNotifyLevelValid(notifyLevel) {
+		return NewAppError("ChannelMember.IsValid", "Invalid notify level", "notify_level="+notifyLevel)
 	}
 
 	markUnreadLevel := o.NotifyProps["mark_unread"]

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -11,10 +11,11 @@ import (
 
 const (
 	CHANNEL_ROLE_ADMIN     = "admin"
+	CHANNEL_NOTIFY_DEFAULT = "default"
 	CHANNEL_NOTIFY_ALL     = "all"
 	CHANNEL_NOTIFY_MENTION = "mention"
 	CHANNEL_NOTIFY_NONE    = "none"
-	CHANNEL_NOTIFY_QUIET   = "quiet"
+	CHANNEL_NOTIFY_QUIET   = "quiet" // TODO deprecate me
 )
 
 type ChannelMember struct {
@@ -76,5 +77,9 @@ func (o *ChannelMember) PreSave() {
 }
 
 func IsChannelNotifyLevelValid(notifyLevel string) bool {
-	return notifyLevel == CHANNEL_NOTIFY_ALL || notifyLevel == CHANNEL_NOTIFY_MENTION || notifyLevel == CHANNEL_NOTIFY_NONE || notifyLevel == CHANNEL_NOTIFY_QUIET
+	return notifyLevel == CHANNEL_NOTIFY_DEFAULT ||
+		notifyLevel == CHANNEL_NOTIFY_ALL ||
+		notifyLevel == CHANNEL_NOTIFY_MENTION ||
+		notifyLevel == CHANNEL_NOTIFY_NONE ||
+		notifyLevel == CHANNEL_NOTIFY_QUIET
 }

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -20,15 +20,15 @@ const (
 )
 
 type ChannelMember struct {
-	ChannelId       string `json:"channel_id"`
-	UserId          string `json:"user_id"`
-	Roles           string `json:"roles"`
-	LastViewedAt    int64  `json:"last_viewed_at"`
-	MsgCount        int64  `json:"msg_count"`
-	MentionCount    int64  `json:"mention_count"`
-	NotifyLevel     string `json:"notify_level"`
-	MarkUnreadLevel string `json:"mark_unread_level"`
-	LastUpdateAt    int64  `json:"last_update_at"`
+	ChannelId    string    `json:"channel_id"`
+	UserId       string    `json:"user_id"`
+	Roles        string    `json:"roles"`
+	LastViewedAt int64     `json:"last_viewed_at"`
+	MsgCount     int64     `json:"msg_count"`
+	MentionCount int64     `json:"mention_count"`
+	NotifyProps  StringMap `json:"notify_props"`
+	NotifyLevel  string    `json:"notify_level"`
+	LastUpdateAt int64     `json:"last_update_at"`
 }
 
 func (o *ChannelMember) ToJson() string {
@@ -71,14 +71,19 @@ func (o *ChannelMember) IsValid() *AppError {
 		return NewAppError("ChannelMember.IsValid", "Invalid notify level", "notify_level="+o.NotifyLevel)
 	}
 
-	if len(o.MarkUnreadLevel) > 20 || !IsChannelMarkUnreadLevelValid(o.MarkUnreadLevel) {
-		return NewAppError("ChannelMember.IsValid", "Invalid mark unread level", "mark_unread_level="+o.MarkUnreadLevel)
+	markUnreadLevel := o.NotifyProps["mark_unread"]
+	if len(markUnreadLevel) > 20 || !IsChannelMarkUnreadLevelValid(markUnreadLevel) {
+		return NewAppError("ChannelMember.IsValid", "Invalid mark unread level", "mark_unread_level="+markUnreadLevel)
 	}
 
 	return nil
 }
 
 func (o *ChannelMember) PreSave() {
+	o.LastUpdateAt = GetMillis()
+}
+
+func (o *ChannelMember) PreUpdate() {
 	o.LastUpdateAt = GetMillis()
 }
 
@@ -91,4 +96,11 @@ func IsChannelNotifyLevelValid(notifyLevel string) bool {
 
 func IsChannelMarkUnreadLevelValid(markUnreadLevel string) bool {
 	return markUnreadLevel == CHANNEL_MARK_UNREAD_ALL || markUnreadLevel == CHANNEL_MARK_UNREAD_MENTION
+}
+
+func GetDefaultChannelNotifyProps() StringMap {
+	return StringMap{
+		"desktop":     CHANNEL_NOTIFY_DEFAULT,
+		"mark_unread": CHANNEL_MARK_UNREAD_ALL,
+	}
 }

--- a/model/channel_member_test.go
+++ b/model/channel_member_test.go
@@ -31,7 +31,6 @@ func TestChannelMemberIsValid(t *testing.T) {
 	}
 
 	o.Roles = "missing"
-	o.NotifyLevel = CHANNEL_NOTIFY_ALL
 	o.NotifyProps = GetDefaultChannelNotifyProps()
 	o.UserId = NewId()
 	if err := o.IsValid(); err == nil {
@@ -39,17 +38,17 @@ func TestChannelMemberIsValid(t *testing.T) {
 	}
 
 	o.Roles = CHANNEL_ROLE_ADMIN
-	o.NotifyLevel = "junk"
+	o.NotifyProps["desktop"] = "junk"
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
 	}
 
-	o.NotifyLevel = "123456789012345678901"
+	o.NotifyProps["desktop"] = "123456789012345678901"
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
 	}
 
-	o.NotifyLevel = CHANNEL_NOTIFY_ALL
+	o.NotifyProps["desktop"] = CHANNEL_NOTIFY_ALL
 	if err := o.IsValid(); err != nil {
 		t.Fatal(err)
 	}

--- a/model/channel_member_test.go
+++ b/model/channel_member_test.go
@@ -32,6 +32,7 @@ func TestChannelMemberIsValid(t *testing.T) {
 
 	o.Roles = "missing"
 	o.NotifyLevel = CHANNEL_NOTIFY_ALL
+	o.MarkUnreadLevel = CHANNEL_MARK_UNREAD_ALL
 	o.UserId = NewId()
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
@@ -49,6 +50,16 @@ func TestChannelMemberIsValid(t *testing.T) {
 	}
 
 	o.NotifyLevel = CHANNEL_NOTIFY_ALL
+	if err := o.IsValid(); err != nil {
+		t.Fatal(err)
+	}
+
+	o.MarkUnreadLevel = "123456789012345678901"
+	if err := o.IsValid(); err == nil {
+		t.Fatal("should be invalid")
+	}
+
+	o.MarkUnreadLevel = CHANNEL_MARK_UNREAD_ALL
 	if err := o.IsValid(); err != nil {
 		t.Fatal(err)
 	}

--- a/model/channel_member_test.go
+++ b/model/channel_member_test.go
@@ -32,7 +32,7 @@ func TestChannelMemberIsValid(t *testing.T) {
 
 	o.Roles = "missing"
 	o.NotifyLevel = CHANNEL_NOTIFY_ALL
-	o.MarkUnreadLevel = CHANNEL_MARK_UNREAD_ALL
+	o.NotifyProps = GetDefaultChannelNotifyProps()
 	o.UserId = NewId()
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
@@ -54,12 +54,12 @@ func TestChannelMemberIsValid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	o.MarkUnreadLevel = "123456789012345678901"
+	o.NotifyProps["mark_unread"] = "123456789012345678901"
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
 	}
 
-	o.MarkUnreadLevel = CHANNEL_MARK_UNREAD_ALL
+	o.NotifyProps["mark_unread"] = CHANNEL_MARK_UNREAD_ALL
 	if err := o.IsValid(); err != nil {
 		t.Fatal(err)
 	}

--- a/model/client.go
+++ b/model/client.go
@@ -459,8 +459,8 @@ func (c *Client) UpdateNotifyLevel(data map[string]string) (*Result, *AppError) 
 	}
 }
 
-func (c *Client) UpdateMarkUnreadLevel(data map[string]string) (*Result, *AppError) {
-	if r, err := c.DoApiPost("/channels/update_mark_unread_level", MapToJson(data)); err != nil {
+func (c *Client) UpdateNotifyProps(data map[string]string) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/channels/update_notify_props", MapToJson(data)); err != nil {
 		return nil, err
 	} else {
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),

--- a/model/client.go
+++ b/model/client.go
@@ -459,6 +459,15 @@ func (c *Client) UpdateNotifyLevel(data map[string]string) (*Result, *AppError) 
 	}
 }
 
+func (c *Client) UpdateMarkUnreadLevel(data map[string]string) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/channels/update_mark_unread_level", MapToJson(data)); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), MapFromJson(r.Body)}, nil
+	}
+}
+
 func (c *Client) GetChannels(etag string) (*Result, *AppError) {
 	if r, err := c.DoApiGet("/channels/", "", etag); err != nil {
 		return nil, err

--- a/model/client.go
+++ b/model/client.go
@@ -450,15 +450,6 @@ func (c *Client) UpdateChannelDesc(data map[string]string) (*Result, *AppError) 
 	}
 }
 
-func (c *Client) UpdateNotifyLevel(data map[string]string) (*Result, *AppError) {
-	if r, err := c.DoApiPost("/channels/update_notify_level", MapToJson(data)); err != nil {
-		return nil, err
-	} else {
-		return &Result{r.Header.Get(HEADER_REQUEST_ID),
-			r.Header.Get(HEADER_ETAG_SERVER), MapFromJson(r.Body)}, nil
-	}
-}
-
 func (c *Client) UpdateNotifyProps(data map[string]string) (*Result, *AppError) {
 	if r, err := c.DoApiPost("/channels/update_notify_props", MapToJson(data)); err != nil {
 		return nil, err

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -78,8 +78,7 @@ func (s SqlChannelStore) UpgradeSchemaIfNeeded() {
 			l4g.Error(err.Error())
 		}
 
-		// TODO uncomment me
-		// s.RemoveColumnIfExists("ChannelMembers", "NotifyLevel")
+		s.RemoveColumnIfExists("ChannelMembers", "NotifyLevel")
 	}
 }
 
@@ -712,36 +711,6 @@ func (s SqlChannelStore) IncrementMentionCount(channelId string, userId string) 
 			map[string]interface{}{"ChannelId": channelId, "UserId": userId})
 		if err != nil {
 			result.Err = model.NewAppError("SqlChannelStore.IncrementMentionCount", "We couldn't increment the mention count", "channel_id="+channelId+", user_id="+userId+", "+err.Error())
-		}
-
-		storeChannel <- result
-		close(storeChannel)
-	}()
-
-	return storeChannel
-}
-
-// TODO remove me
-func (s SqlChannelStore) UpdateNotifyLevel(channelId, userId, notifyLevel string) StoreChannel {
-	storeChannel := make(StoreChannel)
-
-	go func() {
-		result := StoreResult{}
-
-		updateAt := model.GetMillis()
-
-		_, err := s.GetMaster().Exec(
-			`UPDATE
-				ChannelMembers
-			SET
-				NotifyLevel = :NotifyLevel,
-				LastUpdateAt = :LastUpdateAt
-			WHERE
-				UserId = :UserId
-					AND ChannelId = :ChannelId`,
-			map[string]interface{}{"ChannelId": channelId, "UserId": userId, "NotifyLevel": notifyLevel, "LastUpdateAt": updateAt})
-		if err != nil {
-			result.Err = model.NewAppError("SqlChannelStore.UpdateNotifyLevel", "We couldn't update the notify level", "channel_id="+channelId+", user_id="+userId+", "+err.Error())
 		}
 
 		storeChannel <- result

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -136,14 +136,14 @@ func TestChannelStoreDelete(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o2.Id
 	m2.UserId = m1.UserId
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m2))
 
 	if r := <-store.Channel().Delete(o1.Id, model.GetMillis()); r.Err != nil {
@@ -225,14 +225,14 @@ func TestChannelMemberStore(t *testing.T) {
 	o1.ChannelId = c1.Id
 	o1.UserId = u1.Id
 	o1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	o1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	o1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&o1))
 
 	o2 := model.ChannelMember{}
 	o2.ChannelId = c1.Id
 	o2.UserId = u2.Id
 	o2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	o2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	o2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&o2))
 
 	c1t2 := (<-store.Channel().Get(c1.Id)).Data.(*model.Channel)
@@ -296,7 +296,7 @@ func TestChannelStorePermissionsTo(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	count := (<-store.Channel().CheckPermissionsTo(o1.TeamId, o1.Id, m1.UserId)).Data.(int64)
@@ -377,21 +377,21 @@ func TestChannelStoreGetChannels(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
 	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m3.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m3))
 
 	cresult := <-store.Channel().GetChannels(o1.TeamId, m1.UserId)
@@ -423,21 +423,21 @@ func TestChannelStoreGetMoreChannels(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
 	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m3.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m3))
 
 	o3 := model.Channel{}
@@ -494,21 +494,21 @@ func TestChannelStoreGetChannelCounts(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
 	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m3.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m3))
 
 	cresult := <-store.Channel().GetChannelCounts(o1.TeamId, m1.UserId)
@@ -538,7 +538,7 @@ func TestChannelStoreUpdateLastViewedAt(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	err := (<-store.Channel().UpdateLastViewedAt(m1.ChannelId, m1.UserId)).Err
@@ -567,7 +567,7 @@ func TestChannelStoreIncrementMentionCount(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	err := (<-store.Channel().IncrementMentionCount(m1.ChannelId, m1.UserId)).Err

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -136,12 +136,14 @@ func TestChannelStoreDelete(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o2.Id
 	m2.UserId = m1.UserId
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m2))
 
 	if r := <-store.Channel().Delete(o1.Id, model.GetMillis()); r.Err != nil {
@@ -223,12 +225,14 @@ func TestChannelMemberStore(t *testing.T) {
 	o1.ChannelId = c1.Id
 	o1.UserId = u1.Id
 	o1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	o1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&o1))
 
 	o2 := model.ChannelMember{}
 	o2.ChannelId = c1.Id
 	o2.UserId = u2.Id
 	o2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	o2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&o2))
 
 	c1t2 := (<-store.Channel().Get(c1.Id)).Data.(*model.Channel)
@@ -292,6 +296,7 @@ func TestChannelStorePermissionsTo(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	count := (<-store.Channel().CheckPermissionsTo(o1.TeamId, o1.Id, m1.UserId)).Data.(int64)
@@ -372,18 +377,21 @@ func TestChannelStoreGetChannels(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
 	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m3.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m3))
 
 	cresult := <-store.Channel().GetChannels(o1.TeamId, m1.UserId)
@@ -415,18 +423,21 @@ func TestChannelStoreGetMoreChannels(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
 	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m3.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m3))
 
 	o3 := model.Channel{}
@@ -483,18 +494,21 @@ func TestChannelStoreGetChannelCounts(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
 	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m2.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
 	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m3.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m3))
 
 	cresult := <-store.Channel().GetChannelCounts(o1.TeamId, m1.UserId)
@@ -524,6 +538,7 @@ func TestChannelStoreUpdateLastViewedAt(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	err := (<-store.Channel().UpdateLastViewedAt(m1.ChannelId, m1.UserId)).Err
@@ -552,6 +567,7 @@ func TestChannelStoreIncrementMentionCount(t *testing.T) {
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	err := (<-store.Channel().IncrementMentionCount(m1.ChannelId, m1.UserId)).Err

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -135,14 +135,12 @@ func TestChannelStoreDelete(t *testing.T) {
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
-	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o2.Id
 	m2.UserId = m1.UserId
-	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m2))
 
@@ -224,14 +222,12 @@ func TestChannelMemberStore(t *testing.T) {
 	o1 := model.ChannelMember{}
 	o1.ChannelId = c1.Id
 	o1.UserId = u1.Id
-	o1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	o1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&o1))
 
 	o2 := model.ChannelMember{}
 	o2.ChannelId = c1.Id
 	o2.UserId = u2.Id
-	o2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	o2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&o2))
 
@@ -295,7 +291,6 @@ func TestChannelStorePermissionsTo(t *testing.T) {
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
-	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
@@ -376,21 +371,18 @@ func TestChannelStoreGetChannels(t *testing.T) {
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
-	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
-	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
-	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m3))
 
@@ -422,21 +414,18 @@ func TestChannelStoreGetMoreChannels(t *testing.T) {
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
-	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
-	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
-	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m3))
 
@@ -493,21 +482,18 @@ func TestChannelStoreGetChannelCounts(t *testing.T) {
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
-	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o1.Id
 	m2.UserId = model.NewId()
-	m2.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m2))
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = o2.Id
 	m3.UserId = model.NewId()
-	m3.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m3))
 
@@ -537,7 +523,6 @@ func TestChannelStoreUpdateLastViewedAt(t *testing.T) {
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
-	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
@@ -566,7 +551,6 @@ func TestChannelStoreIncrementMentionCount(t *testing.T) {
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
 	m1.UserId = model.NewId()
-	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 

--- a/store/sql_post_store_test.go
+++ b/store/sql_post_store_test.go
@@ -485,6 +485,7 @@ func TestPostStoreSearch(t *testing.T) {
 	m1.ChannelId = c1.Id
 	m1.UserId = userId
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
+	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
 	Must(store.Channel().SaveMember(&m1))
 
 	c2 := &model.Channel{}

--- a/store/sql_post_store_test.go
+++ b/store/sql_post_store_test.go
@@ -485,7 +485,7 @@ func TestPostStoreSearch(t *testing.T) {
 	m1.ChannelId = c1.Id
 	m1.UserId = userId
 	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
-	m1.MarkUnreadLevel = model.CHANNEL_MARK_UNREAD_ALL
+	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
 	c2 := &model.Channel{}

--- a/store/sql_post_store_test.go
+++ b/store/sql_post_store_test.go
@@ -484,7 +484,6 @@ func TestPostStoreSearch(t *testing.T) {
 	m1 := model.ChannelMember{}
 	m1.ChannelId = c1.Id
 	m1.UserId = userId
-	m1.NotifyLevel = model.CHANNEL_NOTIFY_ALL
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 

--- a/store/store.go
+++ b/store/store.go
@@ -72,7 +72,6 @@ type ChannelStore interface {
 	CheckPermissionsToByName(teamId string, channelName string, userId string) StoreChannel
 	UpdateLastViewedAt(channelId string, userId string) StoreChannel
 	IncrementMentionCount(channelId string, userId string) StoreChannel
-	UpdateNotifyLevel(channelId string, userId string, notifyLevel string) StoreChannel
 }
 
 type PostStore interface {

--- a/store/store.go
+++ b/store/store.go
@@ -72,6 +72,7 @@ type ChannelStore interface {
 	UpdateLastViewedAt(channelId string, userId string) StoreChannel
 	IncrementMentionCount(channelId string, userId string) StoreChannel
 	UpdateNotifyLevel(channelId string, userId string, notifyLevel string) StoreChannel
+	UpdateMarkUnreadLevel(channelId string, userId string, markUnreadLevel string) StoreChannel
 }
 
 type PostStore interface {

--- a/store/store.go
+++ b/store/store.go
@@ -62,6 +62,7 @@ type ChannelStore interface {
 	GetForExport(teamId string) StoreChannel
 
 	SaveMember(member *model.ChannelMember) StoreChannel
+	UpdateMember(member *model.ChannelMember) StoreChannel
 	GetMembers(channelId string) StoreChannel
 	GetMember(channelId string, userId string) StoreChannel
 	RemoveMember(channelId string, userId string) StoreChannel
@@ -72,7 +73,6 @@ type ChannelStore interface {
 	UpdateLastViewedAt(channelId string, userId string) StoreChannel
 	IncrementMentionCount(channelId string, userId string) StoreChannel
 	UpdateNotifyLevel(channelId string, userId string, notifyLevel string) StoreChannel
-	UpdateMarkUnreadLevel(channelId string, userId string, markUnreadLevel string) StoreChannel
 }
 
 type PostStore interface {

--- a/web/react/components/channel_notifications.jsx
+++ b/web/react/components/channel_notifications.jsx
@@ -81,6 +81,11 @@ export default class ChannelNotifications extends React.Component {
         var channelId = this.state.channelId;
         var notifyLevel = this.state.notifyLevel;
 
+        if (ChannelStore.getMember(channelId).notify_level === notifyLevel) {
+            this.updateSection('');
+            return;
+        }
+
         var data = {};
         data.channel_id = channelId;
         data.user_id = UserStore.getCurrentId();
@@ -243,6 +248,11 @@ export default class ChannelNotifications extends React.Component {
     handleSubmitMarkUnreadLevel() {
         const channelId = this.state.channelId;
         const markUnreadLevel = this.state.markUnreadLevel;
+
+        if (ChannelStore.getMember(channelId).mark_unread_level === markUnreadLevel) {
+            this.updateSection('');
+            return;
+        }
 
         const data = {
             channel_id: channelId,

--- a/web/react/components/channel_notifications.jsx
+++ b/web/react/components/channel_notifications.jsx
@@ -104,14 +104,28 @@ export default class ChannelNotifications extends React.Component {
     createDesktopSection(serverError) {
         var handleUpdateSection;
 
+        const user = UserStore.getCurrentUser();
+        const globalNotifyLevel = user.notify_props.desktop;
+
+        let globalNotifyLevelName;
+        if (globalNotifyLevel === 'all') {
+            globalNotifyLevelName = 'For all activity';
+        } else if (globalNotifyLevel === 'mention') {
+            globalNotifyLevelName = 'Only for mentions';
+        } else {
+            globalNotifyLevelName = 'Never';
+        }
+
         if (this.state.activeSection === 'desktop') {
-            var notifyActive = [false, false, false];
-            if (this.state.notifyLevel === 'mention') {
-                notifyActive[1] = true;
-            } else if (this.state.notifyLevel === 'all') {
+            var notifyActive = [false, false, false, false];
+            if (this.state.notifyLevel === 'default') {
                 notifyActive[0] = true;
-            } else {
+            } else if (this.state.notifyLevel === 'all') {
+                notifyActive[1] = true;
+            } else if (this.state.notifyLevel === 'mention') {
                 notifyActive[2] = true;
+            } else {
+                notifyActive[3] = true;
             }
 
             var inputs = [];
@@ -123,9 +137,9 @@ export default class ChannelNotifications extends React.Component {
                             <input
                                 type='radio'
                                 checked={notifyActive[0]}
-                                onChange={this.handleRadioClick.bind(this, 'all')}
+                                onChange={this.handleRadioClick.bind(this, 'default')}
                             >
-                                For all activity
+                                {`Global default (${globalNotifyLevelName})`}
                             </input>
                         </label>
                         <br/>
@@ -135,9 +149,9 @@ export default class ChannelNotifications extends React.Component {
                             <input
                                 type='radio'
                                 checked={notifyActive[1]}
-                                onChange={this.handleRadioClick.bind(this, 'mention')}
+                                onChange={this.handleRadioClick.bind(this, 'all')}
                             >
-                                Only for mentions
+                                {'For all activity'}
                             </input>
                         </label>
                         <br/>
@@ -147,9 +161,21 @@ export default class ChannelNotifications extends React.Component {
                             <input
                                 type='radio'
                                 checked={notifyActive[2]}
+                                onChange={this.handleRadioClick.bind(this, 'mention')}
+                            >
+                                {'Only for mentions'}
+                            </input>
+                        </label>
+                        <br/>
+                    </div>
+                    <div className='radio'>
+                        <label>
+                            <input
+                                type='radio'
+                                checked={notifyActive[3]}
                                 onChange={this.handleRadioClick.bind(this, 'none')}
                             >
-                                Never
+                                {'Never'}
                             </input>
                         </label>
                     </div>
@@ -162,24 +188,13 @@ export default class ChannelNotifications extends React.Component {
                 e.preventDefault();
             }.bind(this);
 
-            let curChannel = ChannelStore.get(this.state.channelId);
-            let extraInfo = (
+            const extraInfo = (
                 <span>
-                    These settings will override the global notification settings.
+                    {'Selecting an option other than "Default" will override the global notification settings.'}
                     <br/>
-                    Desktop notifications are available on Firefox, Safari, and Chrome.
+                    {'Desktop notifications are available on Firefox, Safari, and Chrome.'}
                 </span>
             );
-
-            if (curChannel && curChannel.display_name) {
-                extraInfo = (
-                    <span>
-                        These settings will override the global notification settings for the <b>{curChannel.display_name}</b> channel.
-                        <br/>
-                        Desktop notifications are available on Firefox, Safari, and Chrome.
-                    </span>
-                );
-            }
 
             return (
                 <SettingItemMax
@@ -194,7 +209,9 @@ export default class ChannelNotifications extends React.Component {
         }
 
         var describe;
-        if (this.state.notifyLevel === 'mention') {
+        if (this.state.notifyLevel === 'default') {
+            describe = `Global default (${globalNotifyLevelName})`;
+        } else if (this.state.notifyLevel === 'mention') {
             describe = 'Only for mentions';
         } else if (this.state.notifyLevel === 'all') {
             describe = 'For all activity';

--- a/web/react/components/channel_notifications.jsx
+++ b/web/react/components/channel_notifications.jsx
@@ -41,7 +41,7 @@ export default class ChannelNotifications extends React.Component {
             var channelId = button.getAttribute('data-channelid');
 
             const member = ChannelStore.getMember(channelId);
-            var notifyLevel = member.notify_level;
+            var notifyLevel = member.notify_props.desktop;
             var markUnreadLevel = member.notify_props.mark_unread;
 
             this.setState({
@@ -62,7 +62,7 @@ export default class ChannelNotifications extends React.Component {
         }
 
         const member = ChannelStore.getMember(this.state.channelId);
-        var notifyLevel = member.notify_level;
+        var notifyLevel = member.notify_props.desktop;
         var markUnreadLevel = member.notify_props.mark_unread;
 
         var newState = this.state;
@@ -81,7 +81,7 @@ export default class ChannelNotifications extends React.Component {
         var channelId = this.state.channelId;
         var notifyLevel = this.state.notifyLevel;
 
-        if (ChannelStore.getMember(channelId).notify_level === notifyLevel) {
+        if (ChannelStore.getMember(channelId).notify_props.desktop === notifyLevel) {
             this.updateSection('');
             return;
         }
@@ -89,16 +89,12 @@ export default class ChannelNotifications extends React.Component {
         var data = {};
         data.channel_id = channelId;
         data.user_id = UserStore.getCurrentId();
-        data.notify_level = notifyLevel;
+        data.desktop = notifyLevel;
 
-        if (!data.notify_level || data.notify_level.length === 0) {
-            return;
-        }
-
-        Client.updateNotifyLevel(data,
+        Client.updateNotifyProps(data,
             () => {
                 var member = ChannelStore.getMember(channelId);
-                member.notify_level = notifyLevel;
+                member.notify_props.desktop = notifyLevel;
                 ChannelStore.setChannelMember(member);
                 this.updateSection('');
             },

--- a/web/react/components/channel_notifications.jsx
+++ b/web/react/components/channel_notifications.jsx
@@ -42,7 +42,7 @@ export default class ChannelNotifications extends React.Component {
 
             const member = ChannelStore.getMember(channelId);
             var notifyLevel = member.notify_level;
-            var markUnreadLevel = member.mark_unread_level;
+            var markUnreadLevel = member.notify_props.mark_unread;
 
             this.setState({
                 notifyLevel,
@@ -63,7 +63,7 @@ export default class ChannelNotifications extends React.Component {
 
         const member = ChannelStore.getMember(this.state.channelId);
         var notifyLevel = member.notify_level;
-        var markUnreadLevel = member.mark_unread_level;
+        var markUnreadLevel = member.notify_props.mark_unread;
 
         var newState = this.state;
         newState.notifyLevel = notifyLevel;
@@ -249,7 +249,7 @@ export default class ChannelNotifications extends React.Component {
         const channelId = this.state.channelId;
         const markUnreadLevel = this.state.markUnreadLevel;
 
-        if (ChannelStore.getMember(channelId).mark_unread_level === markUnreadLevel) {
+        if (ChannelStore.getMember(channelId).notify_props.mark_unread === markUnreadLevel) {
             this.updateSection('');
             return;
         }
@@ -257,17 +257,13 @@ export default class ChannelNotifications extends React.Component {
         const data = {
             channel_id: channelId,
             user_id: UserStore.getCurrentId(),
-            mark_unread_level: markUnreadLevel
+            mark_unread: markUnreadLevel
         };
 
-        if (!data.mark_unread_level || data.mark_unread_level.length === 0) {
-            return;
-        }
-
-        Client.updateMarkUnreadLevel(data,
+        Client.updateNotifyProps(data,
             () => {
                 var member = ChannelStore.getMember(channelId);
-                member.mark_unread_level = markUnreadLevel;
+                member.notify_props.mark_unread = markUnreadLevel;
                 ChannelStore.setChannelMember(member);
                 this.updateSection('');
             },

--- a/web/react/components/notify_counts.jsx
+++ b/web/react/components/notify_counts.jsx
@@ -15,7 +15,7 @@ function getCountsStateFromStores() {
             count += channel.total_msg_count - channelMember.msg_count;
         } else if (channelMember.mention_count > 0) {
             count += channelMember.mention_count;
-        } else if (channelMember.mark_unread_level !== 'mention' && channel.total_msg_count - channelMember.msg_count > 0) {
+        } else if (channelMember.notify_props.mark_unread !== 'mention' && channel.total_msg_count - channelMember.msg_count > 0) {
             count += 1;
         }
     });

--- a/web/react/components/notify_counts.jsx
+++ b/web/react/components/notify_counts.jsx
@@ -15,7 +15,7 @@ function getCountsStateFromStores() {
             count += channel.total_msg_count - channelMember.msg_count;
         } else if (channelMember.mention_count > 0) {
             count += channelMember.mention_count;
-        } else if (channelMember.notify_level !== 'quiet' && channel.total_msg_count - channelMember.msg_count > 0) {
+        } else if (channelMember.mark_unread_level !== 'mention' && channel.total_msg_count - channelMember.msg_count > 0) {
             count += 1;
         }
     });

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -203,7 +203,7 @@ export default class Sidebar extends React.Component {
                 const user = UserStore.getCurrentUser();
                 const member = ChannelStore.getMember(msg.channel_id);
 
-                var notifyLevel = member.notify_level;
+                var notifyLevel = member.notify_props.desktop;
                 if (notifyLevel === 'default') {
                     notifyLevel = user.notify_props.desktop;
                 }

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -334,7 +334,7 @@ export default class Sidebar extends React.Component {
         var unread = false;
         if (channelMember) {
             msgCount = channel.total_msg_count - channelMember.msg_count;
-            unread = (msgCount > 0 && channelMember.notify_level !== 'quiet') || channelMember.mention_count > 0;
+            unread = (msgCount > 0 && channelMember.mark_unread_level !== 'mention') || channelMember.mention_count > 0;
         }
 
         var titleClass = '';

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -334,7 +334,7 @@ export default class Sidebar extends React.Component {
         var unread = false;
         if (channelMember) {
             msgCount = channel.total_msg_count - channelMember.msg_count;
-            unread = (msgCount > 0 && channelMember.mark_unread_level !== 'mention') || channelMember.mention_count > 0;
+            unread = (msgCount > 0 && channelMember.notify_props.mark_unread !== 'mention') || channelMember.mention_count > 0;
         }
 
         var titleClass = '';

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -200,13 +200,17 @@ export default class Sidebar extends React.Component {
                 }
                 var channel = ChannelStore.get(msg.channel_id);
 
-                var user = UserStore.getCurrentUser();
-                if (user.notify_props && ((user.notify_props.desktop === 'mention' && mentions.indexOf(user.id) === -1 && channel.type !== 'D') || user.notify_props.desktop === 'none')) {
-                    return;
+                const user = UserStore.getCurrentUser();
+                const member = ChannelStore.getMember(msg.channel_id);
+
+                var notifyLevel = member.notify_level;
+                if (notifyLevel === 'default') {
+                    notifyLevel = user.notify_props.desktop;
                 }
 
-                var member = ChannelStore.getMember(msg.channel_id);
-                if ((member.notify_level === 'mention' && mentions.indexOf(user.id) === -1) || member.notify_level === 'none' || member.notify_level === 'quiet') {
+                if (notifyLevel === 'none') {
+                    return;
+                } else if (notifyLevel === 'mention' && mentions.indexOf(user.id) === -1 && channel.type !== 'D') {
                     return;
                 }
 

--- a/web/react/components/user_settings/user_settings_notifications.jsx
+++ b/web/react/components/user_settings/user_settings_notifications.jsx
@@ -17,7 +17,7 @@ function getNotificationsStateFromStores() {
     if (user.notify_props && user.notify_props.desktop_sound) {
         sound = user.notify_props.desktop_sound;
     }
-    var desktop = 'all';
+    var desktop = 'default';
     if (user.notify_props && user.notify_props.desktop) {
         desktop = user.notify_props.desktop;
     }

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -152,21 +152,23 @@ export function getChannel(id) {
 }
 
 export function updateLastViewedAt() {
-    if (isCallInProgress('updateLastViewed')) {
+    const channelId = ChannelStore.getCurrentId();
+
+    if (channelId === null) {
         return;
     }
 
-    if (ChannelStore.getCurrentId() == null) {
+    if (isCallInProgress(`updateLastViewed${channelId}`)) {
         return;
     }
 
-    callTracker.updateLastViewed = utils.getTimestamp();
+    callTracker[`updateLastViewed${channelId}`] = utils.getTimestamp();
     client.updateLastViewedAt(
-        ChannelStore.getCurrentId(),
-        function updateLastViewedAtSuccess() {
+        channelId,
+        () => {
             callTracker.updateLastViewed = 0;
         },
-        function updateLastViewdAtFailure(err) {
+        (err) => {
             callTracker.updateLastViewed = 0;
             dispatchError(err, 'updateLastViewedAt');
         }

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -568,22 +568,6 @@ export function updateChannelDesc(data, success, error) {
     track('api', 'api_channels_desc');
 }
 
-// TODO remove me
-export function updateNotifyLevel(data, success, error) {
-    $.ajax({
-        url: '/api/v1/channels/update_notify_level',
-        dataType: 'json',
-        contentType: 'application/json',
-        type: 'POST',
-        data: JSON.stringify(data),
-        success,
-        error: function onError(xhr, status, err) {
-            var e = handleError('updateNotifyLevel', xhr, status, err);
-            error(e);
-        }
-    });
-}
-
 export function updateNotifyProps(data, success, error) {
     $.ajax({
         url: '/api/v1/channels/update_notify_props',

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -568,6 +568,7 @@ export function updateChannelDesc(data, success, error) {
     track('api', 'api_channels_desc');
 }
 
+// TODO remove me
 export function updateNotifyLevel(data, success, error) {
     $.ajax({
         url: '/api/v1/channels/update_notify_level',
@@ -583,16 +584,16 @@ export function updateNotifyLevel(data, success, error) {
     });
 }
 
-export function updateMarkUnreadLevel(data, success, error) {
+export function updateNotifyProps(data, success, error) {
     $.ajax({
-        url: '/api/v1/channels/update_mark_unread_level',
+        url: '/api/v1/channels/update_notify_props',
         dataType: 'json',
         contentType: 'application/json',
         type: 'POST',
         data: JSON.stringify(data),
         success,
         error: function onError(xhr, status, err) {
-            var e = handleError('updateMarkUnreadLevel', xhr, status, err);
+            var e = handleError('updateNotifyProps', xhr, status, err);
             error(e);
         }
     });

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -583,6 +583,21 @@ export function updateNotifyLevel(data, success, error) {
     });
 }
 
+export function updateMarkUnreadLevel(data, success, error) {
+    $.ajax({
+        url: '/api/v1/channels/update_mark_unread_level',
+        dataType: 'json',
+        contentType: 'application/json',
+        type: 'POST',
+        data: JSON.stringify(data),
+        success,
+        error: function onError(xhr, status, err) {
+            var e = handleError('updateMarkUnreadLevel', xhr, status, err);
+            error(e);
+        }
+    });
+}
+
 export function joinChannel(id, success, error) {
     $.ajax({
         url: '/api/v1/channels/' + id + '/join',


### PR DESCRIPTION
An updated version of my last pull request that:
1) Adds a "default" option for each channel's Desktop Notifications which properly inherits from a user's overall Desktop Notification setting
2) Replaces quiet mode with a Mark Unread option that is exclusive from the Desktop Notification setting
3) (New to this PR) Moves the above settings into a ChannelMember.NotifyProps to mirror how User.NotifyProps works. ChannelMember.NotifyProps is a dictionary with keys "desktop" (equivalent to the old notification level and named to match the setting in the user's notify props) and "mark_unread".