### PR TITLE
PLT-716/717 Added from:, in:, and channel: search filters

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -680,16 +680,16 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hashtagTerms, plainTerms := model.ParseHashtags(terms)
+	plainSearchParams, hashtagSearchParams := model.ParseSearchParams(terms)
 
 	var hchan store.StoreChannel
-	if len(hashtagTerms) != 0 {
-		hchan = Srv.Store.Post().Search(c.Session.TeamId, c.Session.UserId, hashtagTerms, true)
+	if hashtagSearchParams != nil {
+		hchan = Srv.Store.Post().Search(c.Session.TeamId, c.Session.UserId, hashtagSearchParams)
 	}
 
 	var pchan store.StoreChannel
-	if len(plainTerms) != 0 {
-		pchan = Srv.Store.Post().Search(c.Session.TeamId, c.Session.UserId, terms, false)
+	if plainSearchParams != nil {
+		pchan = Srv.Store.Post().Search(c.Session.TeamId, c.Session.UserId, plainSearchParams)
 	}
 
 	mainList := &model.PostList{}

--- a/model/search_params.go
+++ b/model/search_params.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"strings"
+)
+
+type SearchParams struct {
+	Terms     string
+	IsHashtag bool
+	InChannel string
+	FromUser  string
+}
+
+var searchFlags = [...]string{"from", "channel", "in"}
+
+func splitWords(text string) []string {
+	words := []string{}
+
+	for _, word := range strings.Fields(text) {
+		word = puncStart.ReplaceAllString(word, "")
+		word = puncEnd.ReplaceAllString(word, "")
+
+		if len(word) != 0 {
+			words = append(words, word)
+		}
+	}
+
+	return words
+}
+
+func parseSearchFlags(input []string) ([]string, map[string]string) {
+	words := []string{}
+	flags := make(map[string]string)
+
+	skipNextWord := false
+	for i, word := range input {
+		if skipNextWord {
+			skipNextWord = false
+			continue
+		}
+
+		isFlag := false
+
+		if colon := strings.Index(word, ":"); colon != -1 {
+			flag := word[:colon]
+			value := word[colon+1:]
+
+			for _, searchFlag := range searchFlags {
+				// check for case insensitive equality
+				if strings.EqualFold(flag, searchFlag) {
+					if value != "" {
+						flags[searchFlag] = value
+						isFlag = true
+					} else if i < len(input)-1 {
+						flags[searchFlag] = input[i+1]
+						skipNextWord = true
+						isFlag = true
+					}
+
+					if isFlag {
+						break
+					}
+				}
+			}
+		}
+
+		if !isFlag {
+			words = append(words, word)
+		}
+	}
+
+	return words, flags
+}
+
+func ParseSearchParams(text string) (*SearchParams, *SearchParams) {
+	words, flags := parseSearchFlags(splitWords(text))
+
+	hashtagTerms := []string{}
+	plainTerms := []string{}
+
+	for _, word := range words {
+		if validHashtag.MatchString(word) {
+			hashtagTerms = append(hashtagTerms, word)
+		} else {
+			plainTerms = append(plainTerms, word)
+		}
+	}
+
+	inChannel := flags["channel"]
+	if inChannel == "" {
+		inChannel = flags["in"]
+	}
+
+	fromUser := flags["from"]
+
+	var plainParams *SearchParams
+	if len(plainTerms) > 0 {
+		plainParams = &SearchParams{
+			Terms:     strings.Join(plainTerms, " "),
+			IsHashtag: false,
+			InChannel: inChannel,
+			FromUser:  fromUser,
+		}
+	}
+
+	var hashtagParams *SearchParams
+	if len(hashtagTerms) > 0 {
+		hashtagParams = &SearchParams{
+			Terms:     strings.Join(hashtagTerms, " "),
+			IsHashtag: true,
+			InChannel: inChannel,
+			FromUser:  fromUser,
+		}
+	}
+
+	// special case for when no terms are specified but we still have a filter
+	if plainParams == nil && hashtagParams == nil && (inChannel != "" || fromUser != "") {
+		plainParams = &SearchParams{
+			Terms:     "",
+			IsHashtag: false,
+			InChannel: inChannel,
+			FromUser:  fromUser,
+		}
+	}
+
+	return plainParams, hashtagParams
+}

--- a/model/search_params_test.go
+++ b/model/search_params_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"testing"
+)
+
+func TestParseSearchFlags(t *testing.T) {
+	if words, flags := parseSearchFlags(splitWords("")); len(words) != 0 {
+		t.Fatal("got words from empty input")
+	} else if len(flags) != 0 {
+		t.Fatal("got flags from empty input")
+	}
+
+	if words, flags := parseSearchFlags(splitWords("word")); len(words) != 1 || words[0] != "word" {
+		t.Fatalf("got incorrect words %v", words)
+	} else if len(flags) != 0 {
+		t.Fatalf("got incorrect flags %v", flags)
+	}
+
+	if words, flags := parseSearchFlags(splitWords("apple banana cherry")); len(words) != 3 || words[0] != "apple" || words[1] != "banana" || words[2] != "cherry" {
+		t.Fatalf("got incorrect words %v", words)
+	} else if len(flags) != 0 {
+		t.Fatalf("got incorrect flags %v", flags)
+	}
+
+	if words, flags := parseSearchFlags(splitWords("apple banana from:chan")); len(words) != 2 || words[0] != "apple" || words[1] != "banana" {
+		t.Fatalf("got incorrect words %v", words)
+	} else if len(flags) != 1 || flags["from"] != "chan" {
+		t.Fatalf("got incorrect flags %v", flags)
+	}
+
+	if words, flags := parseSearchFlags(splitWords("apple banana from: chan")); len(words) != 2 || words[0] != "apple" || words[1] != "banana" {
+		t.Fatalf("got incorrect words %v", words)
+	} else if len(flags) != 1 || flags["from"] != "chan" {
+		t.Fatalf("got incorrect flags %v", flags)
+	}
+
+	if words, flags := parseSearchFlags(splitWords("apple banana in: chan")); len(words) != 2 || words[0] != "apple" || words[1] != "banana" {
+		t.Fatalf("got incorrect words %v", words)
+	} else if len(flags) != 1 || flags["in"] != "chan" {
+		t.Fatalf("got incorrect flags %v", flags)
+	}
+
+	if words, flags := parseSearchFlags(splitWords("apple banana channel:chan")); len(words) != 2 || words[0] != "apple" || words[1] != "banana" {
+		t.Fatalf("got incorrect words %v", words)
+	} else if len(flags) != 1 || flags["channel"] != "chan" {
+		t.Fatalf("got incorrect flags %v", flags)
+	}
+
+	if words, flags := parseSearchFlags(splitWords("fruit: cherry")); len(words) != 2 || words[0] != "fruit:" || words[1] != "cherry" {
+		t.Fatalf("got incorrect words %v", words)
+	} else if len(flags) != 0 {
+		t.Fatalf("got incorrect flags %v", flags)
+	}
+
+	if words, flags := parseSearchFlags(splitWords("channel:")); len(words) != 1 || words[0] != "channel:" {
+		t.Fatalf("got incorrect words %v", words)
+	} else if len(flags) != 0 {
+		t.Fatalf("got incorrect flags %v", flags)
+	}
+
+	if words, flags := parseSearchFlags(splitWords("channel: first in: second from:")); len(words) != 1 || words[0] != "from:" {
+		t.Fatalf("got incorrect words %v", words)
+	} else if len(flags) != 2 || flags["channel"] != "first" || flags["in"] != "second" {
+		t.Fatalf("got incorrect flags %v", flags)
+	}
+}

