### PR TITLE
PLT-1758 Changed CommandProvider to only set the matched pretext if it actuall…

### DIFF
--- a/web/react/components/suggestion/command_provider.jsx
+++ b/web/react/components/suggestion/command_provider.jsx
@@ -2,7 +2,6 @@
 // See License.txt for license information.
 
 import * as AsyncClient from '../../utils/async_client.jsx';
-import SuggestionStore from '../../stores/suggestion_store.jsx';
 
 class CommandSuggestion extends React.Component {
     render() {
@@ -38,8 +37,6 @@ CommandSuggestion.propTypes = {
 export default class CommandProvider {
     handlePretextChanged(suggestionId, pretext) {
         if (pretext.startsWith('/')) {
-            SuggestionStore.setMatchedPretext(suggestionId, pretext);
-
             AsyncClient.getSuggestedCommands(pretext, suggestionId, CommandSuggestion);
         }
     }

--- a/web/react/stores/suggestion_store.jsx
+++ b/web/react/stores/suggestion_store.jsx
@@ -223,7 +223,9 @@ class SuggestionStore extends EventEmitter {
             this.emitSuggestionsChanged(id);
             break;
         case ActionTypes.SUGGESTION_RECEIVED_SUGGESTIONS:
-            if (other.matchedPretext === this.getMatchedPretext(id)) {
+            if (this.getMatchedPretext(id) === '') {
+                this.setMatchedPretext(id, other.matchedPretext);
+
                 // ensure the matched pretext hasn't changed so that we don't receive suggestions for outdated pretext
                 this.addSuggestions(id, other.terms, other.items, other.component);
 

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -789,14 +789,16 @@ export function getSuggestedCommands(command, suggestionId, component) {
             // pull out the suggested commands from the returned data
             const terms = matches.map((suggestion) => suggestion.suggestion);
 
-            AppDispatcher.handleServerAction({
-                type: ActionTypes.SUGGESTION_RECEIVED_SUGGESTIONS,
-                id: suggestionId,
-                matchedPretext: command,
-                terms,
-                items: matches,
-                component
-            });
+            if (terms.length > 0) {
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.SUGGESTION_RECEIVED_SUGGESTIONS,
+                    id: suggestionId,
+                    matchedPretext: command,
+                    terms,
+                    items: matches,
+                    component
+                });
+            }
         },
         (err) => {
             dispatchError(err, 'getCommandSuggestions');


### PR DESCRIPTION
…y matches anything

This prevents us from replacing the entire post if it begins with a / and happens to have an @mention later on.