### PR TITLE
Parse incoming webhook requests into model instead of string map

### DIFF
--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -23,6 +23,14 @@ type IncomingWebhook struct {
 	TeamId    string `json:"team_id"`
 }
 
+type IncomingWebhookRequest struct {
+	Text        string `json:"text"`
+	Username    string `json:"username"`
+	IconURL     string `json:"icon_url"`
+	IconEmoji   string `json:"icon_emoji"`
+	ChannelName string `json:"channel"`
+}
+
 func (o *IncomingWebhook) ToJson() string {
 	b, err := json.Marshal(o)
 	if err != nil {
@@ -103,4 +111,15 @@ func (o *IncomingWebhook) PreSave() {
 
 func (o *IncomingWebhook) PreUpdate() {
 	o.UpdateAt = GetMillis()
+}
+
+func IncomingWebhookRequestFromJson(data io.Reader) *IncomingWebhookRequest {
+	decoder := json.NewDecoder(data)
+	var o IncomingWebhookRequest
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
+	} else {
+		return nil
+	}
 }

--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -27,7 +27,6 @@ type IncomingWebhookRequest struct {
 	Text        string `json:"text"`
 	Username    string `json:"username"`
 	IconURL     string `json:"icon_url"`
-	IconEmoji   string `json:"icon_emoji"`
 	ChannelName string `json:"channel"`
 }
 


### PR DESCRIPTION
Now it won't fail if someone provides extra fields that aren't strings.