### PR TITLE
Use help-block class from Bootstrap

### DIFF
--- a/web/react/components/signup_user_complete.jsx
+++ b/web/react/components/signup_user_complete.jsx
@@ -206,7 +206,7 @@ export default class SignupUserComplete extends React.Component {
                                     maxLength='128'
                                 />
                                 {nameError}
-                                <p className='form__hint'>Username must begin with a letter, and contain between 3 to 15 lowercase characters made up of numbers, letters, and the symbols '.', '-' and '_'</p>
+                                <span className='help-block'>Username must begin with a letter, and contain between 3 to 15 lowercase characters made up of numbers, letters, and the symbols '.', '-' and '_'</span>
                             </div>
                         </div>
                         <div className='margin--extra'>

--- a/web/react/components/team_signup_password_page.jsx
+++ b/web/react/components/team_signup_password_page.jsx
@@ -110,7 +110,7 @@ export default class TeamSignupPasswordPage extends React.Component {
                                         placeholder=''
                                         maxLength='128'
                                     />
-                                    <div className='color--light form__hint'>Passwords must contain 5 to 50 characters. Your password will be strongest if it contains a mix of symbols, numbers, and upper and lowercase characters.</div>
+                                    <span className='color--light help-block'>Passwords must contain 5 to 50 characters. Your password will be strongest if it contains a mix of symbols, numbers, and upper and lowercase characters.</span>
                                 </div>
                             </div>
                             {passwordError}

--- a/web/react/components/team_signup_username_page.jsx
+++ b/web/react/components/team_signup_username_page.jsx
@@ -69,7 +69,7 @@ export default class TeamSignupUsernamePage extends React.Component {
                                         defaultValue={this.props.state.user.username}
                                         maxLength='128'
                                     />
-                                    <div className='color--light form__hint'>Usernames must begin with a letter and contain 3 to 15 characters made up of lowercase letters, numbers, and the symbols '.', '-' and '_'</div>
+                                    <span className='color--light help-block'>Usernames must begin with a letter and contain 3 to 15 characters made up of lowercase letters, numbers, and the symbols '.', '-' and '_'</span>
                                 </div>
                             </div>
                             {nameError}

--- a/web/sass-files/sass/partials/_forms.scss
+++ b/web/sass-files/sass/partials/_forms.scss
@@ -37,3 +37,8 @@
 		}
 	}
 }
+
+.help-block {
+	font-size: 0.95em;
+	color: #999;
+}

--- a/web/sass-files/sass/partials/_signup.scss
+++ b/web/sass-files/sass/partials/_signup.scss
@@ -96,12 +96,6 @@
         margin-bottom: 0.8em;
     }
 
-    .form__hint {
-        font-size: 0.95em;
-        color: #999;
-        margin: 10px 0 0;
-    }
-
     .signup-team-confirm__container {
         padding: 100px 0px 100px 0px;
     }


### PR DESCRIPTION
Use help-block class provided by Bootstrap instead of using a custom form__hint class.

We still override some styles from the Bootstrap class, though.

![screenshot from 2015-10-09 16-42-54](https://cloud.githubusercontent.com/assets/195210/10395306/dcd7ea20-6ea4-11e5-8b90-92cac9703539.png)
