### PR TITLE
PLT-701 Removed preference migration code

### DIFF
--- a/api/preference.go
+++ b/api/preference.go
@@ -52,58 +52,7 @@ func getPreferenceCategory(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		data := result.Data.(model.Preferences)
 
-		data = transformPreferences(c, data, category)
-
 		w.Write([]byte(data.ToJson()))
-	}
-}
-
-func transformPreferences(c *Context, preferences model.Preferences, category string) model.Preferences {
-	if len(preferences) == 0 && category == model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW {
-		// add direct channels for a user that existed before preferences were added
-		preferences = addDirectChannels(c.Session.UserId, c.Session.TeamId)
-	}
-
-	return preferences
-}
-
-func addDirectChannels(userId, teamId string) model.Preferences {
-	var profiles map[string]*model.User
-	if result := <-Srv.Store.User().GetProfiles(teamId); result.Err != nil {
-		l4g.Error("Failed to add direct channel preferences for user user_id=%s, team_id=%s, err=%v", userId, teamId, result.Err.Error())
-		return model.Preferences{}
-	} else {
-		profiles = result.Data.(map[string]*model.User)
-	}
-
-	var preferences model.Preferences
-
-	for id := range profiles {
-		if id == userId {
-			continue
-		}
-
-		profile := profiles[id]
-
-		preference := model.Preference{
-			UserId:   userId,
-			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW,
-			Name:     profile.Id,
-			Value:    "true",
-		}
-
-		preferences = append(preferences, preference)
-
-		if len(preferences) >= 10 {
-			break
-		}
-	}
-
-	if result := <-Srv.Store.Preference().Save(&preferences); result.Err != nil {
-		l4g.Error("Failed to add direct channel preferences for user user_id=%s, eam_id=%s, err=%v", userId, teamId, result.Err.Error())
-		return model.Preferences{}
-	} else {
-		return preferences
 	}
 }
 

--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -113,54 +113,6 @@ func TestGetPreferenceCategory(t *testing.T) {
 	}
 }
 
-func TestTransformPreferences(t *testing.T) {
-	Setup()
-
-	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
-	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
-
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
-	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
-
-	for i := 0; i < 5; i++ {
-		user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-		Client.Must(Client.CreateUser(user, ""))
-	}
-
-	Client.Must(Client.LoginByEmail(team.Name, user1.Email, "pwd"))
-
-	if result, err := Client.GetPreferenceCategory(model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW); err != nil {
-		t.Fatal(err)
-	} else if data := result.Data.(model.Preferences); len(data) != 5 {
-		t.Fatal("received the wrong number of direct channels")
-	}
-
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
-	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
-
-	for i := 0; i < 10; i++ {
-		user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-		Client.Must(Client.CreateUser(user, ""))
-	}
-
-	// make sure user1's preferences don't change
-	if result, err := Client.GetPreferenceCategory(model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW); err != nil {
-		t.Fatal(err)
-	} else if data := result.Data.(model.Preferences); len(data) != 5 {
-		t.Fatal("received the wrong number of direct channels")
-	}
-
-	Client.Must(Client.LoginByEmail(team.Name, user2.Email, "pwd"))
-
-	if result, err := Client.GetPreferenceCategory(model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW); err != nil {
-		t.Fatal(err)
-	} else if data := result.Data.(model.Preferences); len(data) != 10 {
-		t.Fatal("received the wrong number of direct channels")
-	}
-}
-
 func TestGetPreference(t *testing.T) {
 	Setup()
 


### PR DESCRIPTION
This was making some of the preference APIs messy and after talking to the PMs, we decided that it was unnecessary. This means that users coming from 1.1 to 1.2 will have an empty direct message list, but any new users will still have users in their sidebar.