### PR TITLE
Switched eslint to use babel-eslint parser

### DIFF
--- a/web/react/.eslintrc
+++ b/web/react/.eslintrc
@@ -8,6 +8,7 @@
             "arrowFunctions": true,
             "defaultParams": true, 
         },
+        "parser": "babel-eslint",
         "plugins": [
             "react"
         ],

--- a/web/react/package.json
+++ b/web/react/package.json
@@ -18,7 +18,8 @@
     "uglify-js": "2.4.24",
     "watchify": "3.4.0",
     "eslint": "1.6.0",
-    "eslint-plugin-react": "3.5.1"
+    "eslint-plugin-react": "3.5.1",
+    "babel-eslint": "4.1.4"
   },
   "scripts": {
     "check": "",


### PR DESCRIPTION
This allows eslint to parse some ES6 stuff that it otherwise can't like the spread operator.

```javascript
const obj = {a: 1, b: 2, c: 3, d: 4};
const {a, c, ...otherObj} = obj; // this line currently crashes eslint
console.log(obj); // {a: 1, b: 2, c: 3, d: 4}
console.log(otherObj); // {b: 2, d: 4}
```