### PR TITLE
PLT-983 Fix _emphasizing_ markdown text when it's not the start of the post

### DIFF
--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -24,7 +24,7 @@ class MattermostInlineLexer extends marked.InlineLexer {
         // modified version of the regex that doesn't break up words in snake_case,
         // allows for links starting with www, and allows links succounded by parentheses
         // the original is /^[\s\S]+?(?=[\\<!\[_*`~]|https?:\/\/| {2,}\n|$)/
-        this.rules.text = /^[\s\S]+?(?=[^\w\/]_|[\\<!\[*`~]|https?:\/\/|www\.|\(| {2,}\n|$)/;
+        this.rules.text = /^[\s\S]+?(?:[^\w\/](?=_)|(?=[\\<!\[*`~]|https?:\/\/|www\.|\(| {2,}\n|$))/;
 
         // modified version of the regex that allows links starting with www and those surrounded
         // by parentheses

--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -24,7 +24,7 @@ class MattermostInlineLexer extends marked.InlineLexer {
         // modified version of the regex that doesn't break up words in snake_case,
         // allows for links starting with www, and allows links succounded by parentheses
         // the original is /^[\s\S]+?(?=[\\<!\[_*`~]|https?:\/\/| {2,}\n|$)/
-        this.rules.text = /^[\s\S]+?(?:[^\w\/](?=_)|(?=[\\<!\[*`~]|https?:\/\/|www\.|\(| {2,}\n|$))/;
+        this.rules.text = /^[\s\S]+?(?:[^\w\/](?=_)|(?=_\W|[\\<!\[*`~]|https?:\/\/|www\.|\(| {2,}\n|$))/;
 
         // modified version of the regex that allows links starting with www and those surrounded
         // by parentheses


### PR DESCRIPTION
The plain text regex matches up to certain strings which may represent the start of a new formatting type like in this case "<space>_". It wouldn't actually match the space causing the regex for `_emphasized text_` to fail because it expected the first character to be the underscore. Now it'll properly match whitespace preceeding an underscore.