### PR TITLE
PLT-516 Part 1 of performance fixes for large teams

### DIFF
--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1020,9 +1020,15 @@ func TestStatuses(t *testing.T) {
 	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(ruser.Id))
 
+	user2 := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	ruser2 := Client.Must(Client.CreateUser(&user2, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(ruser2.Id))
+
 	Client.LoginByEmail(team.Name, user.Email, user.Password)
 
-	r1, err := Client.GetStatuses()
+	userIds := []string{ruser2.Id}
+
+	r1, err := Client.GetStatuses(userIds)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/model/client.go
+++ b/model/client.go
@@ -783,8 +783,8 @@ func (c *Client) ResetPassword(data map[string]string) (*Result, *AppError) {
 	}
 }
 
-func (c *Client) GetStatuses() (*Result, *AppError) {
-	if r, err := c.DoApiGet("/users/status", "", ""); err != nil {
+func (c *Client) GetStatuses(data []string) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/users/status", ArrayToJson(data)); err != nil {
 		return nil, err
 	} else {
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),

--- a/model/version.go
+++ b/model/version.go
@@ -21,9 +21,9 @@ var versions = []string{
 }
 
 var CurrentVersion string = versions[0]
-var BuildNumber = "_BUILD_NUMBER_"
-var BuildDate = "_BUILD_DATE_"
-var BuildHash = "_BUILD_HASH_"
+var BuildNumber = "dev"
+var BuildDate = "Tue  3 Nov 2015 20:11:28 UTC"
+var BuildHash = "a26145ef91197ba374d525c947984ae672cbd94d"
 
 func SplitVersion(version string) (int64, int64, int64) {
 	parts := strings.Split(version, ".")
@@ -69,7 +69,7 @@ func GetPreviousVersion(currentVersion string) (int64, int64) {
 }
 
 func IsOfficalBuild() bool {
-	return BuildNumber != "_BUILD_NUMBER_"
+	return BuildNumber != "dev"
 }
 
 func IsCurrentVersion(versionToCheck string) bool {

--- a/model/version.go
+++ b/model/version.go
@@ -21,9 +21,9 @@ var versions = []string{
 }
 
 var CurrentVersion string = versions[0]
-var BuildNumber = "dev"
-var BuildDate = "Tue  3 Nov 2015 20:11:28 UTC"
-var BuildHash = "a26145ef91197ba374d525c947984ae672cbd94d"
+var BuildNumber = "_BUILD_NUMBER_"
+var BuildDate = "_BUILD_DATE_"
+var BuildHash = "_BUILD_HASH_"
 
 func SplitVersion(version string) (int64, int64, int64) {
 	parts := strings.Split(version, ".")
@@ -69,7 +69,7 @@ func GetPreviousVersion(currentVersion string) (int64, int64) {
 }
 
 func IsOfficalBuild() bool {
-	return BuildNumber != "dev"
+	return BuildNumber != "_BUILD_NUMBER_"
 }
 
 func IsCurrentVersion(versionToCheck string) bool {

--- a/web/react/components/channel_loader.jsx
+++ b/web/react/components/channel_loader.jsx
@@ -30,19 +30,14 @@ export default class ChannelLoader extends React.Component {
         AsyncClient.getChannels(true, true);
         AsyncClient.getChannelExtraInfo(true);
         AsyncClient.findTeams();
-        AsyncClient.getStatuses();
         AsyncClient.getMyTeam();
+        setTimeout(() => AsyncClient.getStatuses(), 3000); // temporary until statuses are reworked a bit
 
         /* Perform pending post clean-up */
         PostStore.clearPendingPosts();
 
         /* Set up interval functions */
-        this.intervalId = setInterval(
-            () => {
-                AsyncClient.getStatuses();
-            },
-            30000
-        );
+        this.intervalId = setInterval(() => AsyncClient.getStatuses(), 30000);
 
         /* Device tracking setup */
         var iOS = (/(iPad|iPhone|iPod)/g).test(navigator.userAgent);

--- a/web/react/components/channel_loader.jsx
+++ b/web/react/components/channel_loader.jsx
@@ -38,7 +38,7 @@ export default class ChannelLoader extends React.Component {
 
         /* Set up interval functions */
         this.intervalId = setInterval(
-            function pollStatuses() {
+            () => {
                 AsyncClient.getStatuses();
             },
             30000

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -100,74 +100,53 @@ export default class Sidebar extends React.Component {
     }
     getStateFromStores() {
         const members = ChannelStore.getAllMembers();
-        var teamMemberMap = UserStore.getActiveOnlyProfiles();
-        var currentId = ChannelStore.getCurrentId();
-        const currentUserId = UserStore.getCurrentId();
+        const currentChannelId = ChannelStore.getCurrentId();
 
-        var teammates = [];
-        for (var id in teamMemberMap) {
-            if (id === currentUserId) {
-                continue;
-            }
-            teammates.push(teamMemberMap[id]);
-        }
+        const channels = Object.assign([], ChannelStore.getAll());
+        const publicChannels = channels.filter((channel) => channel.type === Constants.OPEN_CHANNEL);
+        const privateChannels = channels.filter((channel) => channel.type === Constants.PRIVATE_CHANNEL);
+        const directChannels = channels.filter((channel) => channel.type === Constants.DM_CHANNEL);
 
         const preferences = PreferenceStore.getPreferences(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW);
 
         var visibleDirectChannels = [];
-        var hiddenDirectChannelCount = 0;
-        for (var i = 0; i < teammates.length; i++) {
-            const teammate = teammates[i];
+        for (var i = 0; i < directChannels.length; i++) {
+            const dm = directChannels[i];
+            const teammate = Utils.getDirectTeammate(dm.id);
 
-            if (teammate.id === currentUserId) {
-                continue;
-            }
+            const member = members[dm.id];
+            const msgCount = dm.total_msg_count - member.msg_count;
 
-            const channelName = Utils.getDirectChannelName(currentUserId, teammate.id);
+            // always show a channel if either it is the current one or if it is unread, but it is not currently being left
+            const forceShow = (currentChannelId === dm.id || msgCount > 0) && !this.isLeaving.get(dm.id);
+            const preferenceShow = preferences.some((preference) => (preference.name === teammate.id && preference.value !== 'false'));
 
-            let forceShow = false;
-            let channel = ChannelStore.getByName(channelName);
+            if (preferenceShow || forceShow) {
+                dm.display_name = Utils.displayUsername(teammate.id);
+                dm.teammate_id = teammate.id;
+                dm.status = UserStore.getStatus(teammate.id);
 
-            if (channel) {
-                const member = members[channel.id];
-                const msgCount = channel.total_msg_count - member.msg_count;
+                visibleDirectChannels.push(dm);
 
-                // always show a channel if either it is the current one or if it is unread, but it is not currently being left
-                forceShow = (currentId === channel.id || msgCount > 0) && !this.isLeaving.get(channel.id);
-            } else {
-                channel = {};
-                channel.fake = true;
-                channel.name = channelName;
-                channel.last_post_at = 0;
-                channel.total_msg_count = 0;
-                channel.type = 'D';
-            }
-
-            channel.display_name = Utils.displayUsername(teammate.id);
-            channel.teammate_id = teammate.id;
-            channel.status = UserStore.getStatus(teammate.id);
-
-            if (preferences.some((preference) => (preference.name === teammate.id && preference.value !== 'false'))) {
-                visibleDirectChannels.push(channel);
-            } else if (forceShow) {
-                // make sure that unread direct channels are visible
-                const preference = PreferenceStore.setPreference(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, teammate.id, 'true');
-                AsyncClient.savePreferences([preference]);
-
-                visibleDirectChannels.push(channel);
-            } else {
-                hiddenDirectChannelCount += 1;
+                if (forceShow && !preferenceShow) {
+                    // make sure that unread direct channels are visible
+                    const preference = PreferenceStore.setPreference(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, teammate.id, 'true');
+                    AsyncClient.savePreferences([preference]);
+                }
             }
         }
+
+        const hiddenDirectChannelCount = UserStore.getActiveOnlyProfileList().length - visibleDirectChannels.length;
 
         visibleDirectChannels.sort(this.sortChannelsByDisplayName);
 
         const tutorialPref = PreferenceStore.getPreference(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), {value: '0'});
 
         return {
-            activeId: currentId,
-            channels: ChannelStore.getAll(),
+            activeId: currentChannelId,
             members,
+            publicChannels,
+            privateChannels,
             visibleDirectChannels,
             hiddenDirectChannelCount,
             showTutorialTip: parseInt(tutorialPref.value, 10) === TutorialSteps.CHANNEL_POPOVER
@@ -534,11 +513,9 @@ export default class Sidebar extends React.Component {
         this.lastUnreadChannel = null;
 
         // create elements for all 3 types of channels
-        const publicChannels = this.state.channels.filter((channel) => channel.type === 'O');
-        const publicChannelItems = publicChannels.map(this.createChannelElement);
+        const publicChannelItems = this.state.publicChannels.map(this.createChannelElement);
 
-        const privateChannels = this.state.channels.filter((channel) => channel.type === 'P');
-        const privateChannelItems = privateChannels.map(this.createChannelElement);
+        const privateChannelItems = this.state.privateChannels.map(this.createChannelElement);
 
         const directMessageItems = this.state.visibleDirectChannels.map((channel, index, arr) => {
             return this.createChannelElement(channel, index, arr, this.handleLeaveDirectChannel);

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -113,6 +113,9 @@ export default class Sidebar extends React.Component {
         for (var i = 0; i < directChannels.length; i++) {
             const dm = directChannels[i];
             const teammate = Utils.getDirectTeammate(dm.id);
+            if (!teammate) {
+                continue;
+            }
 
             const member = members[dm.id];
             const msgCount = dm.total_msg_count - member.msg_count;

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -593,7 +593,9 @@ export function getStatuses() {
     const teammateIds = [];
     for (var i = 0; i < directChannels.length; i++) {
         const teammate = utils.getDirectTeammate(directChannels[i].id);
-        teammateIds.push(teammate.id);
+        if (teammate) {
+            teammateIds.push(teammate.id);
+        }
     }
 
     if (isCallInProgress('getStatuses') || teammateIds.length === 0) {

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -588,13 +588,21 @@ export function getMe() {
 }
 
 export function getStatuses() {
-    if (isCallInProgress('getStatuses')) {
+    const directChannels = ChannelStore.getAll().filter((channel) => channel.type === Constants.DM_CHANNEL);
+
+    const teammateIds = [];
+    for (var i = 0; i < directChannels.length; i++) {
+        const teammate = utils.getDirectTeammate(directChannels[i].id);
+        teammateIds.push(teammate.id);
+    }
+
+    if (isCallInProgress('getStatuses') || teammateIds.length === 0) {
         return;
     }
 
     callTracker.getStatuses = utils.getTimestamp();
-    client.getStatuses(
-        function getStatusesSuccess(data, textStatus, xhr) {
+    client.getStatuses(teammateIds,
+        (data, textStatus, xhr) => {
             callTracker.getStatuses = 0;
 
             if (xhr.status === 304 || !data) {
@@ -606,7 +614,7 @@ export function getStatuses() {
                 statuses: data
             });
         },
-        function getStatusesFailure(err) {
+        (err) => {
             callTracker.getStatuses = 0;
             dispatchError(err, 'getStatuses');
         }

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -1069,12 +1069,13 @@ export function exportTeam(success, error) {
     });
 }
 
-export function getStatuses(success, error) {
+export function getStatuses(ids, success, error) {
     $.ajax({
         url: '/api/v1/users/status',
         dataType: 'json',
         contentType: 'application/json',
-        type: 'GET',
+        type: 'POST',
+        data: JSON.stringify(ids),
         success,
         error: function onError(xhr, status, err) {
             var e = handleError('getStatuses', xhr, status, err);

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -127,6 +127,7 @@ module.exports = {
     MAX_DMS: 20,
     DM_CHANNEL: 'D',
     OPEN_CHANNEL: 'O',
+    PRIVATE_CHANNEL: 'P',
     INVITE_TEAM: 'I',
     OPEN_TEAM: 'O',
     MAX_POST_LEN: 4000,


### PR DESCRIPTION
##### This includes three major performance improvements for large teams:
1. `getProfiles` no longer does a bunch of slow event emitting/json serializing for every received profile
2. `getStatuses` now only returns the user statuses for the list of provided user ids instead of a status for every user on the team
3. The LHS no longer loops through all user profiles to populate direct messages but rather checks existing channels properly (possible due to new direct channels modal)

##### Some stuff coming in part 2 tomorrow:
1. More intelligently load user profile pictures
2. Return less data in `getProfiles`

##### Related tasks to do for 1.3:
1. Return less data in all API services where possible
2. Rework how user statuses are handled
3. Look in to more refactoring of LHS
4. Handling user profiles better