### PR TITLE
RC3 Fix badge and tab */(1) not disappearing until switching away from channel

### DIFF
--- a/web/react/components/channel_loader.jsx
+++ b/web/react/components/channel_loader.jsx
@@ -95,6 +95,8 @@ class ChannelLoader extends React.Component {
 
         $(window).on('focus', function windowFocus() {
             AsyncClient.updateLastViewedAt();
+            ChannelStore.resetCounts(ChannelStore.getCurrentId());
+            ChannelStore.emitChange();
             window.isActive = true;
         });
 

--- a/web/react/stores/channel_store.jsx
+++ b/web/react/stores/channel_store.jsx
@@ -308,7 +308,7 @@ ChannelStore.dispatchToken = AppDispatcher.register((payload) => {
         ChannelStore.storeChannels(action.channels);
         ChannelStore.storeChannelMembers(action.members);
         currentId = ChannelStore.getCurrentId();
-        if (currentId && !document.hidden) {
+        if (currentId && window.isActive) {
             ChannelStore.resetCounts(currentId);
         }
         ChannelStore.setUnreadCounts();
@@ -321,7 +321,7 @@ ChannelStore.dispatchToken = AppDispatcher.register((payload) => {
             ChannelStore.pStoreChannelMember(action.member);
         }
         currentId = ChannelStore.getCurrentId();
-        if (currentId && !document.hidden) {
+        if (currentId && window.isActive) {
             ChannelStore.resetCounts(currentId);
         }
         ChannelStore.setUnreadCount(action.channel.id);

--- a/web/react/stores/socket_store.jsx
+++ b/web/react/stores/socket_store.jsx
@@ -202,10 +202,10 @@ function handleNewPostEvent(msg, translations) {
 
     // Update channel state
     if (ChannelStore.getCurrentId() === msg.channel_id) {
-        if (document.hidden) {
-            AsyncClient.getChannel(msg.channel_id);
-        } else {
+        if (window.isActive) {
             AsyncClient.updateLastViewedAt();
+        } else {
+            AsyncClient.getChannel(msg.channel_id);
         }
     } else if (UserStore.getCurrentId() !== msg.user_id || post.type !== Constants.POST_TYPE_JOIN_LEAVE) {
         AsyncClient.getChannel(msg.channel_id);


### PR DESCRIPTION
Switched back to using window.isActive since document.hidden will only be true when the tab is not active, when the window is minimized (not including behind another window), or when the screen is locked.

Also reset counts for the current channel when the window becomes active again.

This should fix having to switch away from the channel to get the badge and the tab name to reset.

I ran through the cases with @lfbrock and this is the behaviour we want. I tested on Chrome, Safari, Firefox, IE and Edge.
