### PR TITLE
Disable referer header when loading external resources/link previews

### DIFF
--- a/web/templates/head.html
+++ b/web/templates/head.html
@@ -2,6 +2,7 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="robots" content="noindex, nofollow">
+    <meta name="referrer" content="never">
 
     <title>{{ .Props.Title }}</title>
 


### PR DESCRIPTION
most teams wouldn't like to send their company's name and mattermost link for every URL preview

A member of my team asked me to check this today as we prefer to keep our instance url private.

Changes:
1. Disable refer header _globally_ by adding to head.html
```html
<meta name="referrer" content="never">
```

This feature is considered "best-effort" (from mattermost) which means it's supported by majority of modern browsers.

Please tell me if you think that there's a use-case such that someone would like to keep their referers enabled, but otherwise I think it can be merged as-is.

1. With change
2. Without change
![](https://sc-cdn.scaleengine.net/i/acebee9ae321b363562284d283475b3f.png)