### PR TITLE
Updating help text

### DIFF
--- a/web/react/components/get_link_modal.jsx
+++ b/web/react/components/get_link_modal.jsx
@@ -96,7 +96,6 @@ export default class GetLinkModal extends React.Component {
                                 <p>
                                 Send teammates the link below for them to sign-up to this team site.
                                 <br /><br />
-                                Be careful not to share this link publicly, since anyone with the link can join your team.
                                 </p>
                                 <textarea
                                     className='form-control no-resize'


### PR DESCRIPTION
Removing out-of-date text saying that anyone can join a team from invite link, since there are now options to restrict sign-up based on email domain and SSO options