### PR TITLE
PLT-882 Added warning message when you mention users that aren't in the current channel

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -249,7 +250,7 @@ func handlePostEventsAndForget(c *Context, post *model.Post, triggerWebhooks boo
 		}
 
 		sendNotificationsAndForget(c, post, team, channel)
-		go checkForOutOfChannelMentions(post, channel)
+		go checkForOutOfChannelMentions(c, post, channel)
 
 		var user *model.User
 		if result := <-uchan; result.Err != nil {
@@ -729,18 +730,52 @@ func updateMentionCountAndForget(channelId, userId string) {
 	}()
 }
 
-func checkForOutOfChannelMentions(post *model.Post, channel *model.Channel) {
+func checkForOutOfChannelMentions(c *Context, post *model.Post, channel *model.Channel) {
 	// don't check for out of channel mentions in direct channels
 	if channel.Type == model.CHANNEL_DIRECT {
 		return
 	}
 
 	mentioned := getOutOfChannelMentions(post, channel.TeamId)
-
-	// TODO come up with a way to alert the client of these
-	for _, user := range mentioned {
-		l4g.Debug("%v was mentioned and wasn't in the channel", user.Username)
+	if len(mentioned) == 0 {
+		return
 	}
+
+	usernames := make([]string, len(mentioned))
+	for i, user := range mentioned {
+		usernames[i] = user.Username
+	}
+	sort.Strings(usernames)
+
+	var messageText string
+	if len(usernames) == 1 {
+		messageText = c.T("api.post.check_for_out_of_channel_mentions.message.one", map[string]interface{}{
+			"Username": usernames[0],
+		})
+	} else {
+		messageText = c.T("api.post.check_for_out_of_channel_mentions.message.multiple", map[string]interface{}{
+			"Usernames":    strings.Join(usernames[:len(usernames)-1], ", "),
+			"LastUsername": usernames[len(usernames)-1],
+		})
+	}
+
+	// create an ephemeral post that will be sent only to the sender of this original post and not stored in the DB
+	warningPost := model.Post{
+		Id:        model.NewId(),
+		ChannelId: post.ChannelId,
+		Message:   messageText,
+		Type:      model.POST_OUT_OF_CHANNEL_MENTION,
+		CreateAt:  post.CreateAt + 1,
+		Ephemeral: true,
+		Props:     model.StringInterface{},
+		Filenames: []string{},
+	}
+
+	message := model.NewMessage(c.Session.TeamId, channel.Id, post.UserId, model.ACTION_EPHEMERAL_MESSAGE)
+	message.Add("post", warningPost.ToJson())
+	message.Add("channel_type", channel.Type)
+
+	PublishAndForget(message)
 }
 
 // Gets a list of users that were mentioned in a given post that aren't in the channel that the post was made in

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mattermost/platform/store"
 	"github.com/mattermost/platform/utils"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -861,18 +862,18 @@ func TestMakeDirectChannelVisible(t *testing.T) {
 func TestGetOutOfChannelMentions(t *testing.T) {
 	Setup()
 
-	team1 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team1 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Type: model.TEAM_OPEN}
 	team1 = Client.Must(Client.CreateTeam(team1)).Data.(*model.Team)
 
-	user1 := &model.User{TeamId: team1.Id, Email: model.NewId() + "corey+test@test.com", Nickname: "Corey Hulen", Password: "pwd", Username: "user1"}
+	user1 := &model.User{TeamId: team1.Id, Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "pwd", Username: "user1"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user1.Id))
 
-	user2 := &model.User{TeamId: team1.Id, Email: model.NewId() + "corey+test@test.com", Nickname: "Corey Hulen", Password: "pwd", Username: "user2"}
+	user2 := &model.User{TeamId: team1.Id, Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "pwd", Username: "user2"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user2.Id))
 
-	user3 := &model.User{TeamId: team1.Id, Email: model.NewId() + "corey+test@test.com", Nickname: "Corey Hulen", Password: "pwd", Username: "user3"}
+	user3 := &model.User{TeamId: team1.Id, Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "pwd", Username: "user3"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user3.Id))
 
