### PR TITLE
PLT-1602 Fix ViewImageModal incorrectly assuming it has a file's info in certain cases

### DIFF
--- a/web/react/components/view_image.jsx
+++ b/web/react/components/view_image.jsx
@@ -40,7 +40,7 @@ export default class ViewImageModal extends React.Component {
 
         this.state = {
             imgId: this.props.startId,
-            fileInfo: new Map(),
+            fileInfo: null,
             imgHeight: '100%',
             loaded,
             progress,
@@ -109,12 +109,16 @@ export default class ViewImageModal extends React.Component {
     onFileStoreChange(filename) {
         const id = this.props.filenames.indexOf(filename);
 
-        if (id !== -1 && !this.state.loaded[id]) {
-            const fileInfo = this.state.fileInfo;
-            fileInfo.set(filename, FileStore.getInfo(filename));
-            this.setState({fileInfo});
+        if (id !== -1) {
+            if (id === this.state.imgId) {
+                this.setState({
+                    fileInfo: FileStore.getInfo(filename)
+                });
+            }
 
-            this.loadImage(id, filename);
+            if (!this.state.loaded[id]) {
+                this.loadImage(id, filename);
+            }
         }
     }
 
@@ -131,6 +135,10 @@ export default class ViewImageModal extends React.Component {
             AsyncClient.getFileInfo(filename);
             return;
         }
+
+        this.setState({
+            fileInfo: FileStore.getInfo(filename)
+        });
 
         if (!this.state.loaded[id]) {
             this.loadImage(id, filename);
@@ -227,8 +235,8 @@ export default class ViewImageModal extends React.Component {
 
         var content;
         if (this.state.loaded[this.state.imgId]) {
-            // if a file has been loaded, we also have its info
-            const fileInfo = this.state.fileInfo.get(filename);
+            // this.state.fileInfo is for the current image and we shoudl have it before we load the image
+            const fileInfo = this.state.fileInfo;
 
             const extension = Utils.splitFileLocation(filename).ext;
             const fileType = Utils.getFileType(extension);

--- a/web/react/components/view_image.jsx
+++ b/web/react/components/view_image.jsx
@@ -31,19 +31,12 @@ export default class ViewImageModal extends React.Component {
         this.onMouseEnterImage = this.onMouseEnterImage.bind(this);
         this.onMouseLeaveImage = this.onMouseLeaveImage.bind(this);
 
-        const loaded = [];
-        const progress = [];
-        for (var i = 0; i < this.props.filenames.length; i++) {
-            loaded.push(false);
-            progress.push(0);
-        }
-
         this.state = {
             imgId: this.props.startId,
             fileInfo: null,
             imgHeight: '100%',
-            loaded,
-            progress,
+            loaded: Utils.fillArray(false, this.props.filenames.length),
+            progress: Utils.fillArray(0, this.props.filenames.length),
             showFooter: false
         };
     }
@@ -103,6 +96,13 @@ export default class ViewImageModal extends React.Component {
             this.onModalShown(nextProps);
         } else if (nextProps.show === false && this.props.show === true) {
             this.onModalHidden();
+        }
+
+        if (!Utils.areObjectsEqual(this.props.filenames, nextProps.filenames)) {
+            this.setState({
+                loaded: Utils.fillArray(false, nextProps.filenames.length),
+                progress: Utils.fillArray(0, nextProps.filenames.length)
+            });
         }
     }
 

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1261,3 +1261,13 @@ export function isFeatureEnabled(feature) {
 export function isSystemMessage(post) {
     return post.type && (post.type.lastIndexOf(Constants.SYSTEM_MESSAGE_PREFIX) === 0);
 }
+
+export function fillArray(value, length) {
+    const arr = [];
+
+    for (let i = 0; i < length; i++) {
+        arr.push(value);
+    }
+
+    return arr;
+}


### PR DESCRIPTION
This happens only for root post in the RHS since it's the only time that a ViewImageModal's filenames prop changes after the component has been mounted. I also fixed an issue where the modal thinks an image has already been loaded that happens in the same situation