### PR TITLE
RC3 Fix load more messages being broken by getPostsSince call

### DIFF
--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -549,7 +549,7 @@ export function getPosts(id) {
                 type: ActionTypes.RECEIVED_POSTS,
                 id: channelId,
                 before: true,
-                numRequested: Constants.POST_CHUNK_SIZE,
+                numRequested: 0,
                 post_list: data
             });
 


### PR DESCRIPTION
We don't know how many posts we're requesting so always assume 0. We don't need to update top visibility info from getPostsSince anyways as it should only affect new posts on channel switches.