### PR TITLE
PLT-112 Improves email change verification process

### DIFF
--- a/api/templates/email_change_body.html
+++ b/api/templates/email_change_body.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">You updated your email</h2>
-                                                <p>You email address for {{.Props.TeamDisplayName}} has been changed.<br>If you did not make this change, please contact the system administrator.</p>
+                                                <p>You email address for {{.Props.TeamDisplayName}} has been changed to {{.Props.NewEmail}}.<br>If you did not make this change, please contact the system administrator.</p>
                                             </td>
                                         </tr>
                                         <tr>

--- a/api/templates/email_change_subject.html
+++ b/api/templates/email_change_subject.html
@@ -1,1 +1,1 @@
-{{define "email_change_subject"}}You updated your email for {{.Props.TeamDisplayName}} on {{ .Props.Domain }}{{end}}
+{{define "email_change_subject"}}[{{.ClientProps.SiteName}}] Your email address has changed for {{.Props.TeamDisplayName}}{{end}}

--- a/api/templates/email_change_verify_body.html
+++ b/api/templates/email_change_verify_body.html
@@ -1,4 +1,4 @@
-{{define "verify_new_email_body"}}
+{{define "email_change_verify_body"}}
 
 <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-top: 20px; line-height: 1.7; color: #555;">
     <tr>

--- a/api/templates/email_change_verify_body.html
+++ b/api/templates/email_change_verify_body.html
@@ -1,4 +1,4 @@
-{{define "email_change_body"}}
+{{define "verify_new_email_body"}}
 
 <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-top: 20px; line-height: 1.7; color: #555;">
     <tr>
@@ -18,7 +18,10 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">You updated your email</h2>
-                                                <p>You email address for {{.Props.TeamDisplayName}} has been changed.<br>If you did not make this change, please contact the system administrator.</p>
+                                                <p>To finish updating your email address for {{.Props.TeamDisplayName}}, please click the link below to confirm this is the right address.</p>
+                                                <p style="margin: 20px 0 15px">
+                                                    <a href="{{.Props.VerifyUrl}}" style="background: #2389D7; border-radius: 3px; color: #fff; border: none; outline: none; min-width: 200px; padding: 15px 25px; font-size: 14px; font-family: inherit; cursor: pointer; -webkit-appearance: none;text-decoration: none;">Verify Email</a>
+                                                </p>
                                             </td>
                                         </tr>
                                         <tr>

--- a/api/templates/email_change_verify_subject.html
+++ b/api/templates/email_change_verify_subject.html
@@ -1,1 +1,1 @@
-{{define "verify_new_email_subject"}}[{{.ClientProps.SiteName}}] Verify new email address for {{.Props.TeamDisplayName}}{{end}}
+{{define "email_change_verify_subject"}}[{{.ClientProps.SiteName}}] Verify new email address for {{.Props.TeamDisplayName}}{{end}}

--- a/api/templates/email_change_verify_subject.html
+++ b/api/templates/email_change_verify_subject.html
@@ -1,0 +1,1 @@
+{{define "verify_new_email_subject"}}[{{.ClientProps.SiteName}}] Verify new email address for {{.Props.TeamDisplayName}}{{end}}

--- a/api/user.go
+++ b/api/user.go
@@ -890,7 +890,7 @@ func updateUser(c *Context, w http.ResponseWriter, r *http.Request) {
 				fireAndForgetEmailChangeEmail(rusers[1].Email, team.DisplayName, c.GetTeamURLFromTeam(team), c.GetSiteURL())
 
 				if utils.Cfg.EmailSettings.RequireEmailVerification {
-					fireAndForgetEmailChangeVerifyEmail(rusers[0].Id, rusers[0].Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
+					FireAndForgetEmailChangeVerifyEmail(rusers[0].Id, rusers[0].Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
 				}
 			}
 		}
@@ -1344,7 +1344,7 @@ func fireAndForgetEmailChangeEmail(email, teamDisplayName, teamURL, siteURL stri
 	}()
 }
 
