### PR TITLE
Add styling to channel member popover

### DIFF
--- a/web/react/components/more_direct_channels.jsx
+++ b/web/react/components/more_direct_channels.jsx
@@ -1,13 +1,7 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-const AsyncClient = require('../utils/async_client.jsx');
-const ChannelStore = require('../stores/channel_store.jsx');
-const Constants = require('../utils/constants.jsx');
-const Client = require('../utils/client.jsx');
 const Modal = ReactBootstrap.Modal;
-const PreferenceStore = require('../stores/preference_store.jsx');
-const TeamStore = require('../stores/team_store.jsx');
 const UserStore = require('../stores/user_store.jsx');
 const Utils = require('../utils/utils.jsx');
 
@@ -70,52 +64,24 @@ export default class MoreDirectChannels extends React.Component {
     }
 
     handleShowDirectChannel(teammate, e) {
+        e.preventDefault();
+
         if (this.state.loadingDMChannel !== -1) {
             return;
         }
 
-        e.preventDefault();
-
-        const channelName = Utils.getDirectChannelName(UserStore.getCurrentId(), teammate.id);
-        let channel = ChannelStore.getByName(channelName);
-
-        const preference = PreferenceStore.setPreference(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, teammate.id, 'true');
-        AsyncClient.savePreferences([preference]);
-
-        if (channel) {
-            Utils.switchChannel(channel);
-
-            this.handleHide();
-        } else {
-            this.setState({loadingDMChannel: teammate.id});
-
-            channel = {
-                name: channelName,
-                last_post_at: 0,
-                total_msg_count: 0,
-                type: 'D',
-                display_name: teammate.username,
-                teammate_id: teammate.id,
-                status: UserStore.getStatus(teammate.id)
-            };
-
-            Client.createDirectChannel(
-                channel,
-                teammate.id,
-                (data) => {
-                    this.setState({loadingDMChannel: -1});
-
-                    AsyncClient.getChannel(data.id);
-                    Utils.switchChannel(data);
-
-                    this.handleHide();
-                },
-                () => {
-                    this.setState({loadingDMChannel: -1});
-                    window.location.href = TeamStore.getCurrentTeamUrl() + '/channels/' + channelName;
-                }
-            );
-        }
+        this.setState({loadingDMChannel: teammate.id});
+        Utils.openDirectChannelToUser(
+            teammate,
+            (channel) => {
+                Utils.switchChannel(channel);
+                this.setState({loadingDMChannel: -1});
+                this.handleHide();
+            },
+            () => {
+                this.setState({loadingDMChannel: -1});
+            }
+        );
     }
 
     handleUserChange() {

--- a/web/react/components/popover_list_members.jsx
+++ b/web/react/components/popover_list_members.jsx
@@ -3,7 +3,7 @@
 
 var UserStore = require('../stores/user_store.jsx');
 var Popover = ReactBootstrap.Popover;
-var OverlayTrigger = ReactBootstrap.OverlayTrigger;
+var Overlay = ReactBootstrap.Overlay;
 const Utils = require('../utils/utils.jsx');
 
 const ChannelStore = require('../stores/channel_store.jsx');
@@ -20,6 +20,10 @@ export default class PopoverListMembers extends React.Component {
 
         this.handleShowDirectChannel = this.handleShowDirectChannel.bind(this);
         this.closePopover = this.closePopover.bind(this);
+    }
+
+    componentWillMount() {
+        this.setState({showPopover: false});
     }
 
     componentDidMount() {
@@ -85,10 +89,7 @@ export default class PopoverListMembers extends React.Component {
     }
 
     closePopover() {
-        var overlay = this.refs.overlay;
-        if (overlay.state.isOverlayShown) {
-            overlay.setState({isOverlayShown: false});
-        }
+        this.setState({showPopover: false});
     }
 
     render() {
@@ -188,12 +189,27 @@ export default class PopoverListMembers extends React.Component {
         }
 
         return (
-            <OverlayTrigger
-                ref='overlay'
-                trigger='click'
-                placement='bottom'
-                rootClose={true}
-                overlay={
+            <div>
+                <div
+                    id='member_popover'
+                    ref='member_popover_target'
+                    onClick={(e) => this.setState({popoverTarget: e.target, showPopover: !this.state.showPopover})}
+                >
+                    <div>
+                        {countText}
+                        <span
+                            className='fa fa-user'
+                            aria-hidden='true'
+                        />
+                    </div>
+                </div>
+                <Overlay
+                    rootClose={true}
+                    onHide={this.closePopover}
+                    show={this.state.showPopover}
+                    target={() => this.state.popoverTarget}
+                    placement='bottom'
+                >
                     <Popover
                         title='Members'
                         id='member-list-popover'
@@ -202,18 +218,8 @@ export default class PopoverListMembers extends React.Component {
                             {popoverHtml}
                         </div>
                     </Popover>
-                }
-            >
-            <div id='member_popover'>
-                <div>
-                    {countText}
-                    <span
-                        className='fa fa-user'
-                        aria-hidden='true'
-                    />
-                </div>
+                </Overlay>
             </div>
-            </OverlayTrigger>
         );
     }
 }

--- a/web/react/components/popover_list_members.jsx
+++ b/web/react/components/popover_list_members.jsx
@@ -7,12 +7,6 @@ var Overlay = ReactBootstrap.Overlay;
 const Utils = require('../utils/utils.jsx');
 
 const ChannelStore = require('../stores/channel_store.jsx');
-const AsyncClient = require('../utils/async_client.jsx');
-const PreferenceStore = require('../stores/preference_store.jsx');
-const Client = require('../utils/client.jsx');
-const TeamStore = require('../stores/team_store.jsx');
-
-const Constants = require('../utils/constants.jsx');
 
 export default class PopoverListMembers extends React.Component {
     constructor(props) {
@@ -51,41 +45,18 @@ export default class PopoverListMembers extends React.Component {
     handleShowDirectChannel(teammate, e) {
         e.preventDefault();
 
-        const channelName = Utils.getDirectChannelName(UserStore.getCurrentId(), teammate.id);
-        let channel = ChannelStore.getByName(channelName);
-
-        const preference = PreferenceStore.setPreference(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, teammate.id, 'true');
-        AsyncClient.savePreferences([preference]);
-
-        if (channel) {
-            Utils.switchChannel(channel);
-            this.closePopover();
-        } else {
-            channel = {
-                name: channelName,
-                last_post_at: 0,
-                total_msg_count: 0,
-                type: 'D',
-                display_name: teammate.username,
-                teammate_id: teammate.id,
-                status: UserStore.getStatus(teammate.id)
-            };
-
-            Client.createDirectChannel(
-                channel,
-                teammate.id,
-                (data) => {
-                    AsyncClient.getChannel(data.id);
-                    Utils.switchChannel(data);
-
-                    this.closePopover();
-                },
-                () => {
-                    window.location.href = TeamStore.getCurrentTeamUrl() + '/channels/' + channelName;
+        Utils.openDirectChannelToUser(
+            teammate,
+            (channel, channelAlreadyExisted) => {
+                Utils.switchChannel(channel);
+                if (channelAlreadyExisted) {
                     this.closePopover();
                 }
-            );
-        }
+            },
+            () => {
+                this.closePopover();
+            }
+        );
     }
 
     closePopover() {

--- a/web/sass-files/sass/partials/_popover.scss
+++ b/web/sass-files/sass/partials/_popover.scss
@@ -61,3 +61,36 @@
         @include opacity(1);
     }
 }
+
+#member-list-popover {
+    max-width: initial;
+    .popover-content > div {
+        max-height: 350px;
+        overflow-y: auto;
+        overflow-x: hidden;
+        > div {
+            border-bottom: 1px solid rgba(51,51,51,0.1);
+            padding: 8px 8px 8px 15px;
+            width: 100%;
+            box-sizing: content-box;
+            @include clearfix;
+            .profile-img {
+                border-radius: 50px;
+                margin-right: 8px;
+            }
+            .more-name {
+                font-weight: 600;
+                font-size: 0.95em;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+            .more-description {
+                @include opacity(0.7);
+            }
+            .profile-action {
+                margin-left: 8px;
+                margin-right: 18px;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I thought the channel member popover was a little lacking in style and functionality - this PR turns this:
![before](https://cloud.githubusercontent.com/assets/1024005/10716668/7bcc1c8a-7b40-11e5-8438-c93c4f5726d7.png)
into this:
![after](https://cloud.githubusercontent.com/assets/1024005/10716669/7d2663ce-7b40-11e5-8250-63089a8d5ba6.png)
