### PR TITLE
Added an initial call to get all user preferences on page load

### DIFF
--- a/api/preference.go
+++ b/api/preference.go
@@ -14,9 +14,20 @@ func InitPreference(r *mux.Router) {
 	l4g.Debug("Initializing preference api routes")
 
 	sr := r.PathPrefix("/preferences").Subrouter()
+	sr.Handle("/", ApiUserRequired(getAllPreferences)).Methods("GET")
 	sr.Handle("/save", ApiUserRequired(savePreferences)).Methods("POST")
 	sr.Handle("/{category:[A-Za-z0-9_]+}", ApiUserRequired(getPreferenceCategory)).Methods("GET")
 	sr.Handle("/{category:[A-Za-z0-9_]+}/{name:[A-Za-z0-9_]+}", ApiUserRequired(getPreference)).Methods("GET")
+}
+
+func getAllPreferences(c *Context, w http.ResponseWriter, r *http.Request) {
+	if result := <-Srv.Store.Preference().GetAll(c.Session.UserId); result.Err != nil {
+		c.Err = result.Err
+	} else {
+		data := result.Data.(model.Preferences)
+
+		w.Write([]byte(data.ToJson()))
+	}
 }
 
 func savePreferences(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api/preference.go
+++ b/api/preference.go
@@ -52,58 +52,7 @@ func getPreferenceCategory(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		data := result.Data.(model.Preferences)
 
-		data = transformPreferences(c, data, category)
-
 		w.Write([]byte(data.ToJson()))
-	}
-}
-
-func transformPreferences(c *Context, preferences model.Preferences, category string) model.Preferences {
-	if len(preferences) == 0 && category == model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW {
-		// add direct channels for a user that existed before preferences were added
-		preferences = addDirectChannels(c.Session.UserId, c.Session.TeamId)
-	}
-
-	return preferences
-}
-
-func addDirectChannels(userId, teamId string) model.Preferences {
-	var profiles map[string]*model.User
-	if result := <-Srv.Store.User().GetProfiles(teamId); result.Err != nil {
-		l4g.Error("Failed to add direct channel preferences for user user_id=%s, team_id=%s, err=%v", userId, teamId, result.Err.Error())
-		return model.Preferences{}
-	} else {
-		profiles = result.Data.(map[string]*model.User)
-	}
-
-	var preferences model.Preferences
-
-	for id := range profiles {
-		if id == userId {
-			continue
-		}
-
-		profile := profiles[id]
-
-		preference := model.Preference{
-			UserId:   userId,
-			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW,
-			Name:     profile.Id,
-			Value:    "true",
-		}
-
-		preferences = append(preferences, preference)
-
-		if len(preferences) >= 10 {
-			break
-		}
-	}
-
-	if result := <-Srv.Store.Preference().Save(&preferences); result.Err != nil {
-		l4g.Error("Failed to add direct channel preferences for user user_id=%s, eam_id=%s, err=%v", userId, teamId, result.Err.Error())
-		return model.Preferences{}
-	} else {
-		return preferences
 	}
 }
 

--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -113,54 +113,6 @@ func TestGetPreferenceCategory(t *testing.T) {
 	}
 }
 
