### PR TITLE
PLT-1397/PLT-1580 Fixed spacing around markdown lists

### DIFF
--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -676,12 +676,8 @@ body.ios {
 		}
 
 		ul {
-		    margin-bottom: 0.6em;
+		    margin-bottom: 0.4em;
 			padding: 5px 0 0 20px;
-		}
-
-		ul + p {
-			margin-top: 1em;
 		}
 
 		ul, ol {

--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -417,12 +417,6 @@ body.ios {
 		background-color: beige;
 	}
 
-	ul {
-		margin: 0;
-		padding: 0;
-	}
-
-
 	p {
 		margin: 0;
 		line-height: 1.6em;
@@ -675,12 +669,10 @@ body.ios {
 			max-height: 400px;
 		}
 
-		ul {
-		    margin-bottom: 0.4em;
-			padding: 5px 0 0 20px;
-		}
-
 		ul, ol {
+			padding-top: 5px;
+			margin-bottom: 0.4em;
+
 			p {
 				margin-bottom: 0;
 			}


### PR DESCRIPTION
Fixes the vertical spacing for the two tickets and also changed the left-hand margin match for both numbered and bulleted lists
![image](https://cloud.githubusercontent.com/assets/3277310/12175701/af19434e-b531-11e5-9cc1-ba8867a1fbab.png)
