### PR TITLE
PLT-515 Hid the Copy Link button on the team invite modal if Flash is disabled

### DIFF
--- a/web/react/components/get_link_modal.jsx
+++ b/web/react/components/get_link_modal.jsx
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 var UserStore = require('../stores/user_store.jsx');
+var Utils = require('../utils/utils.jsx');
 
 export default class GetLinkModal extends React.Component {
     constructor(props) {
@@ -23,7 +24,7 @@ export default class GetLinkModal extends React.Component {
     componentDidMount() {
         if (this.refs.modal) {
             $(React.findDOMNode(this.refs.modal)).on('show.bs.modal', this.onShow);
-            $(React.findDOMNode(this.refs.modal)).on('hide.bs.modal', this.onShow);
+            $(React.findDOMNode(this.refs.modal)).on('hide.bs.modal', this.onHide);
         }
     }
     handleClick() {
@@ -43,8 +44,23 @@ export default class GetLinkModal extends React.Component {
     }
     render() {
         var currentUser = UserStore.getCurrentUser();
-        var copyLinkConfirm = null;
 
+        let copyLink = null;
+        if (Utils.doesBrowserSupportFlash()) {
+            copyLink = (
+                <button
+                    data-copy-btn='true'
+                    type='button'
+                    className='btn btn-primary pull-left'
+                    onClick={this.handleClick}
+                    data-clipboard-text={this.state.value}
+                >
+                    Copy Link
+                </button>
+            );
+        }
+
+        var copyLinkConfirm = null;
         if (this.state.copiedLink) {
             copyLinkConfirm = <p className='alert alert-success copy-link-confirm'><i className='fa fa-check'></i> Link copied to clipboard.</p>;
         }
@@ -98,15 +114,7 @@ export default class GetLinkModal extends React.Component {
                                 >
                                     Close
                                 </button>
-                                <button
-                                    data-copy-btn='true'
-                                    type='button'
-                                    className='btn btn-primary pull-left'
-                                    onClick={this.handleClick}
-                                    data-clipboard-text={this.state.value}
-                                >
-                                    Copy Link
-                                </button>
+                                {copyLink}
                                 {copyLinkConfirm}
                             </div>
                         </div>

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -928,3 +928,20 @@ export function getShortenedTeamURL() {
     }
     return teamURL + '/';
 }
+
+// Returns true if the browser has Flash enabled
+export function doesBrowserSupportFlash() {
+    // check newer browsers
+    if (navigator.mimeTypes && navigator.mimeTypes['application/x-shockwave-flash']) {
+        return navigator.mimeTypes['application/x-shockwave-flash'].enabledPlugin;
+    } else {
+        try {
+            // check older versions of IE
+            let flashObject = new ActiveXObject('ShockwaveFlash.ShockwaveFlash');
+
+            return !!flashObject;
+        } catch (e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Since we can't interact with the clipboard without Flash, just hide the button