### PR TITLE
Make the Gitlab SSO Support compatible with Github Enterprise

### DIFF
--- a/doc/integrations/Single-Sign-On/Github.md
+++ b/doc/integrations/Single-Sign-On/Github.md
@@ -1,6 +1,8 @@
-## Configuring GitHub Enterprise Single-Sign-On
+## Configuring GitHub Enterprise Single-Sign-On (unofficial)
 
-Follow these steps to configure Mattermost to use GitHub Enterprise as a single-sign-on (SSO) service for team creation, account creation and sign-in.
+Note: Because the authentication interface of GitHub Enterprise is similar to that of GitLab, the GitLab SSO feature can be used to unofficially also support GitHub Enterprise SSO.
+
+Follow these steps to configure Mattermost to use Github Enterprise as a single-sign-on (SSO) service for team creation, account creation and sign-in using the GitLab SSO interface.
 
 1. Login to your GitHub Enterprise account and go to the Applications section in Profile Settings.
 2. Add a new application called "Mattermost" with the following as Authorization callback URL:

--- a/doc/integrations/Single-Sign-On/Github.md
+++ b/doc/integrations/Single-Sign-On/Github.md
@@ -1,0 +1,18 @@
+## Configuring GitHub Enterprise Single-Sign-On
+
+Follow these steps to configure Mattermost to use GitHub Enterprise as a single-sign-on (SSO) service for team creation, account creation and sign-in.
+
+1. Login to your GitHub Enterprise account and go to the Applications section in Profile Settings.
+2. Add a new application called "Mattermost" with the following as Authorization callback URL:
+  * `<your-mattermost-url>` (example: http://localhost:8065)
+
+3. Submit the application and copy the given _Id_ and _Secret_ into the appropriate _GitLabSettings_ fields in config/config.json
+
+4. Also in config/config.json, set _Enable_ to `true` for the _gitlab_ section, leave _Scope_ blank and use the following for the endpoints:
+  * _AuthEndpoint_: `https://<your-github-enterprise-url>/oauth/authorize` (example https://github.com/oauth/authorize)
+  * _TokenEndpoint_: `https://<your-github-enterprise-url>/oauth/access_token`
+  * _UserApiEndpoint_: `https://<your-github-enterprise-url>/api/v3/user`
+
+5. (Optional) If you would like to force all users to sign-up with GitHub Enterprise only, in the _ServiceSettings_ section of config/config.json set _DisableEmailSignUp_ to `true`.
+
+6. Restart your Mattermost server to see the changes take effect.

--- a/model/gitlab.go
+++ b/model/gitlab.go
@@ -17,13 +17,18 @@ const (
 type GitLabUser struct {
 	Id       int64  `json:"id"`
 	Username string `json:"username"`
+	Login    string `json:"login"`
 	Email    string `json:"email"`
 	Name     string `json:"name"`
 }
 
 func UserFromGitLabUser(glu *GitLabUser) *User {
 	user := &User{}
-	user.Username = CleanUsername(glu.Username)
+	username := glu.Username
+	if username == "" {
+		username = glu.Login
+	}
+	user.Username = CleanUsername(username)
 	splitName := strings.Split(glu.Name, " ")
 	if len(splitName) == 2 {
 		user.FirstName = splitName[0]


### PR DESCRIPTION
See doc/integrations/Single-Sign-On/Github.md for the usage.

Note: I thought it should work also with Github.com but it failed with "Bad
token type" error.