### PR TITLE
Don't auto-add http:// to mailto: and ftp: markdown links

### DIFF
--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -32,7 +32,7 @@ export class MattermostMarkdownRenderer extends marked.Renderer {
     link(href, title, text) {
         let outHref = href;
 
-        if (outHref.lastIndexOf('http', 0) !== 0) {
+        if (!(/^(mailto|https?|ftp)/.test(outHref))) {
             outHref = `http://${outHref}`;
         }
 

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -89,7 +89,7 @@ function autolinkUrls(text, tokens) {
 
         if (match.getType() === 'email') {
             url = `mailto:${url}`;
-        } else if (url.lastIndexOf('http', 0) !== 0) {
+        } else if (!(/^(mailto|https?|ftp)/.test(url))) {
             url = `http://${url}`;
         }
 


### PR DESCRIPTION
Markdown parsing of links has a bug where mailto addresses will automatically prefixed with a http://

Reproduce:
Enter ````[email me](mailto:someone@somemail.com)```` into chat box
Expected:
````<a class="theme markdown__link" href="mailto:someone@somemail.com" target="_blank">email me</a>````
Actual:
````<a class="theme markdown__link" href="http://mailto:someone@somemail.com" target="_blank">email me</a>````

This MR fixes said behavior.
Additionally, links entered with ftp:// will also no longer be prefixed with http://