### PR TITLE
Add .editorconfig file to allow editors/IDEs to auto apply the correct settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# http://editorconfig.org/
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = false
+charset = utf-8
+
+[*.{go,scss}]
+indent_style = tab
+
+[*.{js,jsx,json,html}]
+indent_style = space
+indent_size = 4
+
+[web/react/package.json]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Add an `.editorconfig` file as described here http://editorconfig.org/.
Pretty much every text editor/IDE nowadays supports this or has a plugin for it. This should help to enforce a style guide and minimize failed travis builds caused by wrong indentation.

`scss` files are specified to use a `tab` indent, this is probably something that is to be decided, since currently `scss` files are pretty much mixed (some use tabs, some use spaces).