### PR TITLE
PLT-1670 Added a limit to the number of suggestions when autocompleting at mentions

### DIFF
--- a/web/react/components/suggestion/at_mention_provider.jsx
+++ b/web/react/components/suggestion/at_mention_provider.jsx
@@ -5,6 +5,8 @@ import SuggestionStore from '../../stores/suggestion_store.jsx';
 import UserStore from '../../stores/user_store.jsx';
 import * as Utils from '../../utils/utils.jsx';
 
+const MaxUserSuggestions = 40;
+
 class AtMentionSuggestion extends React.Component {
     render() {
         const {item, isSelection, onClick} = this.props;
@@ -77,6 +79,10 @@ export default class AtMentionProvider {
 
                 if (user.username.startsWith(usernamePrefix)) {
                     filtered.push(user);
+                }
+
+                if (filtered.length >= MaxUserSuggestions) {
+                    break;
                 }
             }
 


### PR DESCRIPTION
I'm still not sure why the at mention autocomplete leaks memory on IE11 when the search user auocomplete does not. I tried everything I could think of such as trading their components and commenting out extra code to figure out what the difference between them was, but I had no luck finding what was different. Reducing the max number of users displayed virtually eliminates the problem so that's what I went with