### PR TITLE
PLT-1883 Update search result components when we receive channels

### DIFF
--- a/web/react/components/search_results_item.jsx
+++ b/web/react/components/search_results_item.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import ChannelStore from '../stores/channel_store.jsx';
 import UserStore from '../stores/user_store.jsx';
 import UserProfile from './user_profile.jsx';
 import * as EventHelpers from '../dispatcher/event_helpers.jsx';
@@ -37,8 +36,8 @@ export default class SearchResultsItem extends React.Component {
     }
 
     render() {
-        var channelName = '';
-        var channel = ChannelStore.get(this.props.post.channel_id);
+        var channelName = null;
+        const channel = this.props.channel;
         var timestamp = UserStore.getCurrentUser().update_at;
 
         if (channel) {
@@ -136,6 +135,7 @@ export default class SearchResultsItem extends React.Component {
 
 SearchResultsItem.propTypes = {
     post: React.PropTypes.object,
+    channel: React.PropTypes.object,
     isMentionSearch: React.PropTypes.bool,
     term: React.PropTypes.string
 };

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -392,6 +392,10 @@ export function areObjectsEqual(x, y) {
         return x.toString() === y.toString();
     }
 
+    if (x instanceof Map && y instanceof Map) {
+        return areMapsEqual(x, y);
+    }
+
     // At last checking prototypes as good a we can
     if (!(x instanceof Object && y instanceof Object)) {
         return false;
@@ -450,6 +454,24 @@ export function areObjectsEqual(x, y) {
                 return false;
             }
             break;
+        }
+    }
+
+    return true;
+}
+
+export function areMapsEqual(a, b) {
+    if (a.size !== b.size) {
+        return false;
+    }
+
+    for (const [key, value] of a) {
+        if (!b.has(key)) {
+            return false;
+        }
+
+        if (!areObjectsEqual(value, b.get(key))) {
+            return false;
         }
     }
 


### PR DESCRIPTION
The reason that the channel names in the search results don't show up sometimes is because the channels haven't been retrieved yet and then once they are retrieved, the search results aren't updated.

I also increased the maximum number of listeners on the ChannelStore by 100 since there will only be 100 search results returned except in incredibly rare circumstances. Any added by this will be very short lived anyway