### PR TITLE
PLT-1817 Fix katex sanitization

### DIFF
--- a/web/react/utils/markdown.jsx
+++ b/web/react/utils/markdown.jsx
@@ -134,7 +134,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
             );
         } else if (usedLanguage === 'tex' || usedLanguage === 'latex') {
             try {
-                const html = katex.renderToString(TextFormatting.sanitizeHtml(code), {throwOnError: false, displayMode: true});
+                const html = katex.renderToString(code, {throwOnError: false, displayMode: true});
 
                 return '<div class="post-body--code tex">' + html + '</div>';
             } catch (e) {


### PR DESCRIPTION
Based off of this commit that was in a closed PR:
https://github.com/florianorben/platform/commit/abd41f6b6c91c82af7a9a731165f4d24487c67d4

No need to pre-sanitize the latex as the katex lib does that itself. It was causing some breakage on certain latex symbols.