### PR TITLE
PLT-592 Correctly measure the length of unicode strings

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"unicode/utf8"
 )
 
 const (
@@ -74,7 +75,7 @@ func (o *Channel) IsValid() *AppError {
 		return NewAppError("Channel.IsValid", "Update at must be a valid time", "id="+o.Id)
 	}
 
-	if len(o.DisplayName) > 64 {
+	if utf8.RuneCountInString(o.DisplayName) > 64 {
 		return NewAppError("Channel.IsValid", "Invalid display name", "id="+o.Id)
 	}
 
@@ -90,11 +91,11 @@ func (o *Channel) IsValid() *AppError {
 		return NewAppError("Channel.IsValid", "Invalid type", "id="+o.Id)
 	}
 
-	if len(o.Header) > 1024 {
+	if utf8.RuneCountInString(o.Header) > 1024 {
 		return NewAppError("Channel.IsValid", "Invalid header", "id="+o.Id)
 	}
 
-	if len(o.Purpose) > 128 {
+	if utf8.RuneCountInString(o.Purpose) > 128 {
 		return NewAppError("Channel.IsValid", "Invalid purpose", "id="+o.Id)
 	}
 

--- a/model/oauth.go
+++ b/model/oauth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"unicode/utf8"
 )
 
 type OAuthApp struct {
@@ -57,7 +58,7 @@ func (a *OAuthApp) IsValid() *AppError {
 		return NewAppError("OAuthApp.IsValid", "Invalid homepage", "app_id="+a.Id)
 	}
 
-	if len(a.Description) > 512 {
+	if utf8.RuneCountInString(a.Description) > 512 {
 		return NewAppError("OAuthApp.IsValid", "Invalid description", "app_id="+a.Id)
 	}
 

--- a/model/post.go
+++ b/model/post.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"unicode/utf8"
 )
 
 const (
@@ -94,11 +95,11 @@ func (o *Post) IsValid() *AppError {
 		return NewAppError("Post.IsValid", "Invalid original id", "")
 	}
 
-	if len(o.Message) > 4000 {
+	if utf8.RuneCountInString(o.Message) > 4000 {
 		return NewAppError("Post.IsValid", "Invalid message", "id="+o.Id)
 	}
 
-	if len(o.Hashtags) > 1000 {
+	if utf8.RuneCountInString(o.Hashtags) > 1000 {
 		return NewAppError("Post.IsValid", "Invalid hashtags", "id="+o.Id)
 	}
 
@@ -106,7 +107,7 @@ func (o *Post) IsValid() *AppError {
 		return NewAppError("Post.IsValid", "Invalid type", "id="+o.Type)
 	}
 
-	if len(ArrayToJson(o.Filenames)) > 4000 {
+	if utf8.RuneCountInString(ArrayToJson(o.Filenames)) > 4000 {
 		return NewAppError("Post.IsValid", "Invalid filenames", "id="+o.Id)
 	}
 

--- a/model/preference.go
+++ b/model/preference.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"unicode/utf8"
 )
 
 const (
@@ -52,7 +53,7 @@ func (o *Preference) IsValid() *AppError {
 		return NewAppError("Preference.IsValid", "Invalid name", "name="+o.Name)
 	}
 
-	if len(o.Value) > 128 {
+	if utf8.RuneCountInString(o.Value) > 128 {
 		return NewAppError("Preference.IsValid", "Value is too long", "value="+o.Value)
 	}
 

--- a/model/team.go
+++ b/model/team.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
@@ -122,7 +123,7 @@ func (o *Team) IsValid(restrictTeamNames bool) *AppError {
 		return NewAppError("Team.IsValid", "Invalid email", "id="+o.Id)
 	}
 
-	if len(o.DisplayName) == 0 || len(o.DisplayName) > 64 {
+	if utf8.RuneCountInString(o.DisplayName) == 0 || utf8.RuneCountInString(o.DisplayName) > 64 {
 		return NewAppError("Team.IsValid", "Invalid name", "id="+o.Id)
 	}
 

--- a/model/user.go
+++ b/model/user.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
@@ -80,15 +81,15 @@ func (u *User) IsValid() *AppError {
 		return NewAppError("User.IsValid", "Invalid email", "user_id="+u.Id)
 	}
 
-	if len(u.Nickname) > 64 {
+	if utf8.RuneCountInString(u.Nickname) > 64 {
 		return NewAppError("User.IsValid", "Invalid nickname", "user_id="+u.Id)
 	}
 
-	if len(u.FirstName) > 64 {
+	if utf8.RuneCountInString(u.FirstName) > 64 {
 		return NewAppError("User.IsValid", "Invalid first name", "user_id="+u.Id)
 	}
 
-	if len(u.LastName) > 64 {
+	if utf8.RuneCountInString(u.LastName) > 64 {
 		return NewAppError("User.IsValid", "Invalid last name", "user_id="+u.Id)
 	}
 


### PR DESCRIPTION
Since the string type in go is just an alias for []byte, the length of a string containing unicode characters calculated when using len is longer than the number of characters which caused some disagreements between the client-side/database length checking and the server-side validation.