### PR TITLE
PLT-741/743 Adds additional checks when sorting channels/teams by display name

### DIFF
--- a/web/react/components/navbar_dropdown.jsx
+++ b/web/react/components/navbar_dropdown.jsx
@@ -18,24 +18,8 @@ function getStateFromStores() {
             teams.push(teamsObject[teamId]);
         }
     }
-    teams.sort((teamA, teamB) => {
-        let teamADisplayName = '';
-        let teamBDisplayName = '';
 
-        if (teamA && teamA.display_name) {
-            teamADisplayName = teamA.display_name.toLowerCase();
-        }
-        if (teamB && teamB.display_name) {
-            teamBDisplayName = teamB.display_name.toLowerCase();
-        }
-
-        if (teamADisplayName < teamBDisplayName) {
-            return -1;
-        } else if (teamADisplayName > teamBDisplayName) {
-            return 1;
-        }
-        return 0;
-    });
+    teams.sort(Utils.sortByDisplayName);
     return {teams};
 }
 

--- a/web/react/components/navbar_dropdown.jsx
+++ b/web/react/components/navbar_dropdown.jsx
@@ -11,16 +11,24 @@ var AboutBuildModal = require('./about_build_modal.jsx');
 var Constants = require('../utils/constants.jsx');
 
 function getStateFromStores() {
-    let teams = [];
-    let teamsObject = UserStore.getTeams();
-    for (let teamId in teamsObject) {
+    const teams = [];
+    const teamsObject = UserStore.getTeams();
+    for (const teamId in teamsObject) {
         if (teamsObject.hasOwnProperty(teamId)) {
             teams.push(teamsObject[teamId]);
         }
     }
-    teams.sort(function sortByDisplayName(teamA, teamB) {
-        let teamADisplayName = teamA.display_name.toLowerCase();
-        let teamBDisplayName = teamB.display_name.toLowerCase();
+    teams.sort((teamA, teamB) => {
+        let teamADisplayName = '';
+        let teamBDisplayName = '';
+
+        if (teamA && teamA.display_name) {
+            teamADisplayName = teamA.display_name.toLowerCase();
+        }
+        if (teamB && teamB.display_name) {
+            teamBDisplayName = teamB.display_name.toLowerCase();
+        }
+
         if (teamADisplayName < teamBDisplayName) {
             return -1;
         } else if (teamADisplayName > teamBDisplayName) {

--- a/web/react/stores/channel_store.jsx
+++ b/web/react/stores/channel_store.jsx
@@ -183,11 +183,21 @@ class ChannelStoreClass extends EventEmitter {
             channels.push(channel);
         }
 
-        channels.sort(function chanSort(a, b) {
-            if (a.display_name.toLowerCase() < b.display_name.toLowerCase()) {
+        channels.sort((a, b) => {
+            let channelADisplayName = '';
+            let channelBDisplayName = '';
+
+            if (a && a.display_name) {
+                channelADisplayName = a.display_name.toLowerCase();
+            }
+            if (b && b.display_name) {
+                channelBDisplayName = b.display_name.toLowerCase();
+            }
+
+            if (channelADisplayName < channelBDisplayName) {
                 return -1;
             }
-            if (a.display_name.toLowerCase() > b.display_name.toLowerCase()) {
+            if (channelADisplayName > channelBDisplayName) {
                 return 1;
             }
             return 0;

--- a/web/react/stores/channel_store.jsx
+++ b/web/react/stores/channel_store.jsx
@@ -4,6 +4,7 @@
 var AppDispatcher = require('../dispatcher/app_dispatcher.jsx');
 var EventEmitter = require('events').EventEmitter;
 
+var Utils;
 var Constants = require('../utils/constants.jsx');
 var ActionTypes = Constants.ActionTypes;
 
@@ -183,26 +184,11 @@ class ChannelStoreClass extends EventEmitter {
             channels.push(channel);
         }
 
-        channels.sort((a, b) => {
-            let channelADisplayName = '';
-            let channelBDisplayName = '';
+        if (!Utils) {
+            Utils = require('../utils/utils.jsx'); //eslint-disable-line global-require
+        }
 
-            if (a && a.display_name) {
-                channelADisplayName = a.display_name.toLowerCase();
-            }
-            if (b && b.display_name) {
-                channelBDisplayName = b.display_name.toLowerCase();
-            }
-
-            if (channelADisplayName < channelBDisplayName) {
-                return -1;
-            }
-            if (channelADisplayName > channelBDisplayName) {
-                return 1;
-            }
-            return 0;
-        });
-
+        channels.sort(Utils.sortByDisplayName);
         this.pStoreChannels(channels);
     }
     pStoreChannels(channels) {

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1090,3 +1090,24 @@ export function openDirectChannelToUser(user, successCb, errorCb) {
         );
     }
 }
+
+// Use when sorting multiple channels or teams by their `display_name` field
+export function sortByDisplayName(a, b) {
+    let aDisplayName = '';
+    let bDisplayName = '';
+
+    if (a && a.display_name) {
+        aDisplayName = a.display_name.toLowerCase();
+    }
+    if (b && b.display_name) {
+        bDisplayName = b.display_name.toLowerCase();
+    }
+
+    if (aDisplayName < bDisplayName) {
+        return -1;
+    }
+    if (aDisplayName > bDisplayName) {
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Hopefully this fixes an error that popped up in the console logs but I wasn't able to reproduce the issue directly.  Also created a new function for sorting by display names since the code was identical, however I wasn't entirely sure about it since they _are_ two different types of objects (channels and teams) but happen to have the same name for a property which allows it to work.  If we want to keep the sort methods separate let me know and I can change it back (my first commit in this PR is exactly that).

Also the "hacky" Util definition in `channel_store.jsx` is derived from similar code in `team_store.jsx`.  Not defining it "on the fly" as shown caused things to break (I'm guessing because `utils.jsx` is defined after `channel_store.jsx`).