### PR TITLE
PLT-521 Changed markdown renderer to only parse emoticons twice

### DIFF
--- a/web/react/utils/emoticons.jsx
+++ b/web/react/utils/emoticons.jsx
@@ -133,7 +133,7 @@ export function handleEmoticons(text, tokens) {
             const alias = `MM_EMOTICON${index}`;
 
             tokens.set(alias, {
-                value: `<img align="absmiddle" alt=${match} class="emoji" src=${getImagePathForEmoticon(name)} title=${match} />`,
+                value: `<img align="absmiddle" alt="${match}" class="emoji" src="${getImagePathForEmoticon(name)}" title="${match}" />`,
                 originalText: match
             });
 

--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -11,6 +11,7 @@ export class MattermostMarkdownRenderer extends marked.Renderer {
         super(options);
 
         this.heading = this.heading.bind(this);
+        this.paragraph = this.paragraph.bind(this);
         this.text = this.text.bind(this);
 
         this.formattingOptions = formattingOptions;
@@ -53,7 +54,11 @@ export class MattermostMarkdownRenderer extends marked.Renderer {
     }
 
     paragraph(text) {
-        let outText = TextFormatting.doFormatText(text, this.options);
+        let outText = text;
+
+        if (!('emoticons' in this.options) || this.options.emoticon) {
+            outText = TextFormatting.doFormatEmoticons(text);
+        }
 
         if (this.formattingOptions.singleline) {
             return `<p class="markdown__paragraph-inline">${outText}</p>`;

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -69,6 +69,15 @@ export function doFormatText(text, options) {
     return output;
 }
 
+export function doFormatEmoticons(text) {
+    const tokens = new Map();
+
+    let output = Emoticons.handleEmoticons(text, tokens);
+    output = replaceTokens(output, tokens);
+
+    return output;
+}
+
 export function sanitizeHtml(text) {
     let output = text;
 


### PR DESCRIPTION
As opposed to parsing everything twice which breaks hashtags