### PR TITLE
PLT-974 Prevented searching for "*"

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -890,7 +890,10 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 	channels := []store.StoreChannel{}
 
 	for _, params := range paramsList {
-		channels = append(channels, Srv.Store.Post().Search(c.Session.TeamId, c.Session.UserId, params))
+		// don't allow users to search for everything
+		if params.Terms != "*" {
+			channels = append(channels, Srv.Store.Post().Search(c.Session.TeamId, c.Session.UserId, params))
+		}
 	}
 
 	posts := &model.PostList{}

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -450,6 +450,10 @@ func TestSearchPosts(t *testing.T) {
 	if len(r3.Order) != 1 && r3.Order[0] == post3.Id {
 		t.Fatal("wrong serach")
 	}
+
+	if r4 := Client.Must(Client.SearchPosts("*")).Data.(*model.PostList); len(r4.Order) != 0 {
+		t.Fatal("searching for just * shouldn't return any results")
+	}
 }
 
 func TestSearchHashtagPosts(t *testing.T) {


### PR DESCRIPTION
Currently it throws an error and it doesn't really make sense to allow that anyway since it'll just return a massive amount of data on larger systems.