### PR TITLE
Add z-index to command-box so that elements behind it do not show through

### DIFF
--- a/web/sass-files/sass/partials/_command-box.scss
+++ b/web/sass-files/sass/partials/_command-box.scss
@@ -5,6 +5,7 @@
     border: $border-gray;
     bottom: 38px;
     overflow: auto;
+    z-index: 100
     @extend %popover-box-shadow;
     .sidebar--right & {
         bottom: 100px;

--- a/web/sass-files/sass/partials/_command-box.scss
+++ b/web/sass-files/sass/partials/_command-box.scss
@@ -5,7 +5,7 @@
     border: $border-gray;
     bottom: 38px;
     overflow: auto;
-    z-index: 100
+    z-index: 100;
     @extend %popover-box-shadow;
     .sidebar--right & {
         bottom: 100px;


### PR DESCRIPTION
Without this z-index you can see some background elements behind the command autocomplete popup.

Example from gitlab.mattermost.com:
![screen shot 2015-10-16 at 12 56 20 pm](https://cloud.githubusercontent.com/assets/195789/10549326/0bcbd7ae-7406-11e5-820a-3ec7fd93eb1a.png)

After applying this fix:
![screen shot 2015-10-16 at 1 02 06 pm](https://cloud.githubusercontent.com/assets/195789/10549346/2a4243e4-7406-11e5-9ff6-4f35a861d67b.png)
