### PR TITLE
PLT-322 Updated Direct Messages menu

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -45,6 +45,7 @@ func InitApi() {
 	InitAdmin(r)
 	InitOAuth(r)
 	InitWebhook(r)
+	InitPreference(r)
 
 	templatesDir := utils.FindDir("api/templates")
 	l4g.Debug("Parsing server templates at %v", templatesDir)

--- a/api/preference.go
+++ b/api/preference.go
@@ -58,6 +58,15 @@ func getPreferencesByName(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = result.Err
 		return
 	} else {
-		w.Write([]byte(model.PreferenceListToJson(result.Data.([]*model.Preference))))
+		data := result.Data.([]*model.Preference)
+
+		if len(data) == 0 {
+			if category == model.PREFERENCE_CATEGORY_DIRECT_CHANNELS && name == model.PREFERENCE_NAME_SHOW {
+				// add direct channels for a user that existed before preferences were added
+				data = AddDirectChannels(c.Session.UserId, c.Session.TeamId)
+			}
+		}
+
+		w.Write([]byte(model.PreferenceListToJson(data)))
 	}
 }

--- a/api/preference.go
+++ b/api/preference.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api
+
+import (
+	l4g "code.google.com/p/log4go"
+	"encoding/json"
+	"github.com/gorilla/mux"
+	"github.com/mattermost/platform/model"
+	"net/http"
+)
+
+func InitPreference(r *mux.Router) {
+	l4g.Debug("Initializing preference api routes")
+
+	sr := r.PathPrefix("/preferences").Subrouter()
+	sr.Handle("/set", ApiAppHandler(setPreferences)).Methods("POST")
+	sr.Handle("/{category:[A-Za-z0-9_]+}/{name:[A-Za-z0-9_]+}", ApiAppHandler(getPreferencesByName)).Methods("GET")
+}
+
+func setPreferences(c *Context, w http.ResponseWriter, r *http.Request) {
+	var preferences []model.Preference
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&preferences); err != nil {
+		c.Err = model.NewAppError("setPreferences", "Unable to decode preferences from request", err.Error())
+		c.Err.StatusCode = http.StatusBadRequest
+		return
+	}
+
+	// just attempt to save/update them one by one and abort if one fails
+	// in the future, this could probably be done in a transaction, but that's unnecessary now
+	for _, preference := range preferences {
+		if c.Session.UserId != preference.UserId {
+			c.Err = model.NewAppError("setPreferences", "Unable to set preferences for other user", "session.user_id="+c.Session.UserId+", preference.user_id="+preference.UserId)
+			c.Err.StatusCode = http.StatusUnauthorized
+			return
+		}
+
+		if result := <-Srv.Store.Preference().Save(&preference); result.Err != nil {
+			if result = <-Srv.Store.Preference().Update(&preference); result.Err != nil {
+				c.Err = result.Err
+				return
+			}
+		}
+	}
+
+	w.Write([]byte("true"))
+}
+
+func getPreferencesByName(c *Context, w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	category := params["category"]
+	name := params["name"]
+
+	if result := <-Srv.Store.Preference().GetByName(c.Session.UserId, category, name); result.Err != nil {
+		c.Err = result.Err
+		return
+	} else {
+		w.Write([]byte(model.PreferenceListToJson(result.Data.([]*model.Preference))))
+	}
+}

