### PR TITLE
PLT-799 Turn-off browser auto-completion in the search bar

### DIFF
--- a/web/react/components/search_bar.jsx
+++ b/web/react/components/search_bar.jsx
@@ -185,6 +185,7 @@ export default class SearchBar extends React.Component {
                     className='search__form relative-div'
                     onSubmit={this.handleSubmit}
                     style={{overflow: 'visible'}}
+                    autoComplete='off'
                 >
                     <span className='glyphicon glyphicon-search sidebar__search-icon' />
                     <input


### PR DESCRIPTION
This should get rid of the issue with Edge pulling auto-completion info from the login screen to the search bar.