### PR TITLE
PLT-7-server-db

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -41,7 +41,7 @@ func getLogs(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		file, err := os.Open(utils.GetLogFileLocation(utils.Cfg.LogSettings.FileLocation))
 		if err != nil {
-			c.Err = model.NewAppError("getLogs", c.T("api.admin.file_read_error"), err.Error())
+			c.Err = model.NewLocAppError("getLogs", "api.admin.file_read_error", nil, err.Error())
 		}
 
 		defer file.Close()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -14,6 +14,7 @@ var Client *model.Client
 func Setup() {
 	if Srv == nil {
 		utils.LoadConfig("config.json")
+		utils.InitTranslations()
 		utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 		NewServer()
 		StartServer()

--- a/api/context.go
+++ b/api/context.go
@@ -206,6 +206,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if c.Err != nil {
+		c.Err.Translate(c.T)
 		c.Err.RequestId = c.RequestId
 		c.LogError(c.Err)
 		c.Err.Where = r.URL.Path
@@ -373,7 +374,7 @@ func (c *Context) RemoveSessionCookie(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *Context) SetInvalidParam(where string, name string) {
-	c.Err = model.NewAppError(where, "Invalid "+name+" parameter", "")
+	c.Err = model.NewLocAppError(where, "api.context.invalid_param", map[string]interface{}{"Name": name}, "")
 	c.Err.StatusCode = http.StatusBadRequest
 }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -10,5 +10,9 @@
     {
         "id": "api.admin.file_read_error",
         "translation": "Error reading log file"
+    },
+    {
+        "id": "api.context.invalid_param",
+        "translation": "Invalid {{.Name}} parameter"
     }
 ]

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -1,14 +1,18 @@
 [
     {
         "id": "utils.i18n.loaded",
-        "translation": "Loaded system translations for '%v' from '%v'"
+        "translation": "Loaded system translations for '%v' from '%v' spanish test!"
     },
     {
         "id": "mattermost.current_version",
-        "translation": "Current version is %v (%v/%v/%v)"
+        "translation": "Current version is %v (%v/%v/%v)  spanish test!"
     },
     {
         "id": "api.admin.file_read_error",
-        "translation": "Error reading log file"
+        "translation": "Error reading log file spanish test!"
+    },
+    {
+        "id": "api.context.invalid_param",
+        "translation": "Invalid {{.Name}} parameter spanish test!"
     }
 ]

--- a/model/utils.go
+++ b/model/utils.go
@@ -25,9 +25,8 @@ type StringMap map[string]string
 type StringArray []string
 type EncryptStringMap map[string]string
 
-// AppError is returned for any http response that's not in the 200 range.
 type AppError struct {
-	LocId         string                 `json:"loc_id"`         // Message to be display to the end user without debugging information
+	Id            string                 `json:"id"`
 	Message       string                 `json:"message"`        // Message to be display to the end user without debugging information
 	DetailedError string                 `json:"detailed_error"` // Internal error string to help the developer
 	RequestId     string                 `json:"request_id"`     // The RequestId that's also set in the header
@@ -44,9 +43,9 @@ func (er *AppError) Error() string {
 func (er *AppError) Translate(T goi18n.TranslateFunc) {
 	if len(er.Message) == 0 {
 		if er.params == nil {
-			er.Message = T(er.LocId)
+			er.Message = T(er.Id)
 		} else {
-			er.Message = T(er.LocId, er.params)
+			er.Message = T(er.Id, er.params)
 		}
 	}
 }
@@ -82,9 +81,9 @@ func NewAppError(where string, message string, details string) *AppError {
 	return ap
 }
 
-func NewLocAppError(where string, locId string, params map[string]interface{}, details string) *AppError {
+func NewLocAppError(where string, id string, params map[string]interface{}, details string) *AppError {
 	ap := &AppError{}
-	ap.LocId = locId
+	ap.Id = id
 	ap.params = params
 	ap.Where = where
 	ap.DetailedError = details

--- a/model/version.go
+++ b/model/version.go
@@ -28,7 +28,7 @@ var CurrentVersion string = versions[0]
 var BuildNumber = "_BUILD_NUMBER_"
 var BuildDate = "_BUILD_DATE_"
 var BuildHash = "_BUILD_HASH_"
-var BuildEnterpriseReady = "false"
+var BuildEnterpriseReady = "_BUILD_ENTERPRISE_READY_"
 
 func SplitVersion(version string) (int64, int64, int64) {
 	parts := strings.Split(version, ".")

--- a/model/version.go
+++ b/model/version.go
@@ -28,7 +28,7 @@ var CurrentVersion string = versions[0]
 var BuildNumber = "_BUILD_NUMBER_"
 var BuildDate = "_BUILD_DATE_"
 var BuildHash = "_BUILD_HASH_"
-var BuildEnterpriseReady = "_BUILD_ENTERPRISE_READY_"
+var BuildEnterpriseReady = "false"
 
 func SplitVersion(version string) (int64, int64, int64) {
 	parts := strings.Split(version, ".")


### PR DESCRIPTION
Anything that calls `l4g.Error("...")` can use the system translations like `lg4.Error(utils.T("..."))`
Anything that returns an `AppError` by calling `NewAppError()` should be refactored to use `NewLocAppError()`

The system will call `err.Translate(T)` before rendering the error to the user or the log file.

Thoughts?