### PR TITLE
Updated Email Check Regex to handle some extra cases

### DIFF
--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -13,7 +13,8 @@ var client = require('./client.jsx');
 var Autolinker = require('autolinker');
 
 export function isEmail(email) {
-    var regex = /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
+    //var regex = /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
+    var regex = /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i;
     return regex.test(email);
 }
 


### PR DESCRIPTION
New Committer here so sorry if I am not fully following the process.

Saw this open issue on Jira:
https://mattermost.atlassian.net/browse/PLT-168

I believe the above handles this case, but there are really no comments as to what is an "invalid email hitting server side" is. I noticed the regex was still hitting the server side with weird emails such as:
.fake@fake.com
fake.@fake.com

I ran it through a cycle of fake emails from this article:
http://blogs.msdn.com/b/testing123/archive/2009/02/05/email-address-test-cases.aspx