### PR TITLE
Check auth_service when constructing messages

### DIFF
--- a/web/react/components/user_settings/user_settings_general.jsx
+++ b/web/react/components/user_settings/user_settings_general.jsx
@@ -531,7 +531,7 @@ export default class UserSettingsGeneralTab extends React.Component {
                 } else {
                     describe = UserStore.getCurrentUser().email;
                 }
-            } else {
+            } else if (this.props.user.auth_service === Constants.GITLAB_SERVICE) {
                 describe = 'Log in done through GitLab';
             }
 

--- a/web/react/components/user_settings/user_settings_general.jsx
+++ b/web/react/components/user_settings/user_settings_general.jsx
@@ -493,7 +493,7 @@ export default class UserSettingsGeneralTab extends React.Component {
                 );
 
                 submit = this.submitEmail;
-            } else {
+            } else if (this.props.user.auth_service === Constants.GITLAB_SERVICE) {
                 inputs.push(
                     <div
                         key='oauthEmailInfo'


### PR DESCRIPTION
Check auth_service value to be gitlab when constructing the UI messages. This is useful when you have multiple oauth providers.