### PR TITLE
PLT-1718 - Provides error message on user sign-up page when no sign-up methods are enabled

### DIFF
--- a/web/react/components/signup_user_complete.jsx
+++ b/web/react/components/signup_user_complete.jsx
@@ -362,6 +362,17 @@ class SignupUserComplete extends React.Component {
             );
         }
 
+        if (signupMessage.length === 0 && !emailSignup) {
+            emailSignup = (
+                <div>
+                    <FormattedMessage
+                        id='signup_user_completed.none'
+                        defaultMessage='No user creation method has been enabled.  Please contact an administrator for access.'
+                    />
+                </div>
+            );
+        }
+
         return (
             <div>
                 <form>

--- a/web/static/i18n/en.json
+++ b/web/static/i18n/en.json
@@ -901,6 +901,7 @@
   "signup_user_completed.choosePwd": "Choose your password",
   "signup_user_completed.create": "Create Account",
   "signup_user_completed.or": "or",
+  "signup_user_completed.none": "No user creation method has been enabled.  Please contact an administrator for access.",
   "signup_user_completed.welcome": "Welcome to:",
   "signup_user_completed.onSite": "on {siteName}",
   "signup_user_completed.lets": "Let's create your account",


### PR DESCRIPTION
Previously the user sign-up page looked broken when no user sign-up methods were enabled.  This provides a simple error message informing the user that sign-ups are disabled.