### PR TITLE
PLT-1397/PLT-1580/PLT-1614 Fixed spacing around markdown lists and paragraphs

### DIFF
--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -676,12 +676,8 @@ body.ios {
 		}
 
 		ul {
-		    margin-bottom: 0.6em;
+		    margin-bottom: 0.4em;
 			padding: 5px 0 0 20px;
-		}
-
-		ul + p {
-			margin-top: 1em;
 		}
 
 		ul, ol {

--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -417,12 +417,6 @@ body.ios {
 		background-color: beige;
 	}
 
-	ul {
-		margin: 0;
-		padding: 0;
-	}
-
-
 	p {
 		margin: 0;
 		line-height: 1.6em;
@@ -675,12 +669,10 @@ body.ios {
 			max-height: 400px;
 		}
 
-		ul {
-		    margin-bottom: 0.4em;
-			padding: 5px 0 0 20px;
-		}
-
 		ul, ol {
+			padding-top: 5px;
+			margin-bottom: 0.4em;
+
 			p {
 				margin-bottom: 0;
 			}

--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -665,12 +665,15 @@ body.ios {
 		@include legacy-pie-clearfix;
 		width: calc(100% - 75px);
 
+		p {
+			margin: 0 0 0.4em;
+		}
+
 		img {
 			max-height: 400px;
 		}
 
 		ul, ol {
-			padding-top: 5px;
 			margin-bottom: 0.4em;
 
 			p {


### PR DESCRIPTION
This PR is to re-add some space around lists and paragraphs in markdown and to make the spacing equal between the two. I've attached some comparison screenshots so you can see the differences between the different versions.

In 1.3:
![image](https://cloud.githubusercontent.com/assets/3277310/12176784/0c6579d2-b537-11e5-9541-53628dd8ce16.png)
![image](https://cloud.githubusercontent.com/assets/3277310/12176696/ae0c45dc-b536-11e5-8290-dc43a44c7a9c.png)

On master:
![image](https://cloud.githubusercontent.com/assets/3277310/12176793/1846a4e2-b537-11e5-9913-495e7cf89efa.png)
![image](https://cloud.githubusercontent.com/assets/3277310/12176722/cd474aaa-b536-11e5-827f-f5da6a6709b6.png)

After PR:
![image](https://cloud.githubusercontent.com/assets/3277310/12176754/f53a17a4-b536-11e5-9a74-20ec5d8da82c.png)
![image](https://cloud.githubusercontent.com/assets/3277310/12176690/9debda5a-b536-11e5-8951-8f2fe0e47b28.png)
