### PR TITLE
PLT-167 Fixes issue with trying to comment on a deleted post

### DIFF
--- a/web/react/components/create_comment.jsx
+++ b/web/react/components/create_comment.jsx
@@ -106,10 +106,11 @@ export default class CreateComment extends React.Component {
                 let state = {};
 
                 if (err.message === 'Invalid RootId parameter') {
+                    PostStore.removePendingPost(post.channel_id, post.pending_post_id);
+
                     if ($('#post_deleted').length > 0) {
                         $('#post_deleted').modal('show');
                     }
-                    PostStore.removePendingPost(post.pending_post_id);
                 } else {
                     post.state = Constants.POST_FAILED;
                     PostStore.updatePendingPost(post);

--- a/web/react/components/post_deleted_modal.jsx
+++ b/web/react/components/post_deleted_modal.jsx
@@ -14,9 +14,12 @@ export default class PostDeletedModal extends React.Component {
 
         this.state = {};
     }
-    handleClose(e) {
-        e.preventDefault();
-
+    componentDidMount() {
+        $(React.findDOMNode(this.refs.modal)).on('hidden.bs.modal', () => {
+            this.handleClose();
+        });
+    }
+    handleClose() {
         AppDispatcher.handleServerAction({
             type: ActionTypes.RECIEVED_SEARCH,
             results: null
@@ -56,26 +59,25 @@ export default class PostDeletedModal extends React.Component {
                                     data-dismiss='modal'
                                     aria-label='Close'
                                 >
-                                    <span aria-hidden='true'>&times;</span>
+                                    <span aria-hidden='true'>{'×'}</span>
                                 </button>
                                 <h4
                                     className='modal-title'
                                     id='myModalLabel'
                                 >
-                                    Post deleted
+                                    {'Comment could not be posted'}
                                 </h4>
                             </div>
                             <div className='modal-body'>
-                                <p>The post you were viewing was deleted by the owner.</p>
+                                <p>{'Someone deleted the message on which you tried to post a comment.'}</p>
                             </div>
                             <div className='modal-footer'>
                                 <button
                                     type='button'
                                     className='btn btn-primary'
                                     data-dismiss='modal'
-                                    onClick={this.handleClose}
                                 >
-                                    Okay
+                                    {'Okay'}
                                 </button>
                             </div>
                         </div>

--- a/web/react/components/post_deleted_modal.jsx
+++ b/web/react/components/post_deleted_modal.jsx
@@ -2,12 +2,37 @@
 // See License.txt for license information.
 
 var UserStore = require('../stores/user_store.jsx');
+var AppDispatcher = require('../dispatcher/app_dispatcher.jsx');
+var Constants = require('../utils/constants.jsx');
+var ActionTypes = Constants.ActionTypes;
 
 export default class PostDeletedModal extends React.Component {
     constructor(props) {
         super(props);
 
+        this.handleClose = this.handleClose.bind(this);
+
         this.state = {};
+    }
+    handleClose(e) {
+        e.preventDefault();
+
+        AppDispatcher.handleServerAction({
+            type: ActionTypes.RECIEVED_SEARCH,
+            results: null
+        });
+
+        AppDispatcher.handleServerAction({
+            type: ActionTypes.RECIEVED_SEARCH_TERM,
+            term: null,
+            do_search: false,
+            is_mention_search: false
+        });
+
+        AppDispatcher.handleServerAction({
+            type: ActionTypes.RECIEVED_POST_SELECTED,
+            results: null
+        });
     }
     render() {
         var currentUser = UserStore.getCurrentUser();
@@ -37,17 +62,18 @@ export default class PostDeletedModal extends React.Component {
                                     className='modal-title'
                                     id='myModalLabel'
                                 >
-                                    Comment could not be posted
+                                    Post deleted
                                 </h4>
                             </div>
                             <div className='modal-body'>
-                                <p>Someone deleted the message on which you tried to post a comment.</p>
+                                <p>The post you were viewing was deleted by the owner.</p>
                             </div>
                             <div className='modal-footer'>
                                 <button
                                     type='button'
                                     className='btn btn-primary'
                                     data-dismiss='modal'
+                                    onClick={this.handleClose}
                                 >
                                     Okay
                                 </button>

--- a/web/react/components/rhs_thread.jsx
+++ b/web/react/components/rhs_thread.jsx
@@ -71,6 +71,13 @@ export default class RhsThread extends React.Component {
             return;
         }
 
+        if (!currentSelected.posts[currentSelected.order[0]]) {
+            if ($('#post_deleted').length > 0) {
+                $('#post_deleted').modal('show');
+                return;
+            }
+        }
+
         var currentPosts = PostStore.getPosts(currentSelected.posts[currentSelected.order[0]].channel_id);
 
         if (!currentPosts || currentPosts.order.length === 0) {

--- a/web/react/components/rhs_thread.jsx
+++ b/web/react/components/rhs_thread.jsx
@@ -23,7 +23,7 @@ export default class RhsThread extends React.Component {
     }
     getStateFromStores() {
         var postList = PostStore.getSelectedPost();
-        if (!postList || postList.order.length < 1) {
+        if (!postList || postList.order.length < 1 || !postList.posts[postList.order[0]]) {
             return {postList: {}};
         }
 
@@ -49,7 +49,10 @@ export default class RhsThread extends React.Component {
         }.bind(this));
     }
     componentDidUpdate() {
-        $('.post-right__scroll').scrollTop($('.post-right__scroll')[0].scrollHeight);
+        if ($('.post-right__scroll')[0]) {
+            $('.post-right__scroll').scrollTop($('.post-right__scroll')[0].scrollHeight);
+        }
+
         $('.post-right__scroll').perfectScrollbar('update');
         this.resize();
     }
@@ -67,15 +70,8 @@ export default class RhsThread extends React.Component {
         // if something was changed in the channel like adding a
         // comment or post then lets refresh the sidebar list
         var currentSelected = PostStore.getSelectedPost();
-        if (!currentSelected || currentSelected.order.length === 0) {
+        if (!currentSelected || currentSelected.order.length === 0 || !currentSelected.posts[currentSelected.order[0]]) {
             return;
-        }
-
-        if (!currentSelected.posts[currentSelected.order[0]]) {
-            if ($('#post_deleted').length > 0) {
-                $('#post_deleted').modal('show');
-                return;
-            }
         }
 
         var currentPosts = PostStore.getPosts(currentSelected.posts[currentSelected.order[0]].channel_id);
@@ -110,7 +106,7 @@ export default class RhsThread extends React.Component {
     render() {
         var postList = this.state.postList;
 
-        if (postList == null) {
+        if (postList == null || !postList.order) {
             return (
                 <div></div>
             );


### PR DESCRIPTION
Fixes a relatively rare issue that occurred when trying to comment on a post that had been deleted.  The previously used `post_deleted_modal` had stopped working consistently as well the pending post never being properly removed.

The modal should now appear consistently and the RHS should close along with the pending post being properly removed.  Also added in some additional checks for the RHS for rare instances where certain data no longer existed when dealing with deleted posts and the RHS.  A few loosely related issues remain and have been filed as bugs.