### PR TITLE
Use display name instead of name in team switcher menu

### DIFF
--- a/api/team.go
+++ b/api/team.go
@@ -409,14 +409,12 @@ func findTeams(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		teams := result.Data.([]*model.Team)
-
-		s := make([]string, 0, len(teams))
-
+		m := make(map[string]*model.Team)
 		for _, v := range teams {
-			s = append(s, v.Name)
+			m[v.Id] = v
 		}
 
-		w.Write([]byte(model.ArrayToJson(s)))
+		w.Write([]byte(model.TeamMapToJson(m)))
 	}
 }
 

--- a/api/team.go
+++ b/api/team.go
@@ -52,7 +52,7 @@ func signupTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !isTreamCreationAllowed(c, email) {
+	if !isTeamCreationAllowed(c, email) {
 		return
 	}
 
@@ -100,7 +100,7 @@ func createTeamFromSSO(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !isTreamCreationAllowed(c, team.Email) {
+	if !isTeamCreationAllowed(c, team.Email) {
 		return
 	}
 
@@ -169,7 +169,7 @@ func createTeamFromSignup(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !isTreamCreationAllowed(c, teamSignup.Team.Email) {
+	if !isTeamCreationAllowed(c, teamSignup.Team.Email) {
 		return
 	}
 
@@ -257,7 +257,7 @@ func CreateTeam(c *Context, team *model.Team) *model.Team {
 		return nil
 	}
 
-	if !isTreamCreationAllowed(c, team.Email) {
+	if !isTeamCreationAllowed(c, team.Email) {
 		return nil
 	}
 
@@ -276,12 +276,12 @@ func CreateTeam(c *Context, team *model.Team) *model.Team {
 	}
 }
 
-func isTreamCreationAllowed(c *Context, email string) bool {
+func isTeamCreationAllowed(c *Context, email string) bool {
 
 	email = strings.ToLower(email)
 
 	if !utils.Cfg.TeamSettings.EnableTeamCreation {
-		c.Err = model.NewAppError("isTreamCreationAllowed", "Team creation has been disabled. Please ask your systems administrator for details.", "")
+		c.Err = model.NewAppError("isTeamCreationAllowed", "Team creation has been disabled. Please ask your systems administrator for details.", "")
 		return false
 	}
 
@@ -298,7 +298,7 @@ func isTreamCreationAllowed(c *Context, email string) bool {
 	}
 
 	if len(utils.Cfg.TeamSettings.RestrictCreationToDomains) > 0 && !matched {
-		c.Err = model.NewAppError("isTreamCreationAllowed", "Email must be from a specific domain (e.g. @example.com). Please ask your systems administrator for details.", "")
+		c.Err = model.NewAppError("isTeamCreationAllowed", "Email must be from a specific domain (e.g. @example.com). Please ask your systems administrator for details.", "")
 		return false
 	}
 

--- a/api/team.go
+++ b/api/team.go
@@ -411,6 +411,7 @@ func findTeams(c *Context, w http.ResponseWriter, r *http.Request) {
 		teams := result.Data.([]*model.Team)
 		m := make(map[string]*model.Team)
 		for _, v := range teams {
+			v.Sanitize()
 			m[v.Id] = v
 		}
 

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -121,9 +121,12 @@ func TestFindTeamByEmail(t *testing.T) {
 	if r1, err := Client.FindTeams(user.Email); err != nil {
 		t.Fatal(err)
 	} else {
-		domains := r1.Data.([]string)
-		if domains[0] != team.Name {
-			t.Fatal(domains)
+		teams := r1.Data.(map[string]*model.Team)
+		if teams[team.Id].Name != team.Name {
+			t.Fatal()
+		}
+		if teams[team.Id].DisplayName != team.DisplayName {
+			t.Fatal()
 		}
 	}
 

--- a/model/client.go
+++ b/model/client.go
@@ -185,7 +185,7 @@ func (c *Client) FindTeams(email string) (*Result, *AppError) {
 	} else {
 
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),
-			r.Header.Get(HEADER_ETAG_SERVER), ArrayFromJson(r.Body)}, nil
+			r.Header.Get(HEADER_ETAG_SERVER), TeamMapFromJson(r.Body)}, nil
 	}
 }
 

--- a/model/team.go
+++ b/model/team.go
@@ -219,3 +219,9 @@ func CleanTeamName(s string) string {
 
 func (o *Team) PreExport() {
 }
+
+func (o *Team) Sanitize() {
+	o.Email = ""
+	o.Type = ""
+	o.AllowedDomains = ""
+}

--- a/web/react/components/navbar_dropdown.jsx
+++ b/web/react/components/navbar_dropdown.jsx
@@ -11,7 +11,25 @@ var AboutBuildModal = require('./about_build_modal.jsx');
 var Constants = require('../utils/constants.jsx');
 
 function getStateFromStores() {
-    return {teams: UserStore.getTeams()};
+    let teams = [];
+    let teamsObject = UserStore.getTeams();
+    for (let teamId in teamsObject) {
+        if (teamsObject.hasOwnProperty(teamId)) {
+            teams.push(teamsObject[teamId])
+        }
+    }
+    teams.sort(function (teamA, teamB) {
+        let teamADisplayName = teamA.display_name.toLowerCase();
+        let teamBDisplayName = teamB.display_name.toLowerCase();
+        if (teamADisplayName < teamBDisplayName) {
+            return -1
+        } else if (teamADisplayName > teamBDisplayName) {
+            return 1;
+        } else {
+            return 0;
+        }
+    });
+    return {teams};
 }
 
 export default class NavbarDropdown extends React.Component {

--- a/web/react/components/navbar_dropdown.jsx
+++ b/web/react/components/navbar_dropdown.jsx
@@ -163,7 +163,7 @@ export default class NavbarDropdown extends React.Component {
 
         var teams = [];
 
-        if (Object.keys(this.state.teams).length > 1) {
+        if (this.state.teams.length > 1) {
             teams.push(
                 <li
                     className='divider'
@@ -172,14 +172,11 @@ export default class NavbarDropdown extends React.Component {
                 </li>
             );
 
-            for (let teamId in this.state.teams) {
-                if (this.state.teams.hasOwnProperty(teamId)) {
-                    let team = this.state.teams[teamId];
-                    if (team.name !== this.props.teamName) {
-                        teams.push(<li key={team.name}><a href={Utils.getWindowLocationOrigin() + '/' + team.name}>{'Switch to ' + team.display_name}</a></li>);
-                    }
+            this.state.teams.forEach((team) => {
+                if (team.name !== this.props.teamName) {
+                    teams.push(<li key={team.name}><a href={Utils.getWindowLocationOrigin() + '/' + team.name}>{'Switch to ' + team.display_name}</a></li>);
                 }
-            }
+            });
         }
 
         if (global.window.config.EnableTeamCreation === 'true') {

--- a/web/react/components/navbar_dropdown.jsx
+++ b/web/react/components/navbar_dropdown.jsx
@@ -15,19 +15,18 @@ function getStateFromStores() {
     let teamsObject = UserStore.getTeams();
     for (let teamId in teamsObject) {
         if (teamsObject.hasOwnProperty(teamId)) {
-            teams.push(teamsObject[teamId])
+            teams.push(teamsObject[teamId]);
         }
     }
-    teams.sort(function (teamA, teamB) {
+    teams.sort(function sortByDisplayName(teamA, teamB) {
         let teamADisplayName = teamA.display_name.toLowerCase();
         let teamBDisplayName = teamB.display_name.toLowerCase();
         if (teamADisplayName < teamBDisplayName) {
-            return -1
+            return -1;
         } else if (teamADisplayName > teamBDisplayName) {
             return 1;
-        } else {
-            return 0;
         }
+        return 0;
     });
     return {teams};
 }

--- a/web/react/components/navbar_dropdown.jsx
+++ b/web/react/components/navbar_dropdown.jsx
@@ -145,7 +145,7 @@ export default class NavbarDropdown extends React.Component {
 
         var teams = [];
 
-        if (this.state.teams.length > 1) {
+        if (Object.keys(this.state.teams).length > 1) {
             teams.push(
                 <li
                     className='divider'
@@ -154,11 +154,14 @@ export default class NavbarDropdown extends React.Component {
                 </li>
             );
 
-            this.state.teams.forEach((teamName) => {
-                if (teamName !== this.props.teamName) {
-                    teams.push(<li key={teamName}><a href={Utils.getWindowLocationOrigin() + '/' + teamName}>{'Switch to ' + teamName}</a></li>);
+            for (let teamId in this.state.teams) {
+                if (this.state.teams.hasOwnProperty(teamId)) {
+                    let team = this.state.teams[teamId];
+                    if (team.name !== this.props.teamName) {
+                        teams.push(<li key={team.name}><a href={Utils.getWindowLocationOrigin() + '/' + team.name}>{'Switch to ' + team.display_name}</a></li>);
+                    }
                 }
-            });
+            }
         }
 
         if (global.window.config.EnableTeamCreation === 'true') {


### PR DESCRIPTION
To me it didn't make sense to show the `name` when we can use the more human-readable `display_name` 

- Use team display name in team switcher menu
  - /teams/find_teams returns team objects instead of just team names
  - use display_name in UI instead of name in the team switch menu

- Fix typo (isTreamCreationAllowed -> isTeamCreationAllowed)