### PR TITLE
fix font not being changed on first page visit (if preferences havent been loaded before)

### DIFF
--- a/web/react/components/channel_loader.jsx
+++ b/web/react/components/channel_loader.jsx
@@ -70,6 +70,7 @@ export default class ChannelLoader extends React.Component {
             Utils.applyTheme(Constants.THEMES.default);
         }
 
+        // if preferences have already been stored in local storage do not wait until preference store change is fired and handled in channel.jsx
         const selectedFont = PreferenceStore.getPreference(Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, 'selected_font', {value: Constants.DEFAULT_FONT}).value;
         Utils.applyFont(selectedFont);
 

--- a/web/react/pages/channel.jsx
+++ b/web/react/pages/channel.jsx
@@ -18,8 +18,19 @@ import RegisterAppModal from '../components/register_app_modal.jsx';
 import ImportThemeModal from '../components/user_settings/import_theme_modal.jsx';
 import InviteMemberModal from '../components/invite_member_modal.jsx';
 
+import PreferenceStore from '../stores/preference_store.jsx';
+
+import * as Utils from '../utils/utils.jsx';
 import * as AsyncClient from '../utils/async_client.jsx';
 import * as EventHelpers from '../dispatcher/event_helpers.jsx';
+
+import Constants from '../utils/constants.jsx';
+
+function onPreferenceChange() {
+    const selectedFont = PreferenceStore.getPreference(Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, 'selected_font', {value: Constants.DEFAULT_FONT}).value;
+    Utils.applyFont(selectedFont);
+    PreferenceStore.removeChangeListener(onPreferenceChange);
+}
 
 function setupChannelPage(props, team, channel) {
     if (props.PostId === '') {
@@ -28,6 +39,7 @@ function setupChannelPage(props, team, channel) {
         EventHelpers.emitPostFocusEvent(props.PostId);
     }
 
+    PreferenceStore.addChangeListener(onPreferenceChange);
     AsyncClient.getAllPreferences();
 
     // ChannelLoader must be rendered first


### PR DESCRIPTION
> Lindsay:
fix font not being changed on first page visit (if preferences havent been loaded before)
#bug New font does not load on first page load
Repro: 
Change display font, and save
Open Core on a new tab
Observed: In the new tab, the old font shows up until you refresh the page