--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -27,7 +27,7 @@ func TestSetPreferences(t *testing.T) {
 		preference := model.Preference{
 			UserId:   user1.Id,
 			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			Name:     model.PREFERENCE_NAME_SHOW,
 			AltId:    model.NewId(),
 		}
 		preferences = append(preferences, &preference)
@@ -74,13 +74,13 @@ func TestGetPreferencesByName(t *testing.T) {
 		&model.Preference{
 			UserId:   user1.Id,
 			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			Name:     model.PREFERENCE_NAME_SHOW,
 			AltId:    model.NewId(),
 		},
 		&model.Preference{
 			UserId:   user1.Id,
 			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			Name:     model.PREFERENCE_NAME_SHOW,
 			AltId:    model.NewId(),
 		},
 		&model.Preference{
@@ -92,7 +92,7 @@ func TestGetPreferencesByName(t *testing.T) {
 		&model.Preference{
 			UserId:   user1.Id,
 			Category: model.PREFERENCE_CATEGORY_TEST,
-			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			Name:     model.PREFERENCE_NAME_SHOW,
 			AltId:    model.NewId(),
 		},
 	}
@@ -101,7 +101,7 @@ func TestGetPreferencesByName(t *testing.T) {
 		&model.Preference{
 			UserId:   user2.Id,
 			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			Name:     model.PREFERENCE_NAME_SHOW,
 			AltId:    model.NewId(),
 		},
 	}
@@ -114,7 +114,7 @@ func TestGetPreferencesByName(t *testing.T) {
 
 	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
-	if result, err := Client.GetPreferencesByName(model.PREFERENCE_CATEGORY_DIRECT_CHANNELS, model.PREFERENCE_NAME_SHOWHIDE); err != nil {
+	if result, err := Client.GetPreferencesByName(model.PREFERENCE_CATEGORY_DIRECT_CHANNELS, model.PREFERENCE_NAME_SHOW); err != nil {
 		t.Fatal(err)
 	} else if data := result.Data.([]*model.Preference); len(data) != 2 {
 		t.Fatal("received the wrong number of preferences")
@@ -124,7 +124,7 @@ func TestGetPreferencesByName(t *testing.T) {
 
 	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
-	if result, err := Client.GetPreferencesByName(model.PREFERENCE_CATEGORY_DIRECT_CHANNELS, model.PREFERENCE_NAME_SHOWHIDE); err != nil {
+	if result, err := Client.GetPreferencesByName(model.PREFERENCE_CATEGORY_DIRECT_CHANNELS, model.PREFERENCE_NAME_SHOW); err != nil {
 		t.Fatal(err)
 	} else if data := result.Data.([]*model.Preference); len(data) != 1 {
 		t.Fatal("received the wrong number of preferences")
@@ -148,7 +148,7 @@ func TestSetAndGetProperties(t *testing.T) {
 	p := model.Preference{
 		UserId:   user.Id,
 		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		Name:     model.PREFERENCE_NAME_SHOW,
 		AltId:    model.NewId(),
 		Value:    model.NewId(),
 	}

--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -51,6 +51,8 @@ func TestSetPreferences(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
+
 	if _, err := Client.SetPreferences(preferences); err == nil {
 		t.Fatal("shouldn't have been able to update another user's preferences")
 	}
@@ -71,25 +73,25 @@ func TestGetPreferencesByName(t *testing.T) {
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
 	preferences1 := []*model.Preference{
-		&model.Preference{
+		{
 			UserId:   user1.Id,
 			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
 			Name:     model.PREFERENCE_NAME_SHOW,
 			AltId:    model.NewId(),
 		},
-		&model.Preference{
+		{
 			UserId:   user1.Id,
 			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
 			Name:     model.PREFERENCE_NAME_SHOW,
 			AltId:    model.NewId(),
 		},
-		&model.Preference{
+		{
 			UserId:   user1.Id,
 			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
 			Name:     model.PREFERENCE_NAME_TEST,
 			AltId:    model.NewId(),
 		},
-		&model.Preference{
+		{
 			UserId:   user1.Id,
 			Category: model.PREFERENCE_CATEGORY_TEST,
 			Name:     model.PREFERENCE_NAME_SHOW,
@@ -97,20 +99,8 @@ func TestGetPreferencesByName(t *testing.T) {
 		},
 	}
 
-	preferences2 := []*model.Preference{
-		&model.Preference{
-			UserId:   user2.Id,
-			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-			Name:     model.PREFERENCE_NAME_SHOW,
-			AltId:    model.NewId(),
-		},
-	}
-
 	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 	Client.Must(Client.SetPreferences(preferences1))
-
-	Client.LoginByEmail(team.Name, user2.Email, "pwd")
-	Client.Must(Client.SetPreferences(preferences2))
 
 	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
@@ -124,12 +114,11 @@ func TestGetPreferencesByName(t *testing.T) {
 
 	Client.LoginByEmail(team.Name, user2.Email, "pwd")
 
+	// note that user2 will start with a preference to show user1 in the sidebar by default
 	if result, err := Client.GetPreferencesByName(model.PREFERENCE_CATEGORY_DIRECT_CHANNELS, model.PREFERENCE_NAME_SHOW); err != nil {
 		t.Fatal(err)
 	} else if data := result.Data.([]*model.Preference); len(data) != 1 {
 		t.Fatal("received the wrong number of preferences")
-	} else if *data[0] != *preferences2[0] {
-		t.Fatal("received incorrect preference")
 	}
 }
 

--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api
+
+import (
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/store"
+	"testing"
+)
+
+func TestSetPreferences(t *testing.T) {
+	Setup()
+
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
+
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
+
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
+
+	// save 10 preferences
+	var preferences []*model.Preference
+	for i := 0; i < 10; i++ {
+		preference := model.Preference{
+			UserId:   user1.Id,
+			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			AltId:    model.NewId(),
+		}
+		preferences = append(preferences, &preference)
+	}
+
+	if _, err := Client.SetPreferences(preferences); err != nil {
+		t.Fatal(err)
+	}
+
+	// update 10 preferences
+	for _, preference := range preferences {
+		preference.Value = "1234garbage"
+	}
+
+	if _, err := Client.SetPreferences(preferences); err != nil {
+		t.Fatal(err)
+	}
+
+	// not able to update as a different user
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
+
+	if _, err := Client.SetPreferences(preferences); err == nil {
+		t.Fatal("shouldn't have been able to update another user's preferences")
+	}
+}
+
+func TestGetPreferencesByName(t *testing.T) {
+	Setup()
+
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
+
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
+
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
+
+	preferences1 := []*model.Preference{
+		&model.Preference{
+			UserId:   user1.Id,
+			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			AltId:    model.NewId(),
+		},
+		&model.Preference{
+			UserId:   user1.Id,
+			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			AltId:    model.NewId(),
+		},
+		&model.Preference{
+			UserId:   user1.Id,
+			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+			Name:     model.PREFERENCE_NAME_TEST,
+			AltId:    model.NewId(),
+		},
+		&model.Preference{
+			UserId:   user1.Id,
+			Category: model.PREFERENCE_CATEGORY_TEST,
+			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			AltId:    model.NewId(),
+		},
+	}
+
+	preferences2 := []*model.Preference{
+		&model.Preference{
+			UserId:   user2.Id,
+			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+			Name:     model.PREFERENCE_NAME_SHOWHIDE,
+			AltId:    model.NewId(),
+		},
+	}
+
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
+	Client.Must(Client.SetPreferences(preferences1))
+
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
+	Client.Must(Client.SetPreferences(preferences2))
+
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
+
+	if result, err := Client.GetPreferencesByName(model.PREFERENCE_CATEGORY_DIRECT_CHANNELS, model.PREFERENCE_NAME_SHOWHIDE); err != nil {
+		t.Fatal(err)
+	} else if data := result.Data.([]*model.Preference); len(data) != 2 {
+		t.Fatal("received the wrong number of preferences")
+	} else if !((*data[0] == *preferences1[0] && *data[1] == *preferences1[1]) || (*data[0] == *preferences1[1] && *data[1] == *preferences1[0])) {
+		t.Fatal("received incorrect preferences")
+	}
+
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
+
+	if result, err := Client.GetPreferencesByName(model.PREFERENCE_CATEGORY_DIRECT_CHANNELS, model.PREFERENCE_NAME_SHOWHIDE); err != nil {
+		t.Fatal(err)
+	} else if data := result.Data.([]*model.Preference); len(data) != 1 {
+		t.Fatal("received the wrong number of preferences")
+	} else if *data[0] != *preferences2[0] {
+		t.Fatal("received incorrect preference")
+	}
+}
+
+func TestSetAndGetProperties(t *testing.T) {
+	Setup()
+
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
+
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(user.Id))
+
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
+
+	p := model.Preference{
+		UserId:   user.Id,
+		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		AltId:    model.NewId(),
+		Value:    model.NewId(),
+	}
+
+	Client.Must(Client.SetPreferences([]*model.Preference{&p}))
+
+	if result, err := Client.GetPreferencesByName(p.Category, p.Name); err != nil {
+		t.Fatal(err)
+	} else if data := result.Data.([]*model.Preference); len(data) != 1 {
+		t.Fatal("received too many preferences")
+	} else if *data[0] != p {
+		t.Fatal("preference saved incorrectly")
+	}
+
+	p.Value = model.NewId()
+	Client.Must(Client.SetPreferences([]*model.Preference{&p}))
+
+	if result, err := Client.GetPreferencesByName(p.Category, p.Name); err != nil {
+		t.Fatal(err)
+	} else if data := result.Data.([]*model.Preference); len(data) != 1 {
+		t.Fatal("received too many preferences")
+	} else if *data[0] != p {
+		t.Fatal("preference updated incorrectly")
+	}
+}

--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -71,13 +71,13 @@ func TestGetPreferenceCategory(t *testing.T) {
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	category := model.PREFERENCE_CATEGORY_TEST
+	category := model.NewId()
 
 	preferences1 := model.Preferences{
 		{
 			UserId:   user1.Id,
 			Category: category,
-			Name:     model.PREFERENCE_NAME_TEST,
+			Name:     model.NewId(),
 		},
 		{
 			UserId:   user1.Id,
@@ -86,8 +86,8 @@ func TestGetPreferenceCategory(t *testing.T) {
 		},
 		{
 			UserId:   user1.Id,
-			Category: model.PREFERENCE_CATEGORY_TEST,
-			Name:     model.PREFERENCE_NAME_TEST,
+			Category: model.NewId(),
+			Name:     model.NewId(),
 		},
 	}
 
@@ -113,7 +113,7 @@ func TestGetPreferenceCategory(t *testing.T) {
 	}
 }
 
-func TestGetDefaultDirectChannels(t *testing.T) {
+func TestTransformPreferences(t *testing.T) {
 	Setup()
 
 	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}

--- a/api/user.go
+++ b/api/user.go
@@ -242,7 +242,7 @@ func fireAndForgetAddDirectChannels(user *model.User, team *model.Team) {
 			preference := &model.Preference{
 				UserId:   user.Id,
 				Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-				Name:     model.PREFERENCE_NAME_SHOWHIDE,
+				Name:     model.PREFERENCE_NAME_SHOW,
 				AltId:    profile.Id,
 				Value:    "true",
 			}

--- a/model/client.go
+++ b/model/client.go
@@ -844,6 +844,24 @@ func (c *Client) ListIncomingWebhooks() (*Result, *AppError) {
 	}
 }
 
+func (c *Client) SetPreferences(preferences []*Preference) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/preferences/set", PreferenceListToJson(preferences)); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), nil}, nil
+	}
+}
+
+func (c *Client) GetPreferencesByName(category string, name string) (*Result, *AppError) {
+	if r, err := c.DoApiGet("/preferences/"+category+"/"+name, "", ""); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), PreferenceListFromJson(r.Body)}, nil
+	}
+}
+
 func (c *Client) MockSession(sessionToken string) {
 	c.AuthToken = sessionToken
 	c.AuthType = HEADER_BEARER

--- a/model/client.go
+++ b/model/client.go
@@ -853,8 +853,16 @@ func (c *Client) SetPreferences(preferences *Preferences) (*Result, *AppError) {
 	}
 }
 
-func (c *Client) GetPreferencesByName(category string, name string) (*Result, *AppError) {
+func (c *Client) GetPreference(category string, name string) (*Result, *AppError) {
 	if r, err := c.DoApiGet("/preferences/"+category+"/"+name, "", ""); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID), r.Header.Get(HEADER_ETAG_SERVER), PreferenceFromJson(r.Body)}, nil
+	}
+}
+
+func (c *Client) GetPreferenceCategory(category string) (*Result, *AppError) {
+	if r, err := c.DoApiGet("/preferences/"+category, "", ""); err != nil {
 		return nil, err
 	} else {
 		preferences, _ := PreferencesFromJson(r.Body)

--- a/model/client.go
+++ b/model/client.go
@@ -844,12 +844,12 @@ func (c *Client) ListIncomingWebhooks() (*Result, *AppError) {
 	}
 }
 
-func (c *Client) SetPreferences(preferences []*Preference) (*Result, *AppError) {
-	if r, err := c.DoApiPost("/preferences/set", PreferenceListToJson(preferences)); err != nil {
+func (c *Client) SetPreferences(preferences *Preferences) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/preferences/save", preferences.ToJson()); err != nil {
 		return nil, err
 	} else {
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),
-			r.Header.Get(HEADER_ETAG_SERVER), nil}, nil
+			r.Header.Get(HEADER_ETAG_SERVER), preferences}, nil
 	}
 }
 
@@ -857,8 +857,8 @@ func (c *Client) GetPreferencesByName(category string, name string) (*Result, *A
 	if r, err := c.DoApiGet("/preferences/"+category+"/"+name, "", ""); err != nil {
 		return nil, err
 	} else {
-		return &Result{r.Header.Get(HEADER_REQUEST_ID),
-			r.Header.Get(HEADER_ETAG_SERVER), PreferenceListFromJson(r.Body)}, nil
+		preferences, _ := PreferencesFromJson(r.Body)
+		return &Result{r.Header.Get(HEADER_REQUEST_ID), r.Header.Get(HEADER_ETAG_SERVER), preferences}, nil
 	}
 }
 

--- a/model/preference.go
+++ b/model/preference.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+const (
+	PREFERENCE_CATEGORY_DIRECT_CHANNELS = "direct_channels"
+	PREFERENCE_NAME_SHOWHIDE            = "show_hide"
+)
+
+type Preference struct {
+	UserId   string `json:"user_id"`
+	Category string `json:"category"`
+	Name     string `json:"name"`
+	AltId    string `json:"alt_id"`
+	Value    string `json:"value"`
+}
+
+func (o *Preference) ToJson() string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func PreferenceFromJson(data io.Reader) *Preference {
+	decoder := json.NewDecoder(data)
+	var o Preference
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
+	} else {
+		return nil
+	}
+}
+
+func (o *Preference) IsValid() *AppError {
+	if len(o.UserId) != 26 {
+		return NewAppError("Preference.IsValid", "Invalid user id", "user_id="+o.UserId)
+	}
+
+	if len(o.Category) == 0 || len(o.Category) > 32 || !IsPreferenceCategoryValid(o.Category) {
+		return NewAppError("Preference.IsValid", "Invalid category", "category="+o.Category)
+	}
+
+	if len(o.Name) == 0 || len(o.Name) > 32 || !IsPreferenceNameValid(o.Name) {
+		return NewAppError("Preference.IsValid", "Invalid name", "name="+o.Name)
+	}
+
+	if o.AltId != "" && len(o.AltId) != 26 {
+		return NewAppError("Preference.IsValid", "Invalid alternate id", "altId="+o.AltId)
+	}
+
+	if len(o.Value) > 128 {
+		return NewAppError("Preference.IsValid", "Value is too long", "value="+o.Value)
+	}
+
+	return nil
+}
+
+func IsPreferenceCategoryValid(category string) bool {
+	return category == PREFERENCE_CATEGORY_DIRECT_CHANNELS
+}
+
+func IsPreferenceNameValid(name string) bool {
+	return name == PREFERENCE_NAME_SHOWHIDE
+}

--- a/model/preference.go
+++ b/model/preference.go
@@ -9,17 +9,15 @@ import (
 )
 
 const (
-	PREFERENCE_CATEGORY_DIRECT_CHANNELS = "direct_channels"
-	PREFERENCE_CATEGORY_TEST            = "test" // do not use, just for testing uniqueness while there's only one real category
-	PREFERENCE_NAME_SHOW                = "show"
-	PREFERENCE_NAME_TEST                = "test" // do not use, just for testing uniqueness while there's only one real name
+	PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW = "direct_channel_show"
+	PREFERENCE_CATEGORY_TEST                = "test" // do not use, just for testing uniqueness while there's only one real category
+	PREFERENCE_NAME_TEST                    = "test" // do not use, just for testing while there's no constant name
 )
 
 type Preference struct {
 	UserId   string `json:"user_id"`
 	Category string `json:"category"`
 	Name     string `json:"name"`
-	AltId    string `json:"alt_id"`
 	Value    string `json:"value"`
 }
 
@@ -52,12 +50,9 @@ func (o *Preference) IsValid() *AppError {
 		return NewAppError("Preference.IsValid", "Invalid category", "category="+o.Category)
 	}
 
-	if len(o.Name) == 0 || len(o.Name) > 32 || !IsPreferenceNameValid(o.Name) {
+	// name can either be a valid constant or an id
+	if len(o.Name) == 0 || len(o.Name) > 32 || !(len(o.Name) == 26 || IsPreferenceNameValid(o.Name)) {
 		return NewAppError("Preference.IsValid", "Invalid name", "name="+o.Name)
-	}
-
-	if o.AltId != "" && len(o.AltId) != 26 {
-		return NewAppError("Preference.IsValid", "Invalid alternate id", "altId="+o.AltId)
 	}
 
 	if len(o.Value) > 128 {
@@ -68,9 +63,9 @@ func (o *Preference) IsValid() *AppError {
 }
 
 func IsPreferenceCategoryValid(category string) bool {
-	return category == PREFERENCE_CATEGORY_DIRECT_CHANNELS || category == PREFERENCE_CATEGORY_TEST
+	return category == PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW || category == PREFERENCE_CATEGORY_TEST
 }
 
 func IsPreferenceNameValid(name string) bool {
-	return name == PREFERENCE_NAME_SHOW || name == PREFERENCE_NAME_TEST
+	return name == PREFERENCE_NAME_TEST
 }

--- a/model/preference.go
+++ b/model/preference.go
@@ -10,7 +10,9 @@ import (
 
 const (
 	PREFERENCE_CATEGORY_DIRECT_CHANNELS = "direct_channels"
+	PREFERENCE_CATEGORY_TEST            = "test" // do not use, just for testing uniqueness while there's only one real category
 	PREFERENCE_NAME_SHOWHIDE            = "show_hide"
+	PREFERENCE_NAME_TEST                = "test" // do not use, just for testing uniqueness while there's only one real name
 )
 
 type Preference struct {
@@ -66,9 +68,9 @@ func (o *Preference) IsValid() *AppError {
 }
 
 func IsPreferenceCategoryValid(category string) bool {
-	return category == PREFERENCE_CATEGORY_DIRECT_CHANNELS
+	return category == PREFERENCE_CATEGORY_DIRECT_CHANNELS || category == PREFERENCE_CATEGORY_TEST
 }
 
 func IsPreferenceNameValid(name string) bool {
-	return name == PREFERENCE_NAME_SHOWHIDE
+	return name == PREFERENCE_NAME_SHOWHIDE || name == PREFERENCE_NAME_TEST
 }

--- a/model/preference.go
+++ b/model/preference.go
@@ -32,12 +32,32 @@ func (o *Preference) ToJson() string {
 	}
 }
 
+func PreferenceListToJson(o []*Preference) string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
 func PreferenceFromJson(data io.Reader) *Preference {
 	decoder := json.NewDecoder(data)
 	var o Preference
 	err := decoder.Decode(&o)
 	if err == nil {
 		return &o
+	} else {
+		return nil
+	}
+}
+
+func PreferenceListFromJson(data io.Reader) []*Preference {
+	decoder := json.NewDecoder(data)
+	var o []*Preference
+	err := decoder.Decode(&o)
+	if err == nil {
+		return o
 	} else {
 		return nil
 	}

--- a/model/preference.go
+++ b/model/preference.go
@@ -32,32 +32,12 @@ func (o *Preference) ToJson() string {
 	}
 }
 
-func PreferenceListToJson(o []*Preference) string {
-	b, err := json.Marshal(o)
-	if err != nil {
-		return ""
-	} else {
-		return string(b)
-	}
-}
-
 func PreferenceFromJson(data io.Reader) *Preference {
 	decoder := json.NewDecoder(data)
 	var o Preference
 	err := decoder.Decode(&o)
 	if err == nil {
 		return &o
-	} else {
-		return nil
-	}
-}
-
-func PreferenceListFromJson(data io.Reader) []*Preference {
-	decoder := json.NewDecoder(data)
-	var o []*Preference
-	err := decoder.Decode(&o)
-	if err == nil {
-		return o
 	} else {
 		return nil
 	}

--- a/model/preference.go
+++ b/model/preference.go
@@ -10,8 +10,6 @@ import (
 
 const (
 	PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW = "direct_channel_show"
-	PREFERENCE_CATEGORY_TEST                = "test" // do not use, just for testing uniqueness while there's only one real category
-	PREFERENCE_NAME_TEST                    = "test" // do not use, just for testing while there's no constant name
 )
 
 type Preference struct {
@@ -46,12 +44,11 @@ func (o *Preference) IsValid() *AppError {
 		return NewAppError("Preference.IsValid", "Invalid user id", "user_id="+o.UserId)
 	}
 
-	if len(o.Category) == 0 || len(o.Category) > 32 || !IsPreferenceCategoryValid(o.Category) {
+	if len(o.Category) == 0 || len(o.Category) > 32 {
 		return NewAppError("Preference.IsValid", "Invalid category", "category="+o.Category)
 	}
 
-	// name can either be a valid constant or an id
-	if len(o.Name) == 0 || len(o.Name) > 32 || !(len(o.Name) == 26 || IsPreferenceNameValid(o.Name)) {
+	if len(o.Name) == 0 || len(o.Name) > 32 {
 		return NewAppError("Preference.IsValid", "Invalid name", "name="+o.Name)
 	}
 
@@ -60,12 +57,4 @@ func (o *Preference) IsValid() *AppError {
 	}
 
 	return nil
-}
-
-func IsPreferenceCategoryValid(category string) bool {
-	return category == PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW || category == PREFERENCE_CATEGORY_TEST
-}
-
-func IsPreferenceNameValid(name string) bool {
-	return name == PREFERENCE_NAME_TEST
 }

--- a/model/preference.go
+++ b/model/preference.go
@@ -11,7 +11,7 @@ import (
 const (
 	PREFERENCE_CATEGORY_DIRECT_CHANNELS = "direct_channels"
 	PREFERENCE_CATEGORY_TEST            = "test" // do not use, just for testing uniqueness while there's only one real category
-	PREFERENCE_NAME_SHOWHIDE            = "show_hide"
+	PREFERENCE_NAME_SHOW                = "show"
 	PREFERENCE_NAME_TEST                = "test" // do not use, just for testing uniqueness while there's only one real name
 )
 
@@ -92,5 +92,5 @@ func IsPreferenceCategoryValid(category string) bool {
 }
 
 func IsPreferenceNameValid(name string) bool {
-	return name == PREFERENCE_NAME_SHOWHIDE || name == PREFERENCE_NAME_TEST
+	return name == PREFERENCE_NAME_SHOW || name == PREFERENCE_NAME_TEST
 }

--- a/model/preference_test.go
+++ b/model/preference_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPreferenceIsValid(t *testing.T) {
+	preference := Preference{}
+
+	if err := preference.IsValid(); err == nil {
+		t.Fatal()
+	}
+
+	preference.UserId = NewId()
+	if err := preference.IsValid(); err == nil {
+		t.Fatal()
+	}
+
+	preference.Category = "1234garbage"
+	if err := preference.IsValid(); err == nil {
+		t.Fatal()
+	}
+
+	preference.Category = PREFERENCE_CATEGORY_DIRECT_CHANNELS
+	if err := preference.IsValid(); err == nil {
+		t.Fatal()
+	}
+
+	preference.Name = "1234garbage"
+	if err := preference.IsValid(); err == nil {
+		t.Fatal()
+	}
+
+	preference.Name = PREFERENCE_NAME_SHOWHIDE
+	if err := preference.IsValid(); err != nil {
+		t.Fatal()
+	}
+
+	preference.AltId = "1234garbage"
+	if err := preference.IsValid(); err == nil {
+		t.Fatal()
+	}
+
+	preference.AltId = NewId()
+	if err := preference.IsValid(); err != nil {
+		t.Fatal()
+	}
+
+	preference.Value = "1234garbage"
+	if err := preference.IsValid(); err != nil {
+		t.Fatal()
+	}
+
+	preference.Value = strings.Repeat("01234567890", 20)
+	if err := preference.IsValid(); err == nil {
+		t.Fatal()
+	}
+}

--- a/model/preference_test.go
+++ b/model/preference_test.go
@@ -35,7 +35,7 @@ func TestPreferenceIsValid(t *testing.T) {
 		t.Fatal()
 	}
 
-	preference.Name = PREFERENCE_NAME_SHOWHIDE
+	preference.Name = PREFERENCE_NAME_SHOW
 	if err := preference.IsValid(); err != nil {
 		t.Fatal()
 	}

--- a/model/preference_test.go
+++ b/model/preference_test.go
@@ -12,7 +12,7 @@ func TestPreferenceIsValid(t *testing.T) {
 	preference := Preference{
 		UserId:   "1234garbage",
 		Category: PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW,
-		Name:     PREFERENCE_NAME_TEST,
+		Name:     NewId(),
 	}
 
 	if err := preference.IsValid(); err == nil {
@@ -24,7 +24,7 @@ func TestPreferenceIsValid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	preference.Category = "1234garbage"
+	preference.Category = strings.Repeat("01234567890", 20)
 	if err := preference.IsValid(); err == nil {
 		t.Fatal()
 	}
@@ -34,17 +34,12 @@ func TestPreferenceIsValid(t *testing.T) {
 		t.Fatal()
 	}
 
-	preference.Name = "1234garbage"
+	preference.Name = strings.Repeat("01234567890", 20)
 	if err := preference.IsValid(); err == nil {
 		t.Fatal()
 	}
 
 	preference.Name = NewId()
-	if err := preference.IsValid(); err != nil {
-		t.Fatal()
-	}
-
-	preference.Name = PREFERENCE_NAME_TEST
 	if err := preference.IsValid(); err != nil {
 		t.Fatal()
 	}

--- a/model/preference_test.go
+++ b/model/preference_test.go
@@ -9,15 +9,19 @@ import (
 )
 
 func TestPreferenceIsValid(t *testing.T) {
-	preference := Preference{}
+	preference := Preference{
+		UserId:   "1234garbage",
+		Category: PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW,
+		Name:     PREFERENCE_NAME_TEST,
+	}
 
 	if err := preference.IsValid(); err == nil {
 		t.Fatal()
 	}
 
 	preference.UserId = NewId()
-	if err := preference.IsValid(); err == nil {
-		t.Fatal()
+	if err := preference.IsValid(); err != nil {
+		t.Fatal(err)
 	}
 
 	preference.Category = "1234garbage"
@@ -25,8 +29,8 @@ func TestPreferenceIsValid(t *testing.T) {
 		t.Fatal()
 	}
 
-	preference.Category = PREFERENCE_CATEGORY_DIRECT_CHANNELS
-	if err := preference.IsValid(); err == nil {
+	preference.Category = PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW
+	if err := preference.IsValid(); err != nil {
 		t.Fatal()
 	}
 
@@ -35,28 +39,23 @@ func TestPreferenceIsValid(t *testing.T) {
 		t.Fatal()
 	}
 
-	preference.Name = PREFERENCE_NAME_SHOW
+	preference.Name = NewId()
 	if err := preference.IsValid(); err != nil {
 		t.Fatal()
 	}
 
-	preference.AltId = "1234garbage"
-	if err := preference.IsValid(); err == nil {
-		t.Fatal()
-	}
-
-	preference.AltId = NewId()
-	if err := preference.IsValid(); err != nil {
-		t.Fatal()
-	}
-
-	preference.Value = "1234garbage"
+	preference.Name = PREFERENCE_NAME_TEST
 	if err := preference.IsValid(); err != nil {
 		t.Fatal()
 	}
 
 	preference.Value = strings.Repeat("01234567890", 20)
 	if err := preference.IsValid(); err == nil {
+		t.Fatal()
+	}
+
+	preference.Value = "1234garbage"
+	if err := preference.IsValid(); err != nil {
 		t.Fatal()
 	}
 }

--- a/model/preferences.go
+++ b/model/preferences.go
@@ -8,7 +8,7 @@ import (
 	"io"
 )
 
-type Preferences []*Preference
+type Preferences []Preference
 
 func (o *Preferences) ToJson() string {
 	b, err := json.Marshal(o)

--- a/model/preferences.go
+++ b/model/preferences.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Preferences []*Preference
+
+func (o *Preferences) ToJson() string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func PreferencesFromJson(data io.Reader) (Preferences, error) {
+	decoder := json.NewDecoder(data)
+	var o Preferences
+	err := decoder.Decode(&o)
+	if err == nil {
+		return o, nil
+	} else {
+		return nil, err
+	}
+}

--- a/store/sql_preference_store.go
+++ b/store/sql_preference_store.go
@@ -162,9 +162,9 @@ func (s SqlPreferenceStore) Get(userId string, category string, name string) Sto
 	go func() {
 		result := StoreResult{}
 
-		var preferences model.Preferences
+		var preference model.Preference
 
-		if _, err := s.GetReplica().Select(&preferences,
+		if err := s.GetReplica().SelectOne(&preference,
 			`SELECT
 				*
 			FROM
@@ -173,9 +173,9 @@ func (s SqlPreferenceStore) Get(userId string, category string, name string) Sto
 				UserId = :UserId
 				AND Category = :Category
 				AND Name = :Name`, map[string]interface{}{"UserId": userId, "Category": category, "Name": name}); err != nil {
-			result.Err = model.NewAppError("SqlPreferenceStore.GetByName", "We encounted an error while finding preferences", err.Error())
+			result.Err = model.NewAppError("SqlPreferenceStore.Get", "We encounted an error while finding preferences", err.Error())
 		} else {
-			result.Data = preferences[0]
+			result.Data = preference
 		}
 
 		storeChannel <- result

--- a/store/sql_preference_store.go
+++ b/store/sql_preference_store.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package store
+
+import (
+	"github.com/mattermost/platform/model"
+)
+
+type SqlPreferenceStore struct {
+	*SqlStore
+}
+
+func NewSqlPreferenceStore(sqlStore *SqlStore) PreferenceStore {
+	s := &SqlPreferenceStore{sqlStore}
+
+	for _, db := range sqlStore.GetAllConns() {
+		table := db.AddTableWithName(model.Preference{}, "Preferences").SetKeys(false, "UserId", "Category", "Name", "AltId")
+		table.ColMap("UserId").SetMaxSize(26)
+		table.ColMap("Category").SetMaxSize(32)
+		table.ColMap("Name").SetMaxSize(32)
+		table.ColMap("AltId").SetMaxSize(26)
+		table.ColMap("Value").SetMaxSize(128)
+	}
+
+	return s
+}
+
+func (s SqlPreferenceStore) UpgradeSchemaIfNeeded() {
+}
+
+func (s SqlPreferenceStore) CreateIndexesIfNotExists() {
+	s.CreateIndexIfNotExists("idx_preferences_user_id", "Preferences", "UserId")
+	s.CreateIndexIfNotExists("idx_preferences_category", "Preferences", "Category")
+	s.CreateIndexIfNotExists("idx_preferences_name", "Preferences", "Name")
+}
+
+func (s SqlPreferenceStore) Save(preference *model.Preference) StoreChannel {
+	storeChannel := make(StoreChannel)
+
+	go func() {
+		result := StoreResult{}
+
+		if result.Err = preference.IsValid(); result.Err != nil {
+			storeChannel <- result
+			close(storeChannel)
+			return
+		}
+
+		if err := s.GetMaster().Insert(preference); err != nil {
+			if IsUniqueConstraintError(err.Error(), "UserId", "preferences_pkey") {
+				result.Err = model.NewAppError("SqlPreferenceStore.Save", "A preference with that user id, category, name, and alt id already exists",
+					"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId+", "+err.Error())
+			} else {
+				result.Err = model.NewAppError("SqlPreferenceStore.Save", "We couldn't save the preference",
+					"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId+", "+err.Error())
+			}
+		} else {
+			result.Data = preference
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlPreferenceStore) Update(preference *model.Preference) StoreChannel {
+	storeChannel := make(StoreChannel)
+
+	go func() {
+		result := StoreResult{}
+
+		if result.Err = preference.IsValid(); result.Err != nil {
+			storeChannel <- result
+			close(storeChannel)
+			return
+		}
+
+		if count, err := s.GetMaster().Update(preference); err != nil {
+			result.Err = model.NewAppError("SqlPreferenceStore.Update", "We couldn't update the preference",
+				"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId+", "+err.Error())
+		} else if count != 1 {
+			result.Err = model.NewAppError("SqlPreferenceStore.Update", "We couldn't update the preference",
+				"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId)
+		} else {
+			result.Data = preference
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlPreferenceStore) GetByName(userId string, category string, name string) StoreChannel {
+	storeChannel := make(StoreChannel)
+
+	go func() {
+		result := StoreResult{}
+
+		var preferences []*model.Preference
+
+		if _, err := s.GetReplica().Select(&preferences,
+			`SELECT
+				*
+			FROM
+				Preferences
+			WHERE
+				UserId = :UserId
+				AND Category = :Category
+				AND Name = :Name`, map[string]interface{}{"UserId": userId, "Category": category, "Name": name}); err != nil {
+			result.Err = model.NewAppError("SqlPreferenceStore.GetByName", "We encounted an error while finding preferences", err.Error())
+		} else {
+			result.Data = preferences
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}

--- a/store/sql_preference_store.go
+++ b/store/sql_preference_store.go
@@ -39,24 +39,97 @@ func (s SqlPreferenceStore) Save(preference *model.Preference) StoreChannel {
 	storeChannel := make(StoreChannel)
 
 	go func() {
+		storeChannel <- s.save(s.GetMaster(), preference)
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlPreferenceStore) save(queryable Queryable, preference *model.Preference) StoreResult {
+	result := StoreResult{}
+
+	if result.Err = preference.IsValid(); result.Err != nil {
+		return result
+	}
+
+	if err := queryable.Insert(preference); err != nil {
+		if IsUniqueConstraintError(err.Error(), "UserId", "preferences_pkey") {
+			result.Err = model.NewAppError("SqlPreferenceStore.Save", "A preference with that user id, category, name, and alt id already exists",
+				"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId+", "+err.Error())
+		} else {
+			result.Err = model.NewAppError("SqlPreferenceStore.Save", "We couldn't save the preference",
+				"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId+", "+err.Error())
+		}
+	} else {
+		result.Data = preference
+	}
+
+	return result
+}
+
+func (s SqlPreferenceStore) Update(preference *model.Preference) StoreChannel {
+	storeChannel := make(StoreChannel)
+
+	go func() {
+		storeChannel <- s.update(s.GetMaster(), preference)
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlPreferenceStore) update(queryable Queryable, preference *model.Preference) StoreResult {
+	result := StoreResult{}
+
+	if result.Err = preference.IsValid(); result.Err != nil {
+		return result
+	}
+
+	if count, err := queryable.Update(preference); err != nil {
+		result.Err = model.NewAppError("SqlPreferenceStore.Update", "We couldn't update the preference",
+			"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId+", "+err.Error())
+	} else {
+		result.Data = count
+	}
+
+	return result
+}
+
+func (s SqlPreferenceStore) SaveOrUpdate(preferences ...*model.Preference) StoreChannel {
+	storeChannel := make(StoreChannel)
+
+	go func() {
 		result := StoreResult{}
 
-		if result.Err = preference.IsValid(); result.Err != nil {
-			storeChannel <- result
-			close(storeChannel)
-			return
-		}
+		db := s.GetReplica()
 
-		if err := s.GetMaster().Insert(preference); err != nil {
-			if IsUniqueConstraintError(err.Error(), "UserId", "preferences_pkey") {
-				result.Err = model.NewAppError("SqlPreferenceStore.Save", "A preference with that user id, category, name, and alt id already exists",
-					"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId+", "+err.Error())
+		if len(preferences) > 1 {
+			// wrap in a transaction so that if one fails, everything fails
+			transaction, err := db.Begin()
+			if err != nil {
+				result.Err = model.NewAppError("SqlPreferenceStore.SaveOrUpdateMultiple", "Unable to open transaction to update preferences", err.Error())
 			} else {
-				result.Err = model.NewAppError("SqlPreferenceStore.Save", "We couldn't save the preference",
-					"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId+", "+err.Error())
+				for _, preference := range preferences {
+					if err := s.saveOrUpdate(transaction, preference); err != nil {
+						result.Err = err
+						break
+					}
+				}
+
+				if result.Err == nil {
+					if err := transaction.Commit(); err != nil {
+						// don't need to rollback here since the transaction is already closed
+						result.Err = model.NewAppError("SqlPreferenceStore.SaveOrUpdateMultiple", "Unable to commit transaction to update preferences", err.Error())
+					}
+				} else {
+					if err := transaction.Rollback(); err != nil {
+						result.Err = model.NewAppError("SqlPreferenceStore.SaveOrUpdateMultiple", "Unable to rollback transaction to update preferences", err.Error())
+					}
+				}
 			}
 		} else {
-			result.Data = preference
+			result.Err = s.saveOrUpdate(db, preferences[0])
 		}
 
 		storeChannel <- result
@@ -66,33 +139,14 @@ func (s SqlPreferenceStore) Save(preference *model.Preference) StoreChannel {
 	return storeChannel
 }
 
-func (s SqlPreferenceStore) Update(preference *model.Preference) StoreChannel {
-	storeChannel := make(StoreChannel)
-
-	go func() {
-		result := StoreResult{}
-
-		if result.Err = preference.IsValid(); result.Err != nil {
-			storeChannel <- result
-			close(storeChannel)
-			return
+func (s SqlPreferenceStore) saveOrUpdate(queryable Queryable, preference *model.Preference) *model.AppError {
+	if result := s.save(queryable, preference); result.Err != nil {
+		if result := s.update(queryable, preference); result.Err != nil {
+			return result.Err
 		}
+	}
 
-		if count, err := s.GetMaster().Update(preference); err != nil {
-			result.Err = model.NewAppError("SqlPreferenceStore.Update", "We couldn't update the preference",
-				"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId+", "+err.Error())
-		} else if count != 1 {
-			result.Err = model.NewAppError("SqlPreferenceStore.Update", "We couldn't update the preference",
-				"user_id="+preference.UserId+", category="+preference.Category+", name="+preference.Name+", alt_id="+preference.AltId)
-		} else {
-			result.Data = preference
-		}
-
-		storeChannel <- result
-		close(storeChannel)
-	}()
-
-	return storeChannel
+	return nil
 }
 
 func (s SqlPreferenceStore) GetByName(userId string, category string, name string) StoreChannel {

--- a/store/sql_preference_store_test.go
+++ b/store/sql_preference_store_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package store
+
+import (
+	"github.com/mattermost/platform/model"
+	"testing"
+)
+
+func TestPreferenceStoreSave(t *testing.T) {
+	Setup()
+
+	p1 := model.Preference{
+		UserId:   model.NewId(),
+		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		AltId:    model.NewId(),
+	}
+
+	if err := (<-store.Preference().Save(&p1)).Err; err != nil {
+		t.Fatal("couldn't save preference", err)
+	}
+
+	if err := (<-store.Preference().Save(&p1)).Err; err == nil {
+		t.Fatal("shouldn't be able to save duplicate preference")
+	}
+
+	p2 := model.Preference{
+		UserId:   model.NewId(),
+		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		AltId:    p1.AltId,
+	}
+
+	if err := (<-store.Preference().Save(&p2)).Err; err != nil {
+		t.Fatal("couldn't save preference with duplicate category, name, alternate id", err)
+	}
+
+	p3 := model.Preference{
+		UserId:   p1.UserId,
+		Category: model.PREFERENCE_CATEGORY_TEST,
+		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		AltId:    p1.AltId,
+	}
+
+	if err := (<-store.Preference().Save(&p3)).Err; err != nil {
+		t.Fatal("couldn't save preference with duplicate user id, name, alternate id", err)
+	}
+
+	p4 := model.Preference{
+		UserId:   p1.UserId,
+		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+		Name:     model.PREFERENCE_NAME_TEST,
+		AltId:    p1.AltId,
+	}
+
+	if err := (<-store.Preference().Save(&p4)).Err; err != nil {
+		t.Fatal("couldn't save preference with duplicate user id, category, alternate id", err)
+	}
+
+	p5 := model.Preference{
+		UserId:   p1.UserId,
+		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		AltId:    model.NewId(),
+	}
+
+	if err := (<-store.Preference().Save(&p5)).Err; err != nil {
+		t.Fatal("couldn't save preference with duplicate user id, category, name", err)
+	}
+}
+
+func TestPreferenceStoreUpdate(t *testing.T) {
+	Setup()
+
+	id := model.NewId()
+
+	p1 := model.Preference{
+		UserId:   id,
+		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+	}
+	Must(store.Preference().Save(&p1))
+
+	p1.Value = "1234garbage"
+	if err := (<-store.Preference().Update(&p1)).Err; err != nil {
+		t.Fatal(err)
+	}
+
+	p1.UserId = model.NewId()
+	if err := (<-store.Preference().Update(&p1)).Err; err == nil {
+		t.Fatal("update should have failed because of changed user id")
+	}
+
+	p1.UserId = id
+	p1.Category = model.PREFERENCE_CATEGORY_TEST
+	if err := (<-store.Preference().Update(&p1)).Err; err == nil {
+		t.Fatal("update should have failed because of changed category")
+	}
+
+	p1.Category = model.PREFERENCE_CATEGORY_DIRECT_CHANNELS
+	p1.Name = model.PREFERENCE_NAME_TEST
+	if err := (<-store.Preference().Update(&p1)).Err; err == nil {
+		t.Fatal("update should have failed because of changed name")
+	}
+
+	p1.Name = model.PREFERENCE_NAME_SHOWHIDE
+	p1.AltId = model.NewId()
+	if err := (<-store.Preference().Update(&p1)).Err; err == nil {
+		t.Fatal("update should have failed because of changed alternate id")
+	}
+}
+
+func TestPreferenceGetByName(t *testing.T) {
+	Setup()
+
+	p1 := model.Preference{
+		UserId:   model.NewId(),
+		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		AltId:    model.NewId(),
+	}
+
+	// same user/category/name, different alt id
+	p2 := model.Preference{
+		UserId:   p1.UserId,
+		Category: p1.Category,
+		Name:     p1.Name,
+		AltId:    model.NewId(),
+	}
+
+	// same user/category/alt id, different name
+	p3 := model.Preference{
+		UserId:   p1.UserId,
+		Category: p1.Category,
+		Name:     model.PREFERENCE_NAME_TEST,
+		AltId:    p1.AltId,
+	}
+
+	// same user/name/alt id, different category
+	p4 := model.Preference{
+		UserId:   p1.UserId,
+		Category: model.PREFERENCE_CATEGORY_TEST,
+		Name:     p1.Name,
+		AltId:    p1.AltId,
+	}
+
+	// same name/category/alt id, different user
+	p5 := model.Preference{
+		UserId:   model.NewId(),
+		Category: p1.Category,
+		Name:     p1.Name,
+		AltId:    p1.AltId,
+	}
+
+	Must(store.Preference().Save(&p1))
+	Must(store.Preference().Save(&p2))
+	Must(store.Preference().Save(&p3))
+	Must(store.Preference().Save(&p4))
+	Must(store.Preference().Save(&p5))
+
+	if result := <-store.Preference().GetByName(p1.UserId, p1.Category, p1.Name); result.Err != nil {
+		t.Fatal(result.Err)
+	} else if data := result.Data.([]*model.Preference); len(data) != 2 {
+		t.Fatal("got the wrong number of preferences")
+	} else if !((*data[0] == p1 && *data[1] == p2) || (*data[0] == p2 && *data[1] == p1)) {
+		t.Fatal("got incorrect preferences")
+	}
+}

--- a/store/sql_preference_store_test.go
+++ b/store/sql_preference_store_test.go
@@ -14,7 +14,7 @@ func TestPreferenceStoreSave(t *testing.T) {
 	p1 := model.Preference{
 		UserId:   model.NewId(),
 		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		Name:     model.PREFERENCE_NAME_SHOW,
 		AltId:    model.NewId(),
 	}
 
@@ -29,7 +29,7 @@ func TestPreferenceStoreSave(t *testing.T) {
 	p2 := model.Preference{
 		UserId:   model.NewId(),
 		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		Name:     model.PREFERENCE_NAME_SHOW,
 		AltId:    p1.AltId,
 	}
 
@@ -40,7 +40,7 @@ func TestPreferenceStoreSave(t *testing.T) {
 	p3 := model.Preference{
 		UserId:   p1.UserId,
 		Category: model.PREFERENCE_CATEGORY_TEST,
-		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		Name:     model.PREFERENCE_NAME_SHOW,
 		AltId:    p1.AltId,
 	}
 
@@ -62,7 +62,7 @@ func TestPreferenceStoreSave(t *testing.T) {
 	p5 := model.Preference{
 		UserId:   p1.UserId,
 		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		Name:     model.PREFERENCE_NAME_SHOW,
 		AltId:    model.NewId(),
 	}
 
@@ -79,7 +79,7 @@ func TestPreferenceStoreUpdate(t *testing.T) {
 	p1 := model.Preference{
 		UserId:   id,
 		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		Name:     model.PREFERENCE_NAME_SHOW,
 	}
 	Must(store.Preference().Save(&p1))
 
@@ -105,7 +105,7 @@ func TestPreferenceStoreUpdate(t *testing.T) {
 		t.Fatal("update should have failed because of changed name")
 	}
 
-	p1.Name = model.PREFERENCE_NAME_SHOWHIDE
+	p1.Name = model.PREFERENCE_NAME_SHOW
 	p1.AltId = model.NewId()
 	if err := (<-store.Preference().Update(&p1)).Err; err == nil {
 		t.Fatal("update should have failed because of changed alternate id")
@@ -118,7 +118,7 @@ func TestPreferenceGetByName(t *testing.T) {
 	p1 := model.Preference{
 		UserId:   model.NewId(),
 		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOWHIDE,
+		Name:     model.PREFERENCE_NAME_SHOW,
 		AltId:    model.NewId(),
 	}
 

--- a/store/sql_preference_store_test.go
+++ b/store/sql_preference_store_test.go
@@ -8,202 +8,104 @@ import (
 	"testing"
 )
 
-func TestPreferenceStoreSave(t *testing.T) {
-	Setup()
-
-	p1 := model.Preference{
-		UserId:   model.NewId(),
-		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOW,
-		AltId:    model.NewId(),
-	}
-
-	if err := (<-store.Preference().Save(&p1)).Err; err != nil {
-		t.Fatal("couldn't save preference", err)
-	}
-
-	if err := (<-store.Preference().Save(&p1)).Err; err == nil {
-		t.Fatal("shouldn't be able to save duplicate preference")
-	}
-
-	p2 := model.Preference{
-		UserId:   model.NewId(),
-		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOW,
-		AltId:    p1.AltId,
-	}
-
-	if err := (<-store.Preference().Save(&p2)).Err; err != nil {
-		t.Fatal("couldn't save preference with duplicate category, name, alternate id", err)
-	}
-
-	p3 := model.Preference{
-		UserId:   p1.UserId,
-		Category: model.PREFERENCE_CATEGORY_TEST,
-		Name:     model.PREFERENCE_NAME_SHOW,
-		AltId:    p1.AltId,
-	}
-
-	if err := (<-store.Preference().Save(&p3)).Err; err != nil {
-		t.Fatal("couldn't save preference with duplicate user id, name, alternate id", err)
-	}
-
-	p4 := model.Preference{
-		UserId:   p1.UserId,
-		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_TEST,
-		AltId:    p1.AltId,
-	}
-
-	if err := (<-store.Preference().Save(&p4)).Err; err != nil {
-		t.Fatal("couldn't save preference with duplicate user id, category, alternate id", err)
-	}
-
-	p5 := model.Preference{
-		UserId:   p1.UserId,
-		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOW,
-		AltId:    model.NewId(),
-	}
-
-	if err := (<-store.Preference().Save(&p5)).Err; err != nil {
-		t.Fatal("couldn't save preference with duplicate user id, category, name", err)
-	}
-}
-
-func TestPreferenceStoreUpdate(t *testing.T) {
+func TestPreferenceSave(t *testing.T) {
 	Setup()
 
 	id := model.NewId()
 
-	p1 := model.Preference{
-		UserId:   id,
-		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOW,
+	preferences := model.Preferences{
+		{
+			UserId:   id,
+			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+			Name:     model.PREFERENCE_NAME_SHOW,
+			Value:    "value1a",
+		},
+		{
+			UserId:   id,
+			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
+			Name:     model.PREFERENCE_NAME_TEST,
+			Value:    "value1b",
+		},
 	}
-	Must(store.Preference().Save(&p1))
-
-	p1.Value = "1234garbage"
-	if result := (<-store.Preference().Update(&p1)); result.Err != nil {
-		t.Fatal(result.Err)
-	} else if result.Data.(int64) != 1 {
-		t.Fatal("update should have changed only 1 row")
-	}
-
-	p1.UserId = model.NewId()
-	if result := (<-store.Preference().Update(&p1)); result.Err != nil {
-		t.Fatal(result.Err)
-	} else if result.Data.(int64) != 0 {
-		t.Fatal("update shouldn't have made changes because of changed user id")
+	if count := Must(store.Preference().Save(&preferences)); count != 2 {
+		t.Fatal("got incorrect number of rows saved")
 	}
 
-	p1.UserId = id
-	p1.Category = model.PREFERENCE_CATEGORY_TEST
-	if result := (<-store.Preference().Update(&p1)); result.Err != nil {
-		t.Fatal(result.Err)
-	} else if result.Data.(int64) != 0 {
-		t.Fatal("update shouldn't have made changes because of changed category")
+	for _, preference := range preferences {
+		if data := Must(store.Preference().GetByName(preference.UserId, preference.Category, preference.Name)).(model.Preferences); len(data) != 1 {
+			t.Fatal("got incorrect number of preferences after first Save")
+		} else if *preference != *data[0] {
+			t.Fatal("got incorrect preference after first Save")
+		}
 	}
 
-	p1.Category = model.PREFERENCE_CATEGORY_DIRECT_CHANNELS
-	p1.Name = model.PREFERENCE_NAME_TEST
-	if result := (<-store.Preference().Update(&p1)); result.Err != nil {
-		t.Fatal(result.Err)
-	} else if result.Data.(int64) != 0 {
-		t.Fatal("update shouldn't have made changes because of changed name")
+	preferences[0].Value = "value2a"
+	preferences[1].Value = "value2b"
+	if count := Must(store.Preference().Save(&preferences)); count != 2 {
+		t.Fatal("got incorrect number of rows saved")
 	}
 
-	p1.Name = model.PREFERENCE_NAME_SHOW
-	p1.AltId = model.NewId()
-	if result := (<-store.Preference().Update(&p1)); result.Err != nil {
-		t.Fatal(result.Err)
-	} else if result.Data.(int64) != 0 {
-		t.Fatal("update shouldn't have made changes because of changed alt id")
-	}
-}
-
-func TestPreferenceSaveOrUpdate(t *testing.T) {
-	Setup()
-
-	id := model.NewId()
-
-	p1 := model.Preference{
-		UserId:   id,
-		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOW,
-		Value:    "value1",
-	}
-	Must(store.Preference().SaveOrUpdate(&p1))
-
-	if preferences := Must(store.Preference().GetByName(p1.UserId, p1.Category, p1.Name)).([]*model.Preference); len(preferences) != 1 {
-		t.Fatal("got incorrect number of preferences after SaveOrUpdate")
-	} else if preferences[0].Value != "value1" {
-		t.Fatal("should have received value1 after SaveOrUpdate")
-	}
-
-	p1.Value = "value2"
-	Must(store.Preference().SaveOrUpdate(&p1))
-
-	if preferences := Must(store.Preference().GetByName(p1.UserId, p1.Category, p1.Name)).([]*model.Preference); len(preferences) != 1 {
-		t.Fatal("got incorrect number of preferences after second SaveOrUpdate")
-	} else if preferences[0].Value != "value2" {
-		t.Fatal("should have received value2 after SaveOrUpdate")
+	for _, preference := range preferences {
+		if data := Must(store.Preference().GetByName(preference.UserId, preference.Category, preference.Name)).(model.Preferences); len(data) != 1 {
+			t.Fatal("got incorrect number of preferences after second Save")
+		} else if *preference != *data[0] {
+			t.Fatal("got incorrect preference after second Save")
+		}
 	}
 }
 
 func TestPreferenceGetByName(t *testing.T) {
 	Setup()
 
-	p1 := model.Preference{
-		UserId:   model.NewId(),
-		Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNELS,
-		Name:     model.PREFERENCE_NAME_SHOW,
-		AltId:    model.NewId(),
+	userId := model.NewId()
+	category := model.PREFERENCE_CATEGORY_DIRECT_CHANNELS
+	name := model.PREFERENCE_NAME_SHOW
+	altId := model.NewId()
+
+	preferences := model.Preferences{
+		{
+			UserId:   userId,
+			Category: category,
+			Name:     name,
+			AltId:    altId,
+		},
+		// same user/category/name, different alt id
+		{
+			UserId:   userId,
+			Category: category,
+			Name:     name,
+			AltId:    model.NewId(),
+		},
+		// same user/category/alt id, different name
+		{
+			UserId:   userId,
+			Category: category,
+			Name:     model.PREFERENCE_NAME_TEST,
+			AltId:    altId,
+		},
+		// same user/name/alt id, different category
+		{
+			UserId:   userId,
+			Category: model.PREFERENCE_CATEGORY_TEST,
+			Name:     name,
+			AltId:    altId,
+		},
+		// same name/category/alt id, different user
+		{
+			UserId:   model.NewId(),
+			Category: category,
+			Name:     name,
+			AltId:    altId,
+		},
 	}
 
-	// same user/category/name, different alt id
-	p2 := model.Preference{
-		UserId:   p1.UserId,
-		Category: p1.Category,
-		Name:     p1.Name,
-		AltId:    model.NewId(),
-	}
+	Must(store.Preference().Save(&preferences))
 
-	// same user/category/alt id, different name
-	p3 := model.Preference{
-		UserId:   p1.UserId,
-		Category: p1.Category,
-		Name:     model.PREFERENCE_NAME_TEST,
-		AltId:    p1.AltId,
-	}
-
-	// same user/name/alt id, different category
-	p4 := model.Preference{
-		UserId:   p1.UserId,
-		Category: model.PREFERENCE_CATEGORY_TEST,
-		Name:     p1.Name,
-		AltId:    p1.AltId,
-	}
-
-	// same name/category/alt id, different user
-	p5 := model.Preference{
-		UserId:   model.NewId(),
-		Category: p1.Category,
-		Name:     p1.Name,
-		AltId:    p1.AltId,
-	}
-
-	Must(store.Preference().Save(&p1))
-	Must(store.Preference().Save(&p2))
-	Must(store.Preference().Save(&p3))
-	Must(store.Preference().Save(&p4))
-	Must(store.Preference().Save(&p5))
-
-	if result := <-store.Preference().GetByName(p1.UserId, p1.Category, p1.Name); result.Err != nil {
+	if result := <-store.Preference().GetByName(userId, category, name); result.Err != nil {
 		t.Fatal(result.Err)
-	} else if data := result.Data.([]*model.Preference); len(data) != 2 {
+	} else if data := result.Data.(model.Preferences); len(data) != 2 {
 		t.Fatal("got the wrong number of preferences")
-	} else if !((*data[0] == p1 && *data[1] == p2) || (*data[0] == p2 && *data[1] == p1)) {
+	} else if !((*data[0] == *preferences[0] && *data[1] == *preferences[1]) || (*data[0] == *preferences[1] && *data[1] == *preferences[0])) {
 		t.Fatal("got incorrect preferences")
 	}
 }

--- a/store/sql_preference_store_test.go
+++ b/store/sql_preference_store_test.go
@@ -55,7 +55,7 @@ func TestPreferenceGet(t *testing.T) {
 
 	userId := model.NewId()
 	category := model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW
-	name := model.PREFERENCE_NAME_TEST
+	name := model.NewId()
 
 	preferences := model.Preferences{
 		{
@@ -70,7 +70,7 @@ func TestPreferenceGet(t *testing.T) {
 		},
 		{
 			UserId:   userId,
-			Category: model.PREFERENCE_CATEGORY_TEST,
+			Category: model.NewId(),
 			Name:     name,
 		},
 		{
@@ -86,6 +86,11 @@ func TestPreferenceGet(t *testing.T) {
 		t.Fatal(result.Err)
 	} else if data := result.Data.(model.Preference); data != preferences[0] {
 		t.Fatal("got incorrect preference")
+	}
+
+	// make sure getting a missing preference fails
+	if result := <-store.Preference().Get(model.NewId(), model.NewId(), model.NewId()); result.Err == nil {
+		t.Fatal("no error on getting a missing preference")
 	}
 }
 
@@ -111,7 +116,7 @@ func TestPreferenceGetCategory(t *testing.T) {
 		// same user/name, different category
 		{
 			UserId:   userId,
-			Category: model.PREFERENCE_CATEGORY_TEST,
+			Category: model.NewId(),
 			Name:     name,
 		},
 		// same name/category, different user
@@ -130,5 +135,12 @@ func TestPreferenceGetCategory(t *testing.T) {
 		t.Fatal("got the wrong number of preferences")
 	} else if !((data[0] == preferences[0] && data[1] == preferences[1]) || (data[0] == preferences[1] && data[1] == preferences[0])) {
 		t.Fatal("got incorrect preferences")
+	}
+
+	// make sure getting a missing preference category doesn't fail
+	if result := <-store.Preference().GetCategory(model.NewId(), model.NewId()); result.Err != nil {
+		t.Fatal(result.Err)
+	} else if data := result.Data.(model.Preferences); len(data) != 0 {
+		t.Fatal("shouldn't have got any preferences")
 	}
 }

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -30,17 +30,18 @@ import (
 )
 
 type SqlStore struct {
-	master   *gorp.DbMap
-	replicas []*gorp.DbMap
-	team     TeamStore
-	channel  ChannelStore
-	post     PostStore
-	user     UserStore
-	audit    AuditStore
-	session  SessionStore
-	oauth    OAuthStore
-	system   SystemStore
-	webhook  WebhookStore
+	master     *gorp.DbMap
+	replicas   []*gorp.DbMap
+	team       TeamStore
+	channel    ChannelStore
+	post       PostStore
+	user       UserStore
+	audit      AuditStore
+	session    SessionStore
+	oauth      OAuthStore
+	system     SystemStore
+	webhook    WebhookStore
+	preference PreferenceStore
 }
 
 func NewSqlStore() Store {
@@ -93,6 +94,7 @@ func NewSqlStore() Store {
 	sqlStore.oauth = NewSqlOAuthStore(sqlStore)
 	sqlStore.system = NewSqlSystemStore(sqlStore)
 	sqlStore.webhook = NewSqlWebhookStore(sqlStore)
+	sqlStore.preference = NewSqlPreferenceStore(sqlStore)
 
 	sqlStore.master.CreateTablesIfNotExists()
 
@@ -105,6 +107,7 @@ func NewSqlStore() Store {
 	sqlStore.oauth.(*SqlOAuthStore).UpgradeSchemaIfNeeded()
 	sqlStore.system.(*SqlSystemStore).UpgradeSchemaIfNeeded()
 	sqlStore.webhook.(*SqlWebhookStore).UpgradeSchemaIfNeeded()
+	sqlStore.preference.(*SqlPreferenceStore).UpgradeSchemaIfNeeded()
 
 	sqlStore.team.(*SqlTeamStore).CreateIndexesIfNotExists()
 	sqlStore.channel.(*SqlChannelStore).CreateIndexesIfNotExists()
@@ -115,6 +118,7 @@ func NewSqlStore() Store {
 	sqlStore.oauth.(*SqlOAuthStore).CreateIndexesIfNotExists()
 	sqlStore.system.(*SqlSystemStore).CreateIndexesIfNotExists()
 	sqlStore.webhook.(*SqlWebhookStore).CreateIndexesIfNotExists()
+	sqlStore.preference.(*SqlPreferenceStore).CreateIndexesIfNotExists()
 
 	if model.IsPreviousVersion(schemaVersion) {
 		sqlStore.system.Update(&model.System{Name: "Version", Value: model.CurrentVersion})
@@ -470,6 +474,10 @@ func (ss SqlStore) System() SystemStore {
 
 func (ss SqlStore) Webhook() WebhookStore {
 	return ss.webhook
+}
+
+func (ss SqlStore) Preference() PreferenceStore {
+	return ss.preference
 }
 
 type mattermConverter struct{}

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -612,3 +612,9 @@ func decrypt(key []byte, cryptoText string) (string, error) {
 
 	return fmt.Sprintf("%s", ciphertext), nil
 }
+
+// Interface for both gorp.DbMap and gorp.Transaction to allow code for one to be reused with the other
+type Queryable interface {
+	Insert(list ...interface{}) error
+	Update(list ...interface{}) (int64, error)
+}

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -615,6 +615,8 @@ func decrypt(key []byte, cryptoText string) (string, error) {
 
 // Interface for both gorp.DbMap and gorp.Transaction to allow code for one to be reused with the other
 type Queryable interface {
+	Exec(query string, args ...interface{}) (dbsql.Result, error)
 	Insert(list ...interface{}) error
+	SelectInt(query string, args ...interface{}) (int64, error)
 	Update(list ...interface{}) (int64, error)
 }

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -612,11 +612,3 @@ func decrypt(key []byte, cryptoText string) (string, error) {
 
 	return fmt.Sprintf("%s", ciphertext), nil
 }
-
-// Interface for both gorp.DbMap and gorp.Transaction to allow code for one to be reused with the other
-type Queryable interface {
-	Exec(query string, args ...interface{}) (dbsql.Result, error)
-	Insert(list ...interface{}) error
-	SelectInt(query string, args ...interface{}) (int64, error)
-	Update(list ...interface{}) (int64, error)
-}

--- a/store/store.go
+++ b/store/store.go
@@ -154,5 +154,6 @@ type WebhookStore interface {
 type PreferenceStore interface {
 	Save(preference *model.Preference) StoreChannel
 	Update(preference *model.Preference) StoreChannel
+	SaveOrUpdate(preferences ...*model.Preference) StoreChannel
 	GetByName(userId string, category string, name string) StoreChannel
 }

--- a/store/store.go
+++ b/store/store.go
@@ -37,6 +37,7 @@ type Store interface {
 	OAuth() OAuthStore
 	System() SystemStore
 	Webhook() WebhookStore
+	Preference() PreferenceStore
 	Close()
 }
 
@@ -148,4 +149,10 @@ type WebhookStore interface {
 	GetIncoming(id string) StoreChannel
 	GetIncomingByUser(userId string) StoreChannel
 	DeleteIncoming(webhookId string, time int64) StoreChannel
+}
+
+type PreferenceStore interface {
+	Save(preference *model.Preference) StoreChannel
+	Update(preference *model.Preference) StoreChannel
+	GetByName(userId string, category string, name string) StoreChannel
 }

--- a/store/store.go
+++ b/store/store.go
@@ -152,8 +152,6 @@ type WebhookStore interface {
 }
 
 type PreferenceStore interface {
-	Save(preference *model.Preference) StoreChannel
-	Update(preference *model.Preference) StoreChannel
-	SaveOrUpdate(preferences ...*model.Preference) StoreChannel
+	Save(preferences *model.Preferences) StoreChannel
 	GetByName(userId string, category string, name string) StoreChannel
 }

--- a/store/store.go
+++ b/store/store.go
@@ -153,5 +153,6 @@ type WebhookStore interface {
 
 type PreferenceStore interface {
 	Save(preferences *model.Preferences) StoreChannel
-	GetByName(userId string, category string, name string) StoreChannel
+	Get(userId string, category string, name string) StoreChannel
+	GetCategory(userId string, category string) StoreChannel
 }

--- a/web/react/components/more_direct_channels.jsx
+++ b/web/react/components/more_direct_channels.jsx
@@ -3,6 +3,7 @@
 
 var TeamStore = require('../stores/team_store.jsx');
 var Client = require('../utils/client.jsx');
+var Constants = require('../utils/constants.jsx');
 var AsyncClient = require('../utils/async_client.jsx');
 var PreferenceStore = require('../stores/preference_store.jsx');
 var utils = require('../utils/utils.jsx');
@@ -23,7 +24,8 @@ export default class MoreDirectChannels extends React.Component {
     }
 
     handleJoinDirectChannel(channel) {
-        const preference = PreferenceStore.setPreferenceWithAltId('direct_channels', 'show_hide', channel.teammate_id, 'true');
+        const preference = PreferenceStore.setPreferenceWithAltId(Constants.Preferences.CATEGORY_DIRECT_CHANNELS,
+            Constants.Preferences.NAME_SHOW, channel.teammate_id, 'true');
         AsyncClient.setPreferences([preference]);
     }
 

--- a/web/react/components/more_direct_channels.jsx
+++ b/web/react/components/more_direct_channels.jsx
@@ -82,21 +82,6 @@ export default class MoreDirectChannels extends React.Component {
                         );
                     };
                 }
-            } else {
-                if (channel.id === ChannelStore.getCurrentId()) {
-                    active = 'active';
-                }
-
-                if (channel.unread) {
-                    badge = <span className='badge pull-right small'>{channel.unread}</span>;
-                    titleClass = 'unread-title';
-                }
-
-                handleClick = function clickHandler(e) {
-                    e.preventDefault();
-                    utils.switchChannel(channel);
-                    $(React.findDOMNode(self.refs.modal)).modal('hide');
-                };
             }
 
             return (

--- a/web/react/components/more_direct_channels.jsx
+++ b/web/react/components/more_direct_channels.jsx
@@ -16,10 +16,9 @@ export default class MoreDirectChannels extends React.Component {
     }
 
     componentDidMount() {
-        var self = this;
-        $(React.findDOMNode(this.refs.modal)).on('show.bs.modal', function showModal(e) {
+        $(React.findDOMNode(this.refs.modal)).on('show.bs.modal', (e) => {
             var button = e.relatedTarget;
-            self.setState({channels: $(button).data('channels')});
+            this.setState({channels: $(button).data('channels')}); // eslint-disable-line react/no-did-mount-set-state
         });
     }
 
@@ -30,14 +29,45 @@ export default class MoreDirectChannels extends React.Component {
     }
 
     render() {
-        var self = this;
-
         var directMessageItems = this.state.channels.map((channel, index) => {
             var badge = '';
             var titleClass = '';
             var handleClick = null;
 
-            if (!channel.fake) {
+            if (channel.fake) {
+                // It's a direct message channel that doesn't exist yet so let's create it now
+                var otherUserId = utils.getUserIdFromChannelName(channel);
+
+                if (this.state.loadingDMChannel === index) {
+                    badge = (
+                        <img
+                            className='channel-loading-gif pull-right'
+                            src='/static/images/load.gif'
+                        />
+                    );
+                }
+
+                if (this.state.loadingDMChannel === -1) {
+                    handleClick = (e) => {
+                        e.preventDefault();
+                        this.setState({loadingDMChannel: index});
+                        this.handleJoinDirectChannel(channel);
+
+                        Client.createDirectChannel(channel, otherUserId,
+                            (data) => {
+                                $(React.findDOMNode(this.refs.modal)).modal('hide');
+                                this.setState({loadingDMChannel: -1});
+                                AsyncClient.getChannel(data.id);
+                                utils.switchChannel(data);
+                            },
+                            () => {
+                                this.setState({loadingDMChannel: -1});
+                                window.location.href = TeamStore.getCurrentTeamUrl() + '/channels/' + channel.name;
+                            }
+                        );
+                    };
+                }
+            } else {
                 if (channel.unread) {
                     badge = <span className='badge pull-right small'>{channel.unread}</span>;
                     titleClass = 'unread-title';
@@ -47,41 +77,8 @@ export default class MoreDirectChannels extends React.Component {
                     e.preventDefault();
                     this.handleJoinDirectChannel(channel);
                     utils.switchChannel(channel);
-                    $(React.findDOMNode(self.refs.modal)).modal('hide');
+                    $(React.findDOMNode(this.refs.modal)).modal('hide');
                 };
-            } else {
-                // It's a direct message channel that doesn't exist yet so let's create it now
-                var otherUserId = utils.getUserIdFromChannelName(channel);
-
-                if (self.state.loadingDMChannel === index) {
-                    badge = (
-                        <img
-                            className='channel-loading-gif pull-right'
-                            src='/static/images/load.gif'
-                        />
-                    );
-                }
-
-                if (self.state.loadingDMChannel === -1) {
-                    handleClick = (e) => {
-                        e.preventDefault();
-                        self.setState({loadingDMChannel: index});
-                        this.handleJoinDirectChannel(channel);
-
-                        Client.createDirectChannel(channel, otherUserId,
-                            function success(data) {
-                                $(React.findDOMNode(self.refs.modal)).modal('hide');
-                                self.setState({loadingDMChannel: -1});
-                                AsyncClient.getChannel(data.id);
-                                utils.switchChannel(data);
-                            },
-                            function error() {
-                                self.setState({loadingDMChannel: -1});
-                                window.location.href = TeamStore.getCurrentTeamUrl() + '/channels/' + channel.name;
-                            }
-                        );
-                    };
-                }
             }
 
             return (
@@ -112,10 +109,10 @@ export default class MoreDirectChannels extends React.Component {
                                 className='close'
                                 data-dismiss='modal'
                             >
-                                <span aria-hidden='true'>&times;</span>
-                                <span className='sr-only'>Close</span>
+                                <span aria-hidden='true'>{'×'}</span>
+                                <span className='sr-only'>{'Close'}</span>
                             </button>
-                            <h4 className='modal-title'>More Direct Messages</h4>
+                            <h4 className='modal-title'>{'More Direct Messages'}</h4>
                         </div>
                         <div className='modal-body'>
                             <ul className='nav nav-pills nav-stacked'>
@@ -127,7 +124,7 @@ export default class MoreDirectChannels extends React.Component {
                                 type='button'
                                 className='btn btn-default'
                                 data-dismiss='modal'
-                            >Close</button>
+                            >{'Close'}</button>
                         </div>
                     </div>
                 </div>

--- a/web/react/components/more_direct_channels.jsx
+++ b/web/react/components/more_direct_channels.jsx
@@ -23,9 +23,8 @@ export default class MoreDirectChannels extends React.Component {
     }
 
     handleJoinDirectChannel(channel) {
-        const preference = PreferenceStore.setPreferenceWithAltId(Constants.Preferences.CATEGORY_DIRECT_CHANNELS,
-            Constants.Preferences.NAME_SHOW, channel.teammate_id, 'true');
-        AsyncClient.setPreferences([preference]);
+        const preference = PreferenceStore.setPreference(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, channel.teammate_id, 'true');
+        AsyncClient.savePreferences([preference]);
     }
 
     render() {

--- a/web/react/components/more_direct_channels.jsx
+++ b/web/react/components/more_direct_channels.jsx
@@ -1,10 +1,10 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-var ChannelStore = require('../stores/channel_store.jsx');
 var TeamStore = require('../stores/team_store.jsx');
 var Client = require('../utils/client.jsx');
 var AsyncClient = require('../utils/async_client.jsx');
+var PreferenceStore = require('../stores/preference_store.jsx');
 var utils = require('../utils/utils.jsx');
 
 export default class MoreDirectChannels extends React.Component {
@@ -22,16 +22,32 @@ export default class MoreDirectChannels extends React.Component {
         });
     }
 
+    handleJoinDirectChannel(channel) {
+        const preference = PreferenceStore.setPreferenceWithAltId('direct_channels', 'show_hide', channel.teammate_id, 'true');
+        AsyncClient.setPreferences([preference]);
+    }
+
     render() {
         var self = this;
 
-        var directMessageItems = this.state.channels.map(function mapActivityToChannel(channel, index) {
+        var directMessageItems = this.state.channels.map((channel, index) => {
             var badge = '';
             var titleClass = '';
-            var active = '';
             var handleClick = null;
 
-            if (channel.fake) {
+            if (!channel.fake) {
+                if (channel.unread) {
+                    badge = <span className='badge pull-right small'>{channel.unread}</span>;
+                    titleClass = 'unread-title';
+                }
+
+                handleClick = (e) => {
+                    e.preventDefault();
+                    this.handleJoinDirectChannel(channel);
+                    utils.switchChannel(channel);
+                    $(React.findDOMNode(self.refs.modal)).modal('hide');
+                };
+            } else {
                 // It's a direct message channel that doesn't exist yet so let's create it now
                 var otherUserId = utils.getUserIdFromChannelName(channel);
 
@@ -45,9 +61,10 @@ export default class MoreDirectChannels extends React.Component {
                 }
 
                 if (self.state.loadingDMChannel === -1) {
-                    handleClick = function clickHandler(e) {
+                    handleClick = (e) => {
                         e.preventDefault();
                         self.setState({loadingDMChannel: index});
+                        this.handleJoinDirectChannel(channel);
 
                         Client.createDirectChannel(channel, otherUserId,
                             function success(data) {
@@ -81,10 +98,7 @@ export default class MoreDirectChannels extends React.Component {
             }
 
             return (
-                <li
-                    key={channel.name}
-                    className={active}
-                >
+                <li key={channel.name}>
                     <a
                         className={'sidebar-channel ' + titleClass}
                         href='#'

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -71,6 +71,7 @@ export default class Sidebar extends React.Component {
                 channelName = teammate.id + '__' + UserStore.getCurrentId();
             }
 
+            let forceShow = false;
             let channel = ChannelStore.getByName(channelName);
 
             if (!channel) {
@@ -80,6 +81,11 @@ export default class Sidebar extends React.Component {
                 channel.last_post_at = 0;
                 channel.total_msg_count = 0;
                 channel.type = 'D';
+            } else {
+                const member = members[channel.id];
+                const msgCount = channel.total_msg_count - member.msg_count;
+
+                forceShow = currentId === channel.id || msgCount > 0;
             }
 
             channel.display_name = teammate.username;
@@ -87,6 +93,12 @@ export default class Sidebar extends React.Component {
             channel.status = UserStore.getStatus(teammate.id);
 
             if (preferences.some((preference) => (preference.alt_id === teammate.id && preference.value !== 'false'))) {
+                visibleDirectChannels.push(channel);
+            } else if (forceShow) {
+                // make sure that unread direct channels are visible
+                const preference = PreferenceStore.setPreferenceWithAltId('direct_channels', 'show_hide', teammate.id, 'true');
+                AsyncClient.setPreferences([preference]);
+
                 visibleDirectChannels.push(channel);
             } else {
                 hiddenDirectChannels.push(channel);

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -452,10 +452,10 @@ export default class Sidebar extends React.Component {
         }
 
         let closeButton = null;
-        if (handleClose) {
+        if (handleClose && !badge) {
             closeButton = (
                 <span
-                    className='sidebar-channel__close'
+                    className='sidebar-channel__close pull-right'
                     data-close='true'
                 >
                     {'×'}

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -54,7 +54,7 @@ export default class Sidebar extends React.Component {
             teammates.push(teamMemberMap[id]);
         }
 
-        const preferences = PreferenceStore.getPreferences(Constants.Preferences.CATEGORY_DIRECT_CHANNELS, Constants.Preferences.NAME_SHOW);
+        const preferences = PreferenceStore.getPreferences(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW);
 
         // Create lists of all read and unread direct channels
         var visibleDirectChannels = [];
@@ -95,13 +95,12 @@ export default class Sidebar extends React.Component {
             channel.teammate_id = teammate.id;
             channel.status = UserStore.getStatus(teammate.id);
 
-            if (preferences.some((preference) => (preference.alt_id === teammate.id && preference.value !== 'false'))) {
+            if (preferences.some((preference) => (preference.name === teammate.id && preference.value !== 'false'))) {
                 visibleDirectChannels.push(channel);
             } else if (forceShow) {
                 // make sure that unread direct channels are visible
-                const preference = PreferenceStore.setPreferenceWithAltId(Constants.Preferences.CATEGORY_DIRECT_CHANNELS,
-                    Constants.Preferences.NAME_SHOW, teammate.id, 'true');
-                AsyncClient.setPreferences([preference]);
+                const preference = PreferenceStore.setPreference(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, teammate.id, 'true');
+                AsyncClient.savePreferences([preference]);
 
                 visibleDirectChannels.push(channel);
             } else {
@@ -129,7 +128,7 @@ export default class Sidebar extends React.Component {
         SocketStore.addChangeListener(this.onSocketChange);
         PreferenceStore.addChangeListener(this.onChange);
 
-        AsyncClient.getDirectChannels();
+        AsyncClient.getDirectChannelPreferences();
 
         $('.nav-pills__container').perfectScrollbar();
 
@@ -310,9 +309,8 @@ export default class Sidebar extends React.Component {
         if (!this.isLeaving.get(channel.id)) {
             this.isLeaving.set(channel.id, true);
 
-            const preference = PreferenceStore.setPreferenceWithAltId(Constants.Preferences.CATEGORY_DIRECT_CHANNELS,
-                Constants.Preferences.NAME_SHOW, channel.teammate_id, 'false');
-            AsyncClient.setPreferences(
+            const preference = PreferenceStore.setPreference(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, channel.teammate_id, 'false');
+            AsyncClient.savePreferences(
                 [preference],
                 () => {
                     this.isLeaving.set(channel.id, false);

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -52,7 +52,7 @@ export default class Sidebar extends React.Component {
             teammates.push(teamMemberMap[id]);
         }
 
-        const preferences = PreferenceStore.getPreferences('direct_channels', 'show_hide');
+        const preferences = PreferenceStore.getPreferences(Constants.Preferences.CATEGORY_DIRECT_CHANNELS, Constants.Preferences.NAME_SHOW);
 
         // Create lists of all read and unread direct channels
         var visibleDirectChannels = [];
@@ -96,7 +96,8 @@ export default class Sidebar extends React.Component {
                 visibleDirectChannels.push(channel);
             } else if (forceShow) {
                 // make sure that unread direct channels are visible
-                const preference = PreferenceStore.setPreferenceWithAltId('direct_channels', 'show_hide', teammate.id, 'true');
+                const preference = PreferenceStore.setPreferenceWithAltId(Constants.Preferences.CATEGORY_DIRECT_CHANNELS,
+                    Constants.Preferences.NAME_SHOW, teammate.id, 'true');
                 AsyncClient.setPreferences([preference]);
 
                 visibleDirectChannels.push(channel);
@@ -306,7 +307,8 @@ export default class Sidebar extends React.Component {
         if (!channel.leaving) {
             channel.leaving = true;
 
-            const preference = PreferenceStore.setPreferenceWithAltId('direct_channels', 'show_hide', channel.teammate_id, 'false');
+            const preference = PreferenceStore.setPreferenceWithAltId(Constants.Preferences.CATEGORY_DIRECT_CHANNELS,
+                Constants.Preferences.NAME_SHOW, channel.teammate_id, 'false');
             AsyncClient.setPreferences(
                 [preference],
                 () => {

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -310,7 +310,9 @@ export default class Sidebar extends React.Component {
             this.isLeaving.set(channel.id, true);
 
             const preference = PreferenceStore.setPreference(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, channel.teammate_id, 'false');
-            AsyncClient.savePreferences(
+
+            // bypass AsyncClient since we've already saved the updated preferences
+            Client.savePreferences(
                 [preference],
                 () => {
                     this.isLeaving.set(channel.id, false);

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -1,19 +1,20 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-var ChannelStore = require('../stores/channel_store.jsx');
-var Client = require('../utils/client.jsx');
-var AsyncClient = require('../utils/async_client.jsx');
-var SocketStore = require('../stores/socket_store.jsx');
-var UserStore = require('../stores/user_store.jsx');
-var TeamStore = require('../stores/team_store.jsx');
-var BrowserStore = require('../stores/browser_store.jsx');
-var Utils = require('../utils/utils.jsx');
-var SidebarHeader = require('./sidebar_header.jsx');
-var SearchBox = require('./search_bar.jsx');
-var Constants = require('../utils/constants.jsx');
-var NewChannelFlow = require('./new_channel_flow.jsx');
-var UnreadChannelIndicator = require('./unread_channel_indicator.jsx');
+const AsyncClient = require('../utils/async_client.jsx');
+const BrowserStore = require('../stores/browser_store.jsx');
+const ChannelStore = require('../stores/channel_store.jsx');
+const Client = require('../utils/client.jsx');
+const Constants = require('../utils/constants.jsx');
+const PreferenceStore = require('../stores/preference_store.jsx');
+const NewChannelFlow = require('./new_channel_flow.jsx');
+const SearchBox = require('./search_bar.jsx');
+const SidebarHeader = require('./sidebar_header.jsx');
+const SocketStore = require('../stores/socket_store.jsx');
+const TeamStore = require('../stores/team_store.jsx');
+const UnreadChannelIndicator = require('./unread_channel_indicator.jsx');
+const UserStore = require('../stores/user_store.jsx');
+const Utils = require('../utils/utils.jsx');
 
 export default class Sidebar extends React.Component {
     constructor(props) {
@@ -22,6 +23,9 @@ export default class Sidebar extends React.Component {
         this.badgesActive = false;
         this.firstUnreadChannel = null;
         this.lastUnreadChannel = null;
+
+        this.getStateFromStores = this.getStateFromStores.bind(this);
+        //this.getDirectChannelsFromStores = this.getDirectChannelsFromStores.bind(this);
 
         this.onChange = this.onChange.bind(this);
         this.onScroll = this.onScroll.bind(this);
@@ -36,7 +40,7 @@ export default class Sidebar extends React.Component {
         this.state = state;
     }
     getStateFromStores() {
-        var members = ChannelStore.getAllMembers();
+        const members = ChannelStore.getAllMembers();
         var teamMemberMap = UserStore.getActiveOnlyProfiles();
         var currentId = ChannelStore.getCurrentId();
 
@@ -48,11 +52,13 @@ export default class Sidebar extends React.Component {
             teammates.push(teamMemberMap[id]);
         }
 
+        const preferences = PreferenceStore.getPreferences('direct_channels', 'show_hide');
+
         // Create lists of all read and unread direct channels
-        var showDirectChannels = [];
-        var readDirectChannels = [];
+        var visibleDirectChannels = [];
+        var hiddenDirectChannels = [];
         for (var i = 0; i < teammates.length; i++) {
-            var teammate = teammates[i];
+            const teammate = teammates[i];
 
             if (teammate.id === UserStore.getCurrentId()) {
                 continue;
@@ -65,7 +71,7 @@ export default class Sidebar extends React.Component {
                 channelName = teammate.id + '__' + UserStore.getCurrentId();
             }
 
-            var channel = ChannelStore.getByName(channelName);
+            let channel = ChannelStore.getByName(channelName);
 
             if (channel == null) {
                 var tempChannel = {};
@@ -84,21 +90,44 @@ export default class Sidebar extends React.Component {
 
                 channel.status = UserStore.getStatus(teammate.id);
 
-                var channelMember = members[channel.id];
+                /*var channelMember = members[channel.id];
                 var msgCount = channel.total_msg_count - channelMember.msg_count;
                 if (msgCount > 0) {
-                    showDirectChannels.push(channel);
+                    visibleDirectChannels.push(channel);
                 } else if (currentId === channel.id) {
-                    showDirectChannels.push(channel);
+                    visibleDirectChannels.push(channel);
                 } else {
-                    readDirectChannels.push(channel);
-                }
+                    hiddenDirectChannels.push(channel);
+                }*/
+            } else {
+                channel = {};
+                channel.fake = true;
+                channel.name = channelName;
+                channel.display_name = teammate.username;
+                channel.teammate_username = teammate.username;
+                channel.status = UserStore.getStatus(teammate.id);
+                channel.last_post_at = 0;
+                channel.total_msg_count = 0;
+                channel.type = 'D';
+            }
+
+            if (preferences.some((preference) => (preference.alt_id === teammate.id && preference.value !== 'false'))) {
+                visibleDirectChannels.push(channel);
+            } else {
+                hiddenDirectChannels.push(channel);
             }
         }
 
-        // If we don't have MAX_DMS unread channels, sort the read list by last_post_at
-        if (showDirectChannels.length < Constants.MAX_DMS) {
-            readDirectChannels.sort(function sortByLastPost(a, b) {
+        function sortByDisplayName(a, b) {
+            return a.display_name.localeCompare(b.display_name);
+        }
+
+        visibleDirectChannels.sort(sortByDisplayName);
+        hiddenDirectChannels.sort(sortByDisplayName);
+
+        /*// If we don't have MAX_DMS unread channels, sort the read list by last_post_at
+        if (visibleDirectChannels.length < Constants.MAX_DMS) {
+            hiddenDirectChannels.sort(function sortByLastPost(a, b) {
                 // sort by last_post_at first
                 if (a.last_post_at > b.last_post_at) {
                     return -1;
@@ -118,13 +147,13 @@ export default class Sidebar extends React.Component {
             });
 
             var index = 0;
-            while (showDirectChannels.length < Constants.MAX_DMS && index < readDirectChannels.length) {
-                showDirectChannels.push(readDirectChannels[index]);
+            while (visibleDirectChannels.length < Constants.MAX_DMS && index < hiddenDirectChannels.length) {
+                visibleDirectChannels.push(hiddenDirectChannels[index]);
                 index++;
             }
-            readDirectChannels = readDirectChannels.slice(index);
+            hiddenDirectChannels = hiddenDirectChannels.slice(index);
 
-            showDirectChannels.sort(function directSort(a, b) {
+            visibleDirectChannels.sort(function directSort(a, b) {
                 if (a.display_name < b.display_name) {
                     return -1;
                 }
@@ -133,22 +162,84 @@ export default class Sidebar extends React.Component {
                 }
                 return 0;
             });
-        }
+        }*/
 
         return {
             activeId: currentId,
             channels: ChannelStore.getAll(),
             members: members,
-            showDirectChannels: showDirectChannels,
-            hideDirectChannels: readDirectChannels
+            visibleDirectChannels: visibleDirectChannels,
+            hiddenDirectChannels: hiddenDirectChannels
         };
     }
+
+    /*getDirectChannelsFromStores() {
+        const id = UserStore.getCurrentId();
+
+        const channels = [];
+        const preferences = PreferenceStore.getPreferences('direct_channels', 'show_hide');
+        for (const preference of preferences) {
+            if (preference.value !== 'true') {
+                continue;
+            }
+
+            const otherId = preference.alt_id;
+
+            if (otherId === id) {
+                continue;
+            }
+
+            const teammate = UserStore.getProfile(otherId);
+
+            if (!teammate) {
+                continue;
+            }
+
+            let channelName = '';
+            if (otherId > id) {
+                channelName = `${id}__${otherId}`;
+            } else {
+                channelName = `${otherId}__${id}`;
+            }
+
+            const channel = ChannelStore.getByName(channelName);
+
+            if (channel != null) {
+                channel.display_name = teammate.username;
+                channel.teammate_username = teammate.username;
+
+                channel.status = UserStore.getStatus(otherId);
+
+                channels.push(channel);
+            } else {
+                const tempChannel = {};
+                tempChannel.fake = true;
+                tempChannel.name = channelName;
+                tempChannel.display_name = teammate.username;
+                tempChannel.teammate_username = teammate.username;
+                tempChannel.status = UserStore.getStatus(teammate.id);
+                tempChannel.last_post_at = 0;
+                tempChannel.total_msg_count = 0;
+                tempChannel.type = 'D';
+                channels.push(tempChannel);
+            }
+        }
+
+        channels.sort((a, b) => a.display_name.localeCompare(b));
+
+        return channels;
+    }*/
+
     componentDidMount() {
         ChannelStore.addChangeListener(this.onChange);
         UserStore.addChangeListener(this.onChange);
         UserStore.addStatusesChangeListener(this.onChange);
         TeamStore.addChangeListener(this.onChange);
         SocketStore.addChangeListener(this.onSocketChange);
+        PreferenceStore.addChangeListener(this.onChange);
+
+        AsyncClient.getDirectChannels();
+
         $('.nav-pills__container').perfectScrollbar();
 
         this.updateTitle();
@@ -178,6 +269,7 @@ export default class Sidebar extends React.Component {
         UserStore.removeStatusesChangeListener(this.onChange);
         TeamStore.removeChangeListener(this.onChange);
         SocketStore.removeChangeListener(this.onSocketChange);
+        PreferenceStore.removeChangeListener(this.onChange);
     }
     onChange() {
         var newState = this.getStateFromStores();
@@ -464,7 +556,7 @@ export default class Sidebar extends React.Component {
         const privateChannels = this.state.channels.filter((channel) => channel.type === 'P');
         const privateChannelItems = privateChannels.map(this.createChannelElement);
 
-        const directMessageItems = this.state.showDirectChannels.map(this.createChannelElement);
+        const directMessageItems = this.state.visibleDirectChannels.map(this.createChannelElement);
 
         // update the favicon to show if there are any notifications
         var link = document.createElement('link');
@@ -484,7 +576,7 @@ export default class Sidebar extends React.Component {
         head.appendChild(link);
 
         var directMessageMore = null;
-        if (this.state.hideDirectChannels.length > 0) {
+        if (this.state.hiddenDirectChannels.length > 0) {
             directMessageMore = (
                 <li>
                     <a
@@ -492,9 +584,9 @@ export default class Sidebar extends React.Component {
                         data-toggle='modal'
                         className='nav-more'
                         data-target='#more_direct_channels'
-                        data-channels={JSON.stringify(this.state.hideDirectChannels)}
+                        data-channels={JSON.stringify(this.state.hiddenDirectChannels)}
                     >
-                        {'More (' + this.state.hideDirectChannels.length + ')'}
+                        {'More (' + this.state.hiddenDirectChannels.length + ')'}
                     </a>
                 </li>
             );

--- a/web/react/stores/preference_store.jsx
+++ b/web/react/stores/preference_store.jsx
@@ -75,13 +75,13 @@ class PreferenceStoreClass extends EventEmitter {
     }
 
     setPreference(category, name, value) {
-        this.setPreferenceWithAltId(category, name, '', value);
+        return this.setPreferenceWithAltId(category, name, '', value);
     }
 
     setPreferenceWithAltId(category, name, altId, value) {
         const preferences = this.getAllPreferences();
 
-        const key = this.getKey(category, name);
+        const key = this.getKey(category, name, altId);
         let preference = preferences.get(key);
 
         if (!preference) {
@@ -97,6 +97,8 @@ class PreferenceStoreClass extends EventEmitter {
         preferences.set(key, preference);
 
         this.setAllPreferences(preferences);
+
+        return preference;
     }
 
     emitChange(preferences) {
@@ -130,6 +132,3 @@ class PreferenceStoreClass extends EventEmitter {
 
 const PreferenceStore = new PreferenceStoreClass();
 export default PreferenceStore;
-
-// TODO remove me
-global.PreferenceStore = PreferenceStore;

--- a/web/react/stores/preference_store.jsx
+++ b/web/react/stores/preference_store.jsx
@@ -15,12 +15,10 @@ class PreferenceStoreClass extends EventEmitter {
 
         this.getAllPreferences = this.getAllPreferences.bind(this);
         this.getPreference = this.getPreference.bind(this);
-        this.getPreferenceWithAltId = this.getPreferenceWithAltId.bind(this);
         this.getPreferences = this.getPreferences.bind(this);
         this.getPreferencesWhere = this.getPreferencesWhere.bind(this);
         this.setAllPreferences = this.setAllPreferences.bind(this);
         this.setPreference = this.setPreference.bind(this);
-        this.setPreferenceWithAltId = this.setPreferenceWithAltId.bind(this);
 
         this.emitChange = this.emitChange.bind(this);
         this.addChangeListener = this.addChangeListener.bind(this);
@@ -30,12 +28,12 @@ class PreferenceStoreClass extends EventEmitter {
         this.dispatchToken = AppDispatcher.register(this.handleEventPayload);
     }
 
-    getKey(category, name, altId = '') {
-        return `${category}-${name}-${altId}`;
+    getKey(category, name) {
+        return `${category}-${name}`;
     }
 
     getKeyForModel(preference) {
-        return `${preference.category}-${preference.name}-${preference.alt_id}`;
+        return `${preference.category}-${preference.name}`;
     }
 
     getAllPreferences() {
@@ -46,12 +44,8 @@ class PreferenceStoreClass extends EventEmitter {
         return this.getAllPreferences().get(this.getKey(category, name)) || defaultValue;
     }
 
-    getPreferenceWithAltId(category, name, altId, defaultValue = '') {
-        return this.getAllPreferences().get(this.getKey(category, name, altId)) || defaultValue;
-    }
-
-    getPreferences(category, name) {
-        return this.getPreferencesWhere((preference) => (preference.category === category && preference.name === name));
+    getPreferences(category) {
+        return this.getPreferencesWhere((preference) => (preference.category === category));
     }
 
     getPreferencesWhere(pred) {
@@ -74,21 +68,16 @@ class PreferenceStoreClass extends EventEmitter {
     }
 
     setPreference(category, name, value) {
-        return this.setPreferenceWithAltId(category, name, '', value);
-    }
-
-    setPreferenceWithAltId(category, name, altId, value) {
         const preferences = this.getAllPreferences();
 
-        const key = this.getKey(category, name, altId);
+        const key = this.getKey(category, name);
         let preference = preferences.get(key);
 
         if (!preference) {
             preference = {
                 user_id: UserStore.getCurrentId(),
                 category,
-                name,
-                alt_id: altId
+                name
             };
         }
         preference.value = value;

--- a/web/react/stores/preference_store.jsx
+++ b/web/react/stores/preference_store.jsx
@@ -39,7 +39,6 @@ class PreferenceStoreClass extends EventEmitter {
     }
 
     getAllPreferences() {
-        console.log('getting preferences'); // eslint-disable-line no-console
         return new Map(BrowserStore.getItem('preferences', []));
     }
 

--- a/web/react/stores/preference_store.jsx
+++ b/web/react/stores/preference_store.jsx
@@ -9,6 +9,14 @@ const UserStore = require('../stores/user_store.jsx');
 
 const CHANGE_EVENT = 'change';
 
+function getPreferenceKey(category, name) {
+    return `${category}-${name}`;
+}
+
+function getPreferenceKeyForModel(preference) {
+    return `${preference.category}-${preference.name}`;
+}
+
 class PreferenceStoreClass extends EventEmitter {
     constructor() {
         super();
@@ -28,20 +36,12 @@ class PreferenceStoreClass extends EventEmitter {
         this.dispatchToken = AppDispatcher.register(this.handleEventPayload);
     }
 
-    getKey(category, name) {
-        return `${category}-${name}`;
-    }
-
-    getKeyForModel(preference) {
-        return `${preference.category}-${preference.name}`;
-    }
-
     getAllPreferences() {
         return new Map(BrowserStore.getItem('preferences', []));
     }
 
     getPreference(category, name, defaultValue = '') {
-        return this.getAllPreferences().get(this.getKey(category, name)) || defaultValue;
+        return this.getAllPreferences().get(getPreferenceKey(category, name)) || defaultValue;
     }
 
     getPreferences(category) {
@@ -70,7 +70,7 @@ class PreferenceStoreClass extends EventEmitter {
     setPreference(category, name, value) {
         const preferences = this.getAllPreferences();
 
-        const key = this.getKey(category, name);
+        const key = getPreferenceKey(category, name);
         let preference = preferences.get(key);
 
         if (!preference) {
@@ -109,7 +109,7 @@ class PreferenceStoreClass extends EventEmitter {
             const preferences = this.getAllPreferences();
 
             for (const preference of action.preferences) {
-                preferences.set(this.getKeyForModel(preference), preference);
+                preferences.set(getPreferenceKeyForModel(preference), preference);
             }
 
             this.setAllPreferences(preferences);

--- a/web/react/stores/preference_store.jsx
+++ b/web/react/stores/preference_store.jsx
@@ -1,0 +1,135 @@
+// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+const ActionTypes = require('../utils/constants.jsx').ActionTypes;
+const AppDispatcher = require('../dispatcher/app_dispatcher.jsx');
+const BrowserStore = require('./browser_store.jsx');
+const EventEmitter = require('events').EventEmitter;
+const UserStore = require('../stores/user_store.jsx');
+
+const CHANGE_EVENT = 'change';
+
+class PreferenceStoreClass extends EventEmitter {
+    constructor() {
+        super();
+
+        this.getAllPreferences = this.getAllPreferences.bind(this);
+        this.getPreference = this.getPreference.bind(this);
+        this.getPreferenceWithAltId = this.getPreferenceWithAltId.bind(this);
+        this.getPreferences = this.getPreferences.bind(this);
+        this.getPreferencesWhere = this.getPreferencesWhere.bind(this);
+        this.setAllPreferences = this.setAllPreferences.bind(this);
+        this.setPreference = this.setPreference.bind(this);
+        this.setPreferenceWithAltId = this.setPreferenceWithAltId.bind(this);
+
+        this.emitChange = this.emitChange.bind(this);
+        this.addChangeListener = this.addChangeListener.bind(this);
+        this.removeChangeListener = this.removeChangeListener.bind(this);
+
+        this.handleEventPayload = this.handleEventPayload.bind(this);
+        this.dispatchToken = AppDispatcher.register(this.handleEventPayload);
+    }
+
+    getKey(category, name, altId = '') {
+        return `${category}-${name}-${altId}`;
+    }
+
+    getKeyForModel(preference) {
+        return `${preference.category}-${preference.name}-${preference.alt_id}`;
+    }
+
+    getAllPreferences() {
+        console.log('getting preferences'); // eslint-disable-line no-console
+        return new Map(BrowserStore.getItem('preferences', []));
+    }
+
+    getPreference(category, name, defaultValue = '') {
+        return this.getAllPreferences().get(this.getKey(category, name)) || defaultValue;
+    }
+
+    getPreferenceWithAltId(category, name, altId, defaultValue = '') {
+        return this.getAllPreferences().get(this.getKey(category, name, altId)) || defaultValue;
+    }
+
+    getPreferences(category, name) {
+        return this.getPreferencesWhere((preference) => (preference.category === category && preference.name === name));
+    }
+
+    getPreferencesWhere(pred) {
+        const all = this.getAllPreferences();
+        const preferences = [];
+
+        for (const [, preference] of all) {
+            if (pred(preference)) {
+                preferences.push(preference);
+            }
+        }
+
+        return preferences;
+    }
+
+    setAllPreferences(preferences) {
+        // note that we store the preferences as an array of key-value pairs so that we can deserialize
+        // it as a proper Map instead of an object
+        BrowserStore.setItem('preferences', [...preferences]);
+    }
+
+    setPreference(category, name, value) {
+        this.setPreferenceWithAltId(category, name, '', value);
+    }
+
+    setPreferenceWithAltId(category, name, altId, value) {
+        const preferences = this.getAllPreferences();
+
+        const key = this.getKey(category, name);
+        let preference = preferences.get(key);
+
+        if (!preference) {
+            preference = {
+                user_id: UserStore.getCurrentId(),
+                category,
+                name,
+                alt_id: altId
+            };
+        }
+        preference.value = value;
+
+        preferences.set(key, preference);
+
+        this.setAllPreferences(preferences);
+    }
+
+    emitChange(preferences) {
+        this.emit(CHANGE_EVENT, preferences);
+    }
+
+    addChangeListener(callback) {
+        this.on(CHANGE_EVENT, callback);
+    }
+
+    removeChangeListener(callback) {
+        this.removeListener(CHANGE_EVENT, callback);
+    }
+
+    handleEventPayload(payload) {
+        const action = payload.action;
+
+        switch (action.type) {
+        case ActionTypes.RECIEVED_PREFERENCES:
+            const preferences = this.getAllPreferences();
+
+            for (const preference of action.preferences) {
+                preferences.set(this.getKeyForModel(preference), preference);
+            }
+
+            this.setAllPreferences(preferences);
+            this.emitChange(preferences);
+        }
+    }
+}
+
+const PreferenceStore = new PreferenceStoreClass();
+export default PreferenceStore;
+
+// TODO remove me
+global.PreferenceStore = PreferenceStore;

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -638,17 +638,16 @@ export function getMyTeam() {
     );
 }
 
-export function getDirectChannels() {
-    if (isCallInProgress('getDirectChannels')) {
+export function getDirectChannelPreferences() {
+    if (isCallInProgress('getDirectChannelPreferences')) {
         return;
     }
 
-    callTracker.getDirectChannels = utils.getTimestamp();
-    client.getPreferencesByName(
-        Constants.Preferences.CATEGORY_DIRECT_CHANNELS,
-        Constants.Preferences.NAME_SHOW,
+    callTracker.getDirectChannelPreferences = utils.getTimestamp();
+    client.getPreferenceCategory(
+        Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
         (data, textStatus, xhr) => {
-            callTracker.getDirectChannels = 0;
+            callTracker.getDirectChannelPreferences = 0;
 
             if (xhr.status === 304 || !data) {
                 return;
@@ -660,14 +659,14 @@ export function getDirectChannels() {
             });
         },
         (err) => {
-            callTracker.getDirectChannels = 0;
-            dispatchError(err, 'getDirectChannels');
+            callTracker.getDirectChannelPreferences = 0;
+            dispatchError(err, 'getDirectChannelPreferences');
         }
     );
 }
 
-export function setPreferences(preferences, success, error) {
-    client.setPreferences(
+export function savePreferences(preferences, success, error) {
+    client.savePreferences(
         preferences,
         (data, textStatus, xhr) => {
             if (xhr.status !== 304) {
@@ -682,7 +681,7 @@ export function setPreferences(preferences, success, error) {
             }
         },
         (err) => {
-            dispatchError(err, 'setPreferences');
+            dispatchError(err, 'savePreferences');
 
             if (error) {
                 error();

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -645,8 +645,8 @@ export function getDirectChannels() {
 
     callTracker.getDirectChannels = utils.getTimestamp();
     client.getPreferencesByName(
-        'direct_channels',
-        'show_hide',
+        Constants.Preferences.CATEGORY_DIRECT_CHANNELS,
+        Constants.Preferences.NAME_SHOW,
         (data, textStatus, xhr) => {
             callTracker.getDirectChannels = 0;
 

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -637,3 +637,32 @@ export function getMyTeam() {
         }
     );
 }
+
+export function getDirectChannels() {
+    if (isCallInProgress('getDirectChannels')) {
+        return;
+    }
+
+    callTracker.getDirectChannels = utils.getTimestamp();
+    client.getPreferencesByName(
+        'direct_channels',
+        'show_hide',
+        (data, textStatus, xhr) => {
+            callTracker.getDirectChannels = 0;
+
+            if (xhr.status === 304 || !data) {
+                return;
+            }
+
+            AppDispatcher.handleServerAction({
+                type: ActionTypes.RECIEVED_PREFERENCES,
+                preferences: data
+            });
+        },
+        (err) => {
+            callTracker.getDirectChannels = 0;
+            dispatchError(err, 'getDirectChannels');
+        }
+    );
+}
+

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -666,3 +666,27 @@ export function getDirectChannels() {
     );
 }
 
+export function setPreferences(preferences, success, error) {
+    client.setPreferences(
+        preferences,
+        (data, textStatus, xhr) => {
+            if (xhr.status !== 304) {
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECIEVED_PREFERENCES,
+                    preferences
+                });
+            }
+
+            if (success) {
+                success(data);
+            }
+        },
+        (err) => {
+            dispatchError(err, 'setPreferences');
+
+            if (error) {
+                error();
+            }
+        }
+    );
+}

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -1141,3 +1141,17 @@ export function listIncomingHooks(success, error) {
         }
     });
 }
+
+export function getPreferencesByName(category, name, success, error) {
+    $.ajax({
+        url: `/api/v1/preferences/${category}/${name}`,
+        dataType: 'json',
+        type: 'GET',
+        success,
+        error: (xhr, status, err) => {
+            var e = handleError('getPreferencesByName', xhr, status, err);
+            error(e);
+        }
+    });
+}
+

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -1155,3 +1155,16 @@ export function getPreferencesByName(category, name, success, error) {
     });
 }
 
+export function setPreferences(preferences, success, error) {
+    $.ajax({
+        url: '/api/v1/preferences/set',
+        dataType: 'json',
+        type: 'POST',
+        data: JSON.stringify(preferences),
+        success,
+        error: (xhr, status, err) => {
+            var e = handleError('setPreferences', xhr, status, err);
+            error(e);
+        }
+    });
+}

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -1159,6 +1159,7 @@ export function setPreferences(preferences, success, error) {
     $.ajax({
         url: '/api/v1/preferences/set',
         dataType: 'json',
+        contentType: 'application/json',
         type: 'POST',
         data: JSON.stringify(preferences),
         success,

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -1142,29 +1142,29 @@ export function listIncomingHooks(success, error) {
     });
 }
 
-export function getPreferencesByName(category, name, success, error) {
+export function getPreferenceCategory(category, success, error) {
     $.ajax({
-        url: `/api/v1/preferences/${category}/${name}`,
+        url: `/api/v1/preferences/${category}`,
         dataType: 'json',
         type: 'GET',
         success,
         error: (xhr, status, err) => {
-            var e = handleError('getPreferencesByName', xhr, status, err);
+            var e = handleError('getPreferenceCategory', xhr, status, err);
             error(e);
         }
     });
 }
 
-export function setPreferences(preferences, success, error) {
+export function savePreferences(preferences, success, error) {
     $.ajax({
-        url: '/api/v1/preferences/set',
+        url: '/api/v1/preferences/save',
         dataType: 'json',
         contentType: 'application/json',
         type: 'POST',
         data: JSON.stringify(preferences),
         success,
         error: (xhr, status, err) => {
-            var e = handleError('setPreferences', xhr, status, err);
+            var e = handleError('savePreferences', xhr, status, err);
             error(e);
         }
     });

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -28,6 +28,7 @@ module.exports = {
         RECIEVED_AUDITS: null,
         RECIEVED_TEAMS: null,
         RECIEVED_STATUSES: null,
+        RECIEVED_PREFERENCES: null,
 
         RECIEVED_MSG: null,
 

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -286,5 +286,9 @@ module.exports = {
             id: 'mentionHighlightLink',
             uiName: 'Mention Highlight Link'
         }
-    ]
+    ],
+    Preferences: {
+        CATEGORY_DIRECT_CHANNELS: 'direct_channels',
+        NAME_SHOW: 'show'
+    }
 };

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -288,7 +288,6 @@ module.exports = {
         }
     ],
     Preferences: {
-        CATEGORY_DIRECT_CHANNELS: 'direct_channels',
-        NAME_SHOW: 'show'
+        CATEGORY_DIRECT_CHANNEL_SHOW: 'direct_channel_show'
     }
 };


### PR DESCRIPTION
Does a bunch of things:
1) Adds Preferences table which is used to store each users' preferences, separate from the user object. Each preference has a category, name, an optional alternate id, and a value. The alt id can be used for things like assigning a preference to a specific channel or user.
2) Changes the Direct Messages list on the left sidebar to be controlled by a preference instead of populated based on who you've received messages from.
3) Adds the ability to add/remove people from your Direct Messages list