### PR TITLE
PLT-1664 Fix unread channel indicators so that they work on IE11

### DIFF
--- a/web/react/components/unread_channel_indicator.jsx
+++ b/web/react/components/unread_channel_indicator.jsx
@@ -10,7 +10,7 @@ export default class UnreadChannelIndicator extends React.Component {
     render() {
         let displayValue = 'none';
         if (this.props.show) {
-            displayValue = 'initial';
+            displayValue = 'block';
         }
         return (
             <div


### PR DESCRIPTION
Turns out that `display: initial` isn't supported on IE11