### PR TITLE
adds trailing slash if missing from Directory in config.json

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -159,6 +159,13 @@ func LoadConfig(fileName string) {
 	configureLog(&config.LogSettings)
 	TestConnection(&config)
 
+	if config.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+		dir := config.FileSettings.Directory
+		if len(dir) > 0 && dir[len(dir)-1:] != "/" {
+			config.FileSettings.Directory += "/"
+		}
+	}
+
 	Cfg = &config
 	SanitizeOptions = getSanitizeOptions(Cfg)
 	ClientCfg = getClientConfig(Cfg)


### PR DESCRIPTION
does it only if "DriverName" == "local", not sure if required for other drivers too.

fixes #942 