### PR TITLE
Support Tasklists like GitHub does

### DIFF
--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -226,9 +226,11 @@ class MattermostMarkdownRenderer extends marked.Renderer {
     listitem(text) {
         const taskListReg = /^\[([ |xX])\] /;
         const isTaskList = taskListReg.exec(text);
-        return isTaskList ?
-            `<li>${'<input type="checkbox" disabled="disabled" ' + (isTaskList[1] === ' ' ? '' : 'checked="checked" ') + '/> '}${text.replace(taskListReg, '')}</li>` :
-            `<li>${text}</li>`;
+
+        if (isTaskList) {
+            return `<li>${'<input type="checkbox" disabled="disabled" ' + (isTaskList[1] === ' ' ? '' : 'checked="checked" ') + '/> '}${text.replace(taskListReg, '')}</li>`;
+        }
+        return `<li>${text}</li>`;
     }
 
     text(txt) {

--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -223,6 +223,14 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         return `<table class="markdown__table"><thead>${header}</thead><tbody>${body}</tbody></table>`;
     }
 
+    listitem(text) {
+        const taskListReg = /^\[([ |xX])\] /;
+        const isTaskList = taskListReg.exec(text);
+        return isTaskList ?
+            `<li>${'<input type="checkbox" disabled="disabled" ' + (isTaskList[1] === ' ' ? '' : 'checked="checked" ') + '/> '}${text.replace(taskListReg, '')}</li>` :
+            `<li>${text}</li>`;
+    }
+
     text(txt) {
         return TextFormatting.doFormatText(txt, this.formattingOptions);
     }

--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -607,6 +607,11 @@ body.ios {
 			li ul, li ol {
 				padding: 0 0 0 20px
 			}
+
+			li input[type="checkbox"]:disabled {
+				vertical-align: sub;
+				cursor: default;
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds markdown support for task list like Github does in its github flavored markdown:

```
- [ ] list syntax required (any unordered or ordered list supported)
- [ ] this is a complete item
- [x] this is an incomplete item
```
renders as
- [x] list syntax required (any unordered or ordered list supported)
- [x] this is a complete item
- [ ] this is an incomplete item