### PR TITLE
Fix: Unable to change password

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -35,7 +35,7 @@ type User struct {
 	Username           string    `json:"username"`
 	Password           string    `json:"password,omitempty"`
 	AuthData           string    `json:"auth_data,omitempty"`
-	AuthService        string    `json:"auth_service,omitempty"`
+	AuthService        string    `json:"auth_service"`
 	Email              string    `json:"email"`
 	EmailVerified      bool      `json:"email_verified,omitempty"`
 	Nickname           string    `json:"nickname"`


### PR DESCRIPTION
Mattermost did not allow me to change my password since it incorrectly thought I was a gitlab SSO user. (Frontend checks the `auth_service` key for this)
Does **not** affect 1.2