### PR TITLE
PLT-1389 Fix edited posts not updating by websocket

### DIFF
--- a/web/react/stores/socket_store.jsx
+++ b/web/react/stores/socket_store.jsx
@@ -225,6 +225,7 @@ function handlePostEditEvent(msg) {
     // Store post
     const post = JSON.parse(msg.props.post);
     PostStore.storePost(post);
+    PostStore.emitChange();
 
     // Update channel state
     if (ChannelStore.getCurrentId() === msg.channel_id) {


### PR DESCRIPTION
Not sure how this fits in with Flux (should/can different stores call each other's functions?) but this was the quickest fix for now and we can discuss further in the dev meeting.