### PR TITLE
PLT-1026 Bolds the team name when the team's statistics page is selected in the system console

### DIFF
--- a/web/react/components/admin_console/admin_sidebar.jsx
+++ b/web/react/components/admin_console/admin_sidebar.jsx
@@ -108,7 +108,7 @@ export default class AdminSidebar extends React.Component {
                                     <a
                                         href='#'
                                         onClick={this.handleClick.bind(this, 'team_users', team.id)}
-                                        className={'nav__sub-menu-item ' + this.isSelected('team_users', team.id)}
+                                        className={'nav__sub-menu-item ' + this.isSelected('team_users', team.id) + ' ' + this.isSelected('team_analytics', team.id)}
                                     >
                                         {team.name}
                                         <OverlayTrigger


### PR DESCRIPTION
Makes the UI consistent with when the team's user page is selected.