### PR TITLE
Code contribution guidelines update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Mattermost. This guide provides a
 
 1. Review the list of [Good First Contribution](https://mattermost.atlassian.net/issues/?filter=10206) tickets listed in Jira.
     - You are welcome to work on any ticket, even if it is assigned, so long as it is not yet marked "in progress"
-    - (optional) You can share with the community that you're working on a specific ticket so no one else inadvertently duplicates your work by sharing on the forum or in the core team Mattermost instance as described in step 3. 
+    - (optional) Comment on the ticket that you're starting so no one else inadvertently duplicates your work
 
 2. These projects are intended to be a straight forward first pull requests from new contributors. 
   - If you don't find something appropriate for your interests, please see the full list of tickets [Accepting Pull Requests](https://mattermost.atlassian.net/issues/?filter=10101). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to Mattermost. This guide provides a
     - You are welcome to work on any ticket, even if it is assigned, so long as it is not yet marked "in progress"
     - (optional) Comment on the ticket that you're starting so no one else inadvertently duplicates your work
 
-2. These projects are intended to be a straight forward first pull requests from new contributors. 
+2. These projects are intended to be a straight forward first pull requests from new contributors
   - If you don't find something appropriate for your interests, please see the full list of tickets [Accepting Pull Requests](https://mattermost.atlassian.net/issues/?filter=10101)
   - Also, feel free to fix bugs you find, or items in GitHub issues that the core team has approved, but not yet added to Jira
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,10 @@ Thank you for your interest in contributing to Mattermost. This guide provides a
 
 ## Choose a Ticket
 
-1. Review the list of [Good First Contribution](https://mattermost.atlassian.net/issues/?filter=10206) tickets listed in Jira. 
+1. Review the list of [Good First Contribution](https://mattermost.atlassian.net/issues/?filter=10206) tickets listed in Jira.
+    - You are welcome to work on any ticket, even if it is assigned, so long as it is not yet marked "in progress"
+    - (optional) You can share with the community that you're working on a specific ticket so no one else inadvertently duplicates your work by sharing on the forum or in the core team Mattermost instance as described in step 3. 
+
 2. These projects are intended to be a straight forward first pull requests from new contributors. 
   - If you don't find something appropriate for your interests, please see the full list of tickets [Accepting Pull Requests](https://mattermost.atlassian.net/issues/?filter=10101). 
   - Also, feel free to fix bugs you find, or items in GitHub issues that the core team has approved, but not yet added to Jira.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ git checkout -b <branch name>
 
 ## Programming and Testing 
 
-1. Please review the [Mattermost Style Guide](Style-Guide.md) prior to making changes
+1. Please review the [Mattermost Style Guide](doc/developer/Style-Guide.md) prior to making changes
 
    To keep code clean and well structured, Mattermost uses ESLint to check that pull requests adhere to style guidelines for React. Code will need to follow Mattermost's React style guidelines in order to pass the automated build tests when a pull request is submitted
    

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,13 @@ Thank you for your interest in contributing to Mattermost. This guide provides a
 
 ## Choose a Ticket
 
-1. Review the list of [Good First Contribution](https://mattermost.atlassian.net/issues/?filter=10206) tickets listed in Jira.
+1. Review the list of [Good First Contribution](https://mattermost.atlassian.net/issues/?filter=10206) tickets listed in Jira
     - You are welcome to work on any ticket, even if it is assigned, so long as it is not yet marked "in progress"
     - (optional) Comment on the ticket that you're starting so no one else inadvertently duplicates your work
 
 2. These projects are intended to be a straight forward first pull requests from new contributors. 
-  - If you don't find something appropriate for your interests, please see the full list of tickets [Accepting Pull Requests](https://mattermost.atlassian.net/issues/?filter=10101). 
-  - Also, feel free to fix bugs you find, or items in GitHub issues that the core team has approved, but not yet added to Jira.
+  - If you don't find something appropriate for your interests, please see the full list of tickets [Accepting Pull Requests](https://mattermost.atlassian.net/issues/?filter=10101)
+  - Also, feel free to fix bugs you find, or items in GitHub issues that the core team has approved, but not yet added to Jira
 
 3. If you have any questions at all about a ticket, there are several options to ask: 
   1. Start a topic in the [Mattermost forum](http://forum.mattermost.org/)
@@ -18,7 +18,7 @@ Thank you for your interest in contributing to Mattermost. This guide provides a
 
 ## Install Mattermost and set up a Fork
 
-1. Follow [developer setup instructions](https://github.com/mattermost/platform/blob/master/doc/developer/Setup.md) to install Mattermost. 
+1. Follow [developer setup instructions](https://github.com/mattermost/platform/blob/master/doc/developer/Setup.md) to install Mattermost
 
 2. Create a branch with <branch name> set to the ID of the ticket you're working on, for example ```PLT-394```, using command: 
 
@@ -28,27 +28,23 @@ git checkout -b <branch name>
 
 ## Programming and Testing 
 
-1. Please review the [Mattermost Style Guide](Style-Guide.md) prior to making changes.
+1. Please review the [Mattermost Style Guide](Style-Guide.md) prior to making changes
 
-   To keep code clean and well structured, Mattermost uses ESLint to check that pull requests adhere to style guidelines for React. Code will need to follow Mattermost's React style guidelines in order to pass the automated build tests when a pull request is submitted.
+   To keep code clean and well structured, Mattermost uses ESLint to check that pull requests adhere to style guidelines for React. Code will need to follow Mattermost's React style guidelines in order to pass the automated build tests when a pull request is submitted
    
-2. Please make sure to thoroughly test your change before submitting a pull request. 
+2. Please make sure to thoroughly test your change before submitting a pull request
 
-   Please review the ["Fast, Obvious, Forgiving" experience design principles](http://www.mattermost.org/design-principles/) for Mattermost and check that your feature meets the criteria. Also, for any changes to user interface or help text, please read the changes out loud, as a quick and easy way to catch any inconsitencies.
+   Please review the ["Fast, Obvious, Forgiving" experience design principles](http://www.mattermost.org/design-principles/) for Mattermost and check that your feature meets the criteria. Also, for any changes to user interface or help text, please read the changes out loud, as a quick and easy way to catch any inconsitencies
 
 
 ## Submitting a Pull Request 
 
 1. Please add yourself to the Mattermost [approved contributor list](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true) prior to submitting by completing the [contributor license agreement](http://www.mattermost.org/mattermost-contributor-agreement/). 
 
-2. When you submit your pull request please make it against `master` and include the Ticket ID at the beginning of your pull request comment, followed by a colon. 
+2. When you submit your pull request please make it against `master` and include the Ticket ID at the beginning of your pull request comment, followed by a colon
 
-  - For example, for a ticket ID `PLT-394` start your comment with:  `PLT-394:`. See [previously closed pull requests](https://github.com/mattermost/platform/pulls?q=is%3Apr+is%3Aclosed) for examples. 
+  - For example, for a ticket ID `PLT-394` start your comment with:  `PLT-394:`. See [previously closed pull requests](https://github.com/mattermost/platform/pulls?q=is%3Apr+is%3Aclosed) for examples
 
-3. Once submitted, your pull request will be checked via an automated build process and will be reviewed by at least two members of the Mattermost core team, who may either accept the PR or follow-up with feedback. It would then get merged into `master` for the next release. 
+3. Once submitted, your pull request will be checked via an automated build process and will be reviewed by at least two members of the Mattermost core team, who may either accept the PR or follow-up with feedback. It would then get merged into `master` for the next release
 
-4. If you've included your mailing address in Step 1, you'll be receiving a [Limited Edition Mattermost Mug](http://forum.mattermost.org/t/limited-edition-mattermost-mugs/143) as a thank you gift after your first pull request has been accepted. 
-
-
-
-
+4. If you've included your mailing address in Step 1, you'll be receiving a [Limited Edition Mattermost Mug](http://forum.mattermost.org/t/limited-edition-mattermost-mugs/143) as a thank you gift after your first pull request has been accepted

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,51 @@
-# Contributing 
+# Code Contribution Guidelines
 
-## Contributing Code
+Thank you for your interest in contributing to Mattermost. This guide provides an overview of important information for contributors to know. 
 
-Please see [Mattermost Code Contribution Guidelines](https://github.com/mattermost/platform/blob/master/doc/developer/Code-Contribution-Guidelines.md)
+## Choose a Ticket
+
+1. Review the list of [Good First Contribution](https://mattermost.atlassian.net/issues/?filter=10206) tickets listed in Jira. 
+2. These projects are intended to be a straight forward first pull requests from new contributors. 
+  - If you don't find something appropriate for your interests, please see the full list of tickets [Accepting Pull Requests](https://mattermost.atlassian.net/issues/?filter=10101). 
+  - Also, feel free to fix bugs you find, or items in GitHub issues that the core team has approved, but not yet added to Jira.
+
+3. If you have any questions at all about a ticket, there are several options to ask: 
+  1. Start a topic in the [Mattermost forum](http://forum.mattermost.org/)
+  2. Join the [Mattermost core team discussion](https://pre-release.mattermost.com/signup_user_complete/?id=rcgiyftm7jyrxnma1osd8zswby) and post in the "Tickets" channel
+
+## Install Mattermost and set up a Fork
+
+1. Follow [developer setup instructions](https://github.com/mattermost/platform/blob/master/doc/developer/Setup.md) to install Mattermost. 
+
+2. Create a branch with <branch name> set to the ID of the ticket you're working on, for example ```PLT-394```, using command: 
+
+```
+git checkout -b <branch name>
+```
+
+## Programming and Testing 
+
+1. Please review the [Mattermost Style Guide](Style-Guide.md) prior to making changes.
+
+   To keep code clean and well structured, Mattermost uses ESLint to check that pull requests adhere to style guidelines for React. Code will need to follow Mattermost's React style guidelines in order to pass the automated build tests when a pull request is submitted.
+   
+2. Please make sure to thoroughly test your change before submitting a pull request. 
+
+   Please review the ["Fast, Obvious, Forgiving" experience design principles](http://www.mattermost.org/design-principles/) for Mattermost and check that your feature meets the criteria. Also, for any changes to user interface or help text, please read the changes out loud, as a quick and easy way to catch any inconsitencies.
+
+
+## Submitting a Pull Request 
+
+1. Please add yourself to the Mattermost [approved contributor list](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true) prior to submitting by completing the [contributor license agreement](http://www.mattermost.org/mattermost-contributor-agreement/). 
+
+2. When you submit your pull request please make it against `master` and include the Ticket ID at the beginning of your pull request comment, followed by a colon. 
+
+  - For example, for a ticket ID `PLT-394` start your comment with:  `PLT-394:`. See [previously closed pull requests](https://github.com/mattermost/platform/pulls?q=is%3Apr+is%3Aclosed) for examples. 
+
+3. Once submitted, your pull request will be checked via an automated build process and will be reviewed by at least two members of the Mattermost core team, who may either accept the PR or follow-up with feedback. It would then get merged into `master` for the next release. 
+
+4. If you've included your mailing address in Step 1, you'll be receiving a [Limited Edition Mattermost Mug](http://forum.mattermost.org/t/limited-edition-mattermost-mugs/143) as a thank you gift after your first pull request has been accepted. 
+
+
+
+

--- a/doc/developer/Code-Contribution-Guidelines.md
+++ b/doc/developer/Code-Contribution-Guidelines.md
@@ -1,48 +1,5 @@
 # Code Contribution Guidelines
 
-Thank you for your interest in contributing to Mattermost. This guide provides an overview of important information for contributors to know. 
-
-## Choose a Ticket
-
-1. Review the list of [Good First Contribution](https://mattermost.atlassian.net/issues/?filter=10206) tickets listed in Jira. 
-2. These projects are intended to be a straight forward first pull requests from new contributors. 
-If you don't find something appropriate for your interests, please see the full list of tickets [Accepting Pull Requests](https://mattermost.atlassian.net/issues/?filter=10101). 
-
-3. If you have any questions at all about a ticket, please post to the [Contributor Discussion section](http://forum.mattermost.org/) of the Mattermost forum, or email the [Mattermost Developer Mailing list](https://groups.google.com/a/mattermost.com/forum/#!forum/developer/join). 
-
-## Install Mattermost and set up a Fork
-
-1. Follow [developer setup instructions](https://github.com/mattermost/platform/blob/master/doc/developer/Setup.md) to install Mattermost. 
-
-2. Create a branch with <branch name> set to the ID of the ticket you're working on, for example ```PLT-394```, using command: 
-
-```
-git checkout -b <branch name>
-```
-
-## Programming and Testing 
-
-1. Please review the [Mattermost Style Guide](Style-Guide.md) prior to making changes.
-
-   To keep code clean and well structured, Mattermost uses ESLint to check that pull requests adhere to style guidelines for React. Code will need to follow Mattermost's React style guidelines in order to pass the automated build tests when a pull request is submitted.
-   
-2. Please make sure to thoroughly test your change before submitting a pull request. 
-
-   Please review the ["Fast, Obvious, Forgiving" experience design principles](http://www.mattermost.org/design-principles/) for Mattermost and check that your feature meets the criteria. Also, for any changes to user interface or help text, please read the changes out loud, as a quick and easy way to catch any inconsitencies.
-
-
-## Submitting a Pull Request 
-
-1. Please add yourself to the Mattermost [approved contributor list](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true) prior to submitting by completing the [contributor license agreement](http://www.mattermost.org/mattermost-contributor-agreement/). 
-
-2. When you submit your pull request please make it against `master` and include the Ticket ID at the beginning of your pull request comment, followed by a colon. 
-
-  For example, for a ticket ID `PLT-394` start your comment with:  `PLT-394:`. See [previously closed pull requests](https://github.com/mattermost/platform/pulls?q=is%3Apr+is%3Aclosed) for examples. 
-
-3. Once submitted, your pull request will be checked via an automated build process and will be reviewed by at least two members of the Mattermost core team, who may either accept the PR or follow-up with feedback. It would then get merged into `master` for the next release. 
-
-4. If you've included your mailing address in Step 1, you'll be receiving a [Limited Edition Mattermost Mug](http://forum.mattermost.org/t/limited-edition-mattermost-mugs/143) as a thank you gift after your first pull request has been accepted. 
-
-
+Please see [CONTRIBUTING.md](../../CONTRIBUTING.md)
 
 

--- a/doc/developer/Code-Contribution-Guidelines.md
+++ b/doc/developer/Code-Contribution-Guidelines.md
@@ -1,5 +1,5 @@
 # Code Contribution Guidelines
 
-Please see [CONTRIBUTING.md](../../CONTRIBUTING.md)
+Please see [CONTRIBUTING.md](https://github.com/mattermost/platform/blob/master/CONTRIBUTING.md)
 
 


### PR DESCRIPTION
Moving code contribution guidelines to CONTRIBUTING.md and replacing old page with redirect (until we can change links from marketing sites)

Also including link to core team Mattermost site for contributors to ask questions