### PR TITLE
[#1923] Make Websocket ports configurable

### DIFF
--- a/doc/install/Configuration-Settings.md
+++ b/doc/install/Configuration-Settings.md
@@ -41,7 +41,7 @@ Set the number of days before SSO sessions expire.
 ```"SessionCacheInMinutes" : 10```
 Set the number of minutes to cache a session in memory.
 
-```"SecureWebsocketPort": 443```
+```"WebsocketSecurePort": 443```
 The port to use for secure websocket connections being initiated from the client. By default wss:// uses port 443. Some server configurations (e.g. Cloudfoundry) support wss on a different port.
 
 ```"WebsocketPort": 80```

--- a/doc/install/Configuration-Settings.md
+++ b/doc/install/Configuration-Settings.md
@@ -41,6 +41,13 @@ Set the number of days before SSO sessions expire.
 ```"SessionCacheInMinutes" : 10```
 Set the number of minutes to cache a session in memory.
 
+```"SecureWebsocketPort": 443```
+The port to use for secure websocket connections being initiated from the client. By default wss:// uses port 443. Some server configurations (e.g. Cloudfoundry) support wss on a different port.
+
+```"WebsocketPort": 80```
+The port to use for websocket connections being initiated from the client. By default ws:// uses port 80.
+
+
 #### Webhooks
 
 ```"EnableIncomingWebhooks": true```  

--- a/model/config.go
+++ b/model/config.go
@@ -40,6 +40,8 @@ type ServiceSettings struct {
 	SessionLengthMobileInDays  *int
 	SessionLengthSSOInDays     *int
 	SessionCacheInMinutes      *int
+	WebsocketSecurePort        *int
+	WebsocketPort              *int
 }
 
 type SSOSettings struct {
@@ -329,6 +331,14 @@ func (o *Config) SetDefaults() {
 	if o.ServiceSettings.SessionCacheInMinutes == nil {
 		o.ServiceSettings.SessionCacheInMinutes = new(int)
 		*o.ServiceSettings.SessionCacheInMinutes = 10
+	}
+	if o.ServiceSettings.WebsocketPort == nil {
+		o.ServiceSettings.WebsocketPort = new(int)
+		*o.ServiceSettings.WebsocketPort = 80
+	}
+	if o.ServiceSettings.WebsocketSecurePort == nil {
+		o.ServiceSettings.WebsocketSecurePort = new(int)
+		*o.ServiceSettings.WebsocketSecurePort = 443
 	}
 }
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -223,5 +223,8 @@ func getClientConfig(c *model.Config) map[string]string {
 
 	props["EnableLdap"] = strconv.FormatBool(*c.LdapSettings.Enable)
 
+	props["WebsocketPort"] = fmt.Sprintf("%v", *c.ServiceSettings.WebsocketPort)
+	props["WebsocketSecurePort"] = fmt.Sprintf("%v", *c.ServiceSettings.WebsocketSecurePort)
+
 	return props
 }

--- a/web/react/stores/socket_store.jsx
+++ b/web/react/stores/socket_store.jsx
@@ -49,7 +49,7 @@ class SocketStoreClass extends EventEmitter {
                 protocol = 'wss://';
             }
 
-            var connUrl = protocol + location.host + '/api/v1/websocket?' + Utils.getSessionIndex();
+            var connUrl = protocol + location.host + ((/:\d+/).test(location.host) ? '' : Utils.getWebsocketPort(protocol)) + '/api/v1/websocket?' + Utils.getSessionIndex();
 
             if (this.failCount === 0) {
                 console.log('websocket connecting to ' + connUrl); //eslint-disable-line no-console

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1103,13 +1103,13 @@ export function getFileName(path) {
 
 // Gets the websocket port to use. Configurable on the server.
 export function getWebsocketPort(protocol) {
-	if ((/^wss:/).test(protocol)) { // wss://
-		return ':' + global.window.mm_config.WebsocketSecurePort;
-	}
-	if ((/^ws:/).test(protocol)) {
-		return ':' + global.window.mm_config.WebsocketPort;
-	}
-	return '';
+    if ((/^wss:/).test(protocol)) { // wss://
+        return ':' + global.window.mm_config.WebsocketSecurePort;
+    }
+    if ((/^ws:/).test(protocol)) {
+        return ':' + global.window.mm_config.WebsocketPort;
+    }
+    return '';
 }
 
 export function getSessionIndex() {

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1101,6 +1101,17 @@ export function getFileName(path) {
     return split[split.length - 1];
 }
 
+// Gets the websocket port to use. Configurable on the server.
+export function getWebsocketPort(protocol) {
+	if ((/^wss:/).test(protocol)) { // wss://
+		return ':' + global.window.mm_config.WebsocketSecurePort;
+	}
+	if ((/^ws:/).test(protocol)) {
+		return ':' + global.window.mm_config.WebsocketPort;
+	}
+	return '';
+}
+
 export function getSessionIndex() {
     if (global.window.mm_session_token_index >= 0) {
         return 'session_token_index=' + global.window.mm_session_token_index;


### PR DESCRIPTION
By default ws:// and wss:// use port 80 and 443 respectively. In some cases (e.g. Cloudfoundry on AWS) it's required to have the websocket connection go over a specific port. This PR introduces 2 new config variables:

```javascript
{
    "ServiceSettings": {
        "WebsocketSecurePort": 4443,
        "WebsocketPort": 80
    },
}
```
The example config above will generate a client side websocket URL which includes the configured port:
 
`wss://host:4443/api/v1/websocket`

overriding the default 443 port config. However an explicitly specified port in the web browser will still be honoured.