@@ -907,10 +908,10 @@ func TestGetOutOfChannelMentions(t *testing.T) {
 
 	Client.Must(Client.Logout())
 
-	team2 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	team2 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-	user4 := &model.User{TeamId: team2.Id, Email: model.NewId() + "corey+test@test.com", Nickname: "Corey Hulen", Password: "pwd", Username: "user4"}
+	user4 := &model.User{TeamId: team2.Id, Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "pwd", Username: "user4"}
 	user4 = Client.Must(Client.CreateUser(user4, "")).Data.(*model.User)
 	store.Must(Srv.Store.User().VerifyEmail(user4.Id))
 

--- a/api/web_team_hub.go
+++ b/api/web_team_hub.go
@@ -101,6 +101,9 @@ func ShouldSendEvent(webCon *WebConn, msg *model.Message) bool {
 			return false
 		} else if msg.Action == model.ACTION_PREFERENCE_CHANGED {
 			return false
+		} else if msg.Action == model.ACTION_EPHEMERAL_MESSAGE {
+			// For now, ephemeral messages are sent directly to individual users
+			return false
 		}
 
 		// Only report events to a user who is the subject of the event, or is in the channel of the event

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -656,6 +656,14 @@
     "translation": "Error getting access token from DB before deletion"
   },
   {
+    "id": "api.post.check_for_out_of_channel_mentions.message.one",
+    "translation": "{{.Username}} was mentioned, but they do not belong to this channel."
+  },
+  {
+    "id": "api.post.check_for_out_of_channel_mentions.message.multiple",
+    "translation": "{{.Usernames}} and {{.LastUsername}} were mentioned, but they do not belong to this channel."
+  },
+  {
     "id": "api.post.create_post.bad_filename.error",
     "translation": "Bad filename discarded, filename=%v"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -684,6 +684,18 @@
     "translation": "You do not have the appropriate permissions"
   },
   {
+    "id": "api.post.get_out_of_channel_mentions.retrieve_members.error",
+    "translation": "Failed to get channel members channel_id=%v err=%v"
+  },
+  {
+    "id": "api.post.get_out_of_channel_mentions.retrieve_profiles.error",
+    "translation": "Failed to retrieve user profiles team_id=%v, err=%v"
+  },
+  {
+    "id": "api.post.get_out_of_channel_mentions.regex.error",
+    "translation": "Failed to compile @mention regex user_id=%v, err=%v"
+  },
+  {
     "id": "api.post.get_post.permissions.app_error",
     "translation": "You do not have the appropriate permissions"
   },

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -656,6 +656,14 @@
     "translation": "Error obteniendo el token de acceso desde la BD antes de ser eliminado"
   },
   {
+    "id": "api.post.check_for_out_of_channel_mentions.message.one",
+    "translation": "{ .Username } was mentioned, but they do not belong to this channel."
+  },
+  {
+    "id": "api.post.check_for_out_of_channel_mentions.message.multiple",
+    "translation": "{ .Usernames } and { .LastUsername} were mentioned, but they do not belong to this channel."
+  },
+  {
     "id": "api.post.create_post.bad_filename.error",
     "translation": "Nombre errado de archivo descartado, archivo=%v"
   },

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -656,14 +656,6 @@
     "translation": "Error obteniendo el token de acceso desde la BD antes de ser eliminado"
   },
   {
-    "id": "api.post.check_for_out_of_channel_mentions.message.one",
-    "translation": "{ .Username } was mentioned, but they do not belong to this channel."
-  },
-  {
-    "id": "api.post.check_for_out_of_channel_mentions.message.multiple",
-    "translation": "{ .Usernames } and { .LastUsername} were mentioned, but they do not belong to this channel."
-  },
-  {
     "id": "api.post.create_post.bad_filename.error",
     "translation": "Nombre errado de archivo descartado, archivo=%v"
   },
@@ -698,10 +690,6 @@
   {
     "id": "api.post.get_out_of_channel_mentions.retrieve_profiles.error",
     "translation": "Falla al recuperar los perfiles de usuario team_id=%v, err=%v"
-  },
-  {
-    "id": "api.post.get_out_of_channel_mentions.regex.error",
-    "translation": "Failed to compile @mention regex user_id=%v, err=%v"
   },
   {
     "id": "api.post.get_post.permissions.app_error",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -684,6 +684,18 @@
     "translation": "No tienes los permisos apropiados"
   },
   {
+    "id": "api.post.get_out_of_channel_mentions.retrieve_members.error",
+    "translation": "Falla al obtener los miembros del canal channel_id=%v err=%v"
+  },
+  {
+    "id": "api.post.get_out_of_channel_mentions.retrieve_profiles.error",
+    "translation": "Falla al recuperar los perfiles de usuario team_id=%v, err=%v"
+  },
+  {
+    "id": "api.post.get_out_of_channel_mentions.regex.error",
+    "translation": "Failed to compile @mention regex user_id=%v, err=%v"
+  },
+  {
     "id": "api.post.get_post.permissions.app_error",
     "translation": "No tienes los permisos apropiados"
   },

