### PR TITLE
PLT-1578 Fixed FileUpload to properly unbind drag handlers when unmounted

### DIFF
--- a/web/react/components/file_upload.jsx
+++ b/web/react/components/file_upload.jsx
@@ -243,6 +243,18 @@ export default class FileUpload extends React.Component {
         });
     }
 
+    componentWillUnmount() {
+        let target;
+        if (this.props.postType === 'post') {
+            target = $('.row.main');
+        } else {
+            target = $('.post-right__container');
+        }
+
+        // jquery-dragster doesn't provide a function to unregister itself so do it manually
+        target.off('dragenter dragleave dragover drop dragster:enter dragster:leave dragster:over dragster:drop');
+    }
+
     cancelUpload(clientId) {
         var requests = this.state.requests;
         var request = requests[clientId];


### PR DESCRIPTION
Thanks @Timmmm for finding a repro case for this! The FileUpload was getting rebound whenever the CreatePost box was rebound (like when the tutorial is shown or you follow a permalink) so we got two handlers that fire each other, causing 4 uploads to happen at once.

When this gets merged, can whoever does that also close https://github.com/mattermost/platform/issues/1767?