### PR TITLE
PLT-1319 Fixed direct channels not being visible when no actual channel exists

### DIFF
--- a/api/web_team_hub.go
+++ b/api/web_team_hub.go
@@ -95,8 +95,10 @@ func ShouldSendEvent(webCon *WebConn, msg *model.Message) bool {
 			return false
 		}
 	} else {
-		// Don't share a user's view events with other users
+		// Don't share a user's view or preference events with other users
 		if msg.Action == model.ACTION_CHANNEL_VIEWED {
+			return false
+		} else if msg.Action == model.ACTION_PREFERENCE_CHANGED {
 			return false
 		}
 

--- a/model/message.go
+++ b/model/message.go
@@ -9,14 +9,15 @@ import (
 )
 
 const (
-	ACTION_TYPING         = "typing"
-	ACTION_POSTED         = "posted"
-	ACTION_POST_EDITED    = "post_edited"
-	ACTION_POST_DELETED   = "post_deleted"
-	ACTION_CHANNEL_VIEWED = "channel_viewed"
-	ACTION_NEW_USER       = "new_user"
-	ACTION_USER_ADDED     = "user_added"
-	ACTION_USER_REMOVED   = "user_removed"
+	ACTION_TYPING             = "typing"
+	ACTION_POSTED             = "posted"
+	ACTION_POST_EDITED        = "post_edited"
+	ACTION_POST_DELETED       = "post_deleted"
+	ACTION_CHANNEL_VIEWED     = "channel_viewed"
+	ACTION_NEW_USER           = "new_user"
+	ACTION_USER_ADDED         = "user_added"
+	ACTION_USER_REMOVED       = "user_removed"
+	ACTION_PREFERENCE_CHANGED = "preference_changed"
 )
 
 type Message struct {

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -89,25 +89,14 @@ export default class Sidebar extends React.Component {
                 continue;
             }
 
-            const member = members[dm.id];
-            const msgCount = dm.total_msg_count - member.msg_count;
+            const show = preferences.some((preference) => (preference.name === teammate.id && preference.value !== 'false'));
 
-            // always show a channel if either it is the current one or if it is unread, but it is not currently being left
-            const forceShow = (currentChannelId === dm.id || msgCount > 0) && !this.isLeaving.get(dm.id);
-            const preferenceShow = preferences.some((preference) => (preference.name === teammate.id && preference.value !== 'false'));
-
-            if (preferenceShow || forceShow) {
+            if (show) {
                 dm.display_name = Utils.displayUsername(teammate.id);
                 dm.teammate_id = teammate.id;
                 dm.status = UserStore.getStatus(teammate.id);
 
                 visibleDirectChannels.push(dm);
-
-                if (forceShow && !preferenceShow) {
-                    // make sure that unread direct channels are visible
-                    const preference = PreferenceStore.setPreference(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, teammate.id, 'true');
-                    AsyncClient.savePreferences([preference]);
-                }
             }
         }
 

--- a/web/react/dispatcher/event_helpers.jsx
+++ b/web/react/dispatcher/event_helpers.jsx
@@ -148,3 +148,10 @@ export function emitClearSuggestions(suggestionId) {
         id: suggestionId
     });
 }
+
+export function emitPreferenceChangedEvent(preference) {
+    AppDispatcher.handleServerAction({
+        type: Constants.ActionTypes.RECIEVED_PREFERENCE,
+        preference
+    });
+}

--- a/web/react/stores/preference_store.jsx
+++ b/web/react/stores/preference_store.jsx
@@ -90,8 +90,8 @@ class PreferenceStoreClass extends EventEmitter {
         return preference;
     }
 
-    emitChange(preferences) {
-        this.emit(CHANGE_EVENT, preferences);
+    emitChange() {
+        this.emit(CHANGE_EVENT);
     }
 
     addChangeListener(callback) {
@@ -106,6 +106,12 @@ class PreferenceStoreClass extends EventEmitter {
         const action = payload.action;
 
         switch (action.type) {
+        case ActionTypes.RECIEVED_PREFERENCE: {
+            const preference = action.preference;
+            this.setPreference(preference.category, preference.name, preference.value);
+            this.emitChange();
+            break;
+        }
         case ActionTypes.RECIEVED_PREFERENCES: {
             const preferences = this.getAllPreferences();
 
@@ -114,7 +120,7 @@ class PreferenceStoreClass extends EventEmitter {
             }
 
             this.setAllPreferences(preferences);
-            this.emitChange(preferences);
+            this.emitChange();
             break;
         }
         }

--- a/web/react/stores/socket_store.jsx
+++ b/web/react/stores/socket_store.jsx
@@ -135,6 +135,10 @@ class SocketStoreClass extends EventEmitter {
             handleChannelViewedEvent(msg);
             break;
 
+        case SocketEvents.PREFERENCE_CHANGED:
+            handlePreferenceChangedEvent(msg);
+            break;
+
         default:
         }
     }
@@ -277,6 +281,11 @@ function handleChannelViewedEvent(msg) {
     if (ChannelStore.getCurrentId() !== msg.channel_id && UserStore.getCurrentId() === msg.user_id) {
         AsyncClient.getChannel(msg.channel_id);
     }
+}
+
+function handlePreferenceChangedEvent(msg) {
+    const preference = JSON.parse(msg.props.preference);
+    EventHelpers.emitPreferenceChangedEvent(preference);
 }
 
 var SocketStore = new SocketStoreClass();

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -35,6 +35,7 @@ export default {
         RECIEVED_AUDITS: null,
         RECIEVED_TEAMS: null,
         RECIEVED_STATUSES: null,
+        RECIEVED_PREFERENCE: null,
         RECIEVED_PREFERENCES: null,
 
         RECIEVED_MSG: null,
@@ -74,7 +75,8 @@ export default {
         NEW_USER: 'new_user',
         USER_ADDED: 'user_added',
         USER_REMOVED: 'user_removed',
-        TYPING: 'typing'
+        TYPING: 'typing',
+        PREFERENCE_CHANGED: 'preference_changed'
     },
 
     //SPECIAL_MENTIONS: ['all', 'channel'],

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1137,6 +1137,11 @@ export function getUserIdFromChannelName(channel) {
     return otherUserId;
 }
 
+// Returns true if the given channel is a direct channel between the current user and the given one
+export function isDirectChannelForUser(otherUserId, channel) {
+    return channel.type === Constants.DM_CHANNEL && getUserIdFromChannelName(channel) === otherUserId;
+}
+
 export function importSlack(file, success, error) {
     var formData = new FormData();
     formData.append('file', file, file.name);


### PR DESCRIPTION
I moved all the code for making direct channels visible when you receive a message to the server so that I could make the sidebar just be driven entirely off the preferences. It also gets rid of the weirdness which involved the client updating the PreferenceStore while it is updating in response to other changes.