### PR TITLE
Missed PR - Help text update to webhooks

### DIFF
--- a/web/react/components/user_settings/manage_incoming_hooks.jsx
+++ b/web/react/components/user_settings/manage_incoming_hooks.jsx
@@ -148,7 +148,7 @@ export default class ManageIncomingHooks extends React.Component {
 
         return (
             <div key='addIncomingHook'>
-                {'For developers building integrations this page lets you create webhook URLs for channels and private groups. Please see http://mattermost.org/webhooks to learn about creating webhooks, view samples, and to let the community know about integrations you have ve built. The URLs created below can be used by outside applications to create posts in any channels or private groups you have access to. The specified channel will be used as the default.'}
+                {'For developers building integrations this page lets you create webhook URLs for channels and private groups. Please see http://mattermost.org/webhooks to learn about creating webhooks, view samples, and to let the community know about integrations you have built. The URLs created below can be used by outside applications to create posts in any channels or private groups you have access to. The specified channel will be used as the default.'}
                 <br/>
                 <label className='control-label'>{'Add a new incoming webhook'}</label>
                 <div className='padding-top'>

--- a/web/react/components/user_settings/manage_incoming_hooks.jsx
+++ b/web/react/components/user_settings/manage_incoming_hooks.jsx
@@ -148,7 +148,7 @@ export default class ManageIncomingHooks extends React.Component {
 
         return (
             <div key='addIncomingHook'>
-                {'Create webhook URLs for channels and private groups. These URLs can be used by outside applications to create posts in any channels or private groups you have access to. The specified channel will be used as the default.'}
+                {'For developers building integrations this page lets you create webhook URLs for channels and private groups. Please see http://mattermost.org/webhooks to learn about creating webhooks, view samples, and to let the community know about integrations you have ve built. The URLs created below can be used by outside applications to create posts in any channels or private groups you have access to. The specified channel will be used as the default.'}
                 <br/>
                 <label className='control-label'>{'Add a new incoming webhook'}</label>
                 <div className='padding-top'>

--- a/web/react/components/user_settings/user_settings_integrations.jsx
+++ b/web/react/components/user_settings/user_settings_integrations.jsx
@@ -49,7 +49,7 @@ export default class UserSettingsIntegrationsTab extends React.Component {
             incomingHooksSection = (
                 <SettingItemMin
                     title='Incoming Webhooks'
-                    describe='Manage your incoming webhooks'
+                    describe='Manage your incoming webhooks (Developer feature)'
                     updateSection={function updateNameSection() {
                         this.updateSection('incoming-hooks');
                     }.bind(this)}


### PR DESCRIPTION
I think [JW had intended to get this in for RC1](https://github.com/mattermost/platform/pull/967) but ran out of time, so adding PR now. 

We'd agreed on the importance of this previously because webhooks is a developer feature and it's showing in the Account Settings menu looking like an end user feature--we need to make it obvious that this isn't for end users. 

@coreyhulen, please help review? 