### PR TITLE
PLT-857: Support `attachments` for Incoming Webhooks

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -212,7 +212,6 @@ func handlePostEventsAndForget(c *Context, post *model.Post, triggerWebhooks boo
 		}
 
 		if triggerWebhooks {
-			fmt.Println("triggerWebhooks", post)
 			handleWebhookEventsAndForget(c, post, team, channel, user)
 		}
 	}()

--- a/model/attachments.go
+++ b/model/attachments.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Attachments []Attachment
+
+type Attachment struct {
+	Id         string            `json:"id"`
+	PostId     string            `json:"post_id"`
+	Fallback   string            `json:"fallback`
+	Color      string            `json:"color`
+	Pretext    string            `json:"pretext`
+	AuthorName string            `json:"author_name`
+	AuthorLink string            `json:"author_link`
+	Title      string            `json:"title`
+	TitleLink  string            `json:"title_link`
+	Text       string            `json:"text`
+	Fields     []AttachmentField `json:"fields"`
+	ImageUrl   string            `json:"image_url"`
+	ThumbUrl   string            `json:"thumb_url"`
+}
+
+type AttachmentField struct {
+	Title string `json:"title`
+	Value string `json:"value`
+	Short bool   `json:"short`
+}
+
+func (a *Attachments) ToJson() string {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func AttachmentsFromJson(data io.Reader) *Attachments {
+	decoder := json.NewDecoder(data)
+	var o Attachments
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
+	} else {
+		return nil
+	}
+}

