### PR TITLE
PLT-761 Allowed @mentions to follow any non-alphanumeric character instead of just following whitespace

### DIFF
--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -166,7 +166,7 @@ function autolinkAtMentions(text, tokens) {
     }
 
     let output = text;
-    output = output.replace(/(^|\s)(@([a-z0-9.\-_]*))/gi, replaceAtMentionWithToken);
+    output = output.replace(/(^|[^a-z0-9])(@([a-z0-9.\-_]*))/gi, replaceAtMentionWithToken);
 
     return output;
 }

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -171,6 +171,10 @@ function autolinkAtMentions(text, tokens) {
     return output;
 }
 
+function escapeRegex(text) {
+    return text.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
 function highlightCurrentMentions(text, tokens) {
     let output = text;
 
@@ -210,7 +214,7 @@ function highlightCurrentMentions(text, tokens) {
     }
 
     for (const mention of UserStore.getCurrentMentionKeys()) {
-        output = output.replace(new RegExp(`(^|\\W)(${mention})\\b`, 'gi'), replaceCurrentMentionWithToken);
+        output = output.replace(new RegExp(`(^|\\W)(${escapeRegex(mention)})\\b`, 'gi'), replaceCurrentMentionWithToken);
     }
 
     return output;
@@ -290,7 +294,7 @@ function highlightSearchTerm(text, tokens, searchTerm) {
         return prefix + alias;
     }
 
-    return output.replace(new RegExp(`()(${searchTerm})`, 'gi'), replaceSearchTermWithToken);
+    return output.replace(new RegExp(`()(${escapeRegex(searchTerm)})`, 'gi'), replaceSearchTermWithToken);
 }
 
 function replaceTokens(text, tokens) {

--- a/web/react/utils/text_formatting.jsx
+++ b/web/react/utils/text_formatting.jsx
@@ -64,22 +64,6 @@ export function doFormatText(text, options) {
     return output;
 }
 
-export function doFormatEmoticons(text) {
-    const tokens = new Map();
-
-    let output = Emoticons.handleEmoticons(text, tokens);
-    output = replaceTokens(output, tokens);
-
-    return output;
-}
-
-export function doFormatMentions(text) {
-    const tokens = new Map();
-    let output = autolinkAtMentions(text, tokens);
-    output = replaceTokens(output, tokens);
-    return output;
-}
-
 export function sanitizeHtml(text) {
     let output = text;
 


### PR DESCRIPTION
Also removes some unused text formatting stuff and adds some escaping so that search terms like "test..." don't end up highlighting 3 extra characters after any occurrence of the word test.

I also just broke mattermost by searching for * and then closing the page so the escaping is actually a lot more important than I expected.