### PR TITLE
PLT-1454 Changed positioning of root elements to fix weird IE11 bug

### DIFF
--- a/web/sass-files/sass/partials/_base.scss
+++ b/web/sass-files/sass/partials/_base.scss
@@ -8,7 +8,8 @@ body {
   font-family: 'Open Sans', sans-serif;
   -webkit-font-smoothing: antialiased;
   background: $body-bg;
-  position: relative;
+  position: absolute;
+  width: 100%;
   height: 100%;
   &.white {
       background: #fff;
@@ -35,13 +36,11 @@ body {
 .container-fluid {
     @include legacy-pie-clearfix;
     height: 100%;
-    position: relative;
 }
 
 .channel-view {
     @include clearfix;
     height: 100%;
-    position: relative;
 }
 
 img {


### PR DESCRIPTION
For some reason, the whole container for the ChannelView was shifting left on IE11 the exact width of the sidebar, pushing it off the screen. If I changed the position of body > div.channel-view > div.container-fluid from relative to fixed and then back again, it fixed the weird positioning, but that didn't seem like that good of a solution since we had to do that repeatedly to fix the wonky positioning. Instead, I went with just removing the positions from the parents of those divs and set the whole thing to be fixed.

I did a quick test of the page on IE11 and Chrome in both desktop mode and mobile mode and it seemed to work fine with these changes. Assigning this to @asaadmahmoodspin since he'll have a better idea if this should break anything horribly.