### PR TITLE
PLT-583 Disables the ability to send email invites when user creation is disabled

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -183,6 +183,7 @@ func getClientConfig(c *model.Config) map[string]string {
 
 	props["SiteName"] = c.TeamSettings.SiteName
 	props["EnableTeamCreation"] = strconv.FormatBool(c.TeamSettings.EnableTeamCreation)
+	props["EnableUserCreation"] = strconv.FormatBool(c.TeamSettings.EnableUserCreation)
 	props["RestrictTeamNames"] = strconv.FormatBool(*c.TeamSettings.RestrictTeamNames)
 	props["EnableTeamListing"] = strconv.FormatBool(*c.TeamSettings.EnableTeamListing)
 

--- a/web/react/components/invite_member_modal.jsx
+++ b/web/react/components/invite_member_modal.jsx
@@ -33,6 +33,7 @@ export default class InviteMemberModal extends React.Component {
             firstNameErrors: {},
             lastNameErrors: {},
             emailEnabled: global.window.mm_config.SendEmailNotifications === 'true',
+            userCreationEnabled: global.window.mm_config.EnableUserCreation === 'true',
             showConfirmModal: false,
             isSendingEmails: false
         };
@@ -252,7 +253,7 @@ export default class InviteMemberModal extends React.Component {
                                             ref={'first_name' + index}
                                             placeholder='First name'
                                             maxLength='64'
-                                            disabled={!this.state.emailEnabled}
+                                            disabled={!this.state.emailEnabled || !this.state.userCreationEnabled}
                                             spellCheck='false'
                                         />
                                         {firstNameError}
@@ -266,7 +267,7 @@ export default class InviteMemberModal extends React.Component {
                                             ref={'last_name' + index}
                                             placeholder='Last name'
                                             maxLength='64'
-                                            disabled={!this.state.emailEnabled}
+                                            disabled={!this.state.emailEnabled || !this.state.userCreationEnabled}
                                             spellCheck='false'
                                         />
                                         {lastNameError}
@@ -285,7 +286,7 @@ export default class InviteMemberModal extends React.Component {
                             className='form-control'
                             placeholder='email@domain.com'
                             maxLength='64'
-                            disabled={!this.state.emailEnabled}
+                            disabled={!this.state.emailEnabled || !this.state.userCreationEnabled}
                             spellCheck='false'
                         />
                         {emailError}
@@ -303,7 +304,7 @@ export default class InviteMemberModal extends React.Component {
             var content = null;
             var sendButton = null;
 
-            if (this.state.emailEnabled) {
+            if (this.state.emailEnabled && this.state.userCreationEnabled) {
                 content = (
                     <div>
                         {serverError}
@@ -337,7 +338,7 @@ export default class InviteMemberModal extends React.Component {
                         {sendButtonLabel}
                     </button>
                 );
-            } else {
+            } else if (this.state.userCreationEnabled) {
                 var teamInviteLink = null;
                 if (currentUser && TeamStore.getCurrent().type === 'O') {
                     var link = (
@@ -358,8 +359,14 @@ export default class InviteMemberModal extends React.Component {
 
                 content = (
                     <div>
-                        <p>Email is currently disabled for your team, and email invitations cannot be sent. Contact your system administrator to enable email and email invitations.</p>
+                        <p>{'Email is currently disabled for your team, and email invitations cannot be sent. Contact your system administrator to enable email and email invitations.'}</p>
                         {teamInviteLink}
+                    </div>
+                );
+            } else {
+                content = (
+                    <div>
+                        <p>{'User creation has been disabled for your team. Please ask your team administrator for details.'}</p>
                     </div>
                 );
             }


### PR DESCRIPTION
Previously users could send email invites that didn't allow users to signup due to user creation being turned off in the system console.  This disables the "Invite New Members" UI similarly to how it is disabled when email is not setup.