### PR TITLE
Markdown image fixes. 

### DIFF
--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -94,7 +94,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         if (title) {
             out += ' title="' + title + '"';
         }
-        out += ' onload="window.markdownImageLoaded(this)" class="markdown-inline-img"';
+        out += ' onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"';
         out += this.options.xhtml ? '/>' : '>';
         return out;
     }

--- a/web/sass-files/sass/partials/_markdown.scss
+++ b/web/sass-files/sass/partials/_markdown.scss
@@ -8,11 +8,14 @@
 		margin-left: 4px;
 	}
 }
-.markdown-inline-img {
-    -moz-force-broken-image-icon: 1;
-    max-height: 500px;
-    height: 500px;
+#post-list {
+    .markdown-inline-img {
+        -moz-force-broken-image-icon: 1;
+        max-height: 500px;
+        height: 500px;
+    }
 }
+
 .post-body {
 	hr {
 		height: 4px;


### PR DESCRIPTION
- Fixed broken markdown images taking up too much space.
- Fixed unnecessary expansion of markdown images not in center channel.