### PR TITLE
PLT-406 Fixes issues with drag and drop overlay in IE11

### DIFF
--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1295,5 +1295,9 @@ export function fillArray(value, length) {
 // Checks if a data transfer contains files not text, folders, etc..
 // Slightly modified from http://stackoverflow.com/questions/6848043/how-do-i-detect-a-file-is-being-dragged-rather-than-a-draggable-element-on-my-pa
 export function isFileTransfer(files) {
+    if (isBrowserIE()) {
+        return files.types != null && files.types.contains('Files');
+    }
+
     return files.types != null && (files.types.indexOf ? files.types.indexOf('Files') !== -1 : files.types.contains('application/x-moz-file'));
 }

--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -183,6 +183,7 @@ body.ios {
 		position: absolute;
 		top: 50%;
 		left: 50%;
+		pointer-events: none;
 	}
 
 	.overlay__files {


### PR DESCRIPTION
This both reenables the drag and drop overlay in IE11 and fixes the issue where it could get stuck if files were dropped in specific part of the overlay.