### PR TITLE
PLT-1232: More channel info

### DIFF
--- a/web/react/components/channel_info_modal.jsx
+++ b/web/react/components/channel_info_modal.jsx
@@ -10,6 +10,7 @@ export default class ChannelInfoModal extends React.Component {
             channel = {
                 display_name: 'No Channel Found',
                 name: 'No Channel Found',
+                purpose: 'No Channel Found',
                 id: 'No Channel Found'
             };
         }
@@ -34,6 +35,10 @@ export default class ChannelInfoModal extends React.Component {
                     <div className='row'>
                         <div className='col-sm-3 info__label'>{'Channel ID:'}</div>
                         <div className='col-sm-9'>{channel.id}</div>
+                    </div>
+                    <div className='row'>
+                        <div className='col-sm-3 info__label'>{'Channel Purpose:'}</div>
+                        <div className='col-sm-9'>{channel.purpose}</div>
                     </div>
                 </Modal.Body>
                 <Modal.Footer>

--- a/web/react/components/channel_info_modal.jsx
+++ b/web/react/components/channel_info_modal.jsx
@@ -29,7 +29,7 @@ export default class ChannelInfoModal extends React.Component {
                         <div className='col-sm-9'>{channel.display_name}</div>
                     </div>
                     <div className='row form-group'>
-                        <div className='col-sm-3 info__label'>{'Channel Handle:'}</div>
+                        <div className='col-sm-3 info__label'>{'Channel URL:'}</div>
                         <div className='col-sm-9'>{channel.name}</div>
                     </div>
                     <div className='row'>

--- a/web/react/components/channel_info_modal.jsx
+++ b/web/react/components/channel_info_modal.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import * as Utils from '../utils/utils.jsx';
 const Modal = ReactBootstrap.Modal;
 
 export default class ChannelInfoModal extends React.Component {
@@ -14,6 +15,8 @@ export default class ChannelInfoModal extends React.Component {
                 id: 'No Channel Found'
             };
         }
+
+        const channelURL = Utils.getShortenedTeamURL() + channel.name;
 
         return (
             <Modal
@@ -30,7 +33,7 @@ export default class ChannelInfoModal extends React.Component {
                     </div>
                     <div className='row form-group'>
                         <div className='col-sm-3 info__label'>{'Channel URL:'}</div>
-                        <div className='col-sm-9'>{channel.name}</div>
+                        <div className='col-sm-9'>{channelURL}</div>
                     </div>
                     <div className='row'>
                         <div className='col-sm-3 info__label'>{'Channel ID:'}</div>


### PR DESCRIPTION
This adds the channel purpose to the channel info modal. It also renames "Channel Handle" to "Channel URL" as requested in [PLT-1232](https://mattermost.atlassian.net/browse/PLT-1232). The only thing that isn't working is that the purpose is not hidden when it's not set. I couldn't figure out how to get that working.

I tried:
```
var purpose = ""
if (channel.purpose != 'No Channel Found') {
  purpose =  `<div className='row'>
    <div className='col-sm-3 info__label'>{'Channel Purpose:'}</div>
    <div className='col-sm-9'>{channel.purpose}</div></div>`
}
```
And then using {purpose} where the HTML previously was, but it escaped all of the HTML and inserted them rather then rendering it. If that's important let me know what the best practices way to do so would be and I'll update the PR.