### PR TITLE
PLT-550 Fixed various issues with commenting on recently deleted posts

### DIFF
--- a/web/react/components/post_info.jsx
+++ b/web/react/components/post_info.jsx
@@ -126,7 +126,7 @@ export default class PostInfo extends React.Component {
             lastCommentClass = ' comment-icon__container__show';
         }
 
-        if (this.props.commentCount >= 1 && post.state !== Constants.POST_FAILED && post.state !== Constants.POST_LOADING) {
+        if (this.props.commentCount >= 1 && post.state !== Constants.POST_FAILED && post.state !== Constants.POST_LOADING && post.state !== Constants.POST_DELETED) {
             comments = (
                 <a
                     href='#'

--- a/web/react/components/post_list.jsx
+++ b/web/react/components/post_list.jsx
@@ -556,6 +556,11 @@ export default class PostList extends React.Component {
             var post = posts[order[i]];
             var parentPost = posts[post.parent_id];
 
+            // If the post is a comment whose parent has been deleted, don't add it to the list.
+            if (parentPost && parentPost.state === Constants.POST_DELETED) {
+                continue;
+            }
+
             var sameUser = false;
             var sameRoot = false;
             var hideProfilePic = false;


### PR DESCRIPTION
This fixes the problem where when a post with other comments was deleted, a user who was viewing them would still be able to open up the RHS to try and comment on the thread.  Now when a user deletes the root post of a thread the whole thread is removed from view immediately for other users as well.  Also removes the "comment bubble" icon, that was hanging around the "(message deleted)" placeholder post in the same scenario.