### PR TITLE
PLT-549 Fixed react warning in RHS calling setState on unmounted component

### DIFF
--- a/web/react/components/rhs_thread.jsx
+++ b/web/react/components/rhs_thread.jsx
@@ -17,6 +17,8 @@ export default class RhsThread extends React.Component {
     constructor(props) {
         super(props);
 
+        this.mounted = false;
+
         this.onChange = this.onChange.bind(this);
         this.onChangeAll = this.onChangeAll.bind(this);
         this.forceUpdateInfo = this.forceUpdateInfo.bind(this);
@@ -50,8 +52,11 @@ export default class RhsThread extends React.Component {
         PostStore.addSelectedPostChangeListener(this.onChange);
         PostStore.addChangeListener(this.onChangeAll);
         PreferenceStore.addChangeListener(this.forceUpdateInfo);
+
         this.resize();
         window.addEventListener('resize', this.handleResize);
+
+        this.mounted = true;
     }
     componentDidUpdate() {
         if ($('.post-right__scroll')[0]) {
@@ -63,7 +68,10 @@ export default class RhsThread extends React.Component {
         PostStore.removeSelectedPostChangeListener(this.onChange);
         PostStore.removeChangeListener(this.onChangeAll);
         PreferenceStore.removeChangeListener(this.forceUpdateInfo);
+
         window.removeEventListener('resize', this.handleResize);
+
+        this.mounted = false;
     }
     forceUpdateInfo() {
         if (this.state.postList) {
@@ -82,7 +90,7 @@ export default class RhsThread extends React.Component {
     }
     onChange() {
         var newState = this.getStateFromStores();
-        if (!Utils.areObjectsEqual(newState, this.state)) {
+        if (this.mounted && !Utils.areObjectsEqual(newState, this.state)) {
             this.setState(newState);
         }
     }
@@ -120,7 +128,7 @@ export default class RhsThread extends React.Component {
         }
 
         var newState = this.getStateFromStores();
-        if (!Utils.areObjectsEqual(newState, this.state)) {
+        if (this.mounted && !Utils.areObjectsEqual(newState, this.state)) {
             this.setState(newState);
         }
     }


### PR DESCRIPTION
Fixes a react warning that would occasionally pop when a post was deleted in the RHS. The `this.mounted` logic was taken from other RHS related files; probably worth refactoring it out at some point, but the RHS seems built around it for the moment.

This was originally going to encompass a larger portion of changes, some of which have already been implemented in the time that I've been plugging away at this (such as another react child flattening warning).  Larger changes would have involved automatically closing the RHS for other users viewing a thread where the root post was deleted.  This was done out of necessity due to the RHS not rendering when the root post no longer existed.  However this issue seems to have already been corrected, making that change nice, but no longer necessary, and isn't worth adding in a lot of extra logic (that I'm not 100% confident in) and spending even more time on what has become a time sink.