### PR TITLE
Trim callback urls for outgoing webhooks

### DIFF
--- a/web/react/components/user_settings/manage_outgoing_hooks.jsx
+++ b/web/react/components/user_settings/manage_outgoing_hooks.jsx
@@ -36,7 +36,7 @@ export default class ManageOutgoingHooks extends React.Component {
         if (this.state.triggerWords.length !== 0) {
             hook.trigger_words = this.state.triggerWords.trim().split(',');
         }
-        hook.callback_urls = this.state.callbackURLs.split('\n');
+        hook.callback_urls = this.state.callbackURLs.split('\n').map((url) => url.trim());
 
         Client.addOutgoingHook(
             hook,


### PR DESCRIPTION
Adding traling whitespace is common mistake.