### PR TITLE
Dont display '1 minute ago' timestamps for post posted < than 1 minute ago

### DIFF
--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -211,11 +211,15 @@ export function displayDateTime(ticks) {
     }
 
     interval = Math.floor(seconds / 60);
-    if (interval > 1) {
+    if (interval >= 2) {
         return interval + ' minutes ago';
     }
 
-    return '1 minute ago';
+    if (interval >= 1) {
+        return '1 minute ago';
+    }
+
+    return 'just now';
 }
 
 export function displayCommentDateTime(ticks) {


### PR DESCRIPTION
I've seen this issue somewhere, though I can't find it in jira/github.
No longer display `1 minute ago` for posts that have been posted less than one minute ago (instead display `just now` for post < 1 min ago; `1 min ago` for posts <2min >1min)