### PR TITLE
PLT-1720 Properly disable the get team link functionality when user creation is disabled

### DIFF
--- a/web/react/components/get_link_modal.jsx
+++ b/web/react/components/get_link_modal.jsx
@@ -41,6 +41,8 @@ export default class GetLinkModal extends React.Component {
     }
 
     render() {
+        const userCreationEnabled = global.window.mm_config.EnableUserCreation === 'true';
+
         let helpText = null;
         if (this.props.helpText) {
             helpText = (
@@ -53,7 +55,7 @@ export default class GetLinkModal extends React.Component {
         }
 
         let copyLink = null;
-        if (document.queryCommandSupported('copy')) {
+        if (userCreationEnabled && document.queryCommandSupported('copy')) {
             copyLink = (
                 <button
                     data-copy-btn='true'
@@ -66,6 +68,18 @@ export default class GetLinkModal extends React.Component {
                         defaultMessage='Copy Link'
                     />
                 </button>
+            );
+        }
+
+        let linkText = null;
+        if (userCreationEnabled) {
+            linkText = (
+                <textarea
+                    className='form-control no-resize min-height'
+                    readOnly='true'
+                    ref='textarea'
+                    value={this.props.link}
+                />
             );
         }
 
@@ -92,12 +106,7 @@ export default class GetLinkModal extends React.Component {
                 </Modal.Header>
                 <Modal.Body>
                     {helpText}
-                    <textarea
-                        className='form-control no-resize min-height'
-                        readOnly='true'
-                        ref='textarea'
-                        value={this.props.link}
-                    />
+                    {linkText}
                 </Modal.Body>
                 <Modal.Footer>
                     <button

--- a/web/react/components/get_team_invite_link_modal.jsx
+++ b/web/react/components/get_team_invite_link_modal.jsx
@@ -16,6 +16,10 @@ const holders = defineMessages({
     help: {
         id: 'get_team_invite_link_modal.help',
         defaultMessage: 'Send teammates the link below for them to sign-up to this team site.'
+    },
+    helpDisabled: {
+        id: 'get_team_invite_link_modal.helpDisabled',
+        defaultMessage: 'User creation has been disabled for your team. Please ask your team administrator for details.'
     }
 });
 
@@ -47,12 +51,18 @@ class GetTeamInviteLinkModal extends React.Component {
     render() {
         const {formatMessage} = this.props.intl;
 
+        let helpText = formatMessage(holders.helpDisabled);
+
+        if (global.window.mm_config.EnableUserCreation === 'true') {
+            helpText = formatMessage(holders.help);
+        }
+
         return (
             <GetLinkModal
                 show={this.state.show}
                 onHide={() => this.setState({show: false})}
                 title={formatMessage(holders.title)}
-                helpText={formatMessage(holders.help)}
+                helpText={helpText}
                 link={TeamStore.getCurrentInviteLink()}
             />
         );

--- a/web/static/i18n/en.json
+++ b/web/static/i18n/en.json
@@ -526,6 +526,7 @@
   "get_link.close": "Close",
   "get_team_invite_link_modal.title": "Team Invite Link",
   "get_team_invite_link_modal.help": "Send teammates the link below for them to sign-up to this team site.",
+  "get_team_invite_link_modal.helpDisabled": "User creation has been disabled for your team. Please ask your team administrator for details.",
   "invite_member.emailError": "Please enter a valid email address",
   "invite_member.firstname": "First name",
   "invite_member.lastname": "Last name",


### PR DESCRIPTION
Previously users could still copy the link for new users to join even though the ability to create new users was disabled.