### PR TITLE
Brings back deleted parent fix lost in center post list refactor

### DIFF
--- a/web/react/components/posts_view.jsx
+++ b/web/react/components/posts_view.jsx
@@ -4,6 +4,7 @@
 const UserStore = require('../stores/user_store.jsx');
 const Utils = require('../utils/utils.jsx');
 const Post = require('./post.jsx');
+const Constants = require('../utils/constants.jsx');
 
 export default class PostsView extends React.Component {
     constructor(props) {
@@ -68,6 +69,11 @@ export default class PostsView extends React.Component {
             const post = posts[order[i]];
             const parentPost = posts[post.parent_id];
             const prevPost = posts[order[i + 1]];
+
+            // If the post is a comment whose parent has been deleted, don't add it to the list.
+            if (parentPost && parentPost.state === Constants.POST_DELETED) {
+                continue;
+            }
 
             let sameUser = false;
             let sameRoot = false;


### PR DESCRIPTION
As per @crspeller's comment on #1222, this transfers the logic checking to make sure that a comment's parent has yet to be deleted before adding it to the list of posts to be rendered that was part of the same PR into the new `post_view.jsx` file.  The same fix for PLT-550 that was previously merged seems to have been lost in the refactor process.