### PR TITLE
PLT-1882 Fixed issue with on-hover timestamps

### DIFF
--- a/web/react/components/time_since.jsx
+++ b/web/react/components/time_since.jsx
@@ -25,7 +25,7 @@ export default class TimeSince extends React.Component {
         if (this.props.sameUser) {
             return (
                 <time className='post__time'>
-                    {Utils.displayTime(this.props.eventTime)}
+                    {Utils.displayTimeFormatted(this.props.eventTime)}
                 </time>
             );
         }

--- a/web/react/components/time_since.jsx
+++ b/web/react/components/time_since.jsx
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import Constants from '../utils/constants.jsx';
+import * as Utils from '../utils/utils.jsx';
 
 import {FormattedRelative, FormattedDate} from 'mm-intl';
 
@@ -24,7 +25,7 @@ export default class TimeSince extends React.Component {
         if (this.props.sameUser) {
             return (
                 <time className='post__time'>
-                    <FormattedRelative value={this.props.eventTime} />
+                    {Utils.displayTime(this.props.eventTime)}
                 </time>
             );
         }

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -14,6 +14,8 @@ import * as AsyncClient from './async_client.jsx';
 import * as client from './client.jsx';
 import Autolinker from 'autolinker';
 
+import {FormattedTime} from 'mm-intl';
+
 export function isEmail(email) {
     // writing a regex to match all valid email addresses is really, really hard (see http://stackoverflow.com/a/201378)
     // so we just do a simple check and rely on a verification email to tell if it's a real address
@@ -209,40 +211,17 @@ export function displayDate(ticks) {
     return monthNames[d.getMonth()] + ' ' + d.getDate() + ', ' + d.getFullYear();
 }
 
-export function displayTime(ticks, utc) {
-    const d = new Date(ticks);
-    let hours;
-    let minutes;
-    let ampm = '';
-    let timezone = '';
-
-    if (utc) {
-        hours = d.getUTCHours();
-        minutes = d.getUTCMinutes();
-        timezone = ' UTC';
-    } else {
-        hours = d.getHours();
-        minutes = d.getMinutes();
-    }
-
-    if (minutes <= 9) {
-        minutes = '0' + minutes;
-    }
-
+export function displayTime(ticks) {
     const useMilitaryTime = PreferenceStore.getBool(Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, 'use_military_time');
-    if (!useMilitaryTime) {
-        ampm = ' AM';
-        if (hours >= 12) {
-            ampm = ' PM';
-        }
 
-        hours = hours % 12;
-        if (!hours) {
-            hours = '12';
-        }
-    }
-
-    return hours + ':' + minutes + ampm + timezone;
+    return (
+        <FormattedTime
+            value={ticks}
+            hour='numeric'
+            minute='numeric'
+            hour12={!useMilitaryTime}
+        />
+    );
 }
 
 export function displayDateTime(ticks) {

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -211,7 +211,43 @@ export function displayDate(ticks) {
     return monthNames[d.getMonth()] + ' ' + d.getDate() + ', ' + d.getFullYear();
 }
 
-export function displayTime(ticks) {
+export function displayTime(ticks, utc) {
+    const d = new Date(ticks);
+    let hours;
+    let minutes;
+    let ampm = '';
+    let timezone = '';
+
+    if (utc) {
+        hours = d.getUTCHours();
+        minutes = d.getUTCMinutes();
+        timezone = ' UTC';
+    } else {
+        hours = d.getHours();
+        minutes = d.getMinutes();
+    }
+
+    if (minutes <= 9) {
+        minutes = '0' + minutes;
+    }
+
+    const useMilitaryTime = PreferenceStore.getBool(Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, 'use_military_time');
+    if (!useMilitaryTime) {
+        ampm = ' AM';
+        if (hours >= 12) {
+            ampm = ' PM';
+        }
+
+        hours = hours % 12;
+        if (!hours) {
+            hours = '12';
+        }
+    }
+
+    return hours + ':' + minutes + ampm + timezone;
+}
+
+export function displayTimeFormatted(ticks) {
     const useMilitaryTime = PreferenceStore.getBool(Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, 'use_military_time');
 
     return (


### PR DESCRIPTION
Due to the localization merges happening at the same time the on-hover timestamp was changed to use the same format as the root post time stamp.  This changes it back to using HH:MM format.  Some minor css issues remain (e.g. when zooming out very far or shrinking the screen) so I'll reassign the ticket to AM after this is in to clean up any remaining issues.