### PR TITLE
RC2 PLT-1933 Emit change after setting preferences in head.html

### DIFF
--- a/web/templates/head.html
+++ b/web/templates/head.html
@@ -79,6 +79,7 @@
         $(function() {
             if (window.mm_preferences != null) {
                 PreferenceStore.setPreferences(window.mm_preferences);
+                PreferenceStore.emitChange();
             }
         });
 


### PR DESCRIPTION
For some reason Firefox mounts a bunch of components before the script tags in head.html run, so we need to emit the change to the preference store.