### PR TITLE
PLT-982 Overhaul of build system.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@ dist
 npm-debug.log
 
 web/static/js/bundle*.js
+web/static/js/bundle*.js.map
 web/static/js/libs*.js
-model/version.go
-model/version.go.bak
+
+# Build Targets
+.prepare
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,23 @@
-language: go
-go:
-- 1.4.2
-- 1.5.1
+language: generic
+sudo: required
+services:
+- docker
 env:
 - TRAVIS_DB=mysql
 - TRAVIS_DB=postgres
 before_install:
-- gem install compass
-- sudo apt-get update -qq
-- sudo apt-get remove mysql-common mysql-server-5.5 mysql-server-core-5.5 mysql-client-5.5
-  mysql-client-core-5.5
-- sudo apt-get autoremove
-- sudo apt-get install libaio1
-- wget -O mysql-5.6.17.deb http://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.17-debian6.0-x86_64.deb
-- sudo dpkg -i mysql-5.6.17.deb
-- sudo cp /opt/mysql/server-5.6/support-files/mysql.server /etc/init.d/mysql.server
-- sudo ln -s /opt/mysql/server-5.6/bin/* /usr/bin/
-- sudo sed -i'' 's/table_cache/table_open_cache/' /etc/mysql/my.cnf
-- sudo sed -i'' 's/log_slow_queries/slow_query_log/' /etc/mysql/my.cnf
-- sudo sed -i'' 's/basedir[^=]\+=.*$/basedir = \/opt\/mysql\/server-5.6/' /etc/mysql/my.cnf
-- sudo /etc/init.d/mysql.server start
-- sudo pip install mkdocs
-install:
-- export PATH=$PATH:$HOME/gopath/bin
-- go get github.com/tools/godep
-#- godep restore
-before_script:
-- mysql -e "CREATE DATABASE IF NOT EXISTS mattermost_test ;" -uroot
-- mysql -e "CREATE USER 'mmuser'@'%' IDENTIFIED BY 'mostest' ;"  -uroot
-- mysql -e "GRANT ALL ON mattermost_test.* TO 'mmuser'@'%' ;" -uroot
-- psql -c "create database mattermost_test ;" -U postgres
-- psql -c "create user mmuser with password 'mostest' ;" -U postgres
-- psql -c 'grant all privileges on database "mattermost_test" to mmuser ;' -U postgres
-services:
-- redis-server
+    - docker run --name mattermost-mysql -e MYSQL_ROOT_PASSWORD=mostest -e MYSQL_USER=mmuser -e MYSQL_PASSWORD=mostest -e MYSQL_DATABASE=mattermost_test -d mysql:5.7
+    - docker run --name mattermost-postgres -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mostest -d postgres:9.4
+    - sleep 10
+    - docker exec mattermost-postgres psql -c 'create database mattermost_test ;' -U postgres
+    - docker exec mattermost-postgres psql -c 'grant all privileges on database "mattermost_test" to mmuser ;' -U postgres
+script: make dist-travis
 addons:
   hosts:
   - 127.0.0.1 dockerhost
+before_deploy:
+    - sudo rm -rf dist/mattermost
+    - rvm 1.9.3 do gem install mime-types -v 2.6.2
 deploy:
 # Github releases, builds only on tags
  - provider: releases
@@ -47,10 +28,9 @@ deploy:
    on:
      repo: mattermost/platform
      tags: true
-     go: 1.4.2
      condition: $TRAVIS_DB = mysql
 
-# S3 deploy for master docker image. (latest compiled bits)
+# S3 deploy for latest master
  - provider: s3
    access_key_id: AKIAJCO3KJYEGWJIKDIQ
    secret_access_key:
@@ -64,22 +44,4 @@ deploy:
    on:
      repo: mattermost/platform
      branch: master
-     go: 1.4.2
      condition: $TRAVIS_DB = mysql
-
-# S3 deploy for documentation
-# - provider: s3
-#   access_key_id: AKIAJCO3KJYEGWJIKDIQ
-#   secret_access_key:
-#     secure: p66X2tJBmKgtcVyPtGgkAwW29IiRojqGA39RjCJkIWNTJ0e/9JvBOiMS2c4a7I4aOads38rsthwdaigBWagDWNH7bGsEZN7B0TszZuFAuU+XGjU5A66MIOfFfzbUg8AnByysr+XG5/bknFIrP/XhM2fbRr6gbYrFUK7TNkpgjFs5u3BzUrz2iTAV8uOpSJqKSnaf0pTZk1EywOK/X8W8ViIjc7Di3FzQcqIW9K3D27N+3rVsv8SRT1hWASVlnG6aThqqebiM8FCGCzAYVgQb3h3Wu8JT5fIz7Qo7A6siVRwNBwWwzP8HkGoinEK32Wsj/fDXk27vjpFQO/+9sV0xfcTbIZA6MnuYWF4rHOT59KcshCWCD3V0FopX57p/dtOzM9+6lxIctAT++izxWoZit/5c5A4633iY1d+RMeTko1POix6MSlxPMRHZUFwSXROgFuWWRpyD6TlUTCST9/wTTd0WDPklAAiYcnuEPW3qCnw0r0xkrA4AwWUXqXdAIwDt5bA27KcjRyY4Fofv9NxH09BNuBTXNPrvnYPZMmaKrv+HOX3NFTreuV6+5LJdhYUxYSBvSWo1jeWIQ5Q9RUdTU0PqmKpMhJKbKey/S4gxCXHg2HR8DwLCcbIZcvneF9yPEAT71YA6zpLKoPVSwWwH97huKSzjpic/RUfFXQOcgCQ=
-#   bucket: docs.mattermost.org
-#   local_dir: documentation-html
-#   acl: public_read
-#   region: us-east-1
-#   skip_cleanup: true
-#   detect_encoding: true
-#   on:
-#     repo: mattermost/platform
-#     branch: master
-#     go: 1.4.2
-#     condition: $TRAVIS_DB = mysql

--- a/web/react/package.json
+++ b/web/react/package.json
@@ -22,13 +22,14 @@
     "watchify": "3.6.1",
     "eslint": "1.9.0",
     "eslint-plugin-react": "3.9.0",
+    "exorcist": "0.4.0",
     "babel-eslint": "4.1.5"
   },
   "scripts": {
     "check": "",
     "build-libs": "browserify -r crypto -r autolinker -r flux -r keymirror -r marked -r object-assign -r twemoji | uglifyjs -c -m --screw-ie8 > ../static/js/libs.min.js",
     "start": "watchify --fast -x crypto -x node -x autolinker -x flux -x keymirror -x marked -x object-assign -x twemoji -o ../static/js/bundle.js -v -d ./**/*.jsx",
