### PR TITLE
Revert #987

### DIFF
--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -6,31 +6,7 @@ const Utils = require('./utils.jsx');
 
 const marked = require('marked');
 
-class MattermostInlineLexer extends marked.InlineLexer {
-    constructor(links, options) {
-        super(links, options);
-
-        // modified version of the regex that doesn't break up words in snake_case
-        // the original is /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/
-        this.rules.text = /^[\s\S]+?(?=__|\b_|[\\<!\[*`]| {2,}\n|$)/;
-    }
-}
-
-class MattermostParser extends marked.Parser {
-    parse(src) {
-        this.inline = new MattermostInlineLexer(src.links, this.options, this.renderer);
-        this.tokens = src.reverse();
-
-        var out = '';
-        while (this.next()) {
-            out += this.tok();
-        }
-
-        return out;
-    }
-}
-
-class MattermostMarkdownRenderer extends marked.Renderer {
+export class MattermostMarkdownRenderer extends marked.Renderer {
     constructor(options, formattingOptions = {}) {
         super(options);
 
@@ -92,15 +68,3 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         return TextFormatting.doFormatText(text, this.formattingOptions);
     }
 }
-
-export function format(text, options) {
-    const markdownOptions = {
-        renderer: new MattermostMarkdownRenderer(null, options),
-        sanitize: true
-    };
-
-    const tokens = marked.lexer(text, markdownOptions);
-
-    return new MattermostParser(markdownOptions).parse(tokens);
-}
-

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -8,6 +8,8 @@ const Markdown = require('./markdown.jsx');
 const UserStore = require('../stores/user_store.jsx');
 const Utils = require('./utils.jsx');
 
+const marked = require('marked');
+
 // Performs formatting of user posts including highlighting mentions and search terms and converting urls, hashtags, and
 // @mentions to links by taking a user's message and returning a string of formatted html. Also takes a number of options
 // as part of the second parameter:
@@ -20,8 +22,11 @@ export function formatText(text, options = {}) {
     let output;
 
     if (!('markdown' in options) || options.markdown) {
-        // the markdown renderer will call doFormatText as necessary
-        output = Markdown.format(text, options);
+        // the markdown renderer will call doFormatText as necessary so just call marked
+        output = marked(text, {
+            renderer: new Markdown.MattermostMarkdownRenderer(null, options),
+            sanitize: true
+        });
     } else {
         output = sanitizeHtml(text);
         output = doFormatText(output, options);


### PR DESCRIPTION
The regex that I changed is breaking url parsing for urls which contain underscores and is causing hashtags to be parsed as headers. Further investigation into how to fix PLT-521 is needed.