### PR TITLE
Do not clear LastActivityAt for GetProfiles

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -233,7 +233,6 @@ func (u *User) ClearNonProfileFields() {
 	u.AuthData = ""
 	u.AuthService = ""
 	u.EmailVerified = false
-	u.LastActivityAt = 0
 	u.LastPingAt = 0
 	u.AllowMarketing = false
 	u.Props = StringMap{}


### PR DESCRIPTION
Do not clear LastActivityAt so we can see when a user was last activity.