### PR TITLE
No longer try to navigate to next/prev image if image preview modal is not open

### DIFF
--- a/web/react/components/view_image.jsx
+++ b/web/react/components/view_image.jsx
@@ -6,6 +6,7 @@ const Utils = require('../utils/utils.jsx');
 const Constants = require('../utils/constants.jsx');
 const ViewImagePopoverBar = require('./view_image_popover_bar.jsx');
 const Modal = ReactBootstrap.Modal;
+const KeyCodes = Constants.KeyCodes;
 
 export default class ViewImageModal extends React.Component {
     constructor(props) {
@@ -63,11 +64,11 @@ export default class ViewImageModal extends React.Component {
         this.loadImage(id);
     }
     handleKeyPress(e) {
-        if (!e) {
+        if (!e || !this.props.show) {
             return;
-        } else if (e.keyCode === 39) {
+        } else if (e.keyCode === KeyCodes.RIGHT) {
             this.handleNext();
-        } else if (e.keyCode === 37) {
+        } else if (e.keyCode === KeyCodes.LEFT) {
             this.handlePrev();
         }
     }


### PR DESCRIPTION
Currently the code in view_image.jsx handles every left/right-arrow keystroke even if the image modal is not open.
This causes a 404 xhr request each time left/right is pressed since the frontend wants load a non-existing next/prev-preview image.

This PR fixes this.