### PR TITLE
Fix duplicate favicon breaking unread mentions display

### DIFF
--- a/web/templates/head.html
+++ b/web/templates/head.html
@@ -28,7 +28,6 @@
     <link rel="stylesheet" class="code_theme" href="">
 
     <link id="favicon" rel="icon" href="/static/images/favicon.ico" type="image/x-icon">
-    <link rel="shortcut icon" href="/static/images/favicon.ico" type="image/x-icon">
 
     <script src="/static/js/react-0.14.3.js"></script>
     <script src="/static/js/react-dom-0.14.3.js"></script>


### PR DESCRIPTION
I found this as part of a bigger refactor for v1.4.0, but here's a simple fix for the red favicon not working when you receive a mention.
Basically there are two favicons in head.html so even if it's changed by javascript the original one is overriding it.

Repro:
1. Switch to channel2, be a member of channel1
2. Get the focus out of your browser
3. Ask someone to mention you in channel1
4. No red favicon before fix.