### PR TITLE
PLT-1263 Fixed broken email unsubscribe instructions

### DIFF
--- a/api/templates/email_change_body.html
+++ b/api/templates/email_change_body.html
@@ -22,25 +22,13 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-                                                Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
-                                                Best wishes,<br>
-                                                The {{.ClientCfg.SiteName}} Team<br>
-                                            </td>
+                                            {{template "email_info" . }}
                                         </tr>
                                     </table>
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>

--- a/api/templates/email_change_verify_body.html
+++ b/api/templates/email_change_verify_body.html
@@ -25,25 +25,13 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-                                                Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
-                                                Best wishes,<br>
-                                                The {{.ClientCfg.SiteName}} Team<br>
-                                            </td>
+                                            {{template "email_info" . }}
                                         </tr>
                                     </table>
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>

--- a/api/templates/email_footer.html
+++ b/api/templates/email_footer.html
@@ -1,0 +1,13 @@
+{{define "email_footer"}}
+
+<td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
+    <p style="margin: 25px 0;">
+        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
+    </p>
+    <p style="padding: 0 50px;">
+        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
+        To change your notification preferences, log in to your team site and go to Account Settings > Notifications.
+    </p>
+</td>
+
+{{end}}

--- a/api/templates/email_info.html
+++ b/api/templates/email_info.html
@@ -1,0 +1,9 @@
+{{define "email_info"}}
+
+<td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
+    Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
+    Best wishes,<br>
+    The {{.ClientCfg.SiteName}} Team<br>
+</td>
+
+{{end}}

--- a/api/templates/find_teams_body.html
+++ b/api/templates/find_teams_body.html
@@ -30,25 +30,13 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-                                                Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
-                                                Best wishes,<br>
-                                                The {{.ClientCfg.SiteName}} Team<br>
-                                            </td>
+                                            {{template "email_info" . }}
                                         </tr>
                                     </table>
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.ClientCfg.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>

--- a/api/templates/invite_body.html
+++ b/api/templates/invite_body.html
@@ -27,25 +27,13 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-                                                Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
-                                                Best wishes,<br>
-                                                The {{.ClientCfg.SiteName}} Team<br>
-                                            </td>
+                                            {{template "email_info" . }}
                                         </tr>
                                     </table>
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>

--- a/api/templates/password_change_body.html
+++ b/api/templates/password_change_body.html
@@ -22,25 +22,13 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-                                                Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
-                                                Best wishes,<br>
-                                                The {{.ClientCfg.SiteName}} Team<br>
-                                            </td>
+                                            {{template "email_info" . }}
                                         </tr>
                                     </table>
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>

--- a/api/templates/post_body.html
+++ b/api/templates/post_body.html
@@ -25,25 +25,13 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-                                                Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
-                                                Best wishes,<br>
-                                                The {{.ClientCfg.SiteName}} Team<br>
-                                            </td>
+                                            {{template "email_info" . }}
                                         </tr>
                                     </table>
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>

--- a/api/templates/reset_body.html
+++ b/api/templates/reset_body.html
@@ -25,25 +25,13 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-                                                Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
-                                                Best wishes,<br>
-                                                The {{.ClientCfg.SiteName}} Team<br>
-                                            </td>
+                                            {{template "email_info" . }}
                                         </tr>
                                     </table>
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>

--- a/api/templates/signup_team_body.html
+++ b/api/templates/signup_team_body.html
@@ -25,25 +25,13 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-                                                Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
-                                                Best wishes,<br>
-                                                The {{.ClientCfg.SiteName}} Team<br>
-                                            </td>
+                                            {{template "email_info" . }}
                                         </tr>
                                     </table>
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>

--- a/api/templates/verify_body.html
+++ b/api/templates/verify_body.html
@@ -25,25 +25,13 @@
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-                                                Any questions at all, mail us any time: <a href="mailto:{{.ClientCfg.FeedbackEmail}}" style="text-decoration: none; color:#2389D7;">{{.ClientCfg.FeedbackEmail}}</a>.<br>
-                                                Best wishes,<br>
-                                                The {{.ClientCfg.SiteName}} Team<br>
-                                            </td>
+                                            {{template "email_info" . }}
                                         </tr>
                                     </table>
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>

--- a/api/templates/welcome_body.html
+++ b/api/templates/welcome_body.html
@@ -37,15 +37,7 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td style="text-align: center;color: #AAA; font-size: 11px; padding-bottom: 10px;">
-                                    <p style="margin: 25px 0;">
-                                        <img width="65" src="{{.Props.SiteURL}}/static/images/circles.png" alt="">
-                                    </p>
-                                    <p style="padding: 0 50px;">
-                                        (c) 2015 Mattermost, Inc. 855 El Camino Real, 13A-168, Palo Alto, CA, 94301.<br>
-                                        If you no longer wish to receive these emails, click on the following link: <a href="mailto:{{.ClientCfg.FeedbackEmail}}?subject=Unsubscribe&body=Unsubscribe" style="text-decoration: none; color:#2389D7;">Unsubscribe</a>
-                                    </p>
-                                </td>
+                                {{template "email_footer" . }}
                             </tr>
                         </table>
                     </td>


### PR DESCRIPTION
Replaces the non-functional unsubscribe link with instructions on how to disable email notifications on your account.  Also refactored the email templates where possible to be more maintainable.