-    "build": "browserify -x crypto -x autolinker -x flux -x keymirror -x marked -x object-assign -x twemoji ./**/*.jsx | uglifyjs -c -m --screw-ie8 > ../static/js/bundle.min.js"
+    "build": "browserify -x crypto -x autolinker -x flux -x keymirror -x marked -x object-assign -x twemoji -d ./**/*.jsx | exorcist ../static/js/inter.js.map > ../static/js/tmp.js && uglifyjs ../static/js/tmp.js --in-source-map \"../static/js/inter.js.map\" --source-map \"../static/js/bundle.min.js.map\" --source-map-url \"/static/js/bundle.min.js.map\" -c -m --screw-ie8 > ../static/js/bundle.min.js && rm ../static/js/tmp.js && rm ../static/js/inter.js.map"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
- Fixes build issues created when we moved to new versions of npm dependencies. 
- Allows for source maps in production build. 
- Travis now uses a prebuilt docker image instead of installing dependencies every time. (Note this does not include npm dependencies which take FOREVER to download) 
 - See: https://github.com/mattermost/builder for image
- Travis does not build for go 1.4.2 anymore. Upgraded to go 1.5.1. (go 1.5.2 will be coming shortly, will upgrade to that before next release)
- `make run` now split into two parts. One builds downloads and installs npm and go dependencies (`.prepare`) and the other (`run`) builds the actual code. To re-download dependencies if you have changed them run a `make clean` or `rm .prepare`. This allows for a faster `make run` experience. 
- Fixed s3 deploy issue as it now affects public builds.
- Removed docs system from build as it is moving to it's own repository. 
- `make clean` will no longer delete your docker containers. It will only stop them. To clean and delete them run `make nuke` (my have additional functionality in the future)