### PR TITLE
PLT-2183 Slash command auto-complete

### DIFF
--- a/api/command.go
+++ b/api/command.go
@@ -44,7 +44,7 @@ func InitCommand(r *mux.Router) {
 	sr := r.PathPrefix("/commands").Subrouter()
 
 	sr.Handle("/execute", ApiUserRequired(executeCommand)).Methods("POST")
-	sr.Handle("/list", ApiUserRequired(listCommands)).Methods("GET")
+	sr.Handle("/list", ApiUserRequired(listCommands)).Methods("POST")
 
 	sr.Handle("/create", ApiUserRequired(createCommand)).Methods("POST")
 	sr.Handle("/list_team_commands", ApiUserRequired(listTeamCommands)).Methods("GET")
@@ -76,7 +76,9 @@ func listCommands(c *Context, w http.ResponseWriter, r *http.Request) {
 		} else {
 			teamCmds := result.Data.([]*model.Command)
 			for _, cmd := range teamCmds {
-				if cmd.AutoComplete && !seen[cmd.Id] {
+				if cmd.ExternalManagement {
+					commands = append(commands, autocompleteCommands(c, cmd, r)...)
+				} else if cmd.AutoComplete && !seen[cmd.Id] {
 					cmd.Sanitize()
 					seen[cmd.Trigger] = true
 					commands = append(commands, cmd)
@@ -86,6 +88,92 @@ func listCommands(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write([]byte(model.CommandListToJson(commands)))
+}
+
+func autocompleteCommands(c *Context, cmd *model.Command, r *http.Request) []*model.Command {
+	props := model.MapFromJson(r.Body)
+	command := strings.TrimSpace(props["command"])
+	channelId := strings.TrimSpace(props["channelId"])
+	parts := strings.Split(command, " ")
+	trigger := parts[0][1:]
+	message := strings.Join(parts[1:], " ")
+
+	chanChan := Srv.Store.Channel().Get(channelId)
+	teamChan := Srv.Store.Team().Get(c.Session.TeamId)
+	userChan := Srv.Store.User().Get(c.Session.UserId)
+
+	var team *model.Team
+	if tr := <-teamChan; tr.Err != nil {
+		c.Err = tr.Err
+		return make([]*model.Command, 0, 32)
+	} else {
+		team = tr.Data.(*model.Team)
+	}
+
+	var user *model.User
+	if ur := <-userChan; ur.Err != nil {
+		c.Err = ur.Err
+		return make([]*model.Command, 0, 32)
+	} else {
+		user = ur.Data.(*model.User)
+	}
+
+	var channel *model.Channel
+	if cr := <-chanChan; cr.Err != nil {
+		c.Err = cr.Err
+		return make([]*model.Command, 0, 32)
+	} else {
+		channel = cr.Data.(*model.Channel)
+	}
+
+	l4g.Debug(fmt.Sprintf(utils.T("api.command.execute_command.debug"), trigger, c.Session.UserId))
+	p := url.Values{}
+	p.Set("token", cmd.Token)
+
+	p.Set("team_id", cmd.TeamId)
+	p.Set("team_domain", team.Name)
+
+	p.Set("channel_id", channelId)
+	p.Set("channel_name", channel.Name)
+
+	p.Set("user_id", c.Session.UserId)
+	p.Set("user_name", user.Username)
+
+	p.Set("command", "/"+trigger)
+	p.Set("text", message)
+	p.Set("response_url", "not supported yet")
+	p.Set("suggest", "true")
+
+	method := "POST"
+	if cmd.Method == model.COMMAND_METHOD_GET {
+		method = "GET"
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: *utils.Cfg.ServiceSettings.EnableInsecureOutgoingConnections},
+	}
+	client := &http.Client{Transport: tr}
+
+	req, _ := http.NewRequest(method, cmd.URL, strings.NewReader(p.Encode()))
+	req.Header.Set("Accept", "application/json")
+	if cmd.Method == model.COMMAND_METHOD_POST {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	if resp, err := client.Do(req); err != nil {
+		c.Err = model.NewLocAppError("command", "api.command.execute_command.failed.app_error", map[string]interface{}{"Trigger": trigger}, err.Error())
+	} else {
+		if resp.StatusCode == http.StatusOK {
+			response := model.CommandListFromJson(resp.Body)
+
+			return response
+
+		} else {
+			body, _ := ioutil.ReadAll(resp.Body)
+			c.Err = model.NewLocAppError("command", "api.command.execute_command.failed_resp.app_error", map[string]interface{}{"Trigger": trigger, "Status": resp.Status}, string(body))
+		}
+	}
+	return make([]*model.Command, 0, 32)
 }
 
 func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -159,7 +247,7 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 
 			teamCmds := result.Data.([]*model.Command)
 			for _, cmd := range teamCmds {
-				if trigger == cmd.Trigger {
+				if trigger == cmd.Trigger || cmd.ExternalManagement {
 					l4g.Debug(fmt.Sprintf(utils.T("api.command.execute_command.debug"), trigger, c.Session.UserId))
 
 					p := url.Values{}

--- a/api/command_test.go
+++ b/api/command_test.go
@@ -24,7 +24,10 @@ func TestListCommands(t *testing.T) {
 
 	Client.LoginByEmail(team.Name, user1.Email, "pwd")
 
-	if results, err := Client.ListCommands(); err != nil {
+	channel1 := &model.Channel{DisplayName: "AA", Name: "aa" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
+
+	if results, err := Client.ListCommands(channel1.Id, "/test"); err != nil {
 		t.Fatal(err)
 	} else {
 		commands := results.Data.([]*model.Command)

--- a/model/client.go
+++ b/model/client.go
@@ -363,8 +363,11 @@ func (c *Client) Command(channelId string, command string, suggest bool) (*Resul
 	}
 }
 
-func (c *Client) ListCommands() (*Result, *AppError) {
-	if r, err := c.DoApiGet("/commands/list", "", ""); err != nil {
+func (c *Client) ListCommands(channelId string, command string) (*Result, *AppError) {
+	m := make(map[string]string)
+	m["command"] = command
+	m["channelId"] = channelId
+	if r, err := c.DoApiPost("/commands/list", MapToJson(m)); err != nil {
 		return nil, err
 	} else {
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),

--- a/model/command.go
+++ b/model/command.go
@@ -14,22 +14,23 @@ const (
 )
 
 type Command struct {
-	Id               string `json:"id"`
-	Token            string `json:"token"`
-	CreateAt         int64  `json:"create_at"`
-	UpdateAt         int64  `json:"update_at"`
-	DeleteAt         int64  `json:"delete_at"`
-	CreatorId        string `json:"creator_id"`
-	TeamId           string `json:"team_id"`
-	Trigger          string `json:"trigger"`
-	Method           string `json:"method"`
-	Username         string `json:"username"`
-	IconURL          string `json:"icon_url"`
-	AutoComplete     bool   `json:"auto_complete"`
-	AutoCompleteDesc string `json:"auto_complete_desc"`
-	AutoCompleteHint string `json:"auto_complete_hint"`
-	DisplayName      string `json:"display_name"`
-	URL              string `json:"url"`
+	Id                 string `json:"id"`
+	Token              string `json:"token"`
+	CreateAt           int64  `json:"create_at"`
+	UpdateAt           int64  `json:"update_at"`
+	DeleteAt           int64  `json:"delete_at"`
+	CreatorId          string `json:"creator_id"`
+	TeamId             string `json:"team_id"`
+	ExternalManagement bool   `json:"external_management"`
+	Trigger            string `json:"trigger"`
+	Method             string `json:"method"`
+	Username           string `json:"username"`
+	IconURL            string `json:"icon_url"`
+	AutoComplete       bool   `json:"auto_complete"`
+	AutoCompleteDesc   string `json:"auto_complete_desc"`
+	AutoCompleteHint   string `json:"auto_complete_hint"`
+	DisplayName        string `json:"display_name"`
+	URL                string `json:"url"`
 }
 
 func (o *Command) ToJson() string {

--- a/store/sql_command_store.go
+++ b/store/sql_command_store.go
@@ -34,6 +34,7 @@ func NewSqlCommandStore(sqlStore *SqlStore) CommandStore {
 }
 
 func (s SqlCommandStore) UpgradeSchemaIfNeeded() {
+	s.CreateColumnIfNotExists("Commands", "ExternalManagement", "tinyint(1)", "boolean", "0")
 }
 
 func (s SqlCommandStore) CreateIndexesIfNotExists() {

--- a/webapp/components/suggestion/command_provider.jsx
+++ b/webapp/components/suggestion/command_provider.jsx
@@ -37,9 +37,9 @@ CommandSuggestion.propTypes = {
 };
 
 export default class CommandProvider {
-    handlePretextChanged(suggestionId, pretext) {
+    handlePretextChanged(suggestionId, pretext, channelId) {
         if (pretext.startsWith('/')) {
-            AsyncClient.getSuggestedCommands(pretext, suggestionId, CommandSuggestion);
+            AsyncClient.getSuggestedCommands(pretext, channelId, suggestionId, CommandSuggestion);
         }
     }
 }

--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -160,6 +160,7 @@ SuggestionBox.propTypes = {
     value: React.PropTypes.string.isRequired,
     onUserInput: React.PropTypes.func,
     providers: React.PropTypes.arrayOf(React.PropTypes.object),
+    channelId: React.PropTypes.string,
 
     // explicitly name any input event handlers we override and need to manually call
     onChange: React.PropTypes.func,

--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -111,7 +111,7 @@ export default class SuggestionBox extends React.Component {
 
     handlePretextChanged(pretext) {
         for (const provider of this.props.providers) {
-            provider.handlePretextChanged(this.suggestionId, pretext);
+            provider.handlePretextChanged(this.suggestionId, pretext, this.props.channelId);
         }
     }
 

--- a/webapp/components/textbox.jsx
+++ b/webapp/components/textbox.jsx
@@ -224,6 +224,7 @@ export default class Textbox extends React.Component {
                     style={{visibility: this.state.preview ? 'hidden' : 'visible'}}
                     listComponent={SuggestionList}
                     providers={this.suggestionProviders}
+                    channelId={this.props.channelId}
                 />
                 <div
                     ref='preview'

--- a/webapp/components/user_settings/manage_command_hooks.jsx
+++ b/webapp/components/user_settings/manage_command_hooks.jsx
@@ -463,8 +463,8 @@ export default class ManageCommandCmds extends React.Component {
                                     onChange={this.updateExternalManagement}
                                 />
                                 <FormattedMessage
-                                    id='user.settings.cmds.external_management_help'
-                                    defaultMessage=' Let an external integration manage commands.'
+                                    id='user.settings.cmds.slashCmd_autocmp'
+                                    defaultMessage='Enable external application to offer autocomplete'
                                 />
                             </label>
                         </div>

--- a/webapp/components/user_settings/manage_command_hooks.jsx
+++ b/webapp/components/user_settings/manage_command_hooks.jsx
@@ -4,8 +4,12 @@
 import LoadingScreen from '../loading_screen.jsx';
 
 import * as Client from 'utils/client.jsx';
+import * as Utils from 'utils/utils.jsx';
+import Constants from 'utils/constants.jsx';
 
 import {intlShape, injectIntl, defineMessages, FormattedMessage, FormattedHTMLMessage} from 'react-intl';
+
+const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
 const holders = defineMessages({
     requestTypePost: {
@@ -277,11 +281,9 @@ export default class ManageCommandCmds extends React.Component {
                 );
             }
 
-            cmds.push(
-                <div
-                    key={cmd.id}
-                    className='webhook__item webcmd__item'
-                >
+            let slashCommandAutocompleteDiv;
+            if (Utils.isFeatureEnabled(PreReleaseFeatures.SLASHCMD_AUTOCMP)) {
+                slashCommandAutocompleteDiv = (
                     <div className='padding-top x2'>
                         <strong>
                             <FormattedMessage
@@ -290,6 +292,15 @@ export default class ManageCommandCmds extends React.Component {
                             />
                         </strong><span className='word-break--all'>{cmd.external_management ? this.props.intl.formatMessage(holders.autocompleteYes) : this.props.intl.formatMessage(holders.autocompleteNo)}</span>
                     </div>
+                );
+            }
+
+            cmds.push(
+                <div
+                    key={cmd.id}
+                    className='webhook__item webcmd__item'
+                >
+                    {slashCommandAutocompleteDiv}
                     {triggerDiv}
                     <div className='padding-top x2 webcmd__url'>
                         <strong>
@@ -433,6 +444,36 @@ export default class ManageCommandCmds extends React.Component {
 
         const disableButton = this.state.cmd.url === '' || (this.state.cmd.trigger === '' && !this.state.external_management);
 
+        let slashCommandAutocompleteCheckbox;
+        if (Utils.isFeatureEnabled(PreReleaseFeatures.SLASHCMD_AUTOCMP)) {
+            slashCommandAutocompleteCheckbox = (
+                <div className='padding-top x2'>
+                    <label className='control-label'>
+                        <FormattedMessage
+                            id='user.settings.cmds.external_management'
+                            defaultMessage='External management: '
+                        />
+                    </label>
+                    <div className='padding-top'>
+                        <div className='checkbox'>
+                            <label>
+                                <input
+                                    type='checkbox'
+                                    checked={this.state.cmd.external_management}
+                                    onChange={this.updateExternalManagement}
+                                />
+                                <FormattedMessage
+                                    id='user.settings.cmds.external_management_help'
+                                    defaultMessage=' Let an external integration manage commands.'
+                                />
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+            );
+        }
+
         return (
             <div key='addCommandCmd'>
                 <FormattedHTMLMessage
@@ -449,30 +490,7 @@ export default class ManageCommandCmds extends React.Component {
                 <div className='padding-top'>
 
                     <div className='padding-top x2'>
-                        <label className='control-label'>
-                            <FormattedMessage
-                                id='user.settings.cmds.external_management'
-                                defaultMessage='External management: '
-                            />
-                        </label>
-                        <div className='padding-top'>
-                            <div className='checkbox'>
-                                <label>
-                                    <input
-                                        type='checkbox'
-                                        checked={this.state.cmd.external_management}
-                                        onChange={this.updateExternalManagement}
-                                    />
-                                    <FormattedMessage
-                                        id='user.settings.cmds.external_management_help'
-                                        defaultMessage=' Let an external integration manage commands.'
-                                    />
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className='padding-top x2'>
+                        {slashCommandAutocompleteCheckbox}
                         <label className='control-label'>
                             <FormattedMessage
                                 id='user.settings.cmds.trigger'

--- a/webapp/components/user_settings/manage_command_hooks.jsx
+++ b/webapp/components/user_settings/manage_command_hooks.jsx
@@ -444,6 +444,35 @@ export default class ManageCommandCmds extends React.Component {
 
         const disableButton = this.state.cmd.url === '' || (this.state.cmd.trigger === '' && !this.state.external_management);
 
+        let triggerInput;
+        if (!this.state.cmd.external_management) {
+            triggerInput = (
+                <div className='padding-top x2'>
+                    <label className='control-label'>
+                        <FormattedMessage
+                            id='user.settings.cmds.trigger'
+                            defaultMessage='Command Trigger Word: '
+                        />
+                    </label>
+                    <div className='padding-top'>
+                        <input
+                            ref='trigger'
+                            className='form-control'
+                            value={this.state.cmd.trigger}
+                            onChange={this.updateTrigger}
+                            placeholder={this.props.intl.formatMessage(holders.addTriggerPlaceholder)}
+                        />
+                    </div>
+                    <div className='padding-top'>
+                        <FormattedMessage
+                            id='user.settings.cmds.trigger_desc'
+                            defaultMessage='Examples: /patient, /client, /employee Reserved: /echo, /join, /logout, /me, /shrug'
+                        />
+                    </div>
+                </div>
+            );
+        }
+
         let slashCommandAutocompleteCheckbox;
         if (Utils.isFeatureEnabled(PreReleaseFeatures.SLASHCMD_AUTOCMP)) {
             slashCommandAutocompleteCheckbox = (
@@ -474,6 +503,110 @@ export default class ManageCommandCmds extends React.Component {
             );
         }
 
+        let autoCompleteSettings;
+        if (!this.state.cmd.external_management) {
+            autoCompleteSettings = (
+                <div>
+                    <div className='padding-top x2'>
+                        <label className='control-label'>
+                            <FormattedMessage
+                                id='user.settings.cmds.auto_complete'
+                                defaultMessage='Autocomplete: '
+                            />
+                        </label>
+                        <div className='padding-top'>
+                            <div className='checkbox'>
+                                <label>
+                                    <input
+                                        type='checkbox'
+                                        checked={this.state.cmd.auto_complete}
+                                        onChange={this.updateAutoComplete}
+                                    />
+                                    <FormattedMessage
+                                        id='user.settings.cmds.auto_complete_help'
+                                        defaultMessage=' Show this command in the autocomplete list.'
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className='padding-top x2'>
+                        <label className='control-label'>
+                            <FormattedMessage
+                                id='user.settings.cmds.auto_complete_hint'
+                                defaultMessage='Autocomplete Hint: '
+                            />
+                        </label>
+                        <div className='padding-top'>
+                            <input
+                                ref='autoCompleteHint'
+                                className='form-control'
+                                value={this.state.cmd.auto_complete_hint}
+                                onChange={this.updateAutoCompleteHint}
+                                placeholder={this.props.intl.formatMessage(holders.addAutoCompleteHintPlaceholder)}
+                            />
+                        </div>
+                        <div className='padding-top'>
+                            <FormattedMessage
+                                id='user.settings.cmds.auto_complete_hint_desc'
+                                defaultMessage='Optional hint in the autocomplete list about parameters needed for command.'
+                            />
+                        </div>
+                    </div>
+
+                    <div className='padding-top x2'>
+                        <label className='control-label'>
+                            <FormattedMessage
+                                id='user.settings.cmds.auto_complete_desc'
+                                defaultMessage='Autocomplete Description: '
+                            />
+                        </label>
+                        <div className='padding-top'>
+                            <input
+                                ref='autoCompleteDesc'
+                                className='form-control'
+                                value={this.state.cmd.auto_complete_desc}
+                                onChange={this.updateAutoCompleteDesc}
+                                placeholder={this.props.intl.formatMessage(holders.addAutoCompleteDescPlaceholder)}
+                            />
+                        </div>
+                        <div className='padding-top'>
+                            <FormattedMessage
+                                id='user.settings.cmds.auto_complete_desc_desc'
+                                defaultMessage='Optional short description of slash command for the autocomplete list.'
+                            />
+                        </div>
+                    </div>
+
+                    <div className='padding-top x2'>
+                        <label className='control-label'>
+                            <FormattedMessage
+                                id='user.settings.cmds.display_name'
+                                defaultMessage='Descriptive Label: '
+                            />
+                        </label>
+                        <div className='padding-top'>
+                            <input
+                                ref='displayName'
+                                className='form-control'
+                                value={this.state.cmd.display_name}
+                                onChange={this.updateDisplayName}
+                                placeholder={this.props.intl.formatMessage(holders.addDisplayNamePlaceholder)}
+                            />
+                        </div>
+                        <div className='padding-top'>
+                            <FormattedMessage
+                                id='user.settings.cmds.cmd_display_name'
+                                defaultMessage='Brief description of slash command to show in listings.'
+                            />
+                        </div>
+                        {addError}
+                    </div>
+                </div>
+            );
+        }
+
         return (
             <div key='addCommandCmd'>
                 <FormattedHTMLMessage
@@ -489,30 +622,8 @@ export default class ManageCommandCmds extends React.Component {
                 <div className='padding-top divider-light'></div>
                 <div className='padding-top'>
 
-                    <div className='padding-top x2'>
-                        {slashCommandAutocompleteCheckbox}
-                        <label className='control-label'>
-                            <FormattedMessage
-                                id='user.settings.cmds.trigger'
-                                defaultMessage='Command Trigger Word: '
-                            />
-                        </label>
-                        <div className='padding-top'>
-                            <input
-                                ref='trigger'
-                                className='form-control'
-                                value={this.state.cmd.trigger}
-                                onChange={this.updateTrigger}
-                                placeholder={this.props.intl.formatMessage(holders.addTriggerPlaceholder)}
-                            />
-                        </div>
-                        <div className='padding-top'>
-                            <FormattedMessage
-                                id='user.settings.cmds.trigger_desc'
-                                defaultMessage='Examples: /patient, /client, /employee Reserved: /echo, /join, /logout, /me, /shrug'
-                            />
-                        </div>
-                    </div>
+                    {slashCommandAutocompleteCheckbox}
+                    {triggerInput}
 
                     <div className='padding-top x2'>
                         <label className='control-label'>
@@ -617,102 +728,7 @@ export default class ManageCommandCmds extends React.Component {
                         </div>
                     </div>
 
-                    <div className='padding-top x2'>
-                        <label className='control-label'>
-                            <FormattedMessage
-                                id='user.settings.cmds.auto_complete'
-                                defaultMessage='Autocomplete: '
-                            />
-                        </label>
-                        <div className='padding-top'>
-                            <div className='checkbox'>
-                                <label>
-                                    <input
-                                        type='checkbox'
-                                        checked={this.state.cmd.auto_complete}
-                                        onChange={this.updateAutoComplete}
-                                    />
-                                    <FormattedMessage
-                                        id='user.settings.cmds.auto_complete_help'
-                                        defaultMessage=' Show this command in the autocomplete list.'
-                                    />
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className='padding-top x2'>
-                        <label className='control-label'>
-                            <FormattedMessage
-                                id='user.settings.cmds.auto_complete_hint'
-                                defaultMessage='Autocomplete Hint: '
-                            />
-                        </label>
-                        <div className='padding-top'>
-                            <input
-                                ref='autoCompleteHint'
-                                className='form-control'
-                                value={this.state.cmd.auto_complete_hint}
-                                onChange={this.updateAutoCompleteHint}
-                                placeholder={this.props.intl.formatMessage(holders.addAutoCompleteHintPlaceholder)}
-                            />
-                        </div>
-                        <div className='padding-top'>
-                            <FormattedMessage
-                                id='user.settings.cmds.auto_complete_hint_desc'
-                                defaultMessage='Optional hint in the autocomplete list about parameters needed for command.'
-                            />
-                        </div>
-                    </div>
-
-                    <div className='padding-top x2'>
-                        <label className='control-label'>
-                            <FormattedMessage
-                                id='user.settings.cmds.auto_complete_desc'
-                                defaultMessage='Autocomplete Description: '
-                            />
-                        </label>
-                        <div className='padding-top'>
-                            <input
-                                ref='autoCompleteDesc'
-                                className='form-control'
-                                value={this.state.cmd.auto_complete_desc}
-                                onChange={this.updateAutoCompleteDesc}
-                                placeholder={this.props.intl.formatMessage(holders.addAutoCompleteDescPlaceholder)}
-                            />
-                        </div>
-                        <div className='padding-top'>
-                            <FormattedMessage
-                                id='user.settings.cmds.auto_complete_desc_desc'
-                                defaultMessage='Optional short description of slash command for the autocomplete list.'
-                            />
-                        </div>
-                    </div>
-
-                    <div className='padding-top x2'>
-                        <label className='control-label'>
-                            <FormattedMessage
-                                id='user.settings.cmds.display_name'
-                                defaultMessage='Descriptive Label: '
-                            />
-                        </label>
-                        <div className='padding-top'>
-                            <input
-                                ref='displayName'
-                                className='form-control'
-                                value={this.state.cmd.display_name}
-                                onChange={this.updateDisplayName}
-                                placeholder={this.props.intl.formatMessage(holders.addDisplayNamePlaceholder)}
-                            />
-                        </div>
-                        <div className='padding-top'>
-                            <FormattedMessage
-                                id='user.settings.cmds.cmd_display_name'
-                                defaultMessage='Brief description of slash command to show in listings.'
-                            />
-                        </div>
-                        {addError}
-                    </div>
+                    {autoCompleteSettings}
 
                     <div className='padding-top x2 padding-bottom'>
                         <a

--- a/webapp/components/user_settings/manage_command_hooks.jsx
+++ b/webapp/components/user_settings/manage_command_hooks.jsx
@@ -59,6 +59,7 @@ export default class ManageCommandCmds extends React.Component {
         this.getCmds = this.getCmds.bind(this);
         this.addNewCmd = this.addNewCmd.bind(this);
         this.emptyCmd = this.emptyCmd.bind(this);
+        this.updateExternalManagement = this.updateExternalManagement.bind(this);
         this.updateTrigger = this.updateTrigger.bind(this);
         this.updateURL = this.updateURL.bind(this);
         this.updateMethod = this.updateMethod.bind(this);
@@ -99,7 +100,7 @@ export default class ManageCommandCmds extends React.Component {
     addNewCmd(e) {
         e.preventDefault();
 
-        if (this.state.cmd.trigger === '' || this.state.cmd.url === '') {
+        if (this.state.cmd.url === '' || (this.state.cmd.trigger === '' && !this.state.external_management)) {
             return;
         }
 
@@ -189,6 +190,12 @@ export default class ManageCommandCmds extends React.Component {
         );
     }
 
+    updateExternalManagement(e) {
+        var cmd = this.state.cmd;
+        cmd.external_management = e.target.checked;
+        this.setState(cmd);
+    }
+
     updateTrigger(e) {
         var cmd = this.state.cmd;
         cmd.trigger = e.target.value;
@@ -275,6 +282,14 @@ export default class ManageCommandCmds extends React.Component {
                     key={cmd.id}
                     className='webhook__item webcmd__item'
                 >
+                    <div className='padding-top x2'>
+                        <strong>
+                            <FormattedMessage
+                                id='user.settings.cmds.external_management'
+                                defaultMessage='External management: '
+                            />
+                        </strong><span className='word-break--all'>{cmd.external_management ? this.props.intl.formatMessage(holders.autocompleteYes) : this.props.intl.formatMessage(holders.autocompleteNo)}</span>
+                    </div>
                     {triggerDiv}
                     <div className='padding-top x2 webcmd__url'>
                         <strong>
@@ -416,7 +431,7 @@ export default class ManageCommandCmds extends React.Component {
             </div>
         );
 
-        const disableButton = this.state.cmd.trigger === '' || this.state.cmd.url === '';
+        const disableButton = this.state.cmd.url === '' || (this.state.cmd.trigger === '' && !this.state.external_management);
 
         return (
             <div key='addCommandCmd'>
@@ -432,6 +447,30 @@ export default class ManageCommandCmds extends React.Component {
                 </label></div>
                 <div className='padding-top divider-light'></div>
                 <div className='padding-top'>
+
+                    <div className='padding-top x2'>
+                        <label className='control-label'>
+                            <FormattedMessage
+                                id='user.settings.cmds.external_management'
+                                defaultMessage='External management: '
+                            />
+                        </label>
+                        <div className='padding-top'>
+                            <div className='checkbox'>
+                                <label>
+                                    <input
+                                        type='checkbox'
+                                        checked={this.state.cmd.external_management}
+                                        onChange={this.updateExternalManagement}
+                                    />
+                                    <FormattedMessage
+                                        id='user.settings.cmds.external_management_help'
+                                        defaultMessage=' Let an external integration manage commands.'
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
 
                     <div className='padding-top x2'>
                         <label className='control-label'>

--- a/webapp/components/user_settings/user_settings_advanced.jsx
+++ b/webapp/components/user_settings/user_settings_advanced.jsx
@@ -51,6 +51,10 @@ const holders = defineMessages({
     EMBED_TOGGLE: {
         id: 'user.settings.advance.embed_toggle',
         defaultMessage: 'Show toggle for all embed previews'
+    },
+    SLASHCMD_AUTOCMP: {
+        id: 'user.settings.advance.slashCmd_autocmp',
+        defaultMessage: 'Enable external application to offer slash command autocomplete'
     }
 });
 

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1139,6 +1139,7 @@
   "user.settings.cmds.url_desc": "The callback URL to receive the HTTP POST or GET event request when the slash command is run.",
   "user.settings.cmds.username": "Response Username: ",
   "user.settings.cmds.username_desc": "Choose a username override for responses for this slash command. Usernames can consist of up to 22 characters consisting of lowercase letters, numbers and they symbols \"-\", \"_\", and \".\" .",
+  "user.settings.cmds.slashCmd_autocmp": "Enable external application to offer autocomplete",
   "user.settings.custom_theme.awayIndicator": "Away Indicator",
   "user.settings.custom_theme.buttonBg": "Button BG",
   "user.settings.custom_theme.buttonColor": "Button Text",

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1091,6 +1091,7 @@
   "tutorial_tip.seen": "Seen this before? ",
   "upload_overlay.info": "Drop a file to upload it.",
   "user.settings.advance.embed_preview": "Show preview snippet of links below message",
+  "user.settings.advance.slashCmd_autocmp": "Enable external application to offer slash command autocomplete",
   "user.settings.advance.embed_toggle": "Show toggle for all embed previews",
   "user.settings.advance.enabled": "enabled",
   "user.settings.advance.feature": " Feature ",

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -756,10 +756,7 @@ export function savePreferences(preferences, success, error) {
 }
 
 export function getSuggestedCommands(command, channelId, suggestionId, component) {
-    client.listCommands({
-            command: command,
-            channelId: channelId
-        },
+    client.listCommands({command: command, channelId: channelId},
         (data) => {
             var matches = [];
             data.forEach((cmd) => {

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -755,12 +755,15 @@ export function savePreferences(preferences, success, error) {
     );
 }
 
-export function getSuggestedCommands(command, suggestionId, component) {
-    client.listCommands(
+export function getSuggestedCommands(command, channelId, suggestionId, component) {
+    client.listCommands({
+            command: command,
+            channelId: channelId
+        },
         (data) => {
             var matches = [];
             data.forEach((cmd) => {
-                if (('/' + cmd.trigger).indexOf(command) === 0) {
+                if (('/' + cmd.trigger).indexOf(command) === 0 || cmd.external_management) {
                     let s = '/' + cmd.trigger;
                     let hint = '';
                     if (cmd.auto_complete_hint && cmd.auto_complete_hint.length !== 0) {

--- a/webapp/utils/client.jsx
+++ b/webapp/utils/client.jsx
@@ -1002,12 +1002,13 @@ export function regenCommandToken(data, success, error) {
     });
 }
 
-export function listCommands(success, error) {
+export function listCommands(data, success, error) {
     $.ajax({
         url: '/api/v1/commands/list',
         dataType: 'json',
         contentType: 'application/json',
-        type: 'GET',
+        type: 'POST',
+        data: JSON.stringify(data),
         success,
         error: function onError(xhr, status, err) {
             var e = handleError('listCommands', xhr, status, err);

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -560,6 +560,10 @@ export default {
         EMBED_TOGGLE: {
             label: 'embed_toggle',
             description: 'Show toggle for all embed previews'
+        },
+        SLASHCMD_AUTOCMP: {
+            label: 'slashCmd_autocmp',
+            description: 'Enable external application to offer slash command autocomplete'
         }
     },
     OVERLAY_TIME_DELAY: 400,


### PR DESCRIPTION
This is a new approach for #1353 but based on slashcommands, not outgoing webhooks.
I believe it will be more consistent this way.

It works like this:
If you create a slash command with"External management" checked and a url, /api/v1/commands/list will contact your server for autocompleted slashcommands.
Then if you send any non built-in command, your server will receive it.

I'll try to make some doc with my bad english.

Please let me know if something is wrong or strange with this PR.

@florianorben and @coreyhulen may have a look, as they may remember my previous work on this.