### PR TITLE
PLT-1331 Fix possible race condition when creating new channels

### DIFF
--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -246,7 +246,8 @@ func (s SqlChannelStore) Get(id string) StoreChannel {
 	go func() {
 		result := StoreResult{}
 
-		if obj, err := s.GetReplica().Get(model.Channel{}, id); err != nil {
+		// reading from master due to expected race condition when creating channels
+		if obj, err := s.GetMaster().Get(model.Channel{}, id); err != nil {
 			result.Err = model.NewAppError("SqlChannelStore.Get", "We encountered an error finding the channel", "id="+id+", "+err.Error())
 		} else if obj == nil {
 			result.Err = model.NewAppError("SqlChannelStore.Get", "We couldn't find the existing channel", "id="+id)


### PR DESCRIPTION
This is a temporary solution to see if the race condition gets fixed. Basically what I believe was happening is that the channel would get saved, then before the read replica gets updated `SaveMember` tries to load the channel from the replica.

If this fixes it, I'll come up with a better solution but this is the least mana heavy way to figure out if this is the issue.