### PR TITLE
PLT-1837 Remove expiry from public links

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -398,13 +398,6 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = model.NewLocAppError("getFile", "api.file.get_file.public_invalid.app_error", nil, "")
 			return
 		}
-		props := model.MapFromJson(strings.NewReader(data))
-
-		t, err := strconv.ParseInt(props["time"], 10, 64)
-		if err != nil || model.GetMillis()-t > 1000*60*60*24*7 { // one week
-			c.Err = model.NewLocAppError("getFile", "api.file.get_file.public_expired.app_error", nil, "")
-			return
-		}
 	} else if !c.HasPermissionsToChannel(cchan, "getFile") {
 		return
 	}
@@ -484,7 +477,6 @@ func getPublicLink(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	newProps := make(map[string]string)
 	newProps["filename"] = filename
-	newProps["time"] = fmt.Sprintf("%v", model.GetMillis())
 
 	data := model.MapToJson(newProps)
 	hash := model.HashPassword(fmt.Sprintf("%v:%v", data, utils.Cfg.FileSettings.PublicLinkSalt))

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -456,10 +456,6 @@
     "translation": "Could not find file."
   },
   {
-    "id": "api.file.get_file.public_expired.app_error",
-    "translation": "The public link has expired"
-  },
-  {
     "id": "api.file.get_file.public_invalid.app_error",
     "translation": "The public link does not appear to be valid"
   },

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -456,10 +456,6 @@
     "translation": "No se encontró el archivo."
   },
   {
-    "id": "api.file.get_file.public_expired.app_error",
-    "translation": "El enlace público ha expirado"
-  },
-  {
     "id": "api.file.get_file.public_invalid.app_error",
     "translation": "El enlace público parece ser inválido"
   },


### PR DESCRIPTION
Old public links will still work and will "unexpire" if they had previously expired.

@coreyhulen / @enahum I'm removing a string here, should I remove the translation as well?