### PR TITLE
PLT-771 Improved Audio/Video preview for unsupported formats

### DIFF
--- a/web/react/components/audio_video_preview.jsx
+++ b/web/react/components/audio_video_preview.jsx
@@ -1,0 +1,114 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import Constants from '../utils/constants.jsx';
+import FileInfoPreview from './file_info_preview.jsx';
+import * as Utils from '../utils/utils.jsx';
+
+export default class AudioVideoPreview extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.handleFileInfoChanged = this.handleFileInfoChanged.bind(this);
+        this.handleLoadError = this.handleLoadError.bind(this);
+
+        this.stop = this.stop.bind(this);
+
+        this.state = {
+            canPlay: true
+        };
+    }
+
+    componentWillMount() {
+        this.handleFileInfoChanged(this.props.fileInfo);
+    }
+
+    componentDidMount() {
+        if (this.refs.source) {
+            $(ReactDOM.findDOMNode(this.refs.source)).one('error', this.handleLoadError);
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (this.props.fileUrl !== nextProps.fileUrl) {
+            this.handleFileInfoChanged(nextProps.fileInfo);
+        }
+    }
+
+    handleFileInfoChanged(fileInfo) {
+        let video = ReactDOM.findDOMNode(this.refs.video);
+        if (!video) {
+            video = document.createElement('video');
+        }
+
+        const canPlayType = video.canPlayType(fileInfo.mime_type);
+
+        this.setState({
+            canPlay: canPlayType === 'probably' || canPlayType === 'maybe'
+        });
+    }
+
+    componentDidUpdate() {
+        if (this.refs.source) {
+            $(ReactDOM.findDOMNode(this.refs.source)).one('error', this.handleLoadError);
+        }
+    }
+
+    handleLoadError() {
+        this.setState({
+            canPlay: false
+        });
+    }
+
+    stop() {
+        if (this.refs.video) {
+            const video = ReactDOM.findDOMNode(this.refs.video);
+            video.pause();
+            video.currentTime = 0;
+        }
+    }
+
+    render() {
+        if (!this.state.canPlay) {
+            return (
+                <FileInfoPreview
+                    filename={this.props.filename}
+                    fileUrl={this.props.fileUrl}
+                    fileInfo={this.props.fileInfo}
+                />
+            );
+        }
+
+        let width = Constants.WEB_VIDEO_WIDTH;
+        let height = Constants.WEB_VIDEO_HEIGHT;
+        if (Utils.isMobile()) {
+            width = Constants.MOBILE_VIDEO_WIDTH;
+            height = Constants.MOBILE_VIDEO_HEIGHT;
+        }
+
+        // add a key to the video to prevent React from using an old video source while a new one is loading
+        return (
+            <video
+                key={this.props.filename}
+                ref='video'
+                style={{maxHeight: this.props.maxHeight}}
+                data-setup='{}'
+                controls='controls'
+                width={width}
+                height={height}
+            >
+                <source
+                    ref='source'
+                    src={this.props.fileUrl}
+                />
+            </video>
+        );
+    }
+}
+
+AudioVideoPreview.propTypes = {
+    filename: React.PropTypes.string.isRequired,
+    fileUrl: React.PropTypes.string.isRequired,
+    fileInfo: React.PropTypes.object.isRequired,
+    maxHeight: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]).isRequired
+};