--- a/model/utils.go
+++ b/model/utils.go
@@ -242,10 +242,10 @@ func Etag(parts ...interface{}) string {
 
 var validHashtag = regexp.MustCompile(`^(#[A-Za-z]+[A-Za-z0-9_\-]*[A-Za-z0-9])$`)
 var puncStart = regexp.MustCompile(`^[.,()&$!\[\]{}"':;\\]+`)
-var puncEnd = regexp.MustCompile(`[.,()&$#!\[\]{}"':;\\]+$`)
+var puncEnd = regexp.MustCompile(`[.,()&$#!\[\]{}"';\\]+$`)
 
 func ParseHashtags(text string) (string, string) {
-	words := strings.Split(strings.Replace(text, "\n", " ", -1), " ")
+	words := strings.Fields(text)
 
 	hashtagString := ""
 	plainString := ""

--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -440,7 +440,7 @@ func (s SqlPostStore) Search(teamId string, userId string, params *model.SearchP
 		if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 			// Parse text for wildcards
 			if wildcard, err := regexp.Compile("\\*($| )"); err == nil {
-				terms = wildcard.ReplaceAllLiteralString(terms, ":* ")
+				terms = wildcard.ReplaceAllLiteralString(terms, "* ")
 			}
 		}
 

--- a/store/sql_post_store_test.go
+++ b/store/sql_post_store_test.go
@@ -525,57 +525,57 @@ func TestPostStoreSearch(t *testing.T) {
 	o5.Hashtags = "#secret #howdy"
 	o5 = (<-store.Post().Save(o5)).Data.(*model.Post)
 
-	r1 := (<-store.Post().Search(teamId, userId, "corey", false)).Data.(*model.PostList)
+	r1 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "corey", IsHashtag: false})).Data.(*model.PostList)
 	if len(r1.Order) != 1 && r1.Order[0] != o1.Id {
 		t.Fatal("returned wrong search result")
 	}
 
