### PR TITLE
Update and rename doc/api/Overview.md to doc/developer/API-Web-Servic…

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -27,7 +27,7 @@ Set up Mattermost in your data center
 - [Code Contribution Guidelines](developer/Code-Contribution-Guidelines.md)
 - [Developer Machine Setup](developer/Setup.md)
 - [Mattermost Style Guide](developer/Style-Guide.md)
-- [API Overview](api/Overview.md)
+- [API Overview](developer/API.md)
  - [Incoming Webhooks](integrations/webhooks/Incoming-Webhooks.md) 
 
 ## Help

--- a/doc/developer/API-Web-Service.md
+++ b/doc/developer/API-Web-Service.md
@@ -1,6 +1,8 @@
-# API Overview
+# Mattermost Web Service API
 
-This provides a basic overview of the Mattermost API. All examples assume there is a Mattermost instance running at http://localhost:8065.
+This provides a basic overview of the Mattermost Web Service API. Drivers interfacing with this API are available in different languages. Current documentation focuses on the transport layer for the API and functional documentation will be developed next.  
+
+All examples assume there is a Mattermost instance running at http://localhost:8065.
 
 ## Schema
 


### PR DESCRIPTION
@coreyhulen, per last chat, propose moving this over to `/developer` and working to integrate it into: https://github.com/mattermost/platform/blob/master/doc/developer/API.md

This is a multi-step process, we need to get everything under `/developer`, then explain from https://github.com/mattermost/platform/blob/master/doc/developer/API.md where to find everything. 

Documentation won't be perfect in first go, but thinking this is a step in the right direction, open to corrections, 