--- a/web/react/components/file_attachment.jsx
+++ b/web/react/components/file_attachment.jsx
@@ -125,10 +125,6 @@ export default class FileAttachment extends React.Component {
     getFileInfoFromName(name) {
         var fileInfo = utils.splitFileLocation(name);
 
-        // This is a temporary patch to fix issue with old files using absolute paths
-        if (fileInfo.path.indexOf('/api/v1/files/get') !== -1) {
-            fileInfo.path = fileInfo.path.split('/api/v1/files/get')[1];
-        }
         fileInfo.path = utils.getWindowLocationOrigin() + '/api/v1/files/get' + fileInfo.path;
 
         return fileInfo;

--- a/web/react/components/file_info_preview.jsx
+++ b/web/react/components/file_info_preview.jsx
@@ -1,0 +1,31 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import * as Utils from '../utils/utils.jsx';
+
+export default function FileInfoPreview({filename, fileUrl, fileInfo}) {
+    // non-image files include a section providing details about the file
+    let infoString = 'File type ' + fileInfo.extension.toUpperCase();
+    if (fileInfo.size > 0) {
+        infoString += ', Size ' + Utils.fileSizeToString(fileInfo.size);
+    }
+
+    const name = decodeURIComponent(Utils.getFileName(filename));
+
+    return (
+        <div className='file-details__container'>
+            <a
+                className={'file-details__preview'}
+                href={fileUrl}
+                target='_blank'
+            >
+                <span className='file-details__preview-helper' />
+                <img src={Utils.getPreviewImagePath(filename)}/>
+            </a>
+            <div className='file-details'>
+                <div className='file-details__name'>{name}</div>
+                <div className='file-details__info'>{infoString}</div>
+            </div>
+        </div>
+    );
+}

--- a/web/react/components/file_preview.jsx
+++ b/web/react/components/file_preview.jsx
@@ -35,12 +35,7 @@ export default class FilePreview extends React.Component {
             var ext = filenameSplit[filenameSplit.length - 1];
             var type = Utils.getFileType(ext);
 
-            // This is a temporary patch to fix issue with old files using absolute paths
-
-            if (filename.indexOf('/api/v1/files/get') !== -1) {
-                filename = filename.split('/api/v1/files/get')[1];
-            }
-            filename = Utils.getWindowLocationOrigin() + '/api/v1/files/get' + filename + '?' + Utils.getSessionIndex();
+            filename = Utils.getFileUrl(filename);
 
             if (type === 'image') {
                 previews.push(

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -527,6 +527,25 @@ export function splitFileLocation(fileLocation) {
     return {ext: ext, name: filename, path: filePath};
 }
 
+export function getPreviewImagePath(filename) {
+    // Returns the path to a preview image that can be used to represent a file.
+    const fileInfo = splitFileLocation(filename);
+    const fileType = getFileType(fileInfo.ext);
+
+    if (fileType === 'image') {
+        // This is a temporary patch to fix issue with old files using absolute paths
+        if (fileInfo.path.indexOf('/api/v1/files/get') !== -1) {
+            fileInfo.path = fileInfo.path.split('/api/v1/files/get')[1];
+        }
+        fileInfo.path = getWindowLocationOrigin() + '/api/v1/files/get' + fileInfo.path;
+
+        return fileInfo.path + '_preview.jpg?' + getSessionIndex();
+    }
+
+    // only images have proper previews, so just use a placeholder icon for non-images
+    return getPreviewImagePathForFileType(fileType);
+}
+
 export function toTitleCase(str) {
     function doTitleCase(txt) {
         return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -533,13 +533,7 @@ export function getPreviewImagePath(filename) {
     const fileType = getFileType(fileInfo.ext);
 
     if (fileType === 'image') {
-        // This is a temporary patch to fix issue with old files using absolute paths
-        if (fileInfo.path.indexOf('/api/v1/files/get') !== -1) {
-            fileInfo.path = fileInfo.path.split('/api/v1/files/get')[1];
-        }
-        fileInfo.path = getWindowLocationOrigin() + '/api/v1/files/get' + fileInfo.path;
-
-        return fileInfo.path + '_preview.jpg?' + getSessionIndex();
+        return getFileUrl(fileInfo.path + '_preview.jpg');
     }
 
     // only images have proper previews, so just use a placeholder icon for non-images
@@ -1069,15 +1063,7 @@ export function fileSizeToString(bytes) {
 
 // Converts a filename (like those attached to Post objects) to a url that can be used to retrieve attachments from the server.
 export function getFileUrl(filename) {
-    var url = filename;
-
-    // This is a temporary patch to fix issue with old files using absolute paths
-    if (url.indexOf('/api/v1/files/get') !== -1) {
-        url = filename.split('/api/v1/files/get')[1];
-    }
-    url = getWindowLocationOrigin() + '/api/v1/files/get' + url + '?' + getSessionIndex();
-
-    return url;
+    return getWindowLocationOrigin() + '/api/v1/files/get' + filename + '?' + getSessionIndex();
 }
 
 // Gets the name of a file (including extension) from a given url or file path.


### PR DESCRIPTION
This makes the preview for unsupported audio and video files just fall back to the default attachment preview (showing file name and size) if it cannot play the file. If either 1) video.canPlayType returns falsey for the file's mime type or 2) the source element throws an error, then it'll fall back to showing the preview. I found a specific case (mp4 file with mp1/2 audio) where this doesn't work on IE11/Edge (the file just fails to load without calling the error handler like a sane browser), but I'm not sure how much more we can do about that without a library to actually read into the mp4 and pull out the contained codecs.

Also should fix PLT-1435