-	r3 := (<-store.Post().Search(teamId, userId, "new", false)).Data.(*model.PostList)
+	r3 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "new", IsHashtag: false})).Data.(*model.PostList)
 	if len(r3.Order) != 2 && r3.Order[0] != o1.Id {
 		t.Fatal("returned wrong search result")
 	}
 
-	r4 := (<-store.Post().Search(teamId, userId, "john", false)).Data.(*model.PostList)
+	r4 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "john", IsHashtag: false})).Data.(*model.PostList)
 	if len(r4.Order) != 1 && r4.Order[0] != o2.Id {
 		t.Fatal("returned wrong search result")
 	}
 
-	r5 := (<-store.Post().Search(teamId, userId, "matter*", false)).Data.(*model.PostList)
+	r5 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "matter*", IsHashtag: false})).Data.(*model.PostList)
 	if len(r5.Order) != 1 && r5.Order[0] != o1.Id {
 		t.Fatal("returned wrong search result")
 	}
 
-	r6 := (<-store.Post().Search(teamId, userId, "#hashtag", true)).Data.(*model.PostList)
+	r6 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "#hashtag", IsHashtag: true})).Data.(*model.PostList)
 	if len(r6.Order) != 1 && r6.Order[0] != o4.Id {
 		t.Fatal("returned wrong search result")
 	}
 
-	r7 := (<-store.Post().Search(teamId, userId, "#secret", true)).Data.(*model.PostList)
+	r7 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "#secret", IsHashtag: true})).Data.(*model.PostList)
 	if len(r7.Order) != 1 && r7.Order[0] != o5.Id {
 		t.Fatal("returned wrong search result")
 	}
 
-	r8 := (<-store.Post().Search(teamId, userId, "@thisshouldmatchnothing", true)).Data.(*model.PostList)
+	r8 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "@thisshouldmatchnothing", IsHashtag: true})).Data.(*model.PostList)
 	if len(r8.Order) != 0 {
 		t.Fatal("returned wrong search result")
 	}
 
-	r9 := (<-store.Post().Search(teamId, userId, "mattermost jersey", false)).Data.(*model.PostList)
+	r9 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "mattermost jersey", IsHashtag: false})).Data.(*model.PostList)
 	if len(r9.Order) != 2 {
 		t.Fatal("returned wrong search result")
 	}
 
-	r10 := (<-store.Post().Search(teamId, userId, "matter* jer*", false)).Data.(*model.PostList)
+	r10 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "matter* jer*", IsHashtag: false})).Data.(*model.PostList)
 	if len(r10.Order) != 2 {
 		t.Fatal("returned wrong search result")
 	}
 
-	r11 := (<-store.Post().Search(teamId, userId, "message blargh", false)).Data.(*model.PostList)
+	r11 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "message blargh", IsHashtag: false})).Data.(*model.PostList)
 	if len(r11.Order) != 1 {
 		t.Fatal("returned wrong search result")
 	}
 
-	r12 := (<-store.Post().Search(teamId, userId, "blargh>", false)).Data.(*model.PostList)
+	r12 := (<-store.Post().Search(teamId, userId, &model.SearchParams{Terms: "blargh>", IsHashtag: false})).Data.(*model.PostList)
 	if len(r12.Order) != 1 {
 		t.Fatal("returned wrong search result")
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -84,7 +84,7 @@ type PostStore interface {
 	GetPosts(channelId string, offset int, limit int) StoreChannel
 	GetPostsSince(channelId string, time int64) StoreChannel
 	GetEtag(channelId string) StoreChannel
-	Search(teamId string, userId string, terms string, isHashtagSearch bool) StoreChannel
+	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	GetForExport(channelId string) StoreChannel
 }
 


### PR DESCRIPTION
Allows searching for posts in specific channels by using "in:NAME" or "channel:NAME" or searching for posts by specific users by using "from:USER".

I've also added tests for searches similar to the following cases:
1) "in:NAME" (no spaces between flag and value)
2) "in: NAME" (spaces between flag and value)
3) "other words in: NAME" (flag and normal search terms)
4) "in:" (flag with no value)
5) "IN: NAME" (flag in different cases)
6) "from: USER in: NAME" (multiple different flags)