### PR TITLE
Parse Slack links in the attachment pretext and fields (Fix #1868)

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -185,6 +185,12 @@ func CreateWebhookPost(c *Context, channelId, text, overrideUsername, overrideIc
 							attachment["text"] = aText
 							list[i] = attachment
 						}
+						if _, ok := attachment["pretext"]; ok {
+							aText := attachment["pretext"].(string)
+							aText = linkWithTextRegex.ReplaceAllString(aText, "[${2}](${1})")
+							attachment["pretext"] = aText
+							list[i] = attachment
+						}
 					}
 					post.AddProp(key, list)
 				}

--- a/api/post.go
+++ b/api/post.go
@@ -191,6 +191,22 @@ func CreateWebhookPost(c *Context, channelId, text, overrideUsername, overrideIc
 							attachment["pretext"] = aText
 							list[i] = attachment
 						}
+						if fVal, ok := attachment["fields"]; ok {
+							if fields, ok := fVal.([]interface{}); ok {
+								// parse attachment field links into Markdown format
+								for j, fInt := range fields {
+									field := fInt.(map[string]interface{})
+									if _, ok := field["text"]; ok {
+										fText := field["text"].(string)
+										fText = linkWithTextRegex.ReplaceAllString(fText, "[${2}](${1})")
+										field["text"] = fText
+										fields[j] = field
+									}
+								}
+								attachment["fields"] = fields
+								list[i] = attachment
+							}
+						}
 					}
 					post.AddProp(key, list)
 				}


### PR DESCRIPTION
Mattermost currently parses Slack links (`<foo|bar>`) in the attachment `text`, but does not do so for its `pretext` and `fields[j].text` (see #1868). This PR fixes that.

For example, here's a sample request that [Visual Studio Team Services](https://www.visualstudio.com/products/visual-studio-team-services-vs) sends to Slack:

``` json
Method: POST
URI: [REDACTED]
HTTP Version: 1.1
Headers:
{
  Content-Type: application/json; charset=utf-8
}
Content:
{
  "attachments": [
    {
      "fields": [
        {
          "title": "Commits (1)",
          "value": "<https://foobar.visualstudio.com/DefaultCollection/_git/InterstellarTravel/commit/6e646e40ec783af21237fb9c3a71655ddbc473a6|6e646e4> The engine works now\r\n",
          "short": false
        }
      ],
      "mrkdwn_in": [
        "pretext",
        "fields"
      ],
      "pretext": "Vu Le pushed updates to branch <https://foobar.visualstudio.com/DefaultCollection/_git/InterstellarTravel/#version=GBfix%2Fengine|fix/engine> of <https://foobar.visualstudio.com/DefaultCollection/_git/InterstellarTravel/|InterstellarTravel>",
      "fallback": "Vu Le pushed 1 commit to branch fix/engine of InterstellarTravel\r\n - The engine works now 6e646e40 (https://foobar.visualstudio.com/DefaultCollection/_git/InterstellarTravel/commit/6e646e40ec783af21237fb9c3a71655ddbc473a6)"
    }
  ]
}
```

(Warning: I could have made some rookie Golang mistake, I don't program in this language.)