### PR TITLE
PLT-1515 Changed wording in the password change email to be consistent

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1165,7 +1165,7 @@
   },
   {
     "id": "api.templates.password_change_body.title",
-    "translation": "You updated your password"
+    "translation": "Your password has been updated"
   },
   {
     "id": "api.templates.password_change_subject",


### PR DESCRIPTION
The wording in the password change email was modified to be more ambiguous in case an admin reset the password (instead of the user initiating the change), but part of the wording was left unchanged.