### PR TITLE
Multiple minor slash command fixes

### DIFF
--- a/web/react/components/user_settings/user_settings_modal.jsx
+++ b/web/react/components/user_settings/user_settings_modal.jsx
@@ -234,7 +234,7 @@ class UserSettingsModal extends React.Component {
             tabs.push({name: 'developer', uiName: formatMessage(holders.developer), icon: 'glyphicon glyphicon-th'});
         }
 
-        if (global.window.mm_config.EnableIncomingWebhooks === 'true' || global.window.mm_config.EnableOutgoingWebhooks === 'true') {
+        if (global.window.mm_config.EnableIncomingWebhooks === 'true' || global.window.mm_config.EnableOutgoingWebhooks === 'true' || global.window.mm_config.EnableCommands === 'true') {
             tabs.push({name: 'integrations', uiName: formatMessage(holders.integrations), icon: 'glyphicon glyphicon-transfer'});
         }
         tabs.push({name: 'display', uiName: formatMessage(holders.display), icon: 'glyphicon glyphicon-eye-open'});

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -779,12 +779,18 @@ export function getSuggestedCommands(command, suggestionId, component) {
             var matches = [];
             data.forEach((cmd) => {
                 if (('/' + cmd.trigger).indexOf(command) === 0) {
+                    let s = '/' + cmd.trigger;
+                    if (cmd.auto_complete_hint && cmd.auto_complete_hint.length !== 0) {
+                        s += ' ' + cmd.auto_complete_hint;
+                    }
                     matches.push({
-                        suggestion: '/' + cmd.trigger + ' ' + cmd.auto_complete_hint,
+                        suggestion: s,
                         description: cmd.auto_complete_desc
                     });
                 }
             });
+
+            matches = matches.sort((a, b) => a.suggestion.localeCompare(b.suggestion));
 
             // pull out the suggested commands from the returned data
             const terms = matches.map((suggestion) => suggestion.suggestion);


### PR DESCRIPTION
Fixes:

1. Show integrations tab when commands are enabled, even if webhooks are disabled
2. For commands without autocomplete hints, don't add an extra space (there were two spaces after these commands)
3. Sort suggested commands alphabetically