### PR TITLE
Temporary fix for babel-eslint

### DIFF
--- a/web/react/package.json
+++ b/web/react/package.json
@@ -13,18 +13,19 @@
     "twemoji": "1.4.1"
   },
   "devDependencies": {
-    "browserify": "12.0.1",
-    "babelify": "7.2.0",
-    "babel-preset-es2015": "6.1.18",
-    "babel-preset-stage-0": "6.1.18",
-    "babel-preset-react": "6.1.18",
+    "babel-eslint": "4.1.5",
     "babel-plugin-transform-runtime": "6.1.4",
-    "uglify-js": "2.6.1",
-    "watchify": "3.6.1",
+    "babel-preset-es2015": "6.1.18",
+    "babel-preset-react": "6.1.18",
+    "babel-preset-stage-0": "6.1.18",
+    "babelify": "7.2.0",
+    "browserify": "12.0.1",
+    "escope": "3.3.0",
     "eslint": "1.9.0",
     "eslint-plugin-react": "3.9.0",
     "exorcist": "0.4.0",
-    "babel-eslint": "4.1.5"
+    "uglify-js": "2.6.1",
+    "watchify": "3.6.1"
   },
   "scripts": {
     "check": "",


### PR DESCRIPTION
Just adds a dependency (escope @ 3.3.0) of babel-eslint to force it to use the correct one while we wait for the babel-eslint guys or escope guys to fix the issue. I'm tracking the [issue here](https://github.com/babel/babel-eslint/issues/243) and will revert this when it's fixed.