### PR TITLE
PLT-1079 Add limit to Props size in Post table

### DIFF
--- a/model/post.go
+++ b/model/post.go
@@ -112,6 +112,10 @@ func (o *Post) IsValid() *AppError {
 		return NewAppError("Post.IsValid", "Invalid filenames", "id="+o.Id)
 	}
 
+	if utf8.RuneCountInString(StringInterfaceToJson(o.Props)) > 8000 {
+		return NewAppError("Post.IsValid", "Invalid props", "id="+o.Id)
+	}
+
 	return nil
 }
 

--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -30,7 +30,7 @@ func NewSqlPostStore(sqlStore *SqlStore) PostStore {
 		table.ColMap("Message").SetMaxSize(4000)
 		table.ColMap("Type").SetMaxSize(26)
 		table.ColMap("Hashtags").SetMaxSize(1000)
-		table.ColMap("Props")
+		table.ColMap("Props").SetMaxSize(8000)
 		table.ColMap("Filenames").SetMaxSize(4000)
 	}
 


### PR DESCRIPTION
An update to Gorp caused any columns in MySQL without a MaxSize or with a MaxSize less than 256 to be automatically be of type `varchar(255)`. Any string type larger than 255 will be a `text` column.

Don't need to update existing columns since the Gorp only affects new installs after 1.2.