### PR TITLE
Force updating last viewed at for new posts

### DIFF
--- a/web/react/stores/socket_store.jsx
+++ b/web/react/stores/socket_store.jsx
@@ -158,7 +158,7 @@ function handleNewPostEvent(msg) {
     // Update channel state
     if (ChannelStore.getCurrentId() === msg.channel_id) {
         if (window.isActive) {
-            AsyncClient.updateLastViewedAt();
+            AsyncClient.updateLastViewedAt(true);
         }
     } else {
         AsyncClient.getChannel(msg.channel_id);

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -152,14 +152,14 @@ export function getChannel(id) {
     );
 }
 
-export function updateLastViewedAt() {
+export function updateLastViewedAt(force) {
     const channelId = ChannelStore.getCurrentId();
 
     if (channelId === null) {
         return;
     }
 
-    if (isCallInProgress(`updateLastViewed${channelId}`)) {
+    if (isCallInProgress(`updateLastViewed${channelId}`) && !force) {
         return;
     }
 


### PR DESCRIPTION
In a rare case if two posts came in very close to one another, when the user is viewing a channel, sometimes the channel would not get marked as read. So if you switched away or closed the window, the channel would be marked as unread even though you saw the latest message.