### PR TITLE
PLT-1070 Added /loadtest url command

### DIFF
--- a/api/command.go
+++ b/api/command.go
@@ -4,7 +4,9 @@
 package api
 
 import (
+	"io"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -325,6 +327,9 @@ func loadTestCommand(c *Context, command *model.Command) bool {
 		if loadTestPostsCommand(c, command) {
 			return true
 		}
+		if loadTestUrlCommand(c, command) {
+			return true
+		}
 	} else if strings.Index(cmd, command.Command) == 0 {
 		command.AddSuggestion(&model.SuggestCommand{Suggestion: cmd, Description: "Debug Load Testing"})
 	}
@@ -567,6 +572,74 @@ func loadTestPostsCommand(c *Context, command *model.Command) bool {
 		command.AddSuggestion(&model.SuggestCommand{Suggestion: cmd2, Description: "Add some random posts with fuzz text to current channel <Min Posts> <Max Posts> <Min Images> <Max Images>"})
 	} else if strings.Index(cmd2, command.Command) == 0 {
 		command.AddSuggestion(&model.SuggestCommand{Suggestion: cmd2, Description: "Add some random posts with fuzz text to current channel <Min Posts> <Max Posts> <Min Images> <Max Images>"})
+	}
+
+	return false
+}
+
+func loadTestUrlCommand(c *Context, command *model.Command) bool {
+	cmd := cmds["loadTestCommand"] + " url"
+
+	if strings.Index(command.Command, cmd) == 0 && !command.Suggest {
+		url := ""
+
+		parameters := strings.SplitN(command.Command, " ", 3)
+		if len(parameters) != 3 {
+			c.Err = model.NewAppError("loadTestUrlCommand", "Command must contain a url", "")
+			return true
+		} else {
+			url = parameters[2]
+		}
+
+		// provide a shortcut to easily access tests stored in doc/developer/tests
+		if !strings.HasPrefix(url, "http") {
+			url = "https://raw.githubusercontent.com/mattermost/platform/master/doc/developer/tests/" + url
+
+			if path.Ext(url) == "" {
+				url += ".md"
+			}
+		}
+
+		var contents io.ReadCloser
+		if r, err := http.Get(url); err != nil {
+			c.Err = model.NewAppError("loadTestUrlCommand", "Unable to get file", err.Error())
+			return false
+		} else if r.StatusCode > 400 {
+			c.Err = model.NewAppError("loadTestUrlCommand", "Unable to get file", r.Status)
+			return false
+		} else {
+			contents = r.Body
+		}
+
+		bytes := make([]byte, 4000)
+
+		// break contents into 4000 byte posts
+		for {
+			length, err := contents.Read(bytes)
+			if err != nil && err != io.EOF {
+				c.Err = model.NewAppError("loadTestUrlCommand", "Encountered error reading file", err.Error())
+				return false
+			}
+
+			if length == 0 {
+				break
+			}
+
+			post := &model.Post{}
+			post.Message = string(bytes[:length])
+			post.ChannelId = command.ChannelId
+
+			if _, err := CreatePost(c, post, false); err != nil {
+				l4g.Error("Unable to create post, err=%v", err)
+				return false
+			}
+		}
+
+		command.Response = model.RESP_EXECUTED
+
+		return true
+	} else if strings.Index(cmd, command.Command) == 0 && strings.Index(command.Command, "/loadtest posts") != 0 {
+		command.AddSuggestion(&model.SuggestCommand{Suggestion: cmd, Description: "Add a post containing the text from a given url to current channel <Url>"})
 	}
 
 	return false

--- a/api/command_test.go
+++ b/api/command_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
+	"github.com/mattermost/platform/utils"
 )
 
 func TestSuggestRootCommands(t *testing.T) {
@@ -182,5 +183,60 @@ func TestEchoCommand(t *testing.T) {
 	p1 := Client.Must(Client.GetPosts(channel1.Id, 0, 2, "")).Data.(*model.PostList)
 	if len(p1.Order) != 1 {
 		t.Fatal("Echo command failed to send")
+	}
+}
+
+func TestLoadTestUrlCommand(t *testing.T) {
+	Setup()
+
+	// enable testing to use /loadtest but don't save it since we don't want to overwrite config.json
+	enableTesting := utils.Cfg.ServiceSettings.EnableTesting
+	defer func() {
+		utils.Cfg.ServiceSettings.EnableTesting = enableTesting
+	}()
+
+	utils.Cfg.ServiceSettings.EnableTesting = true
+
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
+
+	user := &model.User{TeamId: team.Id, Email: model.NewId() + "corey@test.com", Nickname: "Corey Hulen", Password: "pwd"}
+	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(user.Id))
+
+	Client.LoginByEmail(team.Name, user.Email, "pwd")
+
+	channel := &model.Channel{DisplayName: "AA", Name: "aa" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel = Client.Must(Client.CreateChannel(channel)).Data.(*model.Channel)
+
+	command := "/loadtest url "
+	if _, err := Client.Command(channel.Id, command, false); err == nil {
+		t.Fatal("/loadtest url with no url should've failed")
+	}
+
+	command = "/loadtest url http://www.hopefullynonexistent.file/path/asdf/qwerty"
+	if _, err := Client.Command(channel.Id, command, false); err == nil {
+		t.Fatal("/loadtest url with invalid url should've failed")
+	}
+
+	command = "/loadtest url https://raw.githubusercontent.com/mattermost/platform/master/README.md"
+	if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.Command); r.Response != model.RESP_EXECUTED {
+		t.Fatal("/loadtest url for README.md should've executed")
+	}
+
+	command = "/loadtest url test-emoticons.md"
+	if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.Command); r.Response != model.RESP_EXECUTED {
+		t.Fatal("/loadtest url for test-emoticons.md should've executed")
+	}
+
+	command = "/loadtest url test-emoticons"
+	if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.Command); r.Response != model.RESP_EXECUTED {
+		t.Fatal("/loadtest url for test-emoticons should've executed")
+	}
+
+	posts := Client.Must(Client.GetPosts(channel.Id, 0, 5, "")).Data.(*model.PostList)
+	// note that this may make more than 3 posts if files are too long to fit in an individual post
+	if len(posts.Order) < 3 {
+		t.Fatal("/loadtest url made too few posts, perhaps there needs to be a delay before GetPosts in the test?")
 	}
 }

--- a/web/react/components/command_list.jsx
+++ b/web/react/components/command_list.jsx
@@ -81,7 +81,7 @@ export default class CommandList extends React.Component {
             <div
                 ref='mentionlist'
                 className='command-box'
-                style={{height: (this.state.suggestions.length * 56) + 2}}
+                style={{height: (suggestions.length * 56) + 2}}
             >
                 {suggestions}
             </div>


### PR DESCRIPTION
`/loadtest url [url]` will let us load arbitrary files as posts for testing. Since the main use for this will be to post the files in doc/developer/tests, it assumes urls not starting with http are located in that folder and will also append .md if necessary. This means `/loadtest url test-emoticons` will load doc/developer/tests/test-emoticons.md and send it as a series of posts without having to enter the entire url.

Some things to note:
1) This doesn't load any local files and always goes to Github. This is because we're moving those files out of this repo eventually and because I didn't want to worry about path traversal attacks at all.
2) When the docs get moved out of the repo, that url will need to be changed. The unit tests cover that case so we'll know when it needs to be changed.
3) The loaded file is split into 4000 byte chunks which might break unicode characters at the post borders. Since that would be very rare and this is just for testing, I didn't think we needed special handling for that.