### PR TITLE
PLT-1403 Removed incorrect test case for autolinking urls with angle brackets

### DIFF
--- a/doc/developer/tests/test-links.md
+++ b/doc/developer/tests/test-links.md
@@ -40,7 +40,6 @@ http://
 ./make-compiled-client.sh  
 test.:test  
 https://<your-mattermost-url>/signup/gitlab  
-https://your-mattermost-url>/signup/gitlab  
 
 #### Only the links within these sentences should auto-link:
 


### PR DESCRIPTION
Turns out I mixed up when talking with Eric about whether or not this test case should be valid. Angle brackets are allowed in urls (even if they're considered unsafe based on [RFC-1738](http://www.ietf.org/rfc/rfc1738.txt)).

I'm leaving in the previous test case since while you could argue that it should be autolinked, I don't think it's currently possible with how marked's regexes are set up. It's also for very little benefit because, like I mentioned above, angle brackets are considered unsafe and aren't recommended to be used even though they're technically legal.