### PR TITLE
PLT-1290 Fix up arrow to edit posts

### DIFF
--- a/web/react/stores/post_store.jsx
+++ b/web/react/stores/post_store.jsx
@@ -39,6 +39,7 @@ class PostStoreClass extends EventEmitter {
 
         this.makePostsInfo = this.makePostsInfo.bind(this);
 
+        this.getPost = this.getPost.bind(this);
         this.getAllPosts = this.getAllPosts.bind(this);
         this.getEarliestPost = this.getEarliestPost.bind(this);
         this.getLatestPost = this.getLatestPost.bind(this);
@@ -158,6 +159,17 @@ class PostStoreClass extends EventEmitter {
         if (!this.postsInfo.hasOwnProperty(id)) {
             this.postsInfo[id] = {};
         }
+    }
+
+    getPost(channelId, postId) {
+        const posts = this.postsInfo[channelId].postList;
+        let post = null;
+
+        if (posts.posts.hasOwnProperty(postId)) {
+            post = Object.assign({}, posts.posts[postId]);
+        }
+
+        return post;
     }
 
     getAllPosts(id) {

--- a/web/react/stores/post_store.jsx
+++ b/web/react/stores/post_store.jsx
@@ -554,7 +554,7 @@ class PostStoreClass extends EventEmitter {
         return 0;
     }
     getCommentCount(post) {
-        const posts = this.getPosts(post.channel_id).posts;
+        const posts = this.getAllPosts(post.channel_id).posts;
 
         let commentCount = 0;
         for (const id in posts) {


### PR DESCRIPTION
1) Replaces the call in PostStore.getCommentCount to PostStore.getPosts to PostStore.getAllPosts. The line was throwing an error and causing the edit post dialog to not be shown.
2) Re-adds the getPost function used by the edit post modal when attempting to delete a post by clearing its text.