### PR TITLE
PLT-1281 Make sure to have latest posts for the view when switching to a channel

### DIFF
--- a/web/react/components/posts_view_container.jsx
+++ b/web/react/components/posts_view_container.jsx
@@ -99,9 +99,11 @@ export default class PostsViewContainer extends React.Component {
         if (newIndex === -1) {
             newIndex = channels.length;
             channels.push(channelId);
-            postLists[newIndex] = this.getChannelPosts(channelId);
             atTop[newIndex] = PostStore.getVisibilityAtTop(channelId);
         }
+
+        // make sure we have the latest posts from the store
+        postLists[newIndex] = this.getChannelPosts(channelId);
 
         this.setState({
             currentChannelIndex: newIndex,

--- a/web/react/stores/post_store.jsx
+++ b/web/react/stores/post_store.jsx
@@ -211,7 +211,7 @@ class PostStoreClass extends EventEmitter {
                 postList.order = this.postsInfo[id].pendingPosts.order.concat(postList.order);
             }
 
-            // Add delteted posts
+            // Add deleted posts
             if (this.postsInfo[id].hasOwnProperty('deletedPosts')) {
                 Object.assign(postList.posts, this.postsInfo[id].deletedPosts);
 


### PR DESCRIPTION
The issue was after first switching to a channel that had new posts, the PostsView would have the old postList and would then only get the correct posts after the render that caused the scroll to the bottom or new message indicator happened. So the second pass through would render the correct posts but with a free scroll type which prevents the proper scrolling from occurring.