### PR TITLE
Display slack attachments in RHS comment section

### DIFF
--- a/web/react/components/rhs_root_post.jsx
+++ b/web/react/components/rhs_root_post.jsx
@@ -9,6 +9,7 @@ var utils = require('../utils/utils.jsx');
 var FileAttachmentList = require('./file_attachment_list.jsx');
 var twemoji = require('twemoji');
 var Constants = require('../utils/constants.jsx');
+const PostBodyAdditionalContent = require('./post_body_additional_content.jsx');
 
 export default class RhsRootPost extends React.Component {
     constructor(props) {
@@ -179,6 +180,9 @@ export default class RhsRootPost extends React.Component {
                             ref='message_holder'
                             onClick={TextFormatting.handleClick}
                             dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message)}}
+                        />
+                        <PostBodyAdditionalContent
+                            post={post}
                         />
                         {fileAttachment}
                     </div>

--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -674,7 +674,7 @@ body.ios {
         width: 20%;
         float: right;
         img {
-            height: 75px;
+            max-height: 75px;
             max-width: 100%;
         }
     }


### PR DESCRIPTION
Forgot that attachments from 857 were not displayed in RHS comment section, sorry :-/
PR fixes this

![rhs_attachment](https://cloud.githubusercontent.com/assets/1024005/11001860/deb4c500-84a9-11e5-98bf-fc6cad4a6dd1.png)


