### PR TITLE
Use local timezone for notification email

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -465,8 +465,7 @@ func sendNotificationsAndForget(c *Context, post *model.Post, team *model.Team, 
 				teamURL := c.GetSiteURL() + "/" + team.Name
 
 				// Build and send the emails
-				location, _ := time.LoadLocation("UTC")
-				tm := time.Unix(post.CreateAt/1000, 0).In(location)
+				tm := time.Unix(post.CreateAt/1000, 0)
 
 				subjectPage := NewServerTemplatePage("post_subject")
 				subjectPage.Props["SiteURL"] = c.GetSiteURL()
@@ -498,6 +497,7 @@ func sendNotificationsAndForget(c *Context, post *model.Post, team *model.Team, 
 					bodyPage.Props["Minute"] = fmt.Sprintf("%02d", tm.Minute())
 					bodyPage.Props["Month"] = tm.Month().String()[:3]
 					bodyPage.Props["Day"] = fmt.Sprintf("%d", tm.Day())
+					bodyPage.Props["TimeZone"], _ = tm.Zone()
 					bodyPage.Props["PostMessage"] = model.ClearMentionTags(post.Message)
 					bodyPage.Props["TeamLink"] = teamURL + "/channels/" + channel.Name
 

--- a/api/templates/post_body.html
+++ b/api/templates/post_body.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">You were mentioned</h2>
-                                                <p>CHANNEL: {{.Props.ChannelName}}<br>{{.Props.SenderName}} - {{.Props.Hour}}:{{.Props.Minute}} GMT, {{.Props.Month}} {{.Props.Day}}<br><pre style="text-align:left;font-family: 'Lato', sans-serif; white-space: pre-wrap; white-space: -moz-pre-wrap; white-space: -pre-wrap; white-space: -o-pre-wrap; word-wrap: break-word;">{{.Props.PostMessage}}</pre></p>
+                                                <p>CHANNEL: {{.Props.ChannelName}}<br>{{.Props.SenderName}} - {{.Props.Hour}}:{{.Props.Minute}} {{.Props.TimeZone}}, {{.Props.Month}} {{.Props.Day}}<br><pre style="text-align:left;font-family: 'Lato', sans-serif; white-space: pre-wrap; white-space: -moz-pre-wrap; white-space: -pre-wrap; white-space: -o-pre-wrap; word-wrap: break-word;">{{.Props.PostMessage}}</pre></p>
                                                 <p style="margin: 20px 0 15px">
                                                     <a href="{{.Props.TeamLink}}" style="background: #2389D7; display: inline-block; border-radius: 3px; color: #fff; border: none; outline: none; min-width: 170px; padding: 15px 25px; font-size: 14px; font-family: inherit; cursor: pointer; -webkit-appearance: none;text-decoration: none;">Go To Channel</a>
                                                 </p>


### PR DESCRIPTION
Local timezone is better default than UTC because it is common that all
users of a mattermost server live near the server.