### PR TITLE
Implement generic OAuth login

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -111,6 +111,7 @@
     "OAuthSettings": {
         "Enable": false,
         "ProviderName": "",
+        "DisplayName": "",
         "Secret": "",
         "Id": "",
         "Scope": "",

--- a/config/config.json
+++ b/config/config.json
@@ -107,5 +107,42 @@
         "AuthEndpoint": "",
         "TokenEndpoint": "",
         "UserApiEndpoint": ""
+    },
+    "OAuthSettings": {
+        "Enable": false,
+        "ProviderName": "",
+        "Secret": "",
+        "Id": "",
+        "Scope": "",
+        "AuthEndpoint": "",
+        "TokenEndpoint": "",
+        "UserApiEndpoint": "",
+        "UsernameField": "",
+        "EmailField": "",
+        "AuthDataField": ""
+    },
+    "GoogleSettings": {
+        "Enable": false,
+        "Secret": "",
+        "Id": "",
+        "Scope": "",
+        "AuthEndpoint": "",
+        "TokenEndpoint": "",
+        "UserApiEndpoint": ""
+    },
+    "LdapSettings": {
+        "Enable": false,
+        "LdapServer": null,
+        "LdapPort": 389,
+        "BaseDN": null,
+        "BindUsername": null,
+        "BindPassword": null,
+        "FirstNameAttribute": null,
+        "LastNameAttribute": null,
+        "EmailAttribute": null,
+        "UsernameAttribute": null,
+        "IdAttribute": null,
+        "QueryTimeout": 60
     }
 }
+

--- a/mattermost.go
+++ b/mattermost.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mattermost/platform/web"
 
 	// Plugins
+	_ "github.com/mattermost/platform/model/custom_oauth"
 	_ "github.com/mattermost/platform/model/gitlab"
 
 	// Enterprise Deps

