### PR TITLE
PLT-1787 Fix statuses not rendering until a change in the LHS

### DIFF
--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -96,7 +96,7 @@ export default class Sidebar extends React.Component {
             let directChannel = channels.find(Utils.isDirectChannelForUser.bind(null, teammateId));
 
             // a direct channel doesn't exist yet so create a fake one
-            if (!directChannel) {
+            if (directChannel == null) {
                 directChannel = {
                     name: Utils.getDirectChannelName(currentUserId, teammateId),
                     last_post_at: 0,
@@ -104,6 +104,8 @@ export default class Sidebar extends React.Component {
                     type: Constants.DM_CHANNEL,
                     fake: true
                 };
+            } else {
+                directChannel = JSON.parse(JSON.stringify(directChannel));
             }
 
             directChannel.display_name = Utils.displayUsername(teammateId);

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -5,6 +5,7 @@ import * as client from './client.jsx';
 import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import BrowserStore from '../stores/browser_store.jsx';
 import ChannelStore from '../stores/channel_store.jsx';
+import PreferenceStore from '../stores/preference_store.jsx';
 import PostStore from '../stores/post_store.jsx';
 import UserStore from '../stores/user_store.jsx';
 import * as utils from './utils.jsx';
@@ -661,13 +662,12 @@ export function getMe() {
 }
 
 export function getStatuses() {
-    const directChannels = ChannelStore.getAll().filter((channel) => channel.type === Constants.DM_CHANNEL);
+    const preferences = PreferenceStore.getCategory(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW);
 
     const teammateIds = [];
-    for (var i = 0; i < directChannels.length; i++) {
-        const teammate = utils.getDirectTeammate(directChannels[i].id);
-        if (teammate) {
-            teammateIds.push(teammate.id);
+    for (const preference of preferences) {
+        if (preference.value === 'true') {
+            teammateIds.push(preference.name);
         }
     }
 


### PR DESCRIPTION
The store reference problems strike again. Plus we were only asking for statuses on "real" direct messages.