-func TestTransformPreferences(t *testing.T) {
-	Setup()
-
-	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
-	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
-
-	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
-	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
-
-	for i := 0; i < 5; i++ {
-		user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-		Client.Must(Client.CreateUser(user, ""))
-	}
-
-	Client.Must(Client.LoginByEmail(team.Name, user1.Email, "pwd"))
-
-	if result, err := Client.GetPreferenceCategory(model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW); err != nil {
-		t.Fatal(err)
-	} else if data := result.Data.(model.Preferences); len(data) != 5 {
-		t.Fatal("received the wrong number of direct channels")
-	}
-
-	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
-	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
-
-	for i := 0; i < 10; i++ {
-		user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
-		Client.Must(Client.CreateUser(user, ""))
-	}
-
-	// make sure user1's preferences don't change
-	if result, err := Client.GetPreferenceCategory(model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW); err != nil {
-		t.Fatal(err)
-	} else if data := result.Data.(model.Preferences); len(data) != 5 {
-		t.Fatal("received the wrong number of direct channels")
-	}
-
-	Client.Must(Client.LoginByEmail(team.Name, user2.Email, "pwd"))
-
-	if result, err := Client.GetPreferenceCategory(model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW); err != nil {
-		t.Fatal(err)
-	} else if data := result.Data.(model.Preferences); len(data) != 10 {
-		t.Fatal("received the wrong number of direct channels")
-	}
-}
-
 func TestGetPreference(t *testing.T) {
 	Setup()
 

--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -9,6 +9,64 @@ import (
 	"testing"
 )
 
+func TestGetAllPreferences(t *testing.T) {
+	Setup()
+
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
+
+	user1 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
+
+	user2 := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
+
+	category := model.NewId()
+
+	preferences1 := model.Preferences{
+		{
+			UserId:   user1.Id,
+			Category: category,
+			Name:     model.NewId(),
+		},
+		{
+			UserId:   user1.Id,
+			Category: category,
+			Name:     model.NewId(),
+		},
+		{
+			UserId:   user1.Id,
+			Category: model.NewId(),
+			Name:     model.NewId(),
+		},
+	}
+
+	Client.LoginByEmail(team.Name, user1.Email, "pwd")
+	Client.Must(Client.SetPreferences(&preferences1))
+
+	if result, err := Client.GetAllPreferences(); err != nil {
+		t.Fatal(err)
+	} else if data := result.Data.(model.Preferences); len(data) != 3 {
+		t.Fatal("received the wrong number of preferences")
+	} else if !((data[0] == preferences1[0] && data[1] == preferences1[1]) || (data[0] == preferences1[1] && data[1] == preferences1[0])) {
+		for i := 0; i < 3; i++ {
+			if data[0] != preferences1[i] && data[1] != preferences1[i] && data[2] != preferences1[i] {
+				t.Fatal("got incorrect preferences")
+			}
+		}
+	}
+
+	Client.LoginByEmail(team.Name, user2.Email, "pwd")
+
+	if result, err := Client.GetAllPreferences(); err != nil {
+		t.Fatal(err)
+	} else if data := result.Data.(model.Preferences); len(data) != 0 {
+		t.Fatal("received the wrong number of preferences")
+	}
+}
+
 func TestSetPreferences(t *testing.T) {
 	Setup()
 

--- a/model/client.go
+++ b/model/client.go
@@ -844,6 +844,15 @@ func (c *Client) ListIncomingWebhooks() (*Result, *AppError) {
 	}
 }
 
+func (c *Client) GetAllPreferences() (*Result, *AppError) {
+	if r, err := c.DoApiGet("/preferences/", "", ""); err != nil {
+		return nil, err
+	} else {
+		preferences, _ := PreferencesFromJson(r.Body)
+		return &Result{r.Header.Get(HEADER_REQUEST_ID), r.Header.Get(HEADER_ETAG_SERVER), preferences}, nil
+	}
+}
+
 func (c *Client) SetPreferences(preferences *Preferences) (*Result, *AppError) {
 	if r, err := c.DoApiPost("/preferences/save", preferences.ToJson()); err != nil {
 		return nil, err

--- a/store/sql_preference_store.go
+++ b/store/sql_preference_store.go
@@ -212,3 +212,30 @@ func (s SqlPreferenceStore) GetCategory(userId string, category string) StoreCha
 
 	return storeChannel
 }
+
+func (s SqlPreferenceStore) GetAll(userId string) StoreChannel {
+	storeChannel := make(StoreChannel)
+
+	go func() {
+		result := StoreResult{}
+
+		var preferences model.Preferences
+
+		if _, err := s.GetReplica().Select(&preferences,
+			`SELECT
+				*
+			FROM
+				Preferences
+			WHERE
+				UserId = :UserId`, map[string]interface{}{"UserId": userId}); err != nil {
+			result.Err = model.NewAppError("SqlPreferenceStore.GetAll", "We encounted an error while finding preferences", err.Error())
+		} else {
+			result.Data = preferences
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}

--- a/store/sql_preference_store_test.go
+++ b/store/sql_preference_store_test.go
@@ -144,3 +144,51 @@ func TestPreferenceGetCategory(t *testing.T) {
 		t.Fatal("shouldn't have got any preferences")
 	}
 }
+
+func TestPreferenceGetAll(t *testing.T) {
+	Setup()
+
+	userId := model.NewId()
+	category := model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW
+	name := model.NewId()
+
+	preferences := model.Preferences{
+		{
+			UserId:   userId,
+			Category: category,
+			Name:     name,
+		},
+		// same user/category, different name
+		{
+			UserId:   userId,
+			Category: category,
+			Name:     model.NewId(),
+		},
+		// same user/name, different category
+		{
+			UserId:   userId,
+			Category: model.NewId(),
+			Name:     name,
+		},
+		// same name/category, different user
+		{
+			UserId:   model.NewId(),
+			Category: category,
+			Name:     name,
+		},
+	}
+
+	Must(store.Preference().Save(&preferences))
+
+	if result := <-store.Preference().GetAll(userId); result.Err != nil {
+		t.Fatal(result.Err)
+	} else if data := result.Data.(model.Preferences); len(data) != 3 {
+		t.Fatal("got the wrong number of preferences")
+	} else {
+		for i := 0; i < 3; i++ {
+			if data[0] != preferences[i] && data[1] != preferences[i] && data[2] != preferences[i] {
+				t.Fatal("got incorrect preferences")
+			}
+		}
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -156,4 +156,5 @@ type PreferenceStore interface {
 	Save(preferences *model.Preferences) StoreChannel
 	Get(userId string, category string, name string) StoreChannel
 	GetCategory(userId string, category string) StoreChannel
+	GetAll(userId string) StoreChannel
 }

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -132,11 +132,7 @@ export default class Sidebar extends React.Component {
         SocketStore.addChangeListener(this.onSocketChange);
         PreferenceStore.addChangeListener(this.onChange);
 
-        AsyncClient.getDirectChannelPreferences();
-
-        if ($(window).width() > 768) {
-            $('.nav-pills__container').perfectScrollbar();
-        }
+        $('.nav-pills__container').perfectScrollbar();
 
         this.updateTitle();
         this.updateUnreadIndicators();

--- a/web/react/pages/channel.jsx
+++ b/web/react/pages/channel.jsx
@@ -37,6 +37,7 @@ var RegisterAppModal = require('../components/register_app_modal.jsx');
 var ImportThemeModal = require('../components/user_settings/import_theme_modal.jsx');
 var TeamStore = require('../stores/team_store.jsx');
 
+var AsyncClient = require('../utils/async_client.jsx');
 var Constants = require('../utils/constants.jsx');
 var ActionTypes = Constants.ActionTypes;
 
@@ -53,6 +54,8 @@ function setupChannelPage(props) {
         type: ActionTypes.CLICK_TEAM,
         id: props.TeamId
     });
+
+    AsyncClient.getAllPreferences();
 
     // ChannelLoader must be rendered first
     React.render(

--- a/web/react/stores/preference_store.jsx
+++ b/web/react/stores/preference_store.jsx
@@ -120,3 +120,4 @@ class PreferenceStoreClass extends EventEmitter {
 
 const PreferenceStore = new PreferenceStoreClass();
 export default PreferenceStore;
+window.PreferenceStore = PreferenceStore;

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -638,16 +638,15 @@ export function getMyTeam() {
     );
 }
 
-export function getDirectChannelPreferences() {
-    if (isCallInProgress('getDirectChannelPreferences')) {
+export function getAllPreferences() {
+    if (isCallInProgress('getAllPreferences')) {
         return;
     }
 
-    callTracker.getDirectChannelPreferences = utils.getTimestamp();
-    client.getPreferenceCategory(
-        Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
+    callTracker.getAllPreferences = utils.getTimestamp();
+    client.getAllPreferences(
         (data, textStatus, xhr) => {
-            callTracker.getDirectChannelPreferences = 0;
+            callTracker.getAllPreferences = 0;
 
             if (xhr.status === 304 || !data) {
                 return;
@@ -659,8 +658,8 @@ export function getDirectChannelPreferences() {
             });
         },
         (err) => {
-            callTracker.getDirectChannelPreferences = 0;
-            dispatchError(err, 'getDirectChannelPreferences');
+            callTracker.getAllPreferences = 0;
+            dispatchError(err, 'getAllPreferences');
         }
     );
 }

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -1142,6 +1142,19 @@ export function listIncomingHooks(success, error) {
     });
 }
 
+export function getAllPreferences(success, error) {
+    $.ajax({
+        url: `/api/v1/preferences/`,
+        dataType: 'json',
+        type: 'GET',
+        success,
+        error: (xhr, status, err) => {
+            var e = handleError('getAllPreferences', xhr, status, err);
+            error(e);
+        }
+    });
+}
+
 export function getPreferenceCategory(category, success, error) {
     $.ajax({
         url: `/api/v1/preferences/${category}`,


### PR DESCRIPTION
This is so that we don't need components to have to worry about loading their related preferences when they should be safe to just assume they exist.

Note that this is based off of #1078 so that needs to go in first. The actual changes made for this PR in particular are in https://github.com/mattermost/platform/commit/327b0b5a2119ae888c812f682b3934061b8f59bf