### PR TITLE
PLT-1525 Fixed ChannelInviteModal displaying some users that are already in the channel

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -9,7 +9,12 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/mattermost/platform/model"
 	"net/http"
+	"strconv"
 	"strings"
+)
+
+const (
+	defaultExtraMemberLimit = 100
 )
 
 func InitChannel(r *mux.Router) {
@@ -27,6 +32,7 @@ func InitChannel(r *mux.Router) {
 	sr.Handle("/update_notify_props", ApiUserRequired(updateNotifyProps)).Methods("POST")
 	sr.Handle("/{id:[A-Za-z0-9]+}/", ApiUserRequiredActivity(getChannel, false)).Methods("GET")
 	sr.Handle("/{id:[A-Za-z0-9]+}/extra_info", ApiUserRequired(getChannelExtraInfo)).Methods("GET")
+	sr.Handle("/{id:[A-Za-z0-9]+}/extra_info/{member_limit:-?[0-9]+}", ApiUserRequired(getChannelExtraInfo)).Methods("GET")
 	sr.Handle("/{id:[A-Za-z0-9]+}/join", ApiUserRequired(join)).Methods("POST")
 	sr.Handle("/{id:[A-Za-z0-9]+}/leave", ApiUserRequired(leave)).Methods("POST")
 	sr.Handle("/{id:[A-Za-z0-9]+}/delete", ApiUserRequired(deleteChannel)).Methods("POST")
@@ -730,9 +736,18 @@ func getChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getChannelExtraInfo(c *Context, w http.ResponseWriter, r *http.Request) {
-
 	params := mux.Vars(r)
 	id := params["id"]
+
+	var memberLimit int
+	if memberLimitString, ok := params["member_limit"]; !ok {
+		memberLimit = defaultExtraMemberLimit
+	} else if memberLimitInt64, err := strconv.ParseInt(memberLimitString, 10, 0); err != nil {
+		c.Err = model.NewAppError("getChannelExtraInfo", "Failed to parse member limit", err.Error())
+		return
+	} else {
+		memberLimit = int(memberLimitInt64)
+	}
 
 	sc := Srv.Store.Channel().Get(id)
 	var channel *model.Channel
@@ -743,13 +758,13 @@ func getChannelExtraInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 		channel = cresult.Data.(*model.Channel)
 	}
 
-	extraEtag := channel.ExtraEtag()
+	extraEtag := channel.ExtraEtag(memberLimit)
 	if HandleEtag(extraEtag, w, r) {
 		return
 	}
 
 	scm := Srv.Store.Channel().GetMember(id, c.Session.UserId)
-	ecm := Srv.Store.Channel().GetExtraMembers(id, 100)
+	ecm := Srv.Store.Channel().GetExtraMembers(id, memberLimit)
 	ccm := Srv.Store.Channel().GetMemberCount(id)
 
 	if cmresult := <-scm; cmresult.Err != nil {

--- a/api/channel_benchmark_test.go
+++ b/api/channel_benchmark_test.go
@@ -189,7 +189,7 @@ func BenchmarkGetChannelExtraInfo(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := range channels {
-			Client.Must(Client.GetChannelExtraInfo(channels[j].Id, ""))
+			Client.Must(Client.GetChannelExtraInfo(channels[j].Id, -1, ""))
 		}
 	}
 }

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -674,7 +674,7 @@ func TestGetChannelExtraInfo(t *testing.T) {
 	channel1 := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
 
-	rget := Client.Must(Client.GetChannelExtraInfo(channel1.Id, ""))
+	rget := Client.Must(Client.GetChannelExtraInfo(channel1.Id, -1, ""))
 	data := rget.Data.(*model.ChannelExtra)
 	if data.Id != channel1.Id {
 		t.Fatal("couldnt't get extra info")
@@ -690,7 +690,7 @@ func TestGetChannelExtraInfo(t *testing.T) {
 
 	currentEtag := rget.Etag
 
-	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, currentEtag); err != nil {
+	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, -1, currentEtag); err != nil {
 		t.Fatal(err)
 	} else if cache_result.Data.(*model.ChannelExtra) != nil {
 		t.Log(cache_result.Data)
@@ -708,7 +708,7 @@ func TestGetChannelExtraInfo(t *testing.T) {
 	Client2.LoginByEmail(team.Name, user2.Email, "pwd")
 	Client2.Must(Client2.JoinChannel(channel1.Id))
 
-	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, currentEtag); err != nil {
+	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, -1, currentEtag); err != nil {
 		t.Fatal(err)
 	} else if cache_result.Data.(*model.ChannelExtra) == nil {
 		t.Log(cache_result.Data)
@@ -717,7 +717,7 @@ func TestGetChannelExtraInfo(t *testing.T) {
 		currentEtag = cache_result.Etag
 	}
 
-	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, currentEtag); err != nil {
+	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, -1, currentEtag); err != nil {
 		t.Fatal(err)
 	} else if cache_result.Data.(*model.ChannelExtra) != nil {
 		t.Log(cache_result.Data)
@@ -728,7 +728,7 @@ func TestGetChannelExtraInfo(t *testing.T) {
 
 	Client2.Must(Client2.LeaveChannel(channel1.Id))
 
-	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, currentEtag); err != nil {
+	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, -1, currentEtag); err != nil {
 		t.Fatal(err)
 	} else if cache_result.Data.(*model.ChannelExtra) == nil {
 		t.Log(cache_result.Data)
@@ -737,7 +737,7 @@ func TestGetChannelExtraInfo(t *testing.T) {
 		currentEtag = cache_result.Etag
 	}
 
-	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, currentEtag); err != nil {
+	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, -1, currentEtag); err != nil {
 		t.Fatal(err)
 	} else if cache_result.Data.(*model.ChannelExtra) != nil {
 		t.Log(cache_result.Data)
@@ -745,6 +745,42 @@ func TestGetChannelExtraInfo(t *testing.T) {
 	} else {
 		currentEtag = cache_result.Etag
 	}
+
+	Client2.Must(Client2.JoinChannel(channel1.Id))
+
+	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, 2, currentEtag); err != nil {
+		t.Fatal(err)
+	} else if extra := cache_result.Data.(*model.ChannelExtra); extra == nil {
+		t.Fatal("response should not be empty")
+	} else if len(extra.Members) != 2 {
+		t.Fatal("should've returned 2 members")
+	} else if extra.MemberCount != 2 {
+		t.Fatal("should've returned member count of 2")
+	} else {
+		currentEtag = cache_result.Etag
+	}
+
+	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, 1, currentEtag); err != nil {
+		t.Fatal(err)
+	} else if extra := cache_result.Data.(*model.ChannelExtra); extra == nil {
+		t.Fatal("response should not be empty")
+	} else if len(extra.Members) != 1 {
+		t.Fatal("should've returned only 1 member")
+	} else if extra.MemberCount != 2 {
+		t.Fatal("should've returned member count of 2")
+	} else {
+		currentEtag = cache_result.Etag
+	}
+
+	if cache_result, err := Client.GetChannelExtraInfo(channel1.Id, 1, currentEtag); err != nil {
+		t.Fatal(err)
+	} else if cache_result.Data.(*model.ChannelExtra) != nil {
+		t.Log(cache_result.Data)
+		t.Fatal("response should be empty")
+	} else {
+		currentEtag = cache_result.Etag
+	}
+
 }
 
 func TestAddChannelMember(t *testing.T) {

--- a/model/channel.go
+++ b/model/channel.go
@@ -57,8 +57,8 @@ func (o *Channel) Etag() string {
 	return Etag(o.Id, o.UpdateAt)
 }
 
-func (o *Channel) ExtraEtag() string {
-	return Etag(o.Id, o.ExtraUpdateAt)
+func (o *Channel) ExtraEtag(memberLimit int) string {
+	return Etag(o.Id, o.ExtraUpdateAt, memberLimit)
 }
 
 func (o *Channel) IsValid() *AppError {

--- a/model/client.go
+++ b/model/client.go
@@ -591,8 +591,8 @@ func (c *Client) UpdateLastViewedAt(channelId string) (*Result, *AppError) {
 	}
 }
 
-func (c *Client) GetChannelExtraInfo(id string, etag string) (*Result, *AppError) {
-	if r, err := c.DoApiGet("/channels/"+id+"/extra_info", "", etag); err != nil {
+func (c *Client) GetChannelExtraInfo(id string, memberLimit int, etag string) (*Result, *AppError) {
+	if r, err := c.DoApiGet("/channels/"+id+"/extra_info/"+strconv.FormatInt(int64(memberLimit), 10), "", etag); err != nil {
 		return nil, err
 	} else {
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -603,7 +603,14 @@ func (s SqlChannelStore) GetExtraMembers(channelId string, limit int) StoreChann
 		result := StoreResult{}
 
 		var members []model.ExtraMember
-		_, err := s.GetReplica().Select(&members, "SELECT Id, Nickname, Email, ChannelMembers.Roles, Username FROM ChannelMembers, Users WHERE ChannelMembers.UserId = Users.Id AND ChannelId = :ChannelId LIMIT :Limit", map[string]interface{}{"ChannelId": channelId, "Limit": limit})
+		var err error
+
+		if limit != -1 {
+			_, err = s.GetReplica().Select(&members, "SELECT Id, Nickname, Email, ChannelMembers.Roles, Username FROM ChannelMembers, Users WHERE ChannelMembers.UserId = Users.Id AND ChannelId = :ChannelId LIMIT :Limit", map[string]interface{}{"ChannelId": channelId, "Limit": limit})
+		} else {
+			_, err = s.GetReplica().Select(&members, "SELECT Id, Nickname, Email, ChannelMembers.Roles, Username FROM ChannelMembers, Users WHERE ChannelMembers.UserId = Users.Id AND ChannelId = :ChannelId", map[string]interface{}{"ChannelId": channelId})
+		}
+
 		if err != nil {
 			result.Err = model.NewAppError("SqlChannelStore.GetExtraMembers", "We couldn't get the extra info for channel members", "channel_id="+channelId+", "+err.Error())
 		} else {

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -168,7 +168,7 @@ export function getMoreChannels(force) {
     }
 }
 
-export function getChannelExtraInfo(id) {
+export function getChannelExtraInfo(id, memberLimit) {
     let channelId;
     if (id) {
         channelId = id;
@@ -185,6 +185,7 @@ export function getChannelExtraInfo(id) {
 
         client.getChannelExtraInfo(
             channelId,
+            memberLimit,
             (data, textStatus, xhr) => {
                 callTracker['getChannelExtraInfo_' + channelId] = 0;
 

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -824,10 +824,17 @@ export function getChannelCounts(success, error) {
     });
 }
 
-export function getChannelExtraInfo(id, success, error) {
+export function getChannelExtraInfo(id, memberLimit, success, error) {
+    let url = '/api/v1/channels/' + id + '/extra_info';
+
+    if (memberLimit) {
+        url += '/' + memberLimit;
+    }
+
     $.ajax({
-        url: '/api/v1/channels/' + id + '/extra_info',
+        url,
         dataType: 'json',
+        contentType: 'application/json',
         type: 'GET',
         success,
         error: function onError(xhr, status, err) {


### PR DESCRIPTION
This was happening because the client didn't know all the members of the channel and so it displayed them as available to be invited. I changed it so the client can request all members of a channel instead of the default 100 when the Invite Members modal is opened. I also added that to the Manage Members modal while I was in there.