### PR TITLE
PLT-1085 Updated post components to re-render when stored users change

### DIFF
--- a/web/react/components/post_body.jsx
+++ b/web/react/components/post_body.jsx
@@ -16,6 +16,7 @@ export default class PostBody extends React.Component {
         this.receivedYoutubeData = false;
         this.isGifLoading = false;
 
+        this.handleUserChange = this.handleUserChange.bind(this);
         this.parseEmojis = this.parseEmojis.bind(this);
         this.createEmbed = this.createEmbed.bind(this);
         this.createGifEmbed = this.createGifEmbed.bind(this);
@@ -47,10 +48,20 @@ export default class PostBody extends React.Component {
 
     componentDidMount() {
         this.parseEmojis();
+
+        UserStore.addChangeListener(this.handleUserChange);
     }
 
     componentDidUpdate() {
         this.parseEmojis();
+    }
+
+    componentWillUnmount() {
+        UserStore.removeChangeListener(this.handleUserChange);
+    }
+
+    handleUserChange() {
+        this.forceUpdate();
     }
 
     componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Causing posts to re-render when stored users change fixes @mentions not working when posts are rendered before the initial user data has been pulled from the server