--- a/model/attachments.go
+++ b/model/attachments.go
@@ -11,25 +11,24 @@ import (
 type Attachments []Attachment
 
 type Attachment struct {
-	Id         string            `json:"id"`
-	PostId     string            `json:"post_id"`
-	Fallback   string            `json:"fallback`
-	Color      string            `json:"color`
-	Pretext    string            `json:"pretext`
-	AuthorName string            `json:"author_name`
-	AuthorLink string            `json:"author_link`
-	Title      string            `json:"title`
-	TitleLink  string            `json:"title_link`
-	Text       string            `json:"text`
+	Fallback   string            `json:"fallback"`
+	Color      string            `json:"color"`
+	Pretext    string            `json:"pretext"`
+	AuthorName string            `json:"author_name"`
+	AuthorLink string            `json:"author_link"`
+	AuthorIcon string            `json:"author_icon"`
+	Title      string            `json:"title"`
+	TitleLink  string            `json:"title_link"`
+	Text       string            `json:"text"`
 	Fields     []AttachmentField `json:"fields"`
 	ImageUrl   string            `json:"image_url"`
 	ThumbUrl   string            `json:"thumb_url"`
 }
 
 type AttachmentField struct {
-	Title string `json:"title`
-	Value string `json:"value`
-	Short bool   `json:"short`
+	Title string `json:"title"`
+	Value string `json:"value"`
+	Short bool   `json:"short"`
 }
 
 func (a *Attachments) ToJson() string {

--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -24,11 +24,11 @@ type IncomingWebhook struct {
 }
 
 type IncomingWebhookRequest struct {
-	Text        string       `json:"text"`
-	Username    string       `json:"username"`
-	IconURL     string       `json:"icon_url"`
-	ChannelName string       `json:"channel"`
-	Attachments Attachments  `json:"attachments"`
+	Text        string      `json:"text"`
+	Username    string      `json:"username"`
+	IconURL     string      `json:"icon_url"`
+	ChannelName string      `json:"channel"`
+	Attachments Attachments `json:"attachments"`
 }
 
 func (o *IncomingWebhook) ToJson() string {

--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -24,10 +24,11 @@ type IncomingWebhook struct {
 }
 
 type IncomingWebhookRequest struct {
-	Text        string `json:"text"`
-	Username    string `json:"username"`
-	IconURL     string `json:"icon_url"`
-	ChannelName string `json:"channel"`
+	Text        string       `json:"text"`
+	Username    string       `json:"username"`
+	IconURL     string       `json:"icon_url"`
+	ChannelName string       `json:"channel"`
+	Attachments Attachments  `json:"attachments"`
 }
 
 func (o *IncomingWebhook) ToJson() string {

--- a/model/post.go
+++ b/model/post.go
@@ -30,6 +30,7 @@ type Post struct {
 	Hashtags      string      `json:"hashtags"`
 	Filenames     StringArray `json:"filenames"`
 	PendingPostId string      `json:"pending_post_id" db:"-"`
+	Attachments   Attachments `json:"attachments"`
 }
 
 func (o *Post) ToJson() string {
@@ -133,6 +134,10 @@ func (o *Post) PreSave() {
 	if o.Filenames == nil {
 		o.Filenames = []string{}
 	}
+
+	if o.Attachments == nil {
+		o.Attachments = Attachments{}
+	}
 }
 
 func (o *Post) MakeNonNil() {
@@ -141,6 +146,10 @@ func (o *Post) MakeNonNil() {
 	}
 	if o.Filenames == nil {
 		o.Filenames = []string{}
+	}
+
+	if o.Attachments == nil {
+		o.Attachments = Attachments{}
 	}
 }
 

--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
+	l4g "code.google.com/p/log4go"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	l4g "code.google.com/p/log4go"
 )
 
 type SqlPostStore struct {

--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -32,12 +32,14 @@ func NewSqlPostStore(sqlStore *SqlStore) PostStore {
 		table.ColMap("Hashtags").SetMaxSize(1000)
 		table.ColMap("Props").SetMaxSize(4000)
 		table.ColMap("Filenames").SetMaxSize(4000)
+		table.ColMap("Attachments")
 	}
 
 	return s
 }
 
 func (s SqlPostStore) UpgradeSchemaIfNeeded() {
+	s.CreateColumnIfNotExists("Posts", "Attachments", "TEXT", "TEXT", "")
 }
 
 func (s SqlPostStore) CreateIndexesIfNotExists() {

--- a/web/react/components/create_comment.jsx
+++ b/web/react/components/create_comment.jsx
@@ -109,6 +109,7 @@ export default class CreateComment extends React.Component {
         post.pending_post_id = `${userId}:${time}`;
         post.user_id = userId;
         post.create_at = time;
+        post.attachments = [];
 
         PostStore.storePendingPost(post);
         PostStore.storeCommentDraft(this.props.rootId, null);

--- a/web/react/components/create_post.jsx
+++ b/web/react/components/create_post.jsx
@@ -171,6 +171,7 @@ export default class CreatePost extends React.Component {
         post.create_at = time;
         post.root_id = this.state.rootId;
         post.parent_id = this.state.parentId;
+        post.attachments = [];
 
         const channel = ChannelStore.get(this.state.channelId);
 

--- a/web/react/components/post_attachment.jsx
+++ b/web/react/components/post_attachment.jsx
@@ -1,0 +1,240 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+const TextFormatting = require('../utils/text_formatting.jsx');
+
+export default class PostAttachment extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.getFieldsTable = this.getFieldsTable.bind(this);
+    }
+
+    getFieldsTable() {
+        const fields = this.props.attachment.fields;
+        if (!fields || !fields.length) {
+            return '';
+        }
+
+        const compactTable = fields.filter((field) => field.short).length > 0;
+        let tHead;
+        let tBody;
+
+        if (compactTable) {
+            let headerCols = [];
+            let bodyCols = [];
+
+            fields.forEach((field, i) => {
+                headerCols.push(
+                    <th
+                        className='attachment___field-caption'
+                        key={'attachment__field-caption-' + i}
+                    >
+                        {field.title}
+                    </th>
+                );
+                bodyCols.push(
+                    <td
+                        className='attachment___field'
+                        key={'attachment__field-' + i}
+                        dangerouslySetInnerHTML={{__html: TextFormatting.formatText(field.value || '')}}
+                    >
+                    </td>
+                );
+            });
+
+            tHead = (
+                <tr>
+                    {headerCols}
+                </tr>
+            );
+            tBody = (
+                <tr>
+                    {bodyCols}
+                </tr>
+            );
+        } else {
+            tBody = [];
+
+            fields.forEach((field, i) => {
+                tBody.push(
+                    <tr key={'attachment__field-' + i}>
+                        <td
+                            className='attachment___field-caption'
+                        >
+                            {field.title}
+                        </td>
+                        <td
+                            className='attachment___field'
+                            dangerouslySetInnerHTML={{__html: TextFormatting.formatText(field.value || '')}}
+                        >
+                        </td>
+                    </tr>
+                );
+            });
+        }
+
+        return (
+            <table
+                className='attachment___fields'
+            >
+                <thead>
+                    {tHead}
+                </thead>
+                <tbody>
+                    {tBody}
+                </tbody>
+            </table>
+        );
+    }
+
+    render() {
+        const data = this.props.attachment;
+
+        let preText;
+        if (data.pretext) {
+            preText = (
+                <div
+                    className='attachment__thumb-pretext'
+                    dangerouslySetInnerHTML={{__html: TextFormatting.formatText(data.pretext)}}
+                >
+                </div>
+            );
+        }
+
+        let author = [];
+        if (data.author_name || data.author_icon) {
+            if (data.author_icon) {
+                author.push(
+                    <img
+                        className='attachment__author-icon'
+                        src={data.author_icon}
+                        key={'attachment__author-icon'}
+                        height='14'
+                        width='14'
+                    />
+                );
+            }
+            if (data.author_name) {
+                author.push(
+                    <span
+                        className='attachment__author-name'
+                        key={'attachment__author-name'}
+                    >
+                        {data.author_name}
+                    </span>
+                );
+            }
+        }
+        if (data.author_link) {
+            author = (
+                <a
+                    href={data.author_link}
+                    target='_blank'
+                >
+                    {author}
+                </a>
+            );
+        }
+
+        let title;
+        if (data.title) {
+            if (data.title_link) {
+                title = (
+                    <h1
+                        className='attachment__title'
+                    >
+                        <a
+                            className='attachment__title-link'
+                            href={data.title_link}
+                            target='_blank'
+                        >
+                            {data.title}
+                        </a>
+                    </h1>
+                );
+            } else {
+                title = (
+                    <h1
+                        className='attachment__title'
+                    >
+                        {data.title}
+                    </h1>
+                );
+            }
+        }
+
+        let text;
+        if (data.text) {
+            text = (
+                <div
+                    className='attachment__text'
+                    dangerouslySetInnerHTML={{__html: TextFormatting.formatText(data.text || '')}}
+                >
+                </div>
+            );
+        }
+
+        let image;
+        if (data.image_url) {
+            image = (
+                <img
+                    className='attachment__image'
+                    src={data.image_url}
+                />
+            );
+        }
+
+        let thumb;
+        if (data.thumb_url) {
+            thumb = (
+                <div
+                    className='attachment__thumb-container'
+                >
+                    <img
+                        src={data.thumb_url}
+                    />
+                </div>
+            );
+        }
+
+        const fields = this.getFieldsTable();
+
+        let useBorderStyle;
+        if (data.color && data.color[0] === '#') {
+            useBorderStyle = {borderLeftColor: data.color};
+        }
+
+        return (
+            <div
+                className='attachment'
+            >
+                {preText}
+                <div className='attachment__content'>
+                    <div
+                        className={useBorderStyle ? 'attachment__container' : 'attachment__container attachment__container--' + data.color}
+                        style={useBorderStyle}
+                    >
+                        {author}
+                        {title}
+                        <div>
+                            <div
+                                className={thumb ? 'attachment__body' : 'attachment__body attachment__body--no_thumb'}
+                            >
+                                {text}
+                                {image}
+                                {fields}
+                            </div>
+                            {thumb}
+                            <div style={{clear: 'both'}}></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+PostAttachment.propTypes = {
+    attachment: React.PropTypes.object.isRequired
+};

--- a/web/react/components/post_attachment_list.jsx
+++ b/web/react/components/post_attachment_list.jsx
@@ -1,0 +1,32 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+const PostAttachment = require('./post_attachment.jsx');
+
+export default class PostAttachmentList extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        let content = [];
+        this.props.attachments.forEach((attachment, i) => {
+            content.push(
+                <PostAttachment
+                    attachment={attachment}
+                    key={'att_' + i}
+                />
+            );
+        });
+
+        return (
+            <div className='attachment_list'>
+                {content}
+            </div>
+        );
+    }
+}
+
+PostAttachmentList.propTypes = {
+    attachments: React.PropTypes.array.isRequired
+};

--- a/web/react/components/post_body.jsx
+++ b/web/react/components/post_body.jsx
@@ -7,6 +7,7 @@ const Utils = require('../utils/utils.jsx');
 const Constants = require('../utils/constants.jsx');
 const TextFormatting = require('../utils/text_formatting.jsx');
 const twemoji = require('twemoji');
+const PostAttachmentList = require('./post_attachment_list.jsx');
 
 export default class PostBody extends React.Component {
     constructor(props) {
@@ -311,6 +312,15 @@ export default class PostBody extends React.Component {
             );
         }
 
+        let postAttachments = '';
+        if (post.attachments && post.attachments.length) {
+            postAttachments = (
+                <PostAttachmentList
+                    attachments={post.attachments}
+                />
+            );
+        }
+
         return (
             <div className='post-body'>
                 {comment}
@@ -326,6 +336,7 @@ export default class PostBody extends React.Component {
                         dangerouslySetInnerHTML={{__html: TextFormatting.formatText(this.state.message)}}
                     />
                 </div>
+                {postAttachments}
                 {fileAttachmentHolder}
                 {embed}
             </div>

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -468,6 +468,7 @@ export function applyTheme(theme) {
         changeCss('.modal .modal-header', 'background:' + theme.sidebarHeaderBg, 1);
         changeCss('#navbar .navbar-default', 'background:' + theme.sidebarHeaderBg, 1);
         changeCss('@media(max-width: 768px){.search-bar__container', 'background:' + theme.sidebarHeaderBg, 1);
+        changeCss('.attachment .attachment__container', 'border-left-color:' + theme.sidebarHeaderBg, 1);
     }
 
     if (theme.sidebarHeaderTextColor) {
@@ -506,6 +507,7 @@ export function applyTheme(theme) {
         changeCss('.popover.left>.arrow:after', 'border-left-color:' + theme.centerChannelBg, 1);
         changeCss('.popover.top>.arrow:after', 'border-top-color:' + theme.centerChannelBg, 1);
         changeCss('.search-bar__container .search__form .search-bar, .form-control', 'background:' + theme.centerChannelBg, 1);
+        changeCss('.attachment__content', 'background:' + theme.centerChannelBg, 1);
     }
 
     if (theme.centerChannelColor) {
@@ -539,6 +541,7 @@ export function applyTheme(theme) {
         changeCss('@media(max-width: 768px){.search-bar__container .search__form .search-bar', 'background:' + changeOpacity(theme.centerChannelColor, 0.2) + '; color: inherit;', 1);
         changeCss('.input-group-addon, .search-bar__container .search__form, .form-control', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2), 1);
         changeCss('.form-control:focus', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.3), 1);
+        changeCss('.attachment .attachment__content', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.3), 1);
         changeCss('.channel-intro .channel-intro__content, .webhooks__container', 'background:' + changeOpacity(theme.centerChannelColor, 0.05), 1);
         changeCss('.date-separator .separator__text', 'color:' + theme.centerChannelColor, 2);
         changeCss('.date-separator .separator__hr, .modal-footer, .modal .custom-textarea, .post-right__container .post.post--root hr, .search-item-container', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2), 1);

--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -602,3 +602,74 @@ body.ios {
 	font-weight: 600;
 	margin: 0 0 0 -4px;
 }
+
+.attachment {
+    .attachment__content {
+        border-width: 1px;
+        border-style: solid;
+        border-radius: 4px;
+        padding: 2px 5px;
+        margin: 0 0 5px 0;
+    }
+    .attachment__thumb-pretext {
+        border: 0 none;
+        background: transparent;
+    }
+    .attachment__container {
+        border-left-width: 4px;
+        border-left-style: solid;
+        padding: 2px 0 2px 10px;
+        &.attachment__container--good {
+            border-left-color: #00C100;
+        }
+        &.attachment__container--warning {
+            border-left-color: #DEDE01;
+        }
+        &.attachment__container--danger {
+            border-left-color: #E40303;
+        }
+    }
+    .attachment__body {
+        float: left;
+        width: 80%;
+        padding-right: 5px;
+        &.attachment__body--no_thumb {
+            width: 100%;
+        }
+    }
+    .attachment__thumb-pretext {
+        margin-left: 5px;
+    }
+    .attachment__title {
+        margin: 5px 0;
+        padding: 0;
+        line-height: 16px;
+        font-size: 16px;
+        a {
+            font-size: 16px;
+        }
+    }
+    .attachment__author-icon {
+        @include border-radius(50px);
+        margin-right: 5px;
+        width: 14px;
+        height: 14px;
+    }
+    .attachment__image {
+        max-width: 100%;
+    }
+    .attachment__thumb-container {
+        width: 20%;
+        float: right;
+        img {
+            height: 75px;
+            max-width: 100%;
+        }
+    }
+    .attachment___fields {
+        width: 100%;
+        .attachment___field-caption {
+            font-weight: 700;
+        }
+    }
+}

--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -637,6 +637,9 @@ body.ios {
             width: 100%;
         }
     }
+    .attachment__text p:last-of-type {
+        display: inline-block;
+    }
     .attachment__thumb-pretext {
         margin-left: 5px;
     }

--- a/web/web.go
+++ b/web/web.go
@@ -1021,6 +1021,7 @@ func incomingWebhook(c *api.Context, w http.ResponseWriter, r *http.Request) {
 
 	overrideUsername := parsedRequest.Username
 	overrideIconUrl := parsedRequest.IconURL
+	attachments := parsedRequest.Attachments
 
 	if result := <-cchan; result.Err != nil {
 		c.Err = model.NewAppError("incomingWebhook", "Couldn't find the channel", "err="+result.Err.Message)
@@ -1039,7 +1040,7 @@ func incomingWebhook(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := api.CreateWebhookPost(c, channel.Id, text, overrideUsername, overrideIconUrl); err != nil {
+	if _, err := api.CreateWebhookPost(c, channel.Id, text, overrideUsername, overrideIconUrl, attachments); err != nil {
 		c.Err = err
 		return
 	}

--- a/web/web.go
+++ b/web/web.go
@@ -983,8 +983,10 @@ func incomingWebhook(c *api.Context, w http.ResponseWriter, r *http.Request) {
 		parsedRequest = model.IncomingWebhookRequestFromJson(strings.NewReader(r.FormValue("payload")))
 	}
 
+	attachments := parsedRequest.Attachments
+
 	text := parsedRequest.Text
-	if len(text) == 0 {
+	if len(text) == 0 && (attachments == nil || len(attachments) == 0) {
 		c.Err = model.NewAppError("incomingWebhook", "No text specified", "")
 		return
 	}
@@ -1021,7 +1023,6 @@ func incomingWebhook(c *api.Context, w http.ResponseWriter, r *http.Request) {
 
 	overrideUsername := parsedRequest.Username
 	overrideIconUrl := parsedRequest.IconURL
-	attachments := parsedRequest.Attachments
 
 	if result := <-cchan; result.Err != nil {
 		c.Err = model.NewAppError("incomingWebhook", "Couldn't find the channel", "err="+result.Err.Message)


### PR DESCRIPTION
This adds attachments as described in https://api.slack.com/docs/attachments
["Automatic unfurling"](https://api.slack.com/docs/unfurling) is not implemented - my guess is, slack has a bunch of rules for different websites, telling the application what to crawl/fetch.

Addionally, attachments are currently not visible in RHS comment section, I was not quite sure on how to display it - since there is very little space available, do you have any idea - probably leave of any images in the attachments etc.?
Thought I'd already submit the PR anyway since I won't be able to work on it this saturday - perhaps someone can already have a look at it.

Just tell me what/if there's any work to be done!

*Test webhook body, from an up2date gitlab version (if you need one for testing):*
````javascript
{
    "text": "Florian pushed to branch \u003chttp://srv:3000/foo/bar/commits/feature/update-33390|feature/update-33390\u003e of \u003chttp://srv:3000/foo/bar|Foo/Bar\u003e (\u003chttp://srv:3000/foo/bar/compare/5829dfe201a9dbff15729ab99cd33b64c8e11236...36028fd8d43c4434a048f66597588d46fd958733|Compare changes\u003e)",
    "username": "gitlab",
    "channel": "town-square",
    "attachments": [
        {
            "text": "\u003chttp://srv:3000/foo/bar/commit/36028fd8d43c4434a048f66597588d46fd958733|36028fd8\u003e: Some very important fix\n - flo\n\u003chttp://srv:3000/foo/bar/commit/d1291f692b9944535bb569f6841d2972cec4d8ff|d1291f69\u003e: Another important fix\n - mr x\n\u003chttp://srv:3000/foo/bar/commit/5829dfe201a9dbff15729ab99cd33b64c8e11236|5829dfe2\u003e: Some changes\n - someone",
            "color": "#345"
        }
    ]
}
````
 
![bildschirmfoto vom 2015-10-31 04 59 25](https://cloud.githubusercontent.com/assets/1024005/10861770/03d75c16-7f8d-11e5-8acc-14c63a707dfe.png)