### PR TITLE
PLT-1688 Fixed issue with corrupted custom mentions on username change

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -159,7 +159,7 @@ func (us SqlUserStore) Update(user *model.User, allowActiveUpdate bool) StoreCha
 						nonUsernameKeys = append(nonUsernameKeys, key)
 					}
 				}
-				user.NotifyProps["mention_keys"] = strings.Join(nonUsernameKeys, ",") + user.Username + ",@" + user.Username
+				user.NotifyProps["mention_keys"] = strings.Join(nonUsernameKeys, ",") + "," + user.Username + ",@" + user.Username
 			}
 
 			if count, err := us.GetMaster().Update(user); err != nil {


### PR DESCRIPTION
Previously changing your username would cause the new name to be appended to the custom mention string's last value (as there was no comma separator).  Is now properly parsed out to enable the separate username mention setting.