### PR TITLE
Fixes wrong tooltip on user profile

### DIFF
--- a/web/react/components/user_profile.jsx
+++ b/web/react/components/user_profile.jsx
@@ -86,11 +86,11 @@ export default class UserProfile extends React.Component {
             dataContent.push(
                 <div
                     data-toggle='tooltip'
-                    title="' + this.state.profile.email + '"
+                    title={this.state.profile.email}
                     key='user-popover-email'
                 >
                     <a
-                        href="mailto:' + this.state.profile.email + '"
+                        href={'mailto:' + this.state.profile.email}
                         className='text-nowrap text-lowercase user-popover__email'
                     >
                         {this.state.profile.email}


### PR DESCRIPTION
Fixes a bug in a user's profile where the email address' tooltip and link was not parsed - see screen 

![bildschirmfoto vom 2015-10-19 01 05 52](https://cloud.githubusercontent.com/assets/1024005/10567304/2b7c2fe4-7600-11e5-8a5d-abc363dc9147.png)