### PR TITLE
PLT-693 Fixes back button on username page during team signup when email is turned off

### DIFF
--- a/web/react/components/team_signup_username_page.jsx
+++ b/web/react/components/team_signup_username_page.jsx
@@ -15,7 +15,12 @@ export default class TeamSignupUsernamePage extends React.Component {
     }
     submitBack(e) {
         e.preventDefault();
-        this.props.state.wizard = 'send_invites';
+        if (global.window.config.SendEmailNotifications === 'true') {
+            this.props.state.wizard = 'send_invites';
+        } else {
+            this.props.state.wizard = 'team_url';
+        }
+
         this.props.updateParent(this.props.state);
     }
     submitNext(e) {


### PR DESCRIPTION
We skip the send invites part of the signup flow when email is disabled but the back button on the username page was still trying to take the user there causing it to break.