### PR TITLE
PLT-1148 Opens links within help text in a new tab rather than the current tab

### DIFF
--- a/web/react/components/admin_console/service_settings.jsx
+++ b/web/react/components/admin_console/service_settings.jsx
@@ -172,7 +172,16 @@ export default class ServiceSettings extends React.Component {
                                 defaultValue={this.props.config.ServiceSettings.GoogleDeveloperKey}
                                 onChange={this.handleChange}
                             />
-                            <p className='help-text'>{'Set this key to enable embedding of YouTube video previews based on hyperlinks appearing in messages or comments. Instructions to obtain a key available at '}<a href='https://www.youtube.com/watch?v=Im69kzhpR3I'>{'https://www.youtube.com/watch?v=Im69kzhpR3I'}</a>{'. Leaving field blank disables the automatic generation of YouTube video previews from links.'}</p>
+                            <p className='help-text'>
+                                {'Set this key to enable embedding of YouTube video previews based on hyperlinks appearing in messages or comments. Instructions to obtain a key available at '}
+                                <a
+                                    href='https://www.youtube.com/watch?v=Im69kzhpR3I'
+                                    target='_blank'
+                                >
+                                    {'https://www.youtube.com/watch?v=Im69kzhpR3I'}
+                                </a>
+                                {'. Leaving the field blank disables the automatic generation of YouTube video previews from links.'}
+                            </p>
                         </div>
                     </div>
 

--- a/web/react/components/user_settings/manage_incoming_hooks.jsx
+++ b/web/react/components/user_settings/manage_incoming_hooks.jsx
@@ -162,7 +162,14 @@ export default class ManageIncomingHooks extends React.Component {
 
         return (
             <div key='addIncomingHook'>
-                {'Create webhook URLs for use in external integrations. Please see '}<a href='http://mattermost.org/webhooks'>{'http://mattermost.org/webhooks'}</a> {' to learn more.'}
+                {'Create webhook URLs for use in external integrations. Please see '}
+                <a
+                    href='http://mattermost.org/webhooks'
+                    target='_blank'
+                >
+                    {'http://mattermost.org/webhooks'}
+                </a>
+                {' to learn more.'}
                 <div><label className='control-label padding-top x2'>{'Add a new incoming webhook'}</label></div>
                 <div className='row padding-top'>
                     <div className='col-sm-10 padding-bottom'>

--- a/web/react/components/user_settings/manage_outgoing_hooks.jsx
+++ b/web/react/components/user_settings/manage_outgoing_hooks.jsx
@@ -240,7 +240,14 @@ export default class ManageOutgoingHooks extends React.Component {
 
         return (
             <div key='addOutgoingHook'>
-                {'Create webhooks to send new message events to an external integration. Please see '}<a href='http://mattermost.org/webhooks'>{'http://mattermost.org/webhooks'}</a> {' to learn more.'}
+                {'Create webhooks to send new message events to an external integration. Please see '}
+                <a
+                    href='http://mattermost.org/webhooks'
+                    target='_blank'
+                >
+                    {'http://mattermost.org/webhooks'}
+                </a>
+                {' to learn more.'}
                 <div><label className='control-label padding-top x2'>{'Add a new outgoing webhook'}</label></div>
                 <div className='padding-top divider-light'></div>
                 <div className='padding-top'>


### PR DESCRIPTION
Previously would take the user away from the app forcing them to go back in their browser.