### PR TITLE
PLT-590: Change "Manage Team" to "Manage Members"

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -33,7 +33,7 @@ Set up Mattermost in your data center
 _Note: End user help documentation is a new feature being completed for the v1.2 release. The materials below are work in progress._
 
 - User Interface
- - [Manage Team](help/Manage-Team.md)
+ - [Manage Members](help/Manage-Members.md)
  - Team Settings 
    - [Slack Import](help/Slack-Import.md)
 

--- a/doc/help/Manage-Members.md
+++ b/doc/help/Manage-Members.md
@@ -1,10 +1,10 @@
-# Manage Team 
+# Manage Members 
 
-The Manage Team menu is used to change the user roles assigned to members belonging to a team. 
+The Manage Members menu is used to change the user roles assigned to members belonging to a team. 
 
 ## User Roles 
 
-The following user roles are assigned from the **Manage Team** menu option in the team site main menu. 
+The following user roles are assigned from the **Manage Members** menu option in the team site main menu. 
 
 ### System Admin
 
@@ -23,7 +23,7 @@ The Team Administrator is typically a non-technical end user and has the followi
 
 - Access to the "Team Settings" menu from the team site main menu
 - Ability to change the team name and import data from Slack export files
-- Access to the "Manage Team" menu and change user roles to the levels of Team Administrator, Member and Inactive
+- Access to the "Manage Members" menu and change user roles to the levels of Team Administrator, Member and Inactive
 
 ### Member 
 

--- a/doc/help/README.md
+++ b/doc/help/README.md
@@ -8,5 +8,5 @@ _Note: Help documentation is a work-in-progress. Community contributions highly 
 
 You can access the **Team Site Main Menu** by clicking on the three vertical dots at the top of the left sidebar in a team site. Here we describe the various options available from the menu: 
 
-- [Manage Teams](Manage-Team.md)
+- [Manage Members](Manage-Members.md)
 

--- a/web/react/components/navbar_dropdown.jsx
+++ b/web/react/components/navbar_dropdown.jsx
@@ -111,7 +111,7 @@ export default class NavbarDropdown extends React.Component {
                         data-toggle='modal'
                         data-target='#team_members'
                     >
-                        {'Manage Team'}
+                        {'Manage Members'}
                     </a>
                 </li>
             );

--- a/web/react/components/sidebar_right_menu.jsx
+++ b/web/react/components/sidebar_right_menu.jsx
@@ -75,7 +75,7 @@ export default class SidebarRightMenu extends React.Component {
                         data-toggle='modal'
                         data-target='#team_members'
                     >
-                    <i className='glyphicon glyphicon-wrench'></i>Manage Team</a>
+                    <i className='glyphicon glyphicon-wrench'></i>Manage Members</a>
                 </li>
             );
         }


### PR DESCRIPTION
PLT-590: replace "Manage Team" with "Manage Members" in the user interface and docs