### PR TITLE
Added null check when accessing post attachment text

### DIFF
--- a/web/react/components/post_attachment.jsx
+++ b/web/react/components/post_attachment.jsx
@@ -50,7 +50,8 @@ export default class PostAttachment extends React.Component {
     }
 
     shouldCollapse() {
-        return (this.props.attachment.text.match(/\n/g) || []).length >= 5 || this.props.attachment.text.length > 700;
+        const text = this.props.attachment.text || '';
+        return (text.match(/\n/g) || []).length >= 5 || text.length > 700;
     }
 
     getCollapsedText() {


### PR DESCRIPTION
Fixes an issue where a post containing a slack attachment with no text field breaks whatever channel it's in