### PR TITLE
PLT-846 Disable the ability to drag and drop text

### DIFF
--- a/web/react/components/create_comment.jsx
+++ b/web/react/components/create_comment.jsx
@@ -32,7 +32,6 @@ export default class CreateComment extends React.Component {
         this.handleUploadStart = this.handleUploadStart.bind(this);
         this.handleFileUploadComplete = this.handleFileUploadComplete.bind(this);
         this.handleUploadError = this.handleUploadError.bind(this);
-        this.handleTextDrop = this.handleTextDrop.bind(this);
         this.removePreview = this.removePreview.bind(this);
         this.getFileCount = this.getFileCount.bind(this);
         this.handleResize = this.handleResize.bind(this);
@@ -239,11 +238,6 @@ export default class CreateComment extends React.Component {
             this.setState({uploadsInProgress: draft.uploadsInProgress, serverError: err});
         }
     }
-    handleTextDrop(text) {
-        const newText = this.state.messageText + text;
-        this.handleUserInput(newText);
-        Utils.setCaretPosition(ReactDOM.findDOMNode(this.refs.textbox.refs.message), newText.length);
-    }
     removePreview(id) {
         let previews = this.state.previews;
         let uploadsInProgress = this.state.uploadsInProgress;
@@ -344,7 +338,6 @@ export default class CreateComment extends React.Component {
                                 onUploadStart={this.handleUploadStart}
                                 onFileUpload={this.handleFileUploadComplete}
                                 onUploadError={this.handleUploadError}
-                                onTextDrop={this.handleTextDrop}
                                 postType='comment'
                                 channelId={this.props.channelId}
                             />

--- a/web/react/components/create_post.jsx
+++ b/web/react/components/create_post.jsx
@@ -40,7 +40,6 @@ export default class CreatePost extends React.Component {
         this.handleUploadStart = this.handleUploadStart.bind(this);
         this.handleFileUploadComplete = this.handleFileUploadComplete.bind(this);
         this.handleUploadError = this.handleUploadError.bind(this);
-        this.handleTextDrop = this.handleTextDrop.bind(this);
         this.removePreview = this.removePreview.bind(this);
         this.onChange = this.onChange.bind(this);
         this.onPreferenceChange = this.onPreferenceChange.bind(this);
@@ -281,11 +280,6 @@ export default class CreatePost extends React.Component {
             this.setState({uploadsInProgress: draft.uploadsInProgress, serverError: message});
         }
     }
-    handleTextDrop(text) {
-        const newText = this.state.messageText + text;
-        this.handleUserInput(newText);
-        Utils.setCaretPosition(ReactDOM.findDOMNode(this.refs.textbox.refs.message), newText.length);
-    }
     removePreview(id) {
         const previews = Object.assign([], this.state.previews);
         const uploadsInProgress = this.state.uploadsInProgress;
@@ -462,7 +456,6 @@ export default class CreatePost extends React.Component {
                                 onUploadStart={this.handleUploadStart}
                                 onFileUpload={this.handleFileUploadComplete}
                                 onUploadError={this.handleUploadError}
-                                onTextDrop={this.handleTextDrop}
                                 postType='post'
                                 channelId=''
                             />

--- a/web/react/components/file_upload.jsx
+++ b/web/react/components/file_upload.jsx
@@ -109,8 +109,6 @@ export default class FileUpload extends React.Component {
 
         if (typeof files !== 'string' && files.length) {
             this.uploadFiles(files);
-        } else {
-            this.props.onTextDrop(e.originalEvent.dataTransfer.getData('Text'));
         }
     }
 
@@ -120,11 +118,19 @@ export default class FileUpload extends React.Component {
 
         if (this.props.postType === 'post') {
             $('.row.main').dragster({
-                enter() {
-                    $('.center-file-overlay').removeClass('hidden');
+                enter(dragsterEvent, e) {
+                    var files = e.originalEvent.dataTransfer;
+
+                    if (utils.isFileTransfer(files)) {
+                        $('.center-file-overlay').removeClass('hidden');
+                    }
                 },
-                leave() {
-                    $('.center-file-overlay').addClass('hidden');
+                leave(dragsterEvent, e) {
+                    var files = e.originalEvent.dataTransfer;
+
+                    if (utils.isFileTransfer(files)) {
+                        $('.center-file-overlay').addClass('hidden');
+                    }
                 },
                 drop(dragsterEvent, e) {
                     $('.center-file-overlay').addClass('hidden');
@@ -133,11 +139,19 @@ export default class FileUpload extends React.Component {
             });
         } else if (this.props.postType === 'comment') {
             $('.post-right__container').dragster({
-                enter() {
-                    $('.right-file-overlay').removeClass('hidden');
+                enter(dragsterEvent, e) {
+                    var files = e.originalEvent.dataTransfer;
+
+                    if (utils.isFileTransfer(files)) {
+                        $('.right-file-overlay').removeClass('hidden');
+                    }
                 },
-                leave() {
-                    $('.right-file-overlay').addClass('hidden');
+                leave(dragsterEvent, e) {
+                    var files = e.originalEvent.dataTransfer;
+
+                    if (utils.isFileTransfer(files)) {
+                        $('.right-file-overlay').addClass('hidden');
+                    }
                 },
                 drop(dragsterEvent, e) {
                     $('.right-file-overlay').addClass('hidden');

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1276,3 +1276,9 @@ export function fillArray(value, length) {
 
     return arr;
 }
+
+// Checks if a data transfer contains files not text, folders, etc..
+// Slightly modified from http://stackoverflow.com/questions/6848043/how-do-i-detect-a-file-is-being-dragged-rather-than-a-draggable-element-on-my-pa
+export function isFileTransfer(files) {
+    return files.types != null && (files.types.indexOf ? files.types.indexOf('Files') !== -1 : files.types.contains('application/x-moz-file'));
+}


### PR DESCRIPTION
Removes the ability for users to drag and drop text like files (would previously place it in the text box).  In addition any non-files that are dragged/dropped no longer cause the drag and drop UI to appear.