### PR TITLE
RC2 PLT-1774 Fixing the elusive missing post bug

### DIFF
--- a/web/react/stores/post_store.jsx
+++ b/web/react/stores/post_store.jsx
@@ -83,8 +83,6 @@ class PostStoreClass extends EventEmitter {
         this.getCommentDraft = this.getCommentDraft.bind(this);
         this.clearDraftUploads = this.clearDraftUploads.bind(this);
         this.clearCommentDraftUploads = this.clearCommentDraftUploads.bind(this);
-        this.storeLatestUpdate = this.storeLatestUpdate.bind(this);
-        this.getLatestUpdate = this.getLatestUpdate.bind(this);
         this.getCurrentUsersLatestPost = this.getCurrentUsersLatestPost.bind(this);
         this.getCommentCount = this.getCommentCount.bind(this);
 
@@ -258,7 +256,7 @@ class PostStoreClass extends EventEmitter {
                 const np = newPosts.posts[pid];
                 if (np.delete_at === 0) {
                     combinedPosts.posts[pid] = np;
-                    if (combinedPosts.order.indexOf(pid) === -1) {
+                    if (combinedPosts.order.indexOf(pid) === -1 && newPosts.order.indexOf(pid) !== -1) {
                         combinedPosts.order.push(pid);
                     }
                 }
@@ -506,19 +504,6 @@ class PostStoreClass extends EventEmitter {
                 BrowserStore.setItem(key, value);
             }
         });
-    }
-    storeLatestUpdate(channelId, time) {
-        if (!this.postsInfo.hasOwnProperty(channelId)) {
-            this.postsInfo[channelId] = {};
-        }
-        this.postsInfo[channelId].latestPost = time;
-    }
-    getLatestUpdate(channelId) {
-        if (this.postsInfo.hasOwnProperty(channelId) && this.postsInfo[channelId].hasOwnProperty('latestPost')) {
-            return this.postsInfo[channelId].latestPost;
-        }
-
-        return 0;
     }
     getCommentCount(post) {
         const posts = this.getAllPosts(post.channel_id).posts;

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -521,18 +521,18 @@ export function getPosts(id) {
         return;
     }
 
-    if (PostStore.getAllPosts(channelId) == null) {
+    if ($.isEmptyObject(PostStore.getAllPosts(channelId))) {
         getPostsPage(channelId, Constants.POST_CHUNK_SIZE);
         return;
     }
 
-    const latestUpdate = PostStore.getLatestUpdate(channelId);
+    const latestPost = PostStore.getLatestPost(channelId);
 
     callTracker['getPosts_' + channelId] = utils.getTimestamp();
 
     client.getPosts(
         channelId,
-        latestUpdate,
+        latestPost.update_at,
         (data, textStatus, xhr) => {
             if (xhr.status === 304 || !data) {
                 return;

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -527,12 +527,17 @@ export function getPosts(id) {
     }
 
     const latestPost = PostStore.getLatestPost(channelId);
+    let latestPostTime = 0;
+
+    if (latestPost != null && latestPost.update_at != null) {
+        latestPostTime = latestPost.update_at;
+    }
 
     callTracker['getPosts_' + channelId] = utils.getTimestamp();
 
     client.getPosts(
         channelId,
-        latestPost.update_at,
+        latestPostTime,
         (data, textStatus, xhr) => {
             if (xhr.status === 304 || !data) {
                 return;

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -532,7 +532,7 @@ export function getPosts(id) {
     let latestPostTime = 0;
 
     if (latestPost != null && latestPost.update_at != null) {
-        latestPostTime = latestPost.update_at;
+        latestPostTime = latestPost.create_at;
     }
 
     callTracker['getPosts_' + channelId] = utils.getTimestamp();

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -521,7 +521,9 @@ export function getPosts(id) {
         return;
     }
 
-    if ($.isEmptyObject(PostStore.getAllPosts(channelId))) {
+    const postList = PostStore.getAllPosts(channelId);
+
+    if ($.isEmptyObject(postList) || postList.order.length < Constants.POST_CHUNK_SIZE) {
         getPostsPage(channelId, Constants.POST_CHUNK_SIZE);
         return;
     }


### PR DESCRIPTION
Finally! This should fix that crazy annoying bug with missing posts AND fix some major performance issues.

There were three major issues:

1. Merging of new post lists and old post lists added all the posts in the new order to the old order, even if the new post wasn't in the new order. This jacked up `getPostsBefore` and `getPostsAfter` as it screwed with what was considered the latest and earliest posts.
2. The check if a channel has any posts yet wasn't working since the store was returning an empty object rather than a null. So `getPostsSince` was hit with a timestamp of 0 instead of us grabbing the first page of posts. If you're thinking "Wait, so we were loading 1000+ posts on every channel load?!?", you would be correct. It would even happen on channels we have loaded before (though sometimes hitting the etag/caching, if there were no new posts).
3. The latest post time was not getting updated at all anymore, so was returning 0 even if we had posts in the channel. Similar results as above issue.