--- a/model/config.go
+++ b/model/config.go
@@ -59,6 +59,7 @@ type SSOSettings struct {
 	UsernameField string
 	EMailField    string
 	AuthDataField string
+	DisplayName   string
 }
 
 type SqlSettings struct {

--- a/model/config.go
+++ b/model/config.go
@@ -21,6 +21,7 @@ const (
 
 	SERVICE_GITLAB = "gitlab"
 	SERVICE_GOOGLE = "google"
+	SERVICE_OAUTH  = "oauth"
 )
 
 type ServiceSettings struct {
@@ -52,6 +53,12 @@ type SSOSettings struct {
 	AuthEndpoint    string
 	TokenEndpoint   string
 	UserApiEndpoint string
+
+	// custom SSO specific
+	ProviderName  string
+	UsernameField string
+	EMailField    string
+	AuthDataField string
 }
 
 type SqlSettings struct {
@@ -176,6 +183,7 @@ type Config struct {
 	SupportSettings   SupportSettings
 	GitLabSettings    SSOSettings
 	GoogleSettings    SSOSettings
+	OAuthSettings     SSOSettings
 	LdapSettings      LdapSettings
 }
 
@@ -194,6 +202,8 @@ func (o *Config) GetSSOService(service string) *SSOSettings {
 		return &o.GitLabSettings
 	case SERVICE_GOOGLE:
 		return &o.GoogleSettings
+	case SERVICE_OAUTH:
+		return &o.OAuthSettings
 	}
 
 	return nil

--- a/model/custom_oauth/custom_oauth.go
+++ b/model/custom_oauth/custom_oauth.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	l4g "github.com/alecthomas/log4go"
+	"github.com/mattermost/platform/einterfaces"
+	"github.com/mattermost/platform/model"
+	"io"
+)
+
+const (
+	USER_AUTH_SERVICE_OAUTH = "oauth"
+)
+
+type OAuthProvider struct {
+	providerName  string
+	usernameField string
+	emailField    string
+	authDataField string
+}
+
+func userDataFromJson(data io.Reader) map[string]interface{} {
+	decoder := json.NewDecoder(data)
+	userData := make(map[string]interface{})
+	err := decoder.Decode(&userData)
+	if err == nil {
+		return userData
+	} else {
+		l4g.Debug("Error when parsing user data: %v", err)
+		return nil
+	}
+}
+
+func (m *OAuthProvider) GetIdentifier() string {
+	return USER_AUTH_SERVICE_OAUTH
+}
+
+func (m *OAuthProvider) GetUserFromJson(data io.Reader) *model.User {
+	userData := userDataFromJson(data)
+
+	if userData == nil {
+		return nil
+	}
+
+	user := &model.User{}
+	var ok bool
+	if username, ok := userData[m.usernameField].(string); !ok {
+		l4g.Debug("Expecting string in username")
+		return nil
+	} else {
+		user.Username = model.CleanUsername(username)
+	}
+
+	if user.Email, ok = userData[m.emailField].(string); !ok {
+		l4g.Debug("Expecting string in email")
+		return nil
+	}
+	if user.AuthData, ok = userData[m.authDataField].(string); !ok {
+		l4g.Debug("Expecting string in userData")
+		return nil
+	}
+	user.AuthService = USER_AUTH_SERVICE_OAUTH
+	return user
+}
+
+func (m *OAuthProvider) GetAuthDataFromJson(data io.Reader) string {
+	userData := userDataFromJson(data)
+	if userData == nil {
+		return ""
+	}
+	if authData, ok := userData[m.authDataField].(string); ok {
+		return authData
+	} else {
+		return ""
+	}
+}
+
+func LoadOAuthProviderFromConfig(settings *model.SSOSettings) (provider *OAuthProvider, err error) {
+	if settings.UsernameField == "" {
+		err = fmt.Errorf("Missing UsernameField mapping entry", err)
+		return
+	}
+
+	provider = &OAuthProvider{
+		providerName:  settings.ProviderName,
+		usernameField: settings.UsernameField,
+		emailField:    settings.EMailField,
+		authDataField: settings.AuthDataField,
+	}
+
+	einterfaces.RegisterOauthProvider(USER_AUTH_SERVICE_OAUTH, provider)
+
+	return
+}

--- a/utils/config.go
+++ b/utils/config.go
@@ -14,6 +14,7 @@ import (
 	l4g "github.com/alecthomas/log4go"
 
 	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/model/custom_oauth"
 )
 
 const (
@@ -161,6 +162,10 @@ func LoadConfig(fileName string) {
 		panic("Error validating config file=" + fileName + ", err=" + err.Message)
 	}
 
+	if _, err := oauth.LoadOAuthProviderFromConfig(&config.OAuthSettings); err != nil {
+		l4g.Info("Error loading oauth provider: " + err.Error())
+	}
+
 	configureLog(&config.LogSettings)
 	TestConnection(&config)
 
@@ -207,6 +212,7 @@ func getClientConfig(c *model.Config) map[string]string {
 
 	props["EnableSignUpWithGitLab"] = strconv.FormatBool(c.GitLabSettings.Enable)
 	props["EnableSignUpWithGoogle"] = strconv.FormatBool(c.GoogleSettings.Enable)
+	props["EnableSignUpWithOAuth"] = strconv.FormatBool(c.OAuthSettings.Enable)
 
 	props["ShowEmailAddress"] = strconv.FormatBool(c.PrivacySettings.ShowEmailAddress)
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -213,6 +213,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["EnableSignUpWithGitLab"] = strconv.FormatBool(c.GitLabSettings.Enable)
 	props["EnableSignUpWithGoogle"] = strconv.FormatBool(c.GoogleSettings.Enable)
 	props["EnableSignUpWithOAuth"] = strconv.FormatBool(c.OAuthSettings.Enable)
+	props["CustomOAuthDisplayName"] = c.OAuthSettings.DisplayName
 
 	props["ShowEmailAddress"] = strconv.FormatBool(c.PrivacySettings.ShowEmailAddress)
 

--- a/web/react/components/admin_console/admin_controller.jsx
+++ b/web/react/components/admin_console/admin_controller.jsx
@@ -15,6 +15,7 @@ import FileSettingsTab from './image_settings.jsx';
 import PrivacySettingsTab from './privacy_settings.jsx';
 import RateSettingsTab from './rate_settings.jsx';
 import GitLabSettingsTab from './gitlab_settings.jsx';
+import OAuthSettingsTab from './oauth_settings.jsx';
 import SqlSettingsTab from './sql_settings.jsx';
 import TeamSettingsTab from './team_settings.jsx';
 import ServiceSettingsTab from './service_settings.jsx';
@@ -145,6 +146,8 @@ export default class AdminController extends React.Component {
                 tab = <RateSettingsTab config={this.state.config} />;
             } else if (this.state.selected === 'gitlab_settings') {
                 tab = <GitLabSettingsTab config={this.state.config} />;
+            } else if (this.state.selected === 'oauth_settings') {
+                tab = <OAuthSettingsTab config={this.state.config} />;
             } else if (this.state.selected === 'sql_settings') {
                 tab = <SqlSettingsTab config={this.state.config} />;
             } else if (this.state.selected === 'team_settings') {

--- a/web/react/components/admin_console/admin_sidebar.jsx
+++ b/web/react/components/admin_console/admin_sidebar.jsx
@@ -282,6 +282,15 @@ export default class AdminSidebar extends React.Component {
                                             {'GitLab Settings'}
                                         </a>
                                     </li>
+                                    <li>
+                                        <a
+                                            href='#'
+                                            className={this.isSelected('oauth_settings')}
+                                            onClick={this.handleClick.bind(this, 'oauth_settings', null)}
+                                        >
+                                            {'OAuth Settings'}
+                                        </a>
+                                    </li>
                                     {ldapSettings}
                                     <li>
                                         <a

--- a/web/react/components/admin_console/oauth_settings.jsx
+++ b/web/react/components/admin_console/oauth_settings.jsx
@@ -1,0 +1,371 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import * as Client from '../../utils/client.jsx';
+import * as AsyncClient from '../../utils/async_client.jsx';
+
+export default class OAuthSettings extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+
+        this.state = {
+            Enable: this.props.config.OAuthSettings.Enable,
+            saveNeeded: false,
+            serverError: null
+        };
+    }
+
+    handleChange(action) {
+        var s = {saveNeeded: true, serverError: this.state.serverError};
+
+        if (action === 'EnableTrue') {
+            s.Enable = true;
+        }
+
+        if (action === 'EnableFalse') {
+            s.Enable = false;
+        }
+
+        this.setState(s);
+    }
+
+    handleSubmit(e) {
+        e.preventDefault();
+        $('#save-button').button('loading');
+
+        var config = this.props.config;
+        config.OAuthSettings.Enable = ReactDOM.findDOMNode(this.refs.Enable).checked;
+        config.OAuthSettings.Secret = ReactDOM.findDOMNode(this.refs.Secret).value.trim();
+        config.OAuthSettings.Id = ReactDOM.findDOMNode(this.refs.Id).value.trim();
+        config.OAuthSettings.AuthEndpoint = ReactDOM.findDOMNode(this.refs.AuthEndpoint).value.trim();
+        config.OAuthSettings.TokenEndpoint = ReactDOM.findDOMNode(this.refs.TokenEndpoint).value.trim();
+        config.OAuthSettings.UserApiEndpoint = ReactDOM.findDOMNode(this.refs.UserApiEndpoint).value.trim();
+        config.OAuthSettings.ProviderName = ReactDOM.findDOMNode(this.refs.ProviderName).value.trim();
+        config.OAuthSettings.UsernameField = ReactDOM.findDOMNode(this.refs.UsernameField).value.trim();
+        config.OAuthSettings.EMailField = ReactDOM.findDOMNode(this.refs.EMailField).value.trim();
+        config.OAuthSettings.AuthDataField = ReactDOM.findDOMNode(this.refs.AuthDataField).value.trim();
+
+        Client.saveConfig(
+            config,
+            () => {
+                AsyncClient.getConfig();
+                this.setState({
+                    serverError: null,
+                    saveNeeded: false
+                });
+                $('#save-button').button('reset');
+            },
+            (err) => {
+                this.setState({
+                    serverError: err.message,
+                    saveNeeded: true
+                });
+                $('#save-button').button('reset');
+            }
+        );
+    }
+
+    render() {
+        var serverError = '';
+        if (this.state.serverError) {
+            serverError = <div className='form-group has-error'><label className='control-label'>{this.state.serverError}</label></div>;
+        }
+
+        var saveClass = 'btn';
+        if (this.state.saveNeeded) {
+            saveClass = 'btn btn-primary';
+        }
+
+        return (
+            <div className='wrapper--fixed'>
+
+                <h3>{'Qt Settings'}</h3>
+                <form
+                    className='form-horizontal'
+                    role='form'
+                >
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='Enable'
+                        >
+                            {'Enable Sign Up With OAuth: '}
+                        </label>
+                        <div className='col-sm-8'>
+                            <label className='radio-inline'>
+                                <input
+                                    type='radio'
+                                    name='Enable'
+                                    value='true'
+                                    ref='Enable'
+                                    defaultChecked={this.props.config.OAuthSettings.Enable}
+                                    onChange={this.handleChange.bind(this, 'EnableTrue')}
+                                />
+                                    {'true'}
+                            </label>
+                            <label className='radio-inline'>
+                                <input
+                                    type='radio'
+                                    name='Enable'
+                                    value='false'
+                                    defaultChecked={!this.props.config.OAuthSettings.Enable}
+                                    onChange={this.handleChange.bind(this, 'EnableFalse')}
+                                />
+                                    {'false'}
+                            </label>
+                            <p className='help-text'>
+                                {'When true, Mattermost allows team creation and account signup using OAuth.'} <br/>
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='ProviderName'
+                        >
+                            {'Provider Name:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='ProviderName'
+                                ref='ProviderName'
+                                placeholder='Ex "myoauthprovider"'
+                                defaultValue={this.props.config.OAuthSettings.ProviderName}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'OAuth provider name'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='Id'
+                        >
+                            {'Id:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='Id'
+                                ref='Id'
+                                placeholder='Ex "jcuS8PuvcpGhpgHhlcpT1Mx42pnqMxQY"'
+                                defaultValue={this.props.config.OAuthSettings.Id}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'Obtain this value from your OAuth provider for logging into OAuth'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='Secret'
+                        >
+                            {'Secret:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='Secret'
+                                ref='Secret'
+                                placeholder='Ex "jcuS8PuvcpGhpgHhlcpT1Mx42pnqMxQY"'
+                                defaultValue={this.props.config.OAuthSettings.Secret}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'Obtain this value from your OAuth provider for logging into OAuth'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='AuthEndpoint'
+                        >
+                            {'Auth Endpoint:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='AuthEndpoint'
+                                ref='AuthEndpoint'
+                                placeholder='Ex ""'
+                                defaultValue={this.props.config.OAuthSettings.AuthEndpoint}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'This is usually of the form https://<your-OAuth-url>/oauth/authorize. Make sure you use HTTP or HTTPS in your URL depending on your server configuration.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='TokenEndpoint'
+                        >
+                            {'Token Endpoint:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='TokenEndpoint'
+                                ref='TokenEndpoint'
+                                placeholder='Ex ""'
+                                defaultValue={this.props.config.OAuthSettings.TokenEndpoint}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'This is usually of the form https://<your-OAuth-url>/oauth/token. Make sure you use HTTP or HTTPS in your URL depending on your server configuration.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='UserApiEndpoint'
+                        >
+                            {'User API Endpoint:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='UserApiEndpoint'
+                                ref='UserApiEndpoint'
+                                placeholder='Ex ""'
+                                defaultValue={this.props.config.OAuthSettings.UserApiEndpoint}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'This is usually of the form https://<your-OAuth-url>/api/v1/user. Make sure you use HTTP or HTTPS in your URL depending on your server configuration.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='UsernameField'
+                        >
+                            {'Username Field:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='UsernameField'
+                                ref='UsernameField'
+                                placeholder='Ex "username"'
+                                defaultValue={this.props.config.OAuthSettings.UsernameField}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'This field is used to map the User API Endpoint response to the username.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='EMailField'
+                        >
+                            {'EMail Field:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='EMailField'
+                                ref='EMailField'
+                                placeholder='Ex "email"'
+                                defaultValue={this.props.config.OAuthSettings.EMailField}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'This field is used to map the User API Endpoint response to the email.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='AuthDataField'
+                        >
+                            {'AuthData Field:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='AuthDataField'
+                                ref='AuthDataField'
+                                placeholder='Ex "id"'
+                                defaultValue={this.props.config.OAuthSettings.AuthDataField}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'This field is used to map the User API Endpoint response to an unique id.'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <div className='col-sm-12'>
+                            {serverError}
+                            <button
+                                disabled={!this.state.saveNeeded}
+                                type='submit'
+                                className={saveClass}
+                                onClick={this.handleSubmit}
+                                id='save-button'
+                                data-loading-text={'<span class=\'glyphicon glyphicon-refresh glyphicon-refresh-animate\'></span> Saving Config...'}
+                            >
+                                {'Save'}
+                            </button>
+                        </div>
+                    </div>
+
+                </form>
+            </div>
+        );
+    }
+}
+
+//config.OAuthSettings.Scope = ReactDOM.findDOMNode(this.refs.Scope).value.trim();
+//  <div className='form-group'>
+//     <label
+//         className='control-label col-sm-4'
+//         htmlFor='Scope'
+//     >
+//         {'Scope:'}
+//     </label>
+//     <div className='col-sm-8'>
+//         <input
+//             type='text'
+//             className='form-control'
+//             id='Scope'
+//             ref='Scope'
+//             placeholder='Not currently used by OAuth. Please leave blank'
+//             defaultValue={this.props.config.OAuthSettings.Scope}
+//             onChange={this.handleChange}
+//             disabled={!this.state.Allow}
+//         />
+//         <p className='help-text'>{'This field is not yet used by OAuth OAuth. Other OAuth providers may use this field to specify the scope of account data from OAuth provider that is sent to Mattermost.'}</p>
+//     </div>
+// </div>
+
+OAuthSettings.propTypes = {
+    config: React.PropTypes.object
+};

--- a/web/react/components/admin_console/oauth_settings.jsx
+++ b/web/react/components/admin_console/oauth_settings.jsx
@@ -47,6 +47,7 @@ export default class OAuthSettings extends React.Component {
         config.OAuthSettings.UsernameField = ReactDOM.findDOMNode(this.refs.UsernameField).value.trim();
         config.OAuthSettings.EMailField = ReactDOM.findDOMNode(this.refs.EMailField).value.trim();
         config.OAuthSettings.AuthDataField = ReactDOM.findDOMNode(this.refs.AuthDataField).value.trim();
+        config.OAuthSettings.DisplayName = ReactDOM.findDOMNode(this.refs.DisplayName).value.trim();
 
         Client.saveConfig(
             config,
@@ -82,7 +83,7 @@ export default class OAuthSettings extends React.Component {
         return (
             <div className='wrapper--fixed'>
 
-                <h3>{'Qt Settings'}</h3>
+                <h3>{'OAuth Settings'}</h3>
                 <form
                     className='form-horizontal'
                     role='form'
@@ -142,6 +143,28 @@ export default class OAuthSettings extends React.Component {
                                 disabled={!this.state.Enable}
                             />
                             <p className='help-text'>{'OAuth provider name'}</p>
+                        </div>
+                    </div>
+
+                    <div className='form-group'>
+                        <label
+                            className='control-label col-sm-4'
+                            htmlFor='DisplayName'
+                        >
+                            {'Display Name:'}
+                        </label>
+                        <div className='col-sm-8'>
+                            <input
+                                type='text'
+                                className='form-control'
+                                id='DisplayName'
+                                ref='DisplayName'
+                                placeholder='Ex "myoauthprovider"'
+                                defaultValue={this.props.config.OAuthSettings.DisplayName}
+                                onChange={this.handleChange}
+                                disabled={!this.state.Enable}
+                            />
+                            <p className='help-text'>{'The string that appears in Login buttons'}</p>
                         </div>
                     </div>
 

--- a/web/react/components/login.jsx
+++ b/web/react/components/login.jsx
@@ -43,13 +43,14 @@ export default class Login extends React.Component {
         }
 
         if (global.window.mm_config.EnableSignUpWithOAuth === 'true') {
+            var displayName = global.window.mm_config.CustomOAuthDisplayName;
             loginMessage.push(
                     <a
                         className='btn btn-custom-login oauth'
                         href={'/' + teamName + '/login/oauth'}
                     >
                         <span className='icon' />
-                        <span>{'Login with OAuth'}</span>
+                        <span>{'Login with ' + displayName}</span>
                     </a>
            );
         }

--- a/web/react/components/login.jsx
+++ b/web/react/components/login.jsx
@@ -42,6 +42,18 @@ export default class Login extends React.Component {
            );
         }
 
+        if (global.window.mm_config.EnableSignUpWithOAuth === 'true') {
+            loginMessage.push(
+                    <a
+                        className='btn btn-custom-login oauth'
+                        href={'/' + teamName + '/login/oauth'}
+                    >
+                        <span className='icon' />
+                        <span>{'Login with OAuth'}</span>
+                    </a>
+           );
+        }
+
         const extraParam = Utils.getUrlParameter('extra');
         let extraBox = '';
         if (extraParam) {

--- a/web/react/components/signup_team.jsx
+++ b/web/react/components/signup_team.jsx
@@ -28,6 +28,8 @@ export default class TeamSignUp extends React.Component {
             this.state = {page: 'email'};
         } else if (global.window.mm_config.EnableSignUpWithGitLab === 'true') {
             this.state = {page: 'gitlab'};
+        } else if (global.window.mm_config.EnableSignUpWithOAuth === 'true') {
+            this.state = {page: 'oauth'};
         } else {
             this.state = {page: 'none'};
         }
@@ -119,6 +121,13 @@ export default class TeamSignUp extends React.Component {
                 <div>
                     {teamListing}
                     <SSOSignupPage service={Constants.GOOGLE_SERVICE} />
+                </div>
+            );
+        } else if (this.state.page === 'oauth') {
+            return (
+                <div>
+                    {teamListing}
+                    <SSOSignupPage service={Constants.OAUTH_SERVICE} />
                 </div>
             );
         } else if (this.state.page === 'none') {

--- a/web/react/components/signup_user_complete.jsx
+++ b/web/react/components/signup_user_complete.jsx
@@ -203,6 +203,18 @@ export default class SignupUserComplete extends React.Component {
            );
         }
 
+        if (global.window.mm_config.EnableSignUpWithOAuth === 'true') {
+            signupMessage.push(
+                <a
+                    className='btn btn-custom-login oauth'
+                    href={'/' + this.props.teamName + '/signup/oauth' + window.location.search}
+                >
+                    <span className='icon' />
+                    <span>{'Login with OAuth'}</span>
+                </a>
+           );
+        }
+
         var emailSignup;
         if (global.window.mm_config.EnableSignUpWithEmail === 'true') {
             emailSignup = (

--- a/web/react/components/signup_user_complete.jsx
+++ b/web/react/components/signup_user_complete.jsx
@@ -204,13 +204,14 @@ export default class SignupUserComplete extends React.Component {
         }
 
         if (global.window.mm_config.EnableSignUpWithOAuth === 'true') {
+            var displayName = global.window.mm_config.CustomOAuthDisplayName;
             signupMessage.push(
                 <a
                     className='btn btn-custom-login oauth'
                     href={'/' + this.props.teamName + '/signup/oauth' + window.location.search}
                 >
                     <span className='icon' />
-                    <span>{'Login with OAuth'}</span>
+                    <span>{'Login with ' + displayName}</span>
                 </a>
            );
         }

--- a/web/react/components/team_signup_choose_auth.jsx
+++ b/web/react/components/team_signup_choose_auth.jsx
@@ -45,6 +45,7 @@ export default class ChooseAuthPage extends React.Component {
         }
 
         if (global.window.mm_config.EnableSignUpWithOAuth === 'true') {
+            var displayName = global.window.mm_config.CustomOAuthDisplayName;
             buttons.push(
                     <a
                         className='btn btn-custom-login oauth btn-full'
@@ -57,7 +58,7 @@ export default class ChooseAuthPage extends React.Component {
                         }
                     >
                         <span className='icon' />
-                        <span>{'Create new team with OAuth Account'}</span>
+                        <span>{'Create new team with ' + displayName}</span>
                     </a>
             );
         }

--- a/web/react/components/team_signup_choose_auth.jsx
+++ b/web/react/components/team_signup_choose_auth.jsx
@@ -44,6 +44,24 @@ export default class ChooseAuthPage extends React.Component {
             );
         }
 
+        if (global.window.mm_config.EnableSignUpWithOAuth === 'true') {
+            buttons.push(
+                    <a
+                        className='btn btn-custom-login oauth btn-full'
+                        href='#'
+                        onClick={
+                            (e) => {
+                                e.preventDefault();
+                                this.props.updatePage('oauth');
+                            }
+                        }
+                    >
+                        <span className='icon' />
+                        <span>{'Create new team with OAuth Account'}</span>
+                    </a>
+            );
+        }
+
         if (global.window.mm_config.EnableSignUpWithEmail === 'true') {
             buttons.push(
                     <a

--- a/web/react/components/team_signup_with_sso.jsx
+++ b/web/react/components/team_signup_with_sso.jsx
@@ -100,6 +100,19 @@ export default class SSOSignUpPage extends React.Component {
                     <span>{'Create team with Google Apps Account'}</span>
                 </a>
             );
+        } else if (this.props.service === Constants.OAUTH_SERVICE) {
+            var displayName = global.window.mm_config.CustomOAuthDisplayName;
+            button = (
+                <a
+                    className='btn btn-custom-login oauth btn-full'
+                    href='#'
+                    onClick={this.handleSubmit}
+                    disabled={disabled}
+                >
+                    <span className='icon'/>
+                    <span>{'Create team with ' + displayName}</span>
+                </a>
+            );
         }
 
         return (

--- a/web/react/components/user_settings/user_settings_general.jsx
+++ b/web/react/components/user_settings/user_settings_general.jsx
@@ -503,6 +503,16 @@ export default class UserSettingsGeneralTab extends React.Component {
                         {helpText}
                     </div>
                 );
+            } else if (this.props.user.auth_service === Constants.OAUTH_SERVICE) {
+                inputs.push(
+                    <div
+                        key='oauthEmailInfo'
+                        className='form-group'
+                    >
+                        <div className='setting-list__hint'>{'Log in occurs through OAuth. Email cannot be updated.'}</div>
+                        {helpText}
+                    </div>
+                );
             }
 
             emailSection = (
@@ -533,6 +543,8 @@ export default class UserSettingsGeneralTab extends React.Component {
                 }
             } else if (this.props.user.auth_service === Constants.GITLAB_SERVICE) {
                 describe = 'Log in done through GitLab';
+            } else if (this.props.user.auth_service === Constants.OAUTH_SERVICE) {
+                describe = 'Log in done through OAuth';
             }
 
             emailSection = (

--- a/web/react/components/user_settings/user_settings_security.jsx
+++ b/web/react/components/user_settings/user_settings_security.jsx
@@ -247,13 +247,14 @@ export default class SecurityTab extends React.Component {
 
             let oauthOption;
             if (global.window.mm_config.EnableSignUpWithOAuth === 'true' && user.auth_service === '') {
+                var displayName = global.window.mm_config.CustomOAuthDisplayName;
                 oauthOption = (
                     <div>
                         <a
                             className='btn btn-primary'
                             href={'/' + teamName + '/claim?email=' + user.email + '&new_type=' + Constants.OAUTH_SERVICE}
                         >
-                            {'Switch to using OAuth SSO'}
+                            {'Switch to using ' + displayName}
                         </a>
                         <br/>
                     </div>

--- a/web/react/components/user_settings/user_settings_security.jsx
+++ b/web/react/components/user_settings/user_settings_security.jsx
@@ -245,12 +245,29 @@ export default class SecurityTab extends React.Component {
                 );
             }
 
+            let oauthOption;
+            if (global.window.mm_config.EnableSignUpWithOAuth === 'true' && user.auth_service === '') {
+                oauthOption = (
+                    <div>
+                        <a
+                            className='btn btn-primary'
+                            href={'/' + teamName + '/claim?email=' + user.email + '&new_type=' + Constants.OAUTH_SERVICE}
+                        >
+                            {'Switch to using OAuth SSO'}
+                        </a>
+                        <br/>
+                    </div>
+                );
+            }
+
             inputs.push(
                 <div key='userSignInOption'>
                    {emailOption}
                    {gitlabOption}
                    <br/>
                    {googleOption}
+                   <br/>
+                   {oauthOption}
                 </div>
             );
 
@@ -280,6 +297,8 @@ export default class SecurityTab extends React.Component {
         let describe = 'Email and Password';
         if (this.props.user.auth_service === Constants.GITLAB_SERVICE) {
             describe = 'GitLab SSO';
+        } else if (this.props.user.auth_service === Constants.OAUTH_SERVICE) {
+            describe = 'OAuth SSO';
         }
 
         return (
@@ -297,6 +316,7 @@ export default class SecurityTab extends React.Component {
         let numMethods = 0;
         numMethods = global.window.mm_config.EnableSignUpWithGitLab === 'true' ? numMethods + 1 : numMethods;
         numMethods = global.window.mm_config.EnableSignUpWithGoogle === 'true' ? numMethods + 1 : numMethods;
+        numMethods = global.window.mm_config.EnableSignUpWithOAuth === 'true' ? numMethods + 1 : numMethods;
 
         if (global.window.mm_config.EnableSignUpWithEmail && numMethods > 0) {
             signInSection = this.createSignInSection();

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -116,6 +116,7 @@ export default {
     OFFTOPIC_CHANNEL: 'off-topic',
     GITLAB_SERVICE: 'gitlab',
     GOOGLE_SERVICE: 'google',
+    OAUTH_SERVICE: 'oauth',
     EMAIL_SERVICE: 'email',
     SIGNIN_CHANGE: 'signin_change',
     SIGNIN_VERIFIED: 'verified',

--- a/web/sass-files/sass/partials/_signup.scss
+++ b/web/sass-files/sass/partials/_signup.scss
@@ -197,6 +197,15 @@
                     background-image: url("../images/gitlabLogo.png");
                 }
             }
+            &.oauth {
+                background: #43bb34;
+                &:hover {
+                    background: darken(#43bb44, 10%);
+                }
+                span {
+                    vertical-align: middle;
+                }
+            }
             &.google {
                 background: #dd4b39;
                 &:hover {


### PR DESCRIPTION
Putting this up for review, so you we can get some feedback. Note that the first 2 patches in this series are already part of https://github.com/mattermost/platform/pull/1922

This adds the following config:
        "OAuthSettings": {
            "Enable": false,
            "ProviderName": "",  // like 'cloudron', 'qt', 'google', 'gitlab'
            "Secret": "",        // client secret
            "Id": "",            // client id
            "Scope": "",         // oauth scope
            "AuthEndpoint": "",  // auth endpoint
            "TokenEndpoint": "", // token endpoint
            "UserApiEndpoint": "", // user profile end point
            "UsernameField": "",  // the field in user profile to be used as username
            "EmailField": "",    // the field in user profile to be used as email
            "AuthDataField": ""  // the field in user profile to be used as auth data
        },
    
The above values can be configured via the admin panel.
    
We should be able to merge the gitlab oauth code with this code as well. But we can do this in a separate PR.