-func fireAndForgetEmailChangeVerifyEmail(userId, newUserEmail, teamName, teamDisplayName, siteURL, teamURL string) {
+func FireAndForgetEmailChangeVerifyEmail(userId, newUserEmail, teamName, teamDisplayName, siteURL, teamURL string) {
 	go func() {
 
 		link := fmt.Sprintf("%s/verify_email?uid=%s&hid=%s&teamname=%s&email=%s", siteURL, userId, model.HashPassword(userId), teamName, newUserEmail)

--- a/utils/config.go
+++ b/utils/config.go
@@ -189,6 +189,7 @@ func getClientProperties(c *model.Config) map[string]string {
 
 	props["SendEmailNotifications"] = strconv.FormatBool(c.EmailSettings.SendEmailNotifications)
 	props["EnableSignUpWithEmail"] = strconv.FormatBool(c.EmailSettings.EnableSignUpWithEmail)
+	props["RequireEmailVerification"] = strconv.FormatBool(c.EmailSettings.RequireEmailVerification)
 	props["FeedbackEmail"] = c.EmailSettings.FeedbackEmail
 
 	props["EnableSignUpWithGitLab"] = strconv.FormatBool(c.GitLabSettings.Enable)

--- a/web/react/components/user_settings/user_settings_general.jsx
+++ b/web/react/components/user_settings/user_settings_general.jsx
@@ -28,6 +28,7 @@ export default class UserSettingsGeneralTab extends React.Component {
         this.updateLastName = this.updateLastName.bind(this);
         this.updateNickname = this.updateNickname.bind(this);
         this.updateEmail = this.updateEmail.bind(this);
+        this.updateConfirmEmail = this.updateConfirmEmail.bind(this);
         this.updatePicture = this.updatePicture.bind(this);
         this.updateSection = this.updateSection.bind(this);
 
@@ -97,6 +98,7 @@ export default class UserSettingsGeneralTab extends React.Component {
 
         var user = UserStore.getCurrentUser();
         var email = this.state.email.trim().toLowerCase();
+        var confirmEmail = this.state.confirmEmail.trim().toLowerCase();
 
         if (user.email === email) {
             return;
@@ -107,12 +109,17 @@ export default class UserSettingsGeneralTab extends React.Component {
             return;
         }
 
+        if (email !== confirmEmail) {
+            this.setState({emailError: 'The new emails you entered do not match'});
+            return;
+        }
+
         user.email = email;
 
-        if (!this.state.emailEnabled || !this.state.emailVerificationEnabled) {
-            this.submitUser(user, {emailChangeInProgress: false});
-        } else {
+        if (this.state.emailEnabled && this.state.emailVerificationEnabled) {
             this.submitUser(user, {emailChangeInProgress: true});
+        } else {
+            this.submitUser(user, {emailChangeInProgress: false});
         }
     }
     submitUser(user, newState) {
@@ -191,6 +198,9 @@ export default class UserSettingsGeneralTab extends React.Component {
     updateEmail(e) {
         this.setState({email: e.target.value});
     }
+    updateConfirmEmail(e) {
+        this.setState({confirmEmail: e.target.value});
+    }
     updatePicture(e) {
         if (e.target.files && e.target.files[0]) {
             this.setState({picture: e.target.files[0]});
@@ -202,7 +212,8 @@ export default class UserSettingsGeneralTab extends React.Component {
         }
     }
     updateSection(section) {
-        this.setState(assign({}, this.setupInitialState(this.props), {clientError: '', serverError: '', emailError: ''}));
+        const emailChangeInProgress = this.state.emailChangeInProgress;
+        this.setState(assign({}, this.setupInitialState(this.props), {emailChangeInProgress: emailChangeInProgress, clientError: '', serverError: '', emailError: ''}));
         this.submitActive = false;
         this.props.updateSection(section);
     }
@@ -226,7 +237,7 @@ export default class UserSettingsGeneralTab extends React.Component {
         var emailVerificationEnabled = global.window.config.RequireEmailVerification === 'true';
 
         return {username: user.username, firstName: user.first_name, lastName: user.last_name, nickname: user.nickname,
-                        email: user.email, picture: null, loadingPicture: false, emailEnabled: emailEnabled,
+                        email: user.email, confirmEmail: '', picture: null, loadingPicture: false, emailEnabled: emailEnabled,
                         emailVerificationEnabled: emailVerificationEnabled, emailChangeInProgress: false};
     }
     render() {
@@ -474,6 +485,22 @@ export default class UserSettingsGeneralTab extends React.Component {
                                 type='text'
                                 onChange={this.updateEmail}
                                 value={this.state.email}
+                            />
+                        </div>
+                    </div>
+                </div>
+            );
+
+            inputs.push(
+                <div key='confirmEmailSetting'>
+                    <div className='form-group'>
+                        <label className='col-sm-5 control-label'>{'Confirm Email'}</label>
+                        <div className='col-sm-7'>
+                            <input
+                                className='form-control'
+                                type='text'
+                                onChange={this.updateConfirmEmail}
+                                value={this.state.confirmEmail}
                             />
                         </div>
                     </div>

--- a/web/sass-files/sass/partials/_settings.scss
+++ b/web/sass-files/sass/partials/_settings.scss
@@ -131,6 +131,7 @@
 
             .section-describe {
                 @include opacity(0.7);
+                white-space:pre;
             }
 
             .divider-dark {

--- a/web/web.go
+++ b/web/web.go
@@ -414,7 +414,12 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			user := result.Data.(*model.User)
-			api.FireAndForgetVerifyEmail(user.Id, user.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
+
+			if user.LastActivityAt > 0 {
+				api.FireAndForgetEmailChangeVerifyEmail(user.Id, user.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
+			} else {
+				api.FireAndForgetVerifyEmail(user.Id, user.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
+			}
 
 			newAddress := strings.Replace(r.URL.String(), "&resend=true", "&resend_success=true", -1)
 			http.Redirect(w, r, newAddress, http.StatusFound)


### PR DESCRIPTION
Now when a user changes their email (if email is enabled along with email verification) the user automatically receives the email asking them to verify it, rather than requiring them to "resend" it upon login. In addition adds some help text and hits the blue bar status indicator with a message reminding the user to check their email to verify their new address after submitting the change.

Also includes various smaller improvements such as requiring users to confirm their new email before being able to submit to prevent small mistypes.