### PR TITLE
PLT-1006 Changed team statistics page to show usernames with email shown in a tooltip

### DIFF
--- a/web/react/components/admin_console/team_analytics.jsx
+++ b/web/react/components/admin_console/team_analytics.jsx
@@ -3,7 +3,11 @@
 
 import * as Client from '../../utils/client.jsx';
 import * as Utils from '../../utils/utils.jsx';
+import Constants from '../../utils/constants.jsx';
 import LineChart from './line_chart.jsx';
+
+var Tooltip = ReactBootstrap.Tooltip;
+var OverlayTrigger = ReactBootstrap.OverlayTrigger;
 
 export default class TeamAnalytics extends React.Component {
     constructor(props) {
@@ -314,9 +318,25 @@ export default class TeamAnalytics extends React.Component {
                                 <tbody>
                                     {
                                         this.state.recent_active_users.map((user) => {
+                                            const tooltip = (
+                                                <Tooltip id={'recent-user-email-tooltip-' + user.id}>
+                                                    {user.email}
+                                                </Tooltip>
+                                            );
+
                                             return (
-                                                <tr key={user.id}>
-                                                    <td>{user.email}</td>
+                                                <tr key={'recent-user-table-entry-' + user.id}>
+                                                    <td>
+                                                        <OverlayTrigger
+                                                            delayShow={Constants.OVERLAY_TIME_DELAY}
+                                                            placement='top'
+                                                            overlay={tooltip}
+                                                        >
+                                                            <time>
+                                                                {user.username}
+                                                            </time>
+                                                        </OverlayTrigger>
+                                                    </td>
                                                     <td>{Utils.displayDateTime(user.last_activity_at)}</td>
                                                 </tr>
                                             );
@@ -347,9 +367,25 @@ export default class TeamAnalytics extends React.Component {
                                 <tbody>
                                     {
                                         this.state.newly_created_users.map((user) => {
+                                            const tooltip = (
+                                                <Tooltip id={'new-user-email-tooltip-' + user.id}>
+                                                    {user.email}
+                                                </Tooltip>
+                                            );
+
                                             return (
-                                                <tr key={user.id}>
-                                                    <td>{user.email}</td>
+                                                <tr key={'new-user-table-entry-' + user.id}>
+                                                    <td>
+                                                        <OverlayTrigger
+                                                            delayShow={Constants.OVERLAY_TIME_DELAY}
+                                                            placement='top'
+                                                            overlay={tooltip}
+                                                        >
+                                                            <time>
+                                                                {user.username}
+                                                            </time>
+                                                        </OverlayTrigger>
+                                                    </td>
                                                     <td>{Utils.displayDateTime(user.create_at)}</td>
                                                 </tr>
                                             );

--- a/web/react/components/channel_header.jsx
+++ b/web/react/components/channel_header.jsx
@@ -379,7 +379,7 @@ export default class ChannelHeader extends React.Component {
                             <th>
                                 <div className='dropdown channel-header__links'>
                                     <OverlayTrigger
-                                        delayShow={400}
+                                        delayShow={Constants.OVERLAY_TIME_DELAY}
                                         placement='bottom'
                                         overlay={recentMentionsTooltip}
                                     >

--- a/web/react/components/time_since.jsx
+++ b/web/react/components/time_since.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import Constants from '../utils/constants.jsx';
 import * as Utils from '../utils/utils.jsx';
 
 var Tooltip = ReactBootstrap.Tooltip;
@@ -30,7 +31,7 @@ export default class TimeSince extends React.Component {
 
         return (
             <OverlayTrigger
-                delayShow={400}
+                delayShow={Constants.OVERLAY_TIME_DELAY}
                 placement='top'
                 overlay={tooltip}
             >

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -443,5 +443,6 @@ export default {
             label: 'embed_preview',
             description: 'Show preview snippet of links below message'
         }
-    }
+    },
+    OVERLAY_TIME_DELAY: 400
 };


### PR DESCRIPTION
Previously used emails in the columns exclusively, now displays usernames in the table while also showing the user's email in a tooltip if you hover over the username.