### PR TITLE
autocomplete component should enter suggestions on 'tab'

### DIFF
--- a/web/react/components/suggestion/suggestion_box.jsx
+++ b/web/react/components/suggestion/suggestion_box.jsx
@@ -94,7 +94,7 @@ export default class SuggestionBox extends React.Component {
             } else if (e.which === KeyCodes.DOWN) {
                 EventHelpers.emitSelectNextSuggestion(this.suggestionId);
                 e.preventDefault();
-            } else if (e.which === KeyCodes.ENTER || (e.which === KeyCodes.SPACE && SuggestionStore.shouldCompleteOnSpace(this.suggestionId))) {
+            } else if (e.which === KeyCodes.ENTER || e.which === KeyCodes.TAB || (e.which === KeyCodes.SPACE && SuggestionStore.shouldCompleteOnSpace(this.suggestionId))) {
                 EventHelpers.emitCompleteWordSuggestion(this.suggestionId);
                 e.preventDefault();
             } else if (this.props.onKeyDown) {

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -391,7 +391,8 @@ export default {
         BACKSPACE: 8,
         ENTER: 13,
         ESCAPE: 27,
-        SPACE: 32
+        SPACE: 32,
+        TAB: 9
     },
     HighlightedLanguages: {
         diff: 'Diff',


### PR DESCRIPTION
> it33:
#bug Tab should auto-complete in slash commands and emoji auto-complete. Observed: hitting tab move selection across browser. Expected: Tab auto-completes based on default auto-complete item selected. 