### PR TITLE
PLT-1652 Added download param to getFile api call

### DIFF
--- a/web/react/components/view_image.jsx
+++ b/web/react/components/view_image.jsx
@@ -211,7 +211,7 @@ export default class ViewImageModal extends React.Component {
         }
 
         const filename = this.props.filenames[this.state.imgId];
-        const fileUrl = Utils.getFileUrl(filename);
+        const fileUrl = Utils.getFileUrl(filename, true);
 
         var content;
         if (this.state.loaded[this.state.imgId]) {
@@ -377,6 +377,7 @@ function ImagePreview({filename, fileUrl, fileInfo, maxHeight}) {
         <a
             href={fileUrl}
             target='_blank'
+            download={true}
         >
             <img
                 style={{maxHeight}}

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1091,8 +1091,9 @@ export function fileSizeToString(bytes) {
 }
 
 // Converts a filename (like those attached to Post objects) to a url that can be used to retrieve attachments from the server.
-export function getFileUrl(filename) {
-    return getWindowLocationOrigin() + '/api/v1/files/get' + filename + '?' + getSessionIndex();
+export function getFileUrl(filename, isDownload) {
+    const downloadParam = isDownload ? '&download=1' : '';
+    return getWindowLocationOrigin() + '/api/v1/files/get' + filename + '?' + getSessionIndex() + downloadParam;
 }
 
 // Gets the name of a file (including extension) from a given url or file path.


### PR DESCRIPTION
We add some extra headers to getFile api call results for IE, Edge, and Safari to trigger the actual file download to take place. This PR changes those to only be added on based on a query parameter so that images always immediately downloaded when using a public link.