### PR TITLE
hide 'help' link on mobile screens

### DIFF
--- a/web/sass-files/sass/partials/_responsive.scss
+++ b/web/sass-files/sass/partials/_responsive.scss
@@ -304,7 +304,7 @@
 }
 @media screen and (max-width: 768px) {
     .textarea-wrapper {
-        .textbox-preview-link {
+        .textbox-preview-link, .textbox-help-link {
             display: none;
         }
     }


### PR DESCRIPTION
> Markdown help button overlaps file uploads in mobile view