### PR TITLE
allow incoming webhooks even if it doesnt have a text on it if attachment field is present

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -989,7 +989,7 @@ func incomingWebhook(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	text := parsedRequest.Text
-	if len(text) == 0 {
+	if len(text) == 0 && parsedRequest.Attachments == nil {
 		c.Err = model.NewAppError("incomingWebhook", "No text specified", "")
 		return
 	}


### PR DESCRIPTION
Fixes #1432 

This should have been in with plt-857 already, guess i merged it out at some point while refactoring the code :-/