### PR TITLE
Stopped returning inactive members with getExtraInfo calls

### DIFF
--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -615,9 +615,36 @@ func (s SqlChannelStore) GetExtraMembers(channelId string, limit int) StoreChann
 		var err error
 
 		if limit != -1 {
-			_, err = s.GetReplica().Select(&members, "SELECT Id, Nickname, Email, ChannelMembers.Roles, Username FROM ChannelMembers, Users WHERE ChannelMembers.UserId = Users.Id AND ChannelId = :ChannelId LIMIT :Limit", map[string]interface{}{"ChannelId": channelId, "Limit": limit})
+			_, err = s.GetReplica().Select(&members, `
+			SELECT
+				Id,
+				Nickname,
+				Email,
+				ChannelMembers.Roles,
+				Username
+			FROM
+				ChannelMembers,
+				Users
+			WHERE
+				ChannelMembers.UserId = Users.Id
+				AND Users.DeleteAt = 0
+				AND ChannelId = :ChannelId
+			LIMIT :Limit`, map[string]interface{}{"ChannelId": channelId, "Limit": limit})
 		} else {
-			_, err = s.GetReplica().Select(&members, "SELECT Id, Nickname, Email, ChannelMembers.Roles, Username FROM ChannelMembers, Users WHERE ChannelMembers.UserId = Users.Id AND ChannelId = :ChannelId", map[string]interface{}{"ChannelId": channelId})
+			_, err = s.GetReplica().Select(&members, `
+			SELECT
+				Id,
+				Nickname,
+				Email,
+				ChannelMembers.Roles,
+				Username
+			FROM
+				ChannelMembers,
+				Users
+			WHERE
+				ChannelMembers.UserId = Users.Id
+				AND Users.DeleteAt = 0
+				AND ChannelId = :ChannelId`, map[string]interface{}{"ChannelId": channelId})
 		}
 
 		if err != nil {

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -377,6 +377,18 @@ func TestChannelMemberStore(t *testing.T) {
 	if t4 != t3 {
 		t.Fatal("Should not update time upon failure")
 	}
+
+	// rejoin the channel and make sure that an inactive user isn't returned by GetExtraMambers
+	Must(store.Channel().SaveMember(&o2))
+
+	u2.DeleteAt = 1000
+	Must(store.User().Update(&u2, true))
+
+	if result := <-store.Channel().GetExtraMembers(o1.ChannelId, 20); result.Err != nil {
+		t.Fatal(result.Err)
+	} else if extraMembers := result.Data.([]model.ExtraMember); len(extraMembers) != 1 {
+		t.Fatal("should have 1 extra members")
+	}
 }
 
 func TestChannelDeleteMemberStore(t *testing.T) {

--- a/web/react/components/popover_list_members.jsx
+++ b/web/react/components/popover_list_members.jsx
@@ -107,7 +107,7 @@ export default class PopoverListMembers extends React.Component {
                     name = Utils.displayUsername(teamMembers[m.username].id);
                 }
 
-                if (name && teamMembers[m.username].delete_at <= 0) {
+                if (name) {
                     popoverHtml.push(
                         <div
                             className='text-nowrap'


### PR DESCRIPTION
The Invite and Manage Members modals weren't rendering because the extra info had a member_count that was less than the number of members when some of those members were deleted (member_count didn't include inactive users while the member list did). We weren't using those deleted members anywhere so I just removed them from the query.