### PR TITLE
PLT-471 Fix user_added websocket event 

### DIFF
--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -30,11 +30,15 @@ func PublishAndForget(message *model.Message) {
 	}()
 }
 
+func UpdateChannelAccessCache(teamId, userId, channelId string) {
+	if nh, ok := hub.teamHubs[teamId]; ok {
+		nh.UpdateChannelAccessCache(userId, channelId)
+	}
+}
+
 func UpdateChannelAccessCacheAndForget(teamId, userId, channelId string) {
 	go func() {
-		if nh, ok := hub.teamHubs[teamId]; ok {
-			nh.UpdateChannelAccessCache(userId, channelId)
-		}
+		UpdateChannelAccessCache(teamId, userId, channelId)
 	}()
 }
 

--- a/model/message.go
+++ b/model/message.go
@@ -31,8 +31,8 @@ func (m *Message) Add(key string, value string) {
 	m.Props[key] = value
 }
 
-func NewMessage(teamId string, channekId string, userId string, action string) *Message {
-	return &Message{TeamId: teamId, ChannelId: channekId, UserId: userId, Action: action, Props: make(map[string]string)}
+func NewMessage(teamId string, channelId string, userId string, action string) *Message {
+	return &Message{TeamId: teamId, ChannelId: channelId, UserId: userId, Action: action, Props: make(map[string]string)}
 }
 
 func (o *Message) ToJson() string {

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -205,7 +205,7 @@ export default class Sidebar extends React.Component {
                 const user = UserStore.getCurrentUser();
                 const member = ChannelStore.getMember(msg.channel_id);
 
-                var notifyLevel = member.notify_props.desktop;
+                var notifyLevel = member && member.notify_props ? member.notify_props.desktop : 'default';
                 if (notifyLevel === 'default') {
                     notifyLevel = user.notify_props.desktop;
                 }


### PR DESCRIPTION
The channel cache that the websocket uses wasn't updating properly in add/remove/leave channel member so I added it in there but made a blocking version and encapsulated the websocket message creation into a go routine since it didn't need to be completed before the api service returned.

There's more work to be done around our websocket message stuff but I didn't want to go overboard with my changes so we can deal with the rest of it in another release.