### PR TITLE
GIT-1682: Complete the SSL configuration section of the documentation…

### DIFF
--- a/doc/install/Production-Debian.md
+++ b/doc/install/Production-Debian.md
@@ -224,19 +224,20 @@ exit 0
   * Below is a sample configuration with the minimum settings required to configure Mattermost
 ```
    server {
-	  server_name mattermost.example.com;
+      server_name mattermost.example.com;
+
       location / {
-		  client_max_body_size 50M;
-		  proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
-		  proxy_set_header Host $http_host;
-		  proxy_set_header X-Real-IP $remote_addr;
-		  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		  proxy_set_header X-Forwarded-Proto $scheme;
-		  proxy_set_header   X-Frame-Options   SAMEORIGIN;
-          proxy_pass http://localhost:8065;
+         client_max_body_size 50M;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection "upgrade";
+         proxy_set_header Host $http_host;
+         proxy_set_header X-Real-IP $remote_addr;
+         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+         proxy_set_header X-Forwarded-Proto $scheme;
+         proxy_set_header X-Frame-Options SAMEORIGIN;
+         proxy_pass http://10.10.10.2:8065;
       }
-    }
+   }
 ```
   * Remove the existing file with
   * ``` sudo rm /etc/nginx/sites-enabled/default```
@@ -268,28 +269,39 @@ exit 0
   * 
 ```
   server {
-       listen         80;
-       server_name    mattermost.example.com;
-       return         301 https://$server_name$request_uri;
+     listen         80;
+     server_name    mattermost.example.com;
+     return         301 https://$server_name$request_uri;
   }
-  
-  server {
-        listen 443 ssl;
-        server_name mattermost.example.com;
-		
-        ssl on;
-        ssl_certificate /home/mattermost/cert/mattermost.crt;
-        ssl_certificate_key /home/mattermost/cert/mattermost.key;
-        ssl_session_timeout 5m;
-        ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
-        ssl_prefer_server_ciphers on;
-        ssl_session_cache shared:SSL:10m;
 
-		# add to location / above
-		location / {
-			gzip off;
-			proxy_set_header X-Forwarded-Ssl on;
+  server {
+     listen 443 ssl;
+     server_name mattermost.example.com;
+
+     ssl on;
+     ssl_certificate /home/ubuntu/cert/mattermost.crt;
+     ssl_certificate_key /home/ubuntu/cert/mattermost.key;
+     ssl_dhparam /home/ubuntu/cert/dhparam.pem;
+     ssl_session_timeout 5m;
+     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+     ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+     ssl_prefer_server_ciphers on;
+     ssl_session_cache shared:SSL:10m;
+
+     location / {
+        gzip off;
+        proxy_set_header X-Forwarded-Ssl on;
+        client_max_body_size 50M;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Frame-Options SAMEORIGIN;
+        proxy_pass http://10.10.10.2:8065;
+     }
+  }
 ```
 
 

