### PR TITLE
PLT-661 Changed all goroutine functions to use '...AndForget' as the naming convention

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -146,12 +146,12 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		resStruct.ClientIds = append(resStruct.ClientIds, clientId)
 	}
 
-	fireAndForgetHandleImages(imageNameList, imageDataList, c.Session.TeamId, channelId, c.Session.UserId)
+	handleImagesAndForget(imageNameList, imageDataList, c.Session.TeamId, channelId, c.Session.UserId)
 
 	w.Write([]byte(resStruct.ToJson()))
 }
 
-func fireAndForgetHandleImages(filenames []string, fileData [][]byte, teamId, channelId, userId string) {
+func handleImagesAndForget(filenames []string, fileData [][]byte, teamId, channelId, userId string) {
 
 	go func() {
 		dest := "teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/"
@@ -311,7 +311,7 @@ func getFileInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 
 		fileData := make(chan []byte)
-		asyncGetFile(path, fileData)
+		getFileAndForget(path, fileData)
 
 		f := <-fileData
 
@@ -378,7 +378,7 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	fileData := make(chan []byte)
-	asyncGetFile(path, fileData)
+	getFileAndForget(path, fileData)
 
 	if len(hash) > 0 && len(data) > 0 && len(teamId) == 26 {
 		if !model.ComparePassword(hash, fmt.Sprintf("%v:%v", data, utils.Cfg.FileSettings.PublicLinkSalt)) {
@@ -423,7 +423,7 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Write(f)
 }
 
-func asyncGetFile(path string, fileData chan []byte) {
+func getFileAndForget(path string, fileData chan []byte) {
 	go func() {
 		data, getErr := readFile(path)
 		if getErr != nil {

--- a/api/post.go
+++ b/api/post.go
@@ -201,7 +201,7 @@ func handlePostEventsAndForget(c *Context, post *model.Post, triggerWebhooks boo
 			channel = result.Data.(*model.Channel)
 		}
 
-		fireAndForgetNotifications(c, post, team, channel)
+		sendNotificationsAndForget(c, post, team, channel)
 
 		var user *model.User
 		if result := <-uchan; result.Err != nil {
@@ -299,7 +299,7 @@ func handleWebhookEventsAndForget(c *Context, post *model.Post, team *model.Team
 
 }
 
-func fireAndForgetNotifications(c *Context, post *model.Post, team *model.Team, channel *model.Channel) {
+func sendNotificationsAndForget(c *Context, post *model.Post, team *model.Team, channel *model.Channel) {
 
 	go func() {
 		// Get a list of user names (to be used as keywords) and ids for the given team
@@ -434,7 +434,7 @@ func fireAndForgetNotifications(c *Context, post *model.Post, team *model.Team, 
 				}
 
 				for id := range toEmailMap {
-					fireAndForgetMentionUpdate(post.ChannelId, id)
+					updateMentionCountAndForget(post.ChannelId, id)
 				}
 			}
 
@@ -530,7 +530,7 @@ func fireAndForgetNotifications(c *Context, post *model.Post, team *model.Team, 
 
 									alreadySeen[session.DeviceId] = session.DeviceId
 
-									utils.FireAndForgetSendAppleNotify(session.DeviceId, subjectPage.Render(), 1)
+									utils.SendAppleNotifyAndForget(session.DeviceId, subjectPage.Render(), 1)
 								}
 							}
 						}
@@ -562,7 +562,7 @@ func fireAndForgetNotifications(c *Context, post *model.Post, team *model.Team, 
 	}()
 }
 
-func fireAndForgetMentionUpdate(channelId, userId string) {
+func updateMentionCountAndForget(channelId, userId string) {
 	go func() {
 		if result := <-Srv.Store.Channel().IncrementMentionCount(channelId, userId); result.Err != nil {
 			l4g.Error("Failed to update mention count for user_id=%v on channel_id=%v err=%v", userId, channelId, result.Err)

--- a/api/user.go
+++ b/api/user.go
@@ -198,7 +198,7 @@ func CreateUser(c *Context, team *model.Team, user *model.User) *model.User {
 			l4g.Error("Encountered an issue joining default channels user_id=%s, team_id=%s, err=%v", ruser.Id, ruser.TeamId, err)
 		}
 
-		fireAndForgetWelcomeEmail(ruser.Id, ruser.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team), user.EmailVerified)
+		sendWelcomeEmailAndForget(ruser.Id, ruser.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team), user.EmailVerified)
 
 		addDirectChannelsAndForget(ruser)
 
@@ -219,7 +219,7 @@ func CreateUser(c *Context, team *model.Team, user *model.User) *model.User {
 	}
 }
 
-func fireAndForgetWelcomeEmail(userId, email, teamName, teamDisplayName, siteURL, teamURL string, verified bool) {
+func sendWelcomeEmailAndForget(userId, email, teamName, teamDisplayName, siteURL, teamURL string, verified bool) {
 	go func() {
 
 		subjectPage := NewServerTemplatePage("welcome_subject")
@@ -278,7 +278,7 @@ func addDirectChannelsAndForget(user *model.User) {
 	}()
 }
 
-func FireAndForgetVerifyEmail(userId, userEmail, teamName, teamDisplayName, siteURL, teamURL string) {
+func SendVerifyEmailAndForget(userId, userEmail, teamName, teamDisplayName, siteURL, teamURL string) {
 	go func() {
 
 		link := fmt.Sprintf("%s/verify_email?uid=%s&hid=%s&teamname=%s&email=%s", siteURL, userId, model.HashPassword(userId), teamName, userEmail)
@@ -931,10 +931,10 @@ func updateUser(c *Context, w http.ResponseWriter, r *http.Request) {
 				l4g.Error(tresult.Err.Message)
 			} else {
 				team := tresult.Data.(*model.Team)
-				fireAndForgetEmailChangeEmail(rusers[1].Email, rusers[0].Email, team.DisplayName, c.GetTeamURLFromTeam(team), c.GetSiteURL())
+				sendEmailChangeEmailAndForget(rusers[1].Email, rusers[0].Email, team.DisplayName, c.GetTeamURLFromTeam(team), c.GetSiteURL())
 
 				if utils.Cfg.EmailSettings.RequireEmailVerification {
-					FireAndForgetEmailChangeVerifyEmail(rusers[0].Id, rusers[0].Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
+					SendEmailChangeVerifyEmailAndForget(rusers[0].Id, rusers[0].Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
 				}
 			}
 		}
@@ -1014,7 +1014,7 @@ func updatePassword(c *Context, w http.ResponseWriter, r *http.Request) {
 			l4g.Error(tresult.Err.Message)
 		} else {
 			team := tresult.Data.(*model.Team)
-			fireAndForgetPasswordChangeEmail(user.Email, team.DisplayName, c.GetTeamURLFromTeam(team), c.GetSiteURL(), "using the settings menu")
+			sendPasswordChangeEmailAndForget(user.Email, team.DisplayName, c.GetTeamURLFromTeam(team), c.GetSiteURL(), "using the settings menu")
 		}
 
 		data := make(map[string]string)
@@ -1351,13 +1351,13 @@ func resetPassword(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.LogAuditWithUserId(userId, "success")
 	}
 
-	fireAndForgetPasswordChangeEmail(user.Email, team.DisplayName, c.GetTeamURLFromTeam(team), c.GetSiteURL(), "using a reset password link")
+	sendPasswordChangeEmailAndForget(user.Email, team.DisplayName, c.GetTeamURLFromTeam(team), c.GetSiteURL(), "using a reset password link")
 
 	props["new_password"] = ""
 	w.Write([]byte(model.MapToJson(props)))
 }
 
-func fireAndForgetPasswordChangeEmail(email, teamDisplayName, teamURL, siteURL, method string) {
+func sendPasswordChangeEmailAndForget(email, teamDisplayName, teamURL, siteURL, method string) {
 	go func() {
 
 		subjectPage := NewServerTemplatePage("password_change_subject")
@@ -1376,7 +1376,7 @@ func fireAndForgetPasswordChangeEmail(email, teamDisplayName, teamURL, siteURL, 
 	}()
 }
 
-func fireAndForgetEmailChangeEmail(oldEmail, newEmail, teamDisplayName, teamURL, siteURL string) {
+func sendEmailChangeEmailAndForget(oldEmail, newEmail, teamDisplayName, teamURL, siteURL string) {
 	go func() {
 
 		subjectPage := NewServerTemplatePage("email_change_subject")
@@ -1395,7 +1395,7 @@ func fireAndForgetEmailChangeEmail(oldEmail, newEmail, teamDisplayName, teamURL,
 	}()
 }
 
-func FireAndForgetEmailChangeVerifyEmail(userId, newUserEmail, teamName, teamDisplayName, siteURL, teamURL string) {
+func SendEmailChangeVerifyEmailAndForget(userId, newUserEmail, teamName, teamDisplayName, siteURL, teamURL string) {
 	go func() {
 
 		link := fmt.Sprintf("%s/verify_email?uid=%s&hid=%s&teamname=%s&email=%s", siteURL, userId, model.HashPassword(userId), teamName, newUserEmail)

--- a/mattermost.go
+++ b/mattermost.go
@@ -66,7 +66,7 @@ func main() {
 			manualtesting.InitManualTesting()
 		}
 
-		securityAndDiagnosticsJob()
+		runSecurityAndDiagnosticsJobAndForget()
 
 		// wait for kill signal before attempting to gracefully shutdown
 		// the running service
@@ -78,7 +78,7 @@ func main() {
 	}
 }
 
-func securityAndDiagnosticsJob() {
+func runSecurityAndDiagnosticsJobAndForget() {
 	go func() {
 		for {
 			if *utils.Cfg.ServiceSettings.EnableSecurityFixAlert {

--- a/utils/apns.go
+++ b/utils/apns.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/platform/model"
 )
 
-func FireAndForgetSendAppleNotify(deviceId string, message string, badge int) {
+func SendAppleNotifyAndForget(deviceId string, message string, badge int) {
 	go func() {
 		if err := SendAppleNotify(deviceId, message, badge); err != nil {
 			l4g.Error(fmt.Sprintf("%v %v", err.Message, err.DetailedError))

--- a/web/web.go
+++ b/web/web.go
@@ -429,9 +429,9 @@ func verifyEmail(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			user := result.Data.(*model.User)
 
 			if user.LastActivityAt > 0 {
-				api.FireAndForgetEmailChangeVerifyEmail(user.Id, user.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
+				api.SendEmailChangeVerifyEmailAndForget(user.Id, user.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
 			} else {
-				api.FireAndForgetVerifyEmail(user.Id, user.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
+				api.SendVerifyEmailAndForget(user.Id, user.Email, team.Name, team.DisplayName, c.GetSiteURL(), c.GetTeamURLFromTeam(team))
 			}
 
 			newAddress := strings.Replace(r.URL.String(), "&resend=true", "&resend_success=true", -1)


### PR DESCRIPTION
Pretty self-explanatory, this renames all functions that only consist of a goroutine to end with 'AndForget'.  This includes some functions that previously had no reference to any convention (e.g. didn't start with 'FireAndForget...') so please ping me if any of those we're intended to be left out.