### PR TITLE
Cleanup and improve Contribution Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,23 +4,23 @@ Thank you for your interest in contributing to Mattermost. This guide provides a
 
 ## Choose a Ticket
 
-1. Review the list of [Good First Contribution](https://mattermost.atlassian.net/issues/?filter=10206) tickets listed in Jira
+1. Review the list of [Good First Contribution][first-contribs]tickets listed in Jira
     - You are welcome to work on any ticket, even if it is assigned, so long as it is not yet marked "in progress"
     - (optional) Comment on the ticket that you're starting so no one else inadvertently duplicates your work
 
 2. These projects are intended to be a straight forward first pull requests from new contributors
-  - If you don't find something appropriate for your interests, please see the full list of tickets [Accepting Pull Requests](https://mattermost.atlassian.net/issues/?filter=10101)
+  - If you don't find something appropriate for your interests, please see the full list of tickets [Accepting Pull Requests][accepting-pr]
   - Also, feel free to fix bugs you find, or items in GitHub issues that the core team has approved, but not yet added to Jira
 
 3. If you have any questions at all about a ticket, there are several options to ask: 
-  1. Start a topic in the [Mattermost forum](http://forum.mattermost.org/)
-  2. Join the [Mattermost core team discussion](https://pre-release.mattermost.com/signup_user_complete/?id=rcgiyftm7jyrxnma1osd8zswby) and post in the "Tickets" channel
+  1. Start a topic in the [Mattermost forum][forum]
+  2. Join the [Mattermost core team discussion][core-channel-invite] and post in the "Tickets" channel
 
 ## Install Mattermost and set up a Fork
 
-1. Follow [developer setup instructions](https://github.com/mattermost/platform/blob/master/doc/developer/Setup.md) to install Mattermost
+1. Follow [developer setup instructions][setup]to install Mattermost
 
-2. Create a branch with <branch name> set to the ID of the ticket you're working on, for example ```PLT-394```, using command: 
+2. Create a branch with <branch name> set to the ID of the ticket you're working on, for example `PLT-394`, using command: 
 
 ```
 git checkout -b <branch name>
@@ -34,19 +34,36 @@ git checkout -b <branch name>
    
 2. Please make sure to thoroughly test your change before submitting a pull request
 
-   Please review the ["Fast, Obvious, Forgiving" experience design principles](http://www.mattermost.org/design-principles/) for Mattermost and check that your feature meets the criteria. Also, for any changes to user interface or help text, please read the changes out loud, as a quick and easy way to catch any inconsitencies
+   Please review the ["Fast, Obvious, Forgiving" experience design principles][design-principles] for Mattermost and check that your feature meets the criteria. Also, for any changes to user interface or help text, please read the changes out loud, as a quick and easy way to catch any inconsitencies
 
 
 ## Submitting a Pull Request 
 
-1. Please add yourself to the Mattermost [approved contributor list](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true) prior to submitting by completing the [contributor license agreement](http://www.mattermost.org/mattermost-contributor-agreement/). 
+1. Please add yourself to the Mattermost [approved contributor list][approved-contributor-list]prior to submitting by completing the [contributor license agreement][cla].
 
-2. When you submit your pull request please make it against `master` and include the Ticket ID at the beginning of your pull request comment, followed by a colon
+2. All contributors are required to register on the [Mattermost core team channel][core-channel-invite].
 
-  - For example, for a ticket ID `PLT-394` start your comment with:  `PLT-394:`. See [previously closed pull requests](https://github.com/mattermost/platform/pulls?q=is%3Apr+is%3Aclosed) for examples
+3. When you submit your pull request please make it against `master` and include the Ticket ID at the beginning of your pull request comment, followed by a colon
 
-3. Once submitted, your pull request will be checked via an automated build process and will be reviewed by at least two members of the Mattermost core team, who may either accept the PR or follow-up with feedback. It would then get merged into `master` for the next release
+  - For example, for a ticket ID `PLT-394` start your comment with:  `PLT-394:`. See [previously closed pull requests][ticket-examples] for examples
+
+4. Once submitted, your pull request will be checked via an automated build process and will be reviewed by at least two members of the Mattermost core team, who may either accept the PR or follow-up with feedback. It would then get merged into `master` for the next release
   1. If the build fails, check the error log to narrow down the reason
   2. Sometimes one of the multiple build tests will randomly fail due to issues in Travis CI so if you see just one build failure and no clear error message it may be a random issue. Add a comment so the reviewer for your change can re-run the build for you, or close the PR and re-submit and that typically clears the issue
+  3. A member of the core team may contact you via the [Mattermost coreteam channel][core-channel-invite] to discuss your PR. Please check this channel
+  frequently while you have PR's open.
 
-4. If you've included your mailing address in Step 1, you'll be receiving a [Limited Edition Mattermost Mug](http://forum.mattermost.org/t/limited-edition-mattermost-mugs/143) as a thank you gift after your first pull request has been accepted
+5. If you've included your mailing address in Step 1, you'll be receiving a [Limited Edition Mattermost Mug][mattermost-mug] as a thank you gift after your first pull request has been accepted
+
+[//]: Links
+
+[accepting-pr]: https://mattermost.atlassian.net/issues/?filter=10101
+[approved-contributor-list]: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true 
+[cla]: http://www.mattermost.org/mattermost-contributor-agreement/ 
+[core-channel-invite]: https://pre-release.mattermost.com/signup_user_complete/?id=rcgiyftm7jyrxnma1osd8zswby
+[design-principles]: http://www.mattermost.org/design-principles/
+[first-contribs]: https://mattermost.atlassian.net/issues/?filter=10206
+[forum]: http://forum.mattermost.org/
+[mattermost-mug]: http://forum.mattermost.org/t/limited-edition-mattermost-mugs/143 
+[setup]: https://github.com/mattermost/platform/blob/master/doc/developer/Setup.md 
+[ticket-examples]: https://github.com/mattermost/platform/pulls?q=is%3Apr+is%3Aclosed 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Mattermost. This guide provides a
 
 ## Choose a Ticket
 
-1. Review the list of [Good First Contribution][first-contribs]tickets listed in Jira
+1. Review the list of [Good First Contribution][first-contribs] tickets listed in Jira
     - You are welcome to work on any ticket, even if it is assigned, so long as it is not yet marked "in progress"
     - (optional) Comment on the ticket that you're starting so no one else inadvertently duplicates your work
 
@@ -18,9 +18,9 @@ Thank you for your interest in contributing to Mattermost. This guide provides a
 
 ## Install Mattermost and set up a Fork
 
-1. Follow [developer setup instructions][setup]to install Mattermost
+1. Follow [developer setup instructions][setup] to install Mattermost
 
-2. Create a branch with <branch name> set to the ID of the ticket you're working on, for example `PLT-394`, using command: 
+2. Create a branch with `<branch name>` set to the ID of the ticket you're working on, for example `PLT-394`, using command: 
 
 ```
 git checkout -b <branch name>
@@ -39,7 +39,7 @@ git checkout -b <branch name>
 
 ## Submitting a Pull Request 
 
-1. Please add yourself to the Mattermost [approved contributor list][approved-contributor-list]prior to submitting by completing the [contributor license agreement][cla].
+1. Please add yourself to the Mattermost [approved contributor list][approved-contributor-list] prior to submitting by completing the [contributor license agreement][cla].
 
 2. All contributors are required to register on the [Mattermost core team channel][core-channel-invite].
 


### PR DESCRIPTION
- Added a requirement to PR acceptance, contribs must now be registered at core team channel
- added shortcut links to clean up raw document
- moved all external links to bottom of doc
- fixed formatting so markdown syntax highlighting works in all editors