### PR TITLE
PLT-1768 Clear deleted messages after channel leave and fix missig postlist error

### DIFF
--- a/web/react/dispatcher/event_helpers.jsx
+++ b/web/react/dispatcher/event_helpers.jsx
@@ -19,7 +19,8 @@ export function emitChannelClickEvent(channel) {
     AppDispatcher.handleViewAction({
         type: ActionTypes.CLICK_CHANNEL,
         name: channel.name,
-        id: channel.id
+        id: channel.id,
+        prev: ChannelStore.getCurrentId()
     });
 }
 

--- a/web/react/stores/post_store.jsx
+++ b/web/react/stores/post_store.jsx
@@ -451,6 +451,8 @@ class PostStoreClass extends EventEmitter {
         post.filenames = [];
 
         posts[post.id] = post;
+
+        this.makePostsInfo(post.channel_id);
         this.postsInfo[post.channel_id].deletedPosts = posts;
     }
 
@@ -610,7 +612,7 @@ PostStore.dispatchToken = AppDispatcher.register((payload) => {
     case ActionTypes.CLICK_CHANNEL:
         PostStore.clearFocusedPost();
         PostStore.clearChannelVisibility(action.id, true);
-        PostStore.clearUnseenDeletedPosts(action.id);
+        PostStore.clearUnseenDeletedPosts(action.prev);
         break;
     case ActionTypes.CREATE_POST:
         PostStore.storePendingPost(action.post);


### PR DESCRIPTION
While fixing the console error for the ticket I noticed that deleted messages were sometimes cleared when switching to the channel (since the posts render twice if there is new/updated posts). To fix that I changed to clearing the deleted posts when leaving a channel, instead of on join. I tested it thoroughly and it works well.