### PR TITLE
PLT-881 Adds Legal and Support Settings to the System Console

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -82,6 +82,14 @@
         "ShowEmailAddress": true,
         "ShowFullName": true
     },
+    "LegalAndSupportSettings": {
+        "TermsOfServiceLink": "https://github.com/mattermost/platform/blob/master/README.md",
+        "PrivacyPolicyLink": "https://github.com/mattermost/platform/blob/master/README.md",
+        "AboutLink": "http://www.mattermost.org/features/",
+        "HelpLink": "https://github.com/mattermost/platform/blob/master/README.md",
+        "ReportAProblemLink": "https://forum.mattermost.org/c/general/trouble-shoot",
+        "SupportEmail": "feedback@mattermost.com"
+    },
     "GitLabSettings": {
         "Enable": false,
         "Secret": "",

--- a/config/config.json
+++ b/config/config.json
@@ -82,12 +82,12 @@
         "ShowEmailAddress": true,
         "ShowFullName": true
     },
-    "LegalAndSupportSettings": {
-        "TermsOfServiceLink": "https://github.com/mattermost/platform/blob/master/README.md",
-        "PrivacyPolicyLink": "https://github.com/mattermost/platform/blob/master/README.md",
-        "AboutLink": "http://www.mattermost.org/features/",
-        "HelpLink": "https://github.com/mattermost/platform/blob/master/README.md",
-        "ReportAProblemLink": "https://forum.mattermost.org/c/general/trouble-shoot",
+    "SupportSettings": {
+        "TermsOfServiceLink": "/static/help/terms.html",
+        "PrivacyPolicyLink": "/static/help/privacy.html",
+        "AboutLink": "/static/help/about.html",
+        "HelpLink": "/static/help/help.html",
+        "ReportAProblemLink": "/static/help/report_problem.html",
         "SupportEmail": "feedback@mattermost.com"
     },
     "GitLabSettings": {

--- a/docker/dev/config_docker.json
+++ b/docker/dev/config_docker.json
@@ -82,6 +82,14 @@
         "ShowEmailAddress": true,
         "ShowFullName": true
     },
+    "SupportSettings": {
+        "TermsOfServiceLink": "/static/help/terms.html",
+        "PrivacyPolicyLink": "/static/help/privacy.html",
+        "AboutLink": "/static/help/about.html",
+        "HelpLink": "/static/help/help.html",
+        "ReportAProblemLink": "/static/help/report_problem.html",
+        "SupportEmail": "feedback@mattermost.com"
+    },
     "GitLabSettings": {
         "Enable": false,
         "Secret": "",

--- a/docker/local/config_docker.json
+++ b/docker/local/config_docker.json
@@ -82,6 +82,14 @@
         "ShowEmailAddress": true,
         "ShowFullName": true
     },
+    "SupportSettings": {
+        "TermsOfServiceLink": "/static/help/terms.html",
+        "PrivacyPolicyLink": "/static/help/privacy.html",
+        "AboutLink": "/static/help/about.html",
+        "HelpLink": "/static/help/help.html",
+        "ReportAProblemLink": "/static/help/report_problem.html",
+        "SupportEmail": "feedback@mattermost.com"
+    },
     "GitLabSettings": {
         "Enable": false,
         "Secret": "",

--- a/model/config.go
+++ b/model/config.go
@@ -113,6 +113,15 @@ type PrivacySettings struct {
 	ShowFullName     bool
 }
 
+type SupportSettings struct {
+	TermsOfServiceLink *string
+	PrivacyPolicyLink  *string
+	AboutLink          *string
+	HelpLink           *string
+	ReportAProblemLink *string
+	SupportEmail       *string
+}
+
 type TeamSettings struct {
 	SiteName                  string
 	MaxUsersPerTeam           int
@@ -132,6 +141,7 @@ type Config struct {
 	EmailSettings     EmailSettings
 	RateLimitSettings RateLimitSettings
 	PrivacySettings   PrivacySettings
+	SupportSettings   SupportSettings
 	GitLabSettings    SSOSettings
 }
 
@@ -189,6 +199,35 @@ func (o *Config) SetDefaults() {
 		*o.EmailSettings.PushNotificationServer = "https://push.mattermost.com"
 	}
 
+	if o.SupportSettings.TermsOfServiceLink == nil {
+		o.SupportSettings.TermsOfServiceLink = new(string)
+		*o.SupportSettings.TermsOfServiceLink = "/static/help/terms.html"
+	}
+
+	if o.SupportSettings.PrivacyPolicyLink == nil {
+		o.SupportSettings.PrivacyPolicyLink = new(string)
+		*o.SupportSettings.PrivacyPolicyLink = "/static/help/privacy.html"
+	}
+
+	if o.SupportSettings.AboutLink == nil {
+		o.SupportSettings.AboutLink = new(string)
+		*o.SupportSettings.AboutLink = "/static/help/about.html"
+	}
+
+	if o.SupportSettings.HelpLink == nil {
+		o.SupportSettings.HelpLink = new(string)
+		*o.SupportSettings.HelpLink = "/static/help/help.html"
+	}
+
+	if o.SupportSettings.ReportAProblemLink == nil {
+		o.SupportSettings.ReportAProblemLink = new(string)
+		*o.SupportSettings.ReportAProblemLink = "/static/help/report_problem.html"
+	}
+
+	if o.SupportSettings.SupportEmail == nil {
+		o.SupportSettings.SupportEmail = new(string)
+		*o.SupportSettings.SupportEmail = "feedback@mattermost.com"
+	}
 }
 
 func (o *Config) IsValid() *AppError {

--- a/utils/config.go
+++ b/utils/config.go
@@ -214,6 +214,13 @@ func getClientConfig(c *model.Config) map[string]string {
 
 	props["ShowEmailAddress"] = strconv.FormatBool(c.PrivacySettings.ShowEmailAddress)
 
+	props["TermsOfServiceLink"] = *c.SupportSettings.TermsOfServiceLink
+	props["PrivacyPolicyLink"] = *c.SupportSettings.PrivacyPolicyLink
+	props["AboutLink"] = *c.SupportSettings.AboutLink
+	props["HelpLink"] = *c.SupportSettings.HelpLink
+	props["ReportAProblemLink"] = *c.SupportSettings.ReportAProblemLink
+	props["SupportEmail"] = *c.SupportSettings.SupportEmail
+
 	props["EnablePublicLink"] = strconv.FormatBool(c.FileSettings.EnablePublicLink)
 	props["ProfileHeight"] = fmt.Sprintf("%v", c.FileSettings.ProfileHeight)
 	props["ProfileWidth"] = fmt.Sprintf("%v", c.FileSettings.ProfileWidth)

--- a/web/react/components/admin_console/admin_controller.jsx
+++ b/web/react/components/admin_console/admin_controller.jsx
@@ -18,6 +18,7 @@ import GitLabSettingsTab from './gitlab_settings.jsx';
 import SqlSettingsTab from './sql_settings.jsx';
 import TeamSettingsTab from './team_settings.jsx';
 import ServiceSettingsTab from './service_settings.jsx';
+import LegalAndSupportSettingsTab from './legal_and_support_settings.jsx';
 import TeamUsersTab from './team_users.jsx';
 import TeamAnalyticsTab from './team_analytics.jsx';
 
@@ -148,6 +149,8 @@ export default class AdminController extends React.Component {
                 tab = <TeamSettingsTab config={this.state.config} />;
             } else if (this.state.selected === 'service_settings') {
                 tab = <ServiceSettingsTab config={this.state.config} />;
+            } else if (this.state.selected === 'legal_and_support_settings') {
+                tab = <LegalAndSupportSettingsTab config={this.state.config} />;
             } else if (this.state.selected === 'team_users') {
                 if (this.state.teams) {
                     tab = <TeamUsersTab team={this.state.teams[this.state.selectedTeam]} />;

--- a/web/react/components/admin_console/admin_sidebar.jsx
+++ b/web/react/components/admin_console/admin_sidebar.jsx
@@ -238,6 +238,15 @@ export default class AdminSidebar extends React.Component {
                                             {'GitLab Settings'}
                                         </a>
                                     </li>
+                                    <li>
+                                        <a
+                                            href='#'
+                                            className={this.isSelected('legal_and_support_settings')}
+                                            onClick={this.handleClick.bind(this, 'legal_and_support_settings', null)}
+                                        >
+                                            {'Legal and Support Settings'}
+                                        </a>
+                                    </li>
                                 </ul>
                                 <ul className='nav nav__sub-menu'>
                                      <li>

--- a/web/react/components/admin_console/legal_and_support_settings.jsx
+++ b/web/react/components/admin_console/legal_and_support_settings.jsx
@@ -1,0 +1,222 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import * as Client from '../../utils/client.jsx';
+import * as AsyncClient from '../../utils/async_client.jsx';
+
+export default class LegalAndSupportSettings extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+
+        this.state = {
+            saveNeeded: false,
+            serverError: null
+        };
+    }
+
+    handleChange() {
+        var s = {saveNeeded: true, serverError: this.state.serverError};
+        this.setState(s);
+    }
+
+    handleSubmit(e) {
+        e.preventDefault();
+        $('#save-button').button('loading');
+
+        var config = this.props.config;
+
+        config.SupportSettings.TermsOfServiceLink = ReactDOM.findDOMNode(this.refs.TermsOfServiceLink).value.trim();
+        config.SupportSettings.PrivacyPolicyLink = ReactDOM.findDOMNode(this.refs.PrivacyPolicyLink).value.trim();
+        config.SupportSettings.AboutLink = ReactDOM.findDOMNode(this.refs.AboutLink).value.trim();
+        config.SupportSettings.HelpLink = ReactDOM.findDOMNode(this.refs.HelpLink).value.trim();
+        config.SupportSettings.ReportAProblemLink = ReactDOM.findDOMNode(this.refs.ReportAProblemLink).value.trim();
+        config.SupportSettings.SupportEmail = ReactDOM.findDOMNode(this.refs.SupportEmail).value.trim();
+
+        Client.saveConfig(
+            config,
+            () => {
+                AsyncClient.getConfig();
+                this.setState({
+                    serverError: null,
+                    saveNeeded: false
+                });
+                $('#save-button').button('reset');
+            },
+            (err) => {
+                this.setState({
+                    serverError: err.message,
+                    saveNeeded: true
+                });
+                $('#save-button').button('reset');
+            }
+        );
+    }
+
+    render() {
+        var serverError = '';
+        if (this.state.serverError) {
+            serverError = <div className='form-group has-error'><label className='control-label'>{this.state.serverError}</label></div>;
+        }
+
+        var saveClass = 'btn';
+        if (this.state.saveNeeded) {
+            saveClass = 'btn btn-primary';
+        }
+
+        return (
+            <div className='wrapper--fixed'>
+
+                <h3>{'Legal and Support Settings'}</h3>
+                <form
+                    className='form-horizontal'
+                    role='form'
+                >
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='TermsOfServiceLink'
+                        >
+                            {'Terms of Service link:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='TermsOfServiceLink'
+                                ref='TermsOfServiceLink'
+                                defaultValue={this.props.config.SupportSettings.TermsOfServiceLink}
+                                onChange={this.handleChange}
+                            />
+                            <p className='help-text'>{'Link to Terms of Service available to users on desktop and on mobile. Leaving this blank will hide the option to display a notice.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='PrivacyPolicyLink'
+                        >
+                            {'Privacy Policy link:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='PrivacyPolicyLink'
+                                ref='PrivacyPolicyLink'
+                                defaultValue={this.props.config.SupportSettings.PrivacyPolicyLink}
+                                onChange={this.handleChange}
+                            />
+                            <p className='help-text'>{'Link to Privacy Policy available to users on desktop and on mobile. Leaving this blank will hide the option to display a notice.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='AboutLink'
+                        >
+                            {'About link:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='AboutLink'
+                                ref='AboutLink'
+                                defaultValue={this.props.config.SupportSettings.AboutLink}
+                                onChange={this.handleChange}
+                            />
+                            <p className='help-text'>{'Link to About page for more information on your Mattermost deployment, for example its purpose and audience within your organization. Defaults to Mattermost information page.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='HelpLink'
+                        >
+                            {'Help link:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='HelpLink'
+                                ref='HelpLink'
+                                defaultValue={this.props.config.SupportSettings.HelpLink}
+                                onChange={this.handleChange}
+                            />
+                            <p className='help-text'>{'Link to help documentation from team site main menu. Typically not changed unless your organization chooses to create custom documentation.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='ReportAProblemLink'
+                        >
+                            {'Report a Problem link:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='ReportAProblemLink'
+                                ref='ReportAProblemLink'
+                                defaultValue={this.props.config.SupportSettings.ReportAProblemLink}
+                                onChange={this.handleChange}
+                            />
+                            <p className='help-text'>{'Link to help documentation from team site main menu. By default this points to the peer-to-peer troubleshooting forum where users can search for, find and request help with technical issues.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='SupportEmail'
+                        >
+                            {'Support email:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='SupportEmail'
+                                ref='SupportEmail'
+                                defaultValue={this.props.config.SupportSettings.SupportEmail}
+                                onChange={this.handleChange}
+                            />
+                            <p className='help-text'>{'Email shown during tutorial for end users to ask support questions.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <div className='col-sm-12'>
+                            {serverError}
+                            <button
+                                disabled={!this.state.saveNeeded}
+                                type='submit'
+                                className={saveClass}
+                                onClick={this.handleSubmit}
+                                id='save-button'
+                                data-loading-text={'<span class=\'glyphicon glyphicon-refresh glyphicon-refresh-animate\'></span> Saving Config...'}
+                            >
+                                {'Save'}
+                            </button>
+                        </div>
+                    </div>
+
+                </form>
+            </div>
+        );
+    }
+}
+
+LegalAndSupportSettings.propTypes = {
+    config: React.PropTypes.object
+};

--- a/web/react/components/admin_console/service_settings.jsx
+++ b/web/react/components/admin_console/service_settings.jsx
@@ -36,7 +36,7 @@ export default class ServiceSettings extends React.Component {
         config.ServiceSettings.SegmentDeveloperKey = ReactDOM.findDOMNode(this.refs.SegmentDeveloperKey).value.trim();
         config.ServiceSettings.GoogleDeveloperKey = ReactDOM.findDOMNode(this.refs.GoogleDeveloperKey).value.trim();
         config.ServiceSettings.EnableIncomingWebhooks = ReactDOM.findDOMNode(this.refs.EnableIncomingWebhooks).checked;
-        config.ServiceSettings.EnableOutgoingWebhooks = React.findDOMNode(this.refs.EnableOutgoingWebhooks).checked;
+        config.ServiceSettings.EnableOutgoingWebhooks = ReactDOM.findDOMNode(this.refs.EnableOutgoingWebhooks).checked;
         config.ServiceSettings.EnablePostUsernameOverride = ReactDOM.findDOMNode(this.refs.EnablePostUsernameOverride).checked;
         config.ServiceSettings.EnablePostIconOverride = ReactDOM.findDOMNode(this.refs.EnablePostIconOverride).checked;
         config.ServiceSettings.EnableTesting = ReactDOM.findDOMNode(this.refs.EnableTesting).checked;

--- a/web/react/components/navbar_dropdown.jsx
+++ b/web/react/components/navbar_dropdown.jsx
@@ -184,6 +184,34 @@ export default class NavbarDropdown extends React.Component {
             );
         }
 
+        let helpLink = null;
+        if (global.window.mm_config.HelpLink) {
+            helpLink = (
+                <li>
+                    <a
+                        target='_blank'
+                        href={global.window.mm_config.HelpLink}
+                    >
+                        {'Help'}
+                    </a>
+                </li>
+            );
+        }
+
+        let reportLink = null;
+        if (global.window.mm_config.ReportAProblemLink) {
+            reportLink = (
+                <li>
+                    <a
+                        target='_blank'
+                        href={global.window.mm_config.ReportAProblemLink}
+                    >
+                        {'Report a Problem'}
+                    </a>
+                </li>
+            );
+        }
+
         return (
             <ul className='nav navbar-nav navbar-right'>
                 <li
@@ -230,22 +258,8 @@ export default class NavbarDropdown extends React.Component {
                         {sysAdminLink}
                         {teams}
                         <li className='divider'></li>
-                        <li>
-                            <a
-                                target='_blank'
-                                href='/static/help/help.html'
-                            >
-                                {'Help'}
-                            </a>
-                        </li>
-                        <li>
-                            <a
-                                target='_blank'
-                                href='/static/help/report_problem.html'
-                            >
-                                {'Report a Problem'}
-                            </a>
-                        </li>
+                        {helpLink}
+                        {reportLink}
                         <li>
                             <a
                                 href='#'

--- a/web/react/components/sidebar_right_menu.jsx
+++ b/web/react/components/sidebar_right_menu.jsx
@@ -49,7 +49,7 @@ export default class SidebarRightMenu extends React.Component {
                         href='#'
                         onClick={EventHelpers.showInviteMemberModal}
                     >
-                        <i className='fa fa-user'></i>Invite New Member
+                        <i className='fa fa-user'></i>{'Invite New Member'}
                     </a>
                 </li>
             );
@@ -75,7 +75,7 @@ export default class SidebarRightMenu extends React.Component {
                         href='#'
                         data-toggle='modal'
                         data-target='#team_settings'
-                    ><i className='fa fa-globe'></i>Team Settings</a>
+                    ><i className='fa fa-globe'></i>{'Team Settings'}</a>
                 </li>
             );
             manageLink = (
@@ -93,7 +93,7 @@ export default class SidebarRightMenu extends React.Component {
                     <a
                         href={'/admin_console?' + utils.getSessionIndex()}
                     >
-                    <i className='fa fa-wrench'></i>System Console</a>
+                    <i className='fa fa-wrench'></i>{'System Console'}</a>
                 </li>
             );
         }
@@ -107,6 +107,27 @@ export default class SidebarRightMenu extends React.Component {
             teamDisplayName = this.props.teamDisplayName;
         }
 
+        let helpLink = null;
+        if (global.window.mm_config.HelpLink) {
+            helpLink = (
+                <li>
+                    <a
+                        target='_blank'
+                        href={global.window.mm_config.HelpLink}
+                    ><i className='fa fa-question'></i>{'Help'}</a></li>
+            );
+        }
+
+        let reportLink = null;
+        if (global.window.mm_config.ReportAProblemLink) {
+            reportLink = (
+                <li>
+                    <a
+                        target='_blank'
+                        href={global.window.mm_config.ReportAProblemLink}
+                    ><i className='fa fa-phone'></i>{'Report a Problem'}</a></li>
+            );
+        }
         return (
             <div>
                 <div className='team__header theme'>
@@ -123,7 +144,7 @@ export default class SidebarRightMenu extends React.Component {
                                 href='#'
                                 onClick={() => this.setState({showUserSettingsModal: true})}
                             >
-                                <i className='fa fa-cog'></i>Account Settings
+                                <i className='fa fa-cog'></i>{'Account Settings'}
                             </a>
                         </li>
                         {teamSettingsLink}
@@ -135,18 +156,10 @@ export default class SidebarRightMenu extends React.Component {
                             <a
                                 href='#'
                                 onClick={this.handleLogoutClick}
-                            ><i className='fa fa-sign-out'></i>Logout</a></li>
+                            ><i className='fa fa-sign-out'></i>{'Logout'}</a></li>
                         <li className='divider'></li>
-                        <li>
-                            <a
-                                target='_blank'
-                                href='/static/help/help.html'
-                            ><i className='fa fa-question'></i>Help</a></li>
-                        <li>
-                            <a
-                                target='_blank'
-                                href='/static/help/report_problem.html'
-                            ><i className='fa fa-phone'></i>Report a Problem</a></li>
+                        {helpLink}
+                        {reportLink}
                     </ul>
                 </div>
                 <UserSettingsModal

--- a/web/react/components/tutorial/tutorial_intro_screens.jsx
+++ b/web/react/components/tutorial/tutorial_intro_screens.jsx
@@ -112,6 +112,22 @@ export default class TutorialIntroScreens extends React.Component {
 
         const circles = this.createCircles();
 
+        let supportInfo = null;
+        if (global.window.mm_config.SupportEmail) {
+            supportInfo = (
+                <p>
+                    {'Need anything, just email us at '}
+                    <a
+                        href={'mailto:' + global.window.mm_config.SupportEmail}
+                        target='_blank'
+                    >
+                        {global.window.mm_config.SupportEmail}
+                    </a>
+                    {'.'}
+                </p>
+            );
+        }
+
         return (
             <div>
                 <h3>{'You’re all set'}</h3>
@@ -119,16 +135,7 @@ export default class TutorialIntroScreens extends React.Component {
                     {inviteModalLink}
                     {' when you’re ready.'}
                 </p>
-                <p>
-                    {'Need anything, just email us at '}
-                    <a
-                        href='mailto:feedback@mattermost.com'
-                        target='_blank'
-                    >
-                        {'feedback@mattermost.com'}
-                    </a>
-                    {'.'}
-                </p>
+                {supportInfo}
                 {'Click “Next” to enter Town Square. This is the first channel teammates see when they sign up. Use it for posting updates everyone needs to know.'}
                 {circles}
             </div>

--- a/web/templates/footer.html
+++ b/web/templates/footer.html
@@ -12,9 +12,28 @@
     </div>
 </div>
 <script>
-    document.getElementById("help_link").setAttribute("href", '/static/help/help.html');
-    document.getElementById("terms_link").setAttribute("href", '/static/help/terms.html');
-    document.getElementById("privacy_link").setAttribute("href", '/static/help/privacy.html');
-    document.getElementById("about_link").setAttribute("href", '/static/help/about.html');
+    if (window.mm_config.HelpLink) {
+        document.getElementById("help_link").setAttribute("href", window.mm_config.HelpLink);
+    } else {
+        $("#help_link").remove();
+    }
+
+    if (window.mm_config.TermsOfServiceLink) {
+        document.getElementById("terms_link").setAttribute("href", window.mm_config.TermsOfServiceLink);
+    } else {
+        $("#terms_link").remove();
+    }
+
+    if (window.mm_config.PrivacyPolicyLink) {
+        document.getElementById("privacy_link").setAttribute("href", window.mm_config.PrivacyPolicyLink);
+    } else {
+        $("#privacy_link").remove();
+    }
+    
+    if (window.mm_config.AboutLink) {
+        document.getElementById("about_link").setAttribute("href", window.mm_config.AboutLink);
+    } else {
+        $("#about_link").remove();
+    }
 </script>
 {{end}}


### PR DESCRIPTION
Makes the following options configurable in the System Console in a new tab under a new tab called 'Legal and Support Settings', in addition to adding respective fields to the config file.

+ Terms of Service Link
+ Privacy Policy Link
+ About Link
+ Help Link
+ Report a Problem Link
+ Support Email

This also implements the functionality described in the help text for each of the above settings to a basic level.

When reviewing please double-check I've done the necessary back-end work for adding new fields to the config file, it's been a while since I've done so and the process has changed a bit!

PM Documentation:  To change the above default links/email to something more appropriate, a Mattermost System Admin can simply go to the System Console -> Settings -> Legal and Support Settings to find fields for each of the above options.  Upon saving their changes the links are then updated across all teams on that server (or removed if left blank).
