### PR TITLE
PLT-1047 Fixed issue with Team Settings modal visually saving items instead of cancelling 

### DIFF
--- a/api/preference.go
+++ b/api/preference.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package api

--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package api

--- a/model/outgoing_webhook.go
+++ b/model/outgoing_webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package model

--- a/model/outgoing_webhook_test.go
+++ b/model/outgoing_webhook_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package model

--- a/model/preference.go
+++ b/model/preference.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package model

--- a/model/preference_test.go
+++ b/model/preference_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package model

--- a/model/preferences.go
+++ b/model/preferences.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package model

--- a/store/sql_preference_store.go
+++ b/store/sql_preference_store.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package store

--- a/store/sql_preference_store_test.go
+++ b/store/sql_preference_store_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package store

--- a/web/react/components/team_general_tab.jsx
+++ b/web/react/components/team_general_tab.jsx
@@ -12,6 +12,7 @@ export default class GeneralTab extends React.Component {
     constructor(props) {
         super(props);
 
+        this.updateSection = this.updateSection.bind(this);
         this.handleNameSubmit = this.handleNameSubmit.bind(this);
         this.handleInviteIdSubmit = this.handleInviteIdSubmit.bind(this);
         this.handleOpenInviteSubmit = this.handleOpenInviteSubmit.bind(this);
@@ -27,11 +28,22 @@ export default class GeneralTab extends React.Component {
         this.handleTeamListingRadio = this.handleTeamListingRadio.bind(this);
         this.handleGenerateInviteId = this.handleGenerateInviteId.bind(this);
 
-        this.state = {
-            name: props.team.display_name,
-            invite_id: props.team.invite_id,
-            allow_open_invite: props.team.allow_open_invite,
-            allow_team_listing: props.team.allow_team_listing,
+        this.state = this.setupInitialState(props);
+    }
+
+    updateSection(section) {
+        this.setState(this.setupInitialState(this.props));
+        this.props.updateSection(section);
+    }
+
+    setupInitialState(props) {
+        const team = props.team;
+
+        return {
+            name: team.display_name,
+            invite_id: team.invite_id,
+            allow_open_invite: team.allow_open_invite,
+            allow_team_listing: team.allow_team_listing,
             serverError: '',
             clientError: ''
         };
@@ -71,7 +83,7 @@ export default class GeneralTab extends React.Component {
             (team) => {
                 TeamStore.saveTeam(team);
                 TeamStore.emitChange();
-                this.props.updateSection('');
+                this.updateSection('');
             },
             (err) => {
                 state.serverError = err.message;
@@ -91,7 +103,7 @@ export default class GeneralTab extends React.Component {
             (team) => {
                 TeamStore.saveTeam(team);
                 TeamStore.emitChange();
-                this.props.updateSection('');
+                this.updateSection('');
             },
             (err) => {
                 state.serverError = err.message;
@@ -129,7 +141,7 @@ export default class GeneralTab extends React.Component {
             (team) => {
                 TeamStore.saveTeam(team);
                 TeamStore.emitChange();
-                this.props.updateSection('');
+                this.updateSection('');
             },
             (err) => {
                 state.serverError = err.message;
@@ -164,7 +176,7 @@ export default class GeneralTab extends React.Component {
             (team) => {
                 TeamStore.saveTeam(team);
                 TeamStore.emitChange();
-                this.props.updateSection('');
+                this.updateSection('');
             },
             (err) => {
                 state.serverError = err.message;
@@ -180,8 +192,7 @@ export default class GeneralTab extends React.Component {
     }
 
     handleClose() {
-        this.setState({clientError: '', serverError: ''});
-        this.props.updateSection('');
+        this.updateSection('');
     }
 
     componentDidMount() {
@@ -195,36 +206,36 @@ export default class GeneralTab extends React.Component {
     onUpdateNameSection(e) {
         e.preventDefault();
         if (this.props.activeSection === 'name') {
-            this.props.updateSection('');
+            this.updateSection('');
         } else {
-            this.props.updateSection('name');
+            this.updateSection('name');
         }
     }
 
     onUpdateInviteIdSection(e) {
         e.preventDefault();
         if (this.props.activeSection === 'invite_id') {
-            this.props.updateSection('');
+            this.updateSection('');
         } else {
-            this.props.updateSection('invite_id');
+            this.updateSection('invite_id');
         }
     }
 
     onUpdateOpenInviteSection(e) {
         e.preventDefault();
         if (this.props.activeSection === 'open_invite') {
-            this.props.updateSection('');
+            this.updateSection('');
         } else {
-            this.props.updateSection('open_invite');
+            this.updateSection('open_invite');
         }
     }
 
     onUpdateTeamListingSection(e) {
         e.preventDefault();
         if (this.props.activeSection === 'team_listing') {
-            this.props.updateSection('');
+            this.updateSection('');
         } else {
-            this.props.updateSection('team_listing');
+            this.updateSection('team_listing');
         }
     }
 

--- a/web/react/components/user_settings/manage_outgoing_hooks.jsx
+++ b/web/react/components/user_settings/manage_outgoing_hooks.jsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 import LoadingScreen from '../loading_screen.jsx';

--- a/web/react/stores/preference_store.jsx
+++ b/web/react/stores/preference_store.jsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Spinpunch, Inc. All Rights Reserved.
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 import Constants from '../utils/constants.jsx';


### PR DESCRIPTION
Previously appeared to have kept changes in the modal as if they had saved when the user cancelled out or closed the modal.  Now the state is updated whenever the user leaves a section or closes the modal like the Account Settings modal.

Also changed a few remaining copyrights to Mattermost for consistency.