### PR TITLE
PLT-1749 Return channel type in new post websocket events

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -698,6 +698,7 @@ func sendNotificationsAndForget(c *Context, post *model.Post, team *model.Team, 
 
 		message := model.NewMessage(c.Session.TeamId, post.ChannelId, post.UserId, model.ACTION_POSTED)
 		message.Add("post", post.ToJson())
+		message.Add("channel_type", channel.Type)
 
 		if len(post.Filenames) != 0 {
 			message.Add("otherFile", "true")

--- a/web/react/stores/socket_store.jsx
+++ b/web/react/stores/socket_store.jsx
@@ -176,6 +176,7 @@ function handleNewPostEvent(msg) {
             mentions = JSON.parse(msg.props.mentions);
         }
 
+        const channelType = msgProps.channel_type;
         const channel = ChannelStore.get(msg.channel_id);
         const user = UserStore.getCurrentUser();
         const member = ChannelStore.getMember(msg.channel_id);
@@ -187,7 +188,7 @@ function handleNewPostEvent(msg) {
 
         if (notifyLevel === 'none') {
             return;
-        } else if (notifyLevel === 'mention' && mentions.indexOf(user.id) === -1 && channel.type !== 'D') {
+        } else if (notifyLevel === 'mention' && mentions.indexOf(user.id) === -1 && channelType !== Constants.DM_CHANNEL) {
             return;
         }
 


### PR DESCRIPTION
Client didn't have info about new DMs so we were getting a console error trying to check the type of a null channel. Easiest solution was to just return the channel type with the post event so the notification didn't need to wait on getting the new channel data and always fires properly.