### PR TITLE
[Fix #1669] Allow parameters in Content-Type of incoming webhook request

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -1017,7 +1017,8 @@ func incomingWebhook(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 
 	var parsedRequest *model.IncomingWebhookRequest
-	if r.Header.Get("Content-Type") == "application/json" {
+	contentType := r.Header.Get("Content-Type")
+	if strings.Split(contentType, "; ")[0] == "application/json" {
 		parsedRequest = model.IncomingWebhookRequestFromJson(r.Body)
 	} else {
 		parsedRequest = model.IncomingWebhookRequestFromJson(strings.NewReader(r.FormValue("payload")))


### PR DESCRIPTION
As #1669 notices, Mattermost currently does not allow optional parameters in the `Content-Type` of an incoming webhook request. [Visual Studio Team Services's Slack integration](https://www.visualstudio.com/get-started/integrate/service-hooks/slack-and-vso-vs) sends its messages with `Content-Type: application/json; charset=utf-8`, whereas Mattermost currently requires precisely `Content-Type: application/json`. This PR relaxes this check, looking only at the media part of the header.

There's no JIRA ticket for this bug yet, as far as I can see.