--- a/model/message.go
+++ b/model/message.go
@@ -18,6 +18,7 @@ const (
 	ACTION_USER_ADDED         = "user_added"
 	ACTION_USER_REMOVED       = "user_removed"
 	ACTION_PREFERENCE_CHANGED = "preference_changed"
+	ACTION_EPHEMERAL_MESSAGE  = "ephemeral_message"
 )
 
 type Message struct {

--- a/model/post.go
+++ b/model/post.go
@@ -10,11 +10,12 @@ import (
 )
 
 const (
-	POST_SYSTEM_MESSAGE_PREFIX = "system_"
-	POST_DEFAULT               = ""
-	POST_SLACK_ATTACHMENT      = "slack_attachment"
-	POST_JOIN_LEAVE            = "system_join_leave"
-	POST_HEADER_CHANGE         = "system_header_change"
+	POST_SYSTEM_MESSAGE_PREFIX  = "system_"
+	POST_DEFAULT                = ""
+	POST_SLACK_ATTACHMENT       = "slack_attachment"
+	POST_JOIN_LEAVE             = "system_join_leave"
+	POST_HEADER_CHANGE          = "system_header_change"
+	POST_OUT_OF_CHANNEL_MENTION = "system_out_of_channel_mention"
 )
 
 type Post struct {
@@ -33,6 +34,7 @@ type Post struct {
 	Hashtags      string          `json:"hashtags"`
 	Filenames     StringArray     `json:"filenames"`
 	PendingPostId string          `json:"pending_post_id" db:"-"`
+	Ephemeral     bool            `json:"ephemeral" db:"-"`
 }
 
 func (o *Post) ToJson() string {

--- a/web/react/components/delete_post_modal.jsx
+++ b/web/react/components/delete_post_modal.jsx
@@ -85,7 +85,7 @@ export default class DeletePostModal extends React.Component {
                     }
                 }
 
-                PostStore.removePost(this.state.post.id, this.state.post.channel_id);
+                PostStore.deletePost(this.state.post);
                 AsyncClient.getPosts(this.state.post.channel_id);
             },
             (err) => {

--- a/web/react/components/post_info.jsx
+++ b/web/react/components/post_info.jsx
@@ -21,13 +21,14 @@ export default class PostInfo extends React.Component {
         };
 
         this.handlePermalinkCopy = this.handlePermalinkCopy.bind(this);
+        this.removePost = this.removePost.bind(this);
     }
     createDropdown() {
         var post = this.props.post;
         var isOwner = UserStore.getCurrentId() === post.user_id;
         var isAdmin = Utils.isAdmin(UserStore.getCurrentUser().roles);
 
-        if (post.state === Constants.POST_FAILED || post.state === Constants.POST_LOADING || post.state === Constants.POST_DELETED) {
+        if (post.state === Constants.POST_FAILED || post.state === Constants.POST_LOADING || post.ephemeral) {
             return '';
         }
 
@@ -152,6 +153,25 @@ export default class PostInfo extends React.Component {
             this.setState({copiedLink: false});
         }
     }
+    removePost() {
+        EventHelpers.emitRemovePost(this.props.post);
+    }
+    createRemovePostButton(post) {
+        if (!post.ephemeral) {
+            return null;
+        }
+
+        return (
+            <a
+                href='#'
+                className='post__remove theme'
+                type='button'
+                onClick={this.removePost}
+            >
+                {'×'}
+            </a>
+        );
+    }
     render() {
         var post = this.props.post;
         var comments = '';
@@ -164,7 +184,7 @@ export default class PostInfo extends React.Component {
             commentCountText = '';
         }
 
-        if (post.state !== Constants.POST_FAILED && post.state !== Constants.POST_LOADING && post.state !== Constants.POST_DELETED) {
+        if (post.state !== Constants.POST_FAILED && post.state !== Constants.POST_LOADING && !post.ephemeral) {
             comments = (
                 <a
                     href='#'
@@ -241,6 +261,7 @@ export default class PostInfo extends React.Component {
                     >
                         {permalinkOverlay}
                     </Overlay>
+                    {this.createRemovePostButton(post)}
                 </li>
             </ul>
         );

--- a/web/react/dispatcher/event_helpers.jsx
+++ b/web/react/dispatcher/event_helpers.jsx
@@ -180,3 +180,10 @@ export function emitPreferenceChangedEvent(preference) {
         preference
     });
 }
+
+export function emitRemovePost(post) {
+    AppDispatcher.handleViewAction({
+        type: Constants.ActionTypes.REMOVE_POST,
+        post
+    });
+}

--- a/web/react/stores/post_store.jsx
+++ b/web/react/stores/post_store.jsx
@@ -57,6 +57,7 @@ class PostStoreClass extends EventEmitter {
         this.clearFocusedPost = this.clearFocusedPost.bind(this);
         this.clearChannelVisibility = this.clearChannelVisibility.bind(this);
 
+        this.deletePost = this.deletePost.bind(this);
         this.removePost = this.removePost.bind(this);
 
         this.getPendingPosts = this.getPendingPosts.bind(this);
@@ -64,10 +65,6 @@ class PostStoreClass extends EventEmitter {
         this.removePendingPost = this.removePendingPost.bind(this);
         this.clearPendingPosts = this.clearPendingPosts.bind(this);
         this.updatePendingPost = this.updatePendingPost.bind(this);
-
-        this.storeUnseenDeletedPost = this.storeUnseenDeletedPost.bind(this);
-        this.getUnseenDeletedPosts = this.getUnseenDeletedPosts.bind(this);
-        this.clearUnseenDeletedPosts = this.clearUnseenDeletedPosts.bind(this);
 
         // These functions are bad and work should be done to remove this system when the RHS dies
         this.storeSelectedPost = this.storeSelectedPost.bind(this);
@@ -211,28 +208,6 @@ class PostStoreClass extends EventEmitter {
                 postList.order = this.postsInfo[id].pendingPosts.order.concat(postList.order);
             }
 
-            // Add deleted posts
-            if (this.postsInfo[id].hasOwnProperty('deletedPosts')) {
-                Object.assign(postList.posts, this.postsInfo[id].deletedPosts);
-
-                for (const postID in this.postsInfo[id].deletedPosts) {
-                    if (this.postsInfo[id].deletedPosts.hasOwnProperty(postID)) {
-                        postList.order.push(postID);
-                    }
-                }
-
-                // Merge would be faster
-                postList.order.sort((a, b) => {
-                    if (postList.posts[a].create_at > postList.posts[b].create_at) {
-                        return -1;
-                    }
-                    if (postList.posts[a].create_at < postList.posts[b].create_at) {
-                        return 1;
-                    }
-                    return 0;
-                });
-            }
-
             return postList;
         }
 
@@ -285,15 +260,6 @@ class PostStoreClass extends EventEmitter {
                     combinedPosts.posts[pid] = np;
                     if (combinedPosts.order.indexOf(pid) === -1) {
                         combinedPosts.order.push(pid);
-                    }
-                } else {
-                    if (pid in combinedPosts.posts) {
-                        Reflect.deleteProperty(combinedPosts.posts, pid);
-                    }
-
-                    const index = combinedPosts.order.indexOf(pid);
-                    if (index !== -1) {
-                        combinedPosts.order.splice(index, 1);
                     }
                 }
             }
@@ -363,6 +329,24 @@ class PostStoreClass extends EventEmitter {
         this.postsInfo[id].endVisible = Constants.POST_CHUNK_SIZE;
         this.postsInfo[id].atTop = false;
         this.postsInfo[id].atBottom = atBottom;
+    }
+
+    deletePost(post) {
+        const postList = this.postsInfo[post.channel_id].postList;
+
+        if (isPostListNull(postList)) {
+            return;
+        }
+
+        if (post.id in postList.posts) {
+            // make sure to copy the post so that component state changes work properly
+            postList.posts[post.id] = Object.assign({}, post, {
+                message: '(message deleted)',
+                state: Constants.POST_DELETED,
+                filenames: [],
+                ephemeral: true
+            });
+        }
     }
 
     removePost(post) {
@@ -437,37 +421,6 @@ class PostStoreClass extends EventEmitter {
         postList.posts[post.pending_post_id] = post;
         this.postsInfo[post.channel_id].pendingPosts = postList;
         this.emitChange();
-    }
-
-    storeUnseenDeletedPost(post) {
-        let posts = this.getUnseenDeletedPosts(post.channel_id);
-
-        if (!posts) {
-            posts = {};
-        }
-
-        post.message = '(message deleted)';
-        post.state = Constants.POST_DELETED;
-        post.filenames = [];
-
-        posts[post.id] = post;
-
-        this.makePostsInfo(post.channel_id);
-        this.postsInfo[post.channel_id].deletedPosts = posts;
-    }
-
-    getUnseenDeletedPosts(channelId) {
-        if (this.postsInfo.hasOwnProperty(channelId)) {
-            return this.postsInfo[channelId].deletedPosts;
-        }
-
-        return null;
-    }
-
-    clearUnseenDeletedPosts(channelId) {
-        if (this.postsInfo.hasOwnProperty(channelId)) {
-            Reflect.deleteProperty(this.postsInfo[channelId], 'deletedPosts');
-        }
     }
 
     storeSelectedPost(postList) {
@@ -612,7 +565,6 @@ PostStore.dispatchToken = AppDispatcher.register((payload) => {
     case ActionTypes.CLICK_CHANNEL:
         PostStore.clearFocusedPost();
         PostStore.clearChannelVisibility(action.id, true);
-        PostStore.clearUnseenDeletedPosts(action.prev);
         break;
     case ActionTypes.CREATE_POST:
         PostStore.storePendingPost(action.post);
@@ -620,7 +572,10 @@ PostStore.dispatchToken = AppDispatcher.register((payload) => {
         PostStore.jumpPostsViewToBottom();
         break;
     case ActionTypes.POST_DELETED:
-        PostStore.storeUnseenDeletedPost(action.post);
+        PostStore.deletePost(action.post);
+        PostStore.emitChange();
+        break;
+    case ActionTypes.REMOVE_POST:
         PostStore.removePost(action.post);
         PostStore.emitChange();
         break;

--- a/web/react/stores/socket_store.jsx
+++ b/web/react/stores/socket_store.jsx
@@ -109,6 +109,7 @@ class SocketStoreClass extends EventEmitter {
     handleMessage(msg) {
         switch (msg.action) {
         case SocketEvents.POSTED:
+        case SocketEvents.EPHEMERAL_MESSAGE:
             handleNewPostEvent(msg);
             break;
 

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -12,6 +12,7 @@ export default {
         LEAVE_CHANNEL: null,
         CREATE_POST: null,
         POST_DELETED: null,
+        REMOVE_POST: null,
 
         RECIEVED_CHANNELS: null,
         RECIEVED_CHANNEL: null,
@@ -126,6 +127,7 @@ export default {
     POST_FAILED: 'failed',
     POST_DELETED: 'deleted',
     POST_TYPE_JOIN_LEAVE: 'system_join_leave',
+    POST_TYPE_EPHEMERAL: 'system_ephemeral',
     SYSTEM_MESSAGE_PREFIX: 'system_',
     SYSTEM_MESSAGE_PROFILE_NAME: 'System',
     SYSTEM_MESSAGE_PROFILE_IMAGE: '/static/images/logo_compact.png',

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -78,7 +78,8 @@ export default {
         USER_ADDED: 'user_added',
         USER_REMOVED: 'user_removed',
         TYPING: 'typing',
-        PREFERENCE_CHANGED: 'preference_changed'
+        PREFERENCE_CHANGED: 'preference_changed',
+        EPHEMERAL_MESSAGE: 'ephemeral_message'
     },
 
     //SPECIAL_MENTIONS: ['all', 'channel'],

--- a/web/sass-files/sass/partials/_post.scss
+++ b/web/sass-files/sass/partials/_post.scss
@@ -408,7 +408,7 @@ body.ios {
 	@include legacy-pie-clearfix;
 
 	&:hover {
-		.dropdown, .comment-icon__container, .post__reply {
+		.dropdown, .comment-icon__container, .post__reply, .post__remove {
 			visibility: visible;
 		}
 		.permalink-icon {
@@ -660,6 +660,13 @@ body.ios {
 			top: -1px;
 			position: relative;
 		}
+	}
+
+	.post__remove {
+		display: inline-block;
+		visibility: hidden;
+		margin-right: 5px;
+		top: -1px;
 	}
 
 	.post__body {


### PR DESCRIPTION
Also adds ephemeral message support. They're stored solely in the PostStore on the client and disposed of if a user clicks the X button on the given post or when they reload the page (which unloads the rest of the PostStore as well).
![image](https://cloud.githubusercontent.com/assets/3277310/12754966/82943904-c99b-11e5-8131-c974641f741b.png)
When a post is deleted, it's also turned into an ephemeral message on the client now.
![image](https://cloud.githubusercontent.com/assets/3277310/12755048/d330479a-c99b-11e5-86a6-c77b325d46c3.png)

