### PR TITLE
Pass-through post creation time when importing posts

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -88,6 +88,8 @@ func CreatePost(c *Context, post *model.Post, doUpdateLastViewed bool) (*model.P
 		}
 	}
 
+	post.CreateAt = 0
+
 	post.Hashtags, _ = model.ParseHashtags(post.Message)
 
 	post.UserId = c.Session.UserId

--- a/model/post.go
+++ b/model/post.go
@@ -120,7 +120,10 @@ func (o *Post) PreSave() {
 
 	o.OriginalId = ""
 
-	o.CreateAt = GetMillis()
+	if o.CreateAt == 0 {
+		o.CreateAt = GetMillis()
+	}
+
 	o.UpdateAt = o.CreateAt
 
 	if o.Props == nil {

--- a/model/post_test.go
+++ b/model/post_test.go
@@ -83,5 +83,18 @@ func TestPostIsValid(t *testing.T) {
 func TestPostPreSave(t *testing.T) {
 	o := Post{Message: "test"}
 	o.PreSave()
+
+	if o.CreateAt == 0 {
+		t.Fatal("should be set")
+	}
+
+	past := GetMillis() - 1
+	o = Post{Message: "test", CreateAt: past}
+	o.PreSave()
+
+	if o.CreateAt > past {
+		t.Fatal("should not be updated")
+	}
+
 	o.Etag()
 }


### PR DESCRIPTION
To resolve #902. Existing timestamps are no longer cleared during pre-save, to accomodate imports. Clearing arbitrary (user-supplied) creation dates is moved up into CreatePost().