### PR TITLE
PLT-1689 Fixed duplicate email team sign-up error

### DIFF
--- a/web/react/components/team_signup_welcome_page.jsx
+++ b/web/react/components/team_signup_welcome_page.jsx
@@ -59,7 +59,13 @@ export default class TeamSignupWelcomePage extends React.Component {
                 }
             }.bind(this),
             function error(err) {
-                this.setState({serverError: err.message});
+                let errorMsg = err.message;
+
+                if (err.detailed_error.indexOf('Invalid RCPT TO address provided') >= 0) {
+                    errorMsg = 'Please enter a valid email address';
+                }
+
+                this.setState({emailError: '', serverError: errorMsg});
             }.bind(this)
         );
     }


### PR DESCRIPTION
Previously a non-useful error was being provided in some cases along with not clearing certain other errors.