--- a/doc/install/Production-Debian.md
+++ b/doc/install/Production-Debian.md
@@ -265,8 +265,8 @@ exit 0
     Common Name (e.g. server FQDN or YOUR name) []:mattermost.example.com
     Email Address []:admin@mattermost.example.com
 ```
-1. Modify the file at `/etc/nginx/sites-available/mattermost` and add the following lines
-  * 
+1. Run `openssl dhparam -out dhparam.pem 4096` (it will take some time).
+1. Modify the file at `/etc/nginx/sites-available/mattermost` and add the following lines:
 ```
   server {
      listen         80;

--- a/doc/install/Production-RHEL6.md
+++ b/doc/install/Production-RHEL6.md
@@ -165,8 +165,8 @@ enabled=1
     Common Name (e.g. server FQDN or YOUR name) []:mattermost.example.com
     Email Address []:admin@mattermost.example.com
 ```
+1. Run `openssl dhparam -out dhparam.pem 4096` (it will take some time).
 1. Modify the file at `/etc/nginx/conf.d/mattermost.conf` and add the following lines
-  * 
 ```
   server {
      listen         80;

--- a/doc/install/Production-RHEL6.md
+++ b/doc/install/Production-RHEL6.md
@@ -124,19 +124,20 @@ enabled=1
   * Below is a sample configuration with the minimum settings required to configure Mattermost
 ```
    server {
-    server_name mattermost.example.com;
+      server_name mattermost.example.com;
+
       location / {
-      client_max_body_size 50M;
-      proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header   X-Frame-Options   SAMEORIGIN;
-          proxy_pass http://10.10.10.2:8065;
+         client_max_body_size 50M;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection "upgrade";
+         proxy_set_header Host $http_host;
+         proxy_set_header X-Real-IP $remote_addr;
+         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+         proxy_set_header X-Forwarded-Proto $scheme;
+         proxy_set_header X-Frame-Options SAMEORIGIN;
+         proxy_pass http://10.10.10.2:8065;
       }
-    }
+   }
 ```
   * Remove the existing file with:
   * ``` sudo mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.bak```
@@ -168,28 +169,39 @@ enabled=1
   * 
 ```
   server {
-       listen         80;
-       server_name    mattermost.example.com;
-       return         301 https://$server_name$request_uri;
+     listen         80;
+     server_name    mattermost.example.com;
+     return         301 https://$server_name$request_uri;
   }
-  
-  server {
-        listen 443 ssl;
-        server_name mattermost.example.com;
-    
-        ssl on;
-        ssl_certificate /opt/mattermost/cert/mattermost.crt;
-        ssl_certificate_key /opt/mattermost/cert/mattermost.key;
-        ssl_session_timeout 5m;
-        ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
-        ssl_prefer_server_ciphers on;
-        ssl_session_cache shared:SSL:10m;
 
-    # add to location / above
-    location / {
-      gzip off;
-      proxy_set_header X-Forwarded-Ssl on;
+  server {
+     listen 443 ssl;
+     server_name mattermost.example.com;
+
+     ssl on;
+     ssl_certificate /home/ubuntu/cert/mattermost.crt;
+     ssl_certificate_key /home/ubuntu/cert/mattermost.key;
+     ssl_dhparam /home/ubuntu/cert/dhparam.pem;
+     ssl_session_timeout 5m;
+     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+     ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+     ssl_prefer_server_ciphers on;
+     ssl_session_cache shared:SSL:10m;
+
+     location / {
+        gzip off;
+        proxy_set_header X-Forwarded-Ssl on;
+        client_max_body_size 50M;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Frame-Options SAMEORIGIN;
+        proxy_pass http://10.10.10.2:8065;
+     }
+  }
 ```
 
 ## Finish Mattermost Server setup

--- a/doc/install/Production-RHEL7.md
+++ b/doc/install/Production-RHEL7.md
@@ -172,8 +172,8 @@ enabled=1
     Common Name (e.g. server FQDN or YOUR name) []:mattermost.example.com
     Email Address []:admin@mattermost.example.com
 ```
+1. Run `openssl dhparam -out dhparam.pem 4096` (it will take some time).
 1. Modify the file at `/etc/nginx/conf.d/mattermost.conf` and add the following lines
-  * 
 ```
   server {
      listen         80;

--- a/doc/install/Production-RHEL7.md
+++ b/doc/install/Production-RHEL7.md
@@ -131,19 +131,20 @@ enabled=1
   * Below is a sample configuration with the minimum settings required to configure Mattermost
 ```
    server {
-    server_name mattermost.example.com;
+      server_name mattermost.example.com;
+
       location / {
-      client_max_body_size 50M;
-      proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header   X-Frame-Options   SAMEORIGIN;
-          proxy_pass http://10.10.10.2:8065;
+         client_max_body_size 50M;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection "upgrade";
+         proxy_set_header Host $http_host;
+         proxy_set_header X-Real-IP $remote_addr;
+         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+         proxy_set_header X-Forwarded-Proto $scheme;
+         proxy_set_header X-Frame-Options SAMEORIGIN;
+         proxy_pass http://10.10.10.2:8065;
       }
-    }
+   }
 ```
   * Remove the existing file with:
   * ``` sudo mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.bak```
@@ -175,28 +176,39 @@ enabled=1
   * 
 ```
   server {
-       listen         80;
-       server_name    mattermost.example.com;
-       return         301 https://$server_name$request_uri;
+     listen         80;
+     server_name    mattermost.example.com;
+     return         301 https://$server_name$request_uri;
   }
-  
-  server {
-        listen 443 ssl;
-        server_name mattermost.example.com;
-    
-        ssl on;
-        ssl_certificate /opt/mattermost/cert/mattermost.crt;
-        ssl_certificate_key /opt/mattermost/cert/mattermost.key;
-        ssl_session_timeout 5m;
-        ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
-        ssl_prefer_server_ciphers on;
-        ssl_session_cache shared:SSL:10m;
 
-    # add to location / above
-    location / {
-      gzip off;
-      proxy_set_header X-Forwarded-Ssl on;
+  server {
+     listen 443 ssl;
+     server_name mattermost.example.com;
+
+     ssl on;
+     ssl_certificate /home/ubuntu/cert/mattermost.crt;
+     ssl_certificate_key /home/ubuntu/cert/mattermost.key;
+     ssl_dhparam /home/ubuntu/cert/dhparam.pem;
+     ssl_session_timeout 5m;
+     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+     ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+     ssl_prefer_server_ciphers on;
+     ssl_session_cache shared:SSL:10m;
+
+     location / {
+        gzip off;
+        proxy_set_header X-Forwarded-Ssl on;
+        client_max_body_size 50M;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Frame-Options SAMEORIGIN;
+        proxy_pass http://10.10.10.2:8065;
+     }
+  }
 ```
 
 ## Finish Mattermost Server setup

--- a/doc/install/Production-Ubuntu.md
+++ b/doc/install/Production-Ubuntu.md
@@ -107,19 +107,20 @@ exec bin/platform
   * Below is a sample configuration with the minimum settings required to configure Mattermost
 ```
    server {
-	  server_name mattermost.example.com;
+      server_name mattermost.example.com;
+
       location / {
-		  client_max_body_size 50M;
-		  proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "upgrade";
-		  proxy_set_header Host $http_host;
-		  proxy_set_header X-Real-IP $remote_addr;
-		  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		  proxy_set_header X-Forwarded-Proto $scheme;
-		  proxy_set_header   X-Frame-Options   SAMEORIGIN;
-          proxy_pass http://10.10.10.2:8065;
+         client_max_body_size 50M;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection "upgrade";
+         proxy_set_header Host $http_host;
+         proxy_set_header X-Real-IP $remote_addr;
+         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+         proxy_set_header X-Forwarded-Proto $scheme;
+         proxy_set_header X-Frame-Options SAMEORIGIN;
+         proxy_pass http://10.10.10.2:8065;
       }
-    }
+   }
 ```
   * Remove the existing file with
   * ``` sudo rm /etc/nginx/sites-enabled/default```
@@ -151,29 +152,39 @@ exec bin/platform
 4. Modify the file at `/etc/nginx/sites-available/mattermost` and add the following lines:
 ```
   server {
-       listen         80;
-       server_name    mattermost.example.com;
-       return         301 https://$server_name$request_uri;
+     listen         80;
+     server_name    mattermost.example.com;
+     return         301 https://$server_name$request_uri;
   }
   
   server {
-        listen 443 ssl;
-        server_name mattermost.example.com;
-		
-        ssl on;
-        ssl_certificate /home/ubuntu/cert/mattermost.crt;
-        ssl_certificate_key /home/ubuntu/cert/mattermost.key;
-        ssl_dhparam /home/ubuntu/cert/dhparam.pem;
-        ssl_session_timeout 5m;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
-        ssl_prefer_server_ciphers on;
-        ssl_session_cache shared:SSL:10m;
+     listen 443 ssl;
+     server_name mattermost.example.com;
 
-		# add to location / above
-		location / {
-			gzip off;
-			proxy_set_header X-Forwarded-Ssl on;
+     ssl on;
+     ssl_certificate /home/ubuntu/cert/mattermost.crt;
+     ssl_certificate_key /home/ubuntu/cert/mattermost.key;
+     ssl_dhparam /home/ubuntu/cert/dhparam.pem;
+     ssl_session_timeout 5m;
+     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+     ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+     ssl_prefer_server_ciphers on;
+     ssl_session_cache shared:SSL:10m;
+
+     location / {
+        gzip off;
+        proxy_set_header X-Forwarded-Ssl on;
+        client_max_body_size 50M;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Frame-Options SAMEORIGIN;
+        proxy_pass http://10.10.10.2:8065;
+     }
+  }
 ```
 
 


### PR DESCRIPTION
… and normalise the spacing in the NGINX config examples

The original documentation states in the SSL documentation that the user should add the config from above, this isn't as helpful to the user as reproducing with the required section in the sample block.

This pull request does that and cleans up the spacing in the NGINX samples so the user can copy and paste it into an NGINX config file.