### PR TITLE
Updating SSO help on HTTP/HTTPS

### DIFF
--- a/doc/install/Configuration-Settings.md
+++ b/doc/install/Configuration-Settings.md
@@ -257,19 +257,19 @@ Settings to configure account and team creation using GitLab OAuth.
 “true”: Allow team creation and account signup using GitLab OAuth. To configure, input the **Secret** and **Id** credentials. 
 
 ```"Secret": ""```  
-Obtain this value by logging into your GitLab account. Go to Profile Settings -> Applications -> New Application, enter a Name, then enter Redirect URLs "<your-mattermost-url>/login/gitlab/complete" (example: http://localhost:8065/login/gitlab/complete) and "<your-mattermost-url>/signup/gitlab/complete".
+Obtain this value by logging into your GitLab account. Go to Profile Settings -> Applications -> New Application, enter a Name, then enter Redirect URLs "https://<your-mattermost-url>/login/gitlab/complete" (example: https://example.com:8065/login/gitlab/complete) and "https://<your-mattermost-url>/signup/gitlab/complete".
 
 ```"Id": ""```  
-Obtain this value by logging into your GitLab account. Go to Applications -> Profile Settings. Enter Redirect URLs "<your-mattermost-url>/login/gitlab/complete" (example: http://localhost:8065/login/gitlab/complete) and "<your-mattermost-url>/signup/gitlab/complete".
+Obtain this value by logging into your GitLab account. Go to Profile Settings -> Applications -> New Application, enter a Name, then enter Redirect URLs "https://<your-mattermost-url>/login/gitlab/complete" (example: https://example.com:8065/login/gitlab/complete) and "https://<your-mattermost-url>/signup/gitlab/complete".
 
 ```"AuthEndpoint": ""```  
-Enter <your-gitlab-url>/oauth/authorize (example: http://localhost:3000/oauth/authorize). Use HTTP or HTTPS in your URLs as appropriate.
+Enter https://<your-gitlab-url>/oauth/authorize (example: https://example.com:3000/oauth/authorize). Use HTTP or HTTPS depending on how your server is configured.
 
 ```"TokenEndpoint": ""```  
-Enter <your-gitlab-url>/oauth/token (example: http://localhost:3000/oauth/token). Use HTTP or HTTPS in your URLs as appropriate.
+Enter https://<your-gitlab-url>/oauth/authorize (example: https://example.com:3000/oauth/token). Use HTTP or HTTPS depending on how your server is configured.
 
 ```"UserApiEndpoint": ""```  
-Enter <your-gitlab-url>/api/v3/user (example: http://localhost:3000/api/v3/user). Use HTTP or HTTPS in your URLs as appropriate.
+Enter https://<your-gitlab-url>/oauth/authorize (example: https://example.com:3000/api/v3/user). Use HTTP or HTTPS depending on how your server is configured.
 
 ## Config.json Settings Not in System Console
 

--- a/doc/integrations/Single-Sign-On/Gitlab.md
+++ b/doc/integrations/Single-Sign-On/Gitlab.md
@@ -12,10 +12,12 @@ The following steps can be used to configure Mattermost to use GitLab as a singl
 3. Submit the application and copy the given _Id_ and _Secret_ into the appropriate _SSOSettings_ fields in config/config.json
 
 4. Also in config/config.json, set _Allow_ to `true` for the _gitlab_ section, leave _Scope_ blank and use the following for the endpoints:
-  * _AuthEndpoint_: `<your-gitlab-url>/oauth/authorize` (example http://localhost:3000/oauth/authorize)
-  * _TokenEndpoint_: `<your-gitlab-url>/oauth/token` 
-  * _UserApiEndpoint_: `<your-gitlab-url>/api/v3/user`
+  * _AuthEndpoint_: `https://<your-gitlab-url>/oauth/authorize` (example https://example.com/oauth/authorize)  
+  * _TokenEndpoint_: `https://<your-gitlab-url>/oauth/token`  
+  * _UserApiEndpoint_: `https://<your-gitlab-url>/api/v3/user`  
+  
+  Note: Make sure your `HTTPS` or `HTTP` prefix for endpoint URLs matches how your server configuration. 
 
-6. (Optional) If you would like to force all users to sign-up with GitLab only, in the _ServiceSettings_ section of config/config.json please set _DisableEmailSignUp_ to `true`.
+5. (Optional) If you would like to force all users to sign-up with GitLab only, in the _ServiceSettings_ section of config/config.json please set _DisableEmailSignUp_ to `true`.
 
-7. Restart your Mattermost server to see the changes take effect.
+6. Restart your Mattermost server to see the changes take effect.

--- a/web/react/components/admin_console/gitlab_settings.jsx
+++ b/web/react/components/admin_console/gitlab_settings.jsx
@@ -179,7 +179,7 @@ export default class GitLabSettings extends React.Component {
                                 onChange={this.handleChange}
                                 disabled={!this.state.Enable}
                             />
-                            <p className='help-text'>{'Enter <your-gitlab-url>/oauth/authorize (example http://localhost:3000/oauth/authorize).  Make sure you use HTTP or HTTPS in your URLs as appropriate.'}</p>
+                            <p className='help-text'>{'Enter https://<your-gitlab-url>/oauth/authorize (example https://example.com:3000/oauth/authorize).   Make sure you use HTTP or HTTPS in your URL depending on your server configuration.'}</p>
                         </div>
                     </div>
 
@@ -201,7 +201,7 @@ export default class GitLabSettings extends React.Component {
                                 onChange={this.handleChange}
                                 disabled={!this.state.Enable}
                             />
-                            <p className='help-text'>{'Enter <your-gitlab-url>/oauth/token.   Make sure you use HTTP or HTTPS in your URLs as appropriate.'}</p>
+                            <p className='help-text'>{'Enter https://<your-gitlab-url>/oauth/token.   Make sure you use HTTP or HTTPS in your URL depending on your server configuration.'}</p>
                         </div>
                     </div>
 
@@ -223,7 +223,7 @@ export default class GitLabSettings extends React.Component {
                                 onChange={this.handleChange}
                                 disabled={!this.state.Enable}
                             />
-                            <p className='help-text'>{'Enter <your-gitlab-url>/api/v3/user.  Make sure you use HTTP or HTTPS in your URLs as appropriate.'}</p>
+                            <p className='help-text'>{'Enter https://<your-gitlab-url>/api/v3/user.   Make sure you use HTTP or HTTPS in your URL depending on your server configuration.'}</p>
                         </div>
                     </div>
 


### PR DESCRIPTION
GitLab SSO config seems to repeatedly hit the same usability issue on HTTP vs HTTPS