### PR TITLE
PLT-1770 Refactor store listeners out of highly used components

### DIFF
--- a/web/react/components/center_panel.jsx
+++ b/web/react/components/center_panel.jsx
@@ -27,20 +27,24 @@ export default class CenterPanel extends React.Component {
 
         this.onPreferenceChange = this.onPreferenceChange.bind(this);
         this.onChannelChange = this.onChannelChange.bind(this);
+        this.onUserChange = this.onUserChange.bind(this);
 
         const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 999);
         this.state = {
             showTutorialScreens: tutorialStep === TutorialSteps.INTRO_SCREENS,
-            showPostFocus: ChannelStore.getPostMode() === ChannelStore.POST_MODE_FOCUS
+            showPostFocus: ChannelStore.getPostMode() === ChannelStore.POST_MODE_FOCUS,
+            user: UserStore.getCurrentUser()
         };
     }
     componentDidMount() {
         PreferenceStore.addChangeListener(this.onPreferenceChange);
         ChannelStore.addChangeListener(this.onChannelChange);
+        UserStore.addChangeListener(this.onUserChange);
     }
     componentWillUnmount() {
         PreferenceStore.removeChangeListener(this.onPreferenceChange);
         ChannelStore.removeChangeListener(this.onChannelChange);
+        UserStore.removeChangeListener(this.onUserChange);
     }
     onPreferenceChange() {
         const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 999);
@@ -48,6 +52,9 @@ export default class CenterPanel extends React.Component {
     }
     onChannelChange() {
         this.setState({showPostFocus: ChannelStore.getPostMode() === ChannelStore.POST_MODE_FOCUS});
+    }
+    onUserChange() {
+        this.setState({user: UserStore.getCurrentUser()});
     }
     render() {
         const channel = ChannelStore.getCurrent();
@@ -108,7 +115,9 @@ export default class CenterPanel extends React.Component {
                         className='app__content'
                     >
                         <div id='channel-header'>
-                            <ChannelHeader/>
+                            <ChannelHeader
+                                user={this.state.user}
+                            />
                         </div>
                         {postsContainer}
                         {createPost}

--- a/web/react/components/channel_header.jsx
+++ b/web/react/components/channel_header.jsx
@@ -147,8 +147,8 @@ export default class ChannelHeader extends React.Component {
             </Popover>
         );
         let channelTitle = channel.display_name;
-        const currentId = this.prop.user.id;
-        const isAdmin = Utils.isAdmin(this.state.memberChannel.roles) || Utils.isAdmin(this.state.memberTeam.roles);
+        const currentId = this.props.user.id;
+        const isAdmin = Utils.isAdmin(this.state.memberChannel.roles) || Utils.isAdmin(this.props.user.roles);
         const isDirect = (this.state.channel.type === 'D');
 
         if (isDirect) {

--- a/web/react/components/channel_header.jsx
+++ b/web/react/components/channel_header.jsx
@@ -51,7 +51,6 @@ export default class ChannelHeader extends React.Component {
         return {
             channel: ChannelStore.getCurrent(),
             memberChannel: ChannelStore.getCurrentMember(),
-            memberTeam: UserStore.getCurrentUser(),
             users: extraInfo.members,
             userCount: extraInfo.member_count,
             searchVisible: SearchStore.getSearchResults() !== null
@@ -61,14 +60,12 @@ export default class ChannelHeader extends React.Component {
         ChannelStore.addChangeListener(this.onListenerChange);
         ChannelStore.addExtraInfoChangeListener(this.onListenerChange);
         SearchStore.addSearchChangeListener(this.onListenerChange);
-        UserStore.addChangeListener(this.onListenerChange);
         PreferenceStore.addChangeListener(this.onListenerChange);
     }
     componentWillUnmount() {
         ChannelStore.removeChangeListener(this.onListenerChange);
         ChannelStore.removeExtraInfoChangeListener(this.onListenerChange);
         SearchStore.removeSearchChangeListener(this.onListenerChange);
-        UserStore.removeChangeListener(this.onListenerChange);
         PreferenceStore.removeChangeListener(this.onListenerChange);
     }
     onListenerChange() {
@@ -97,11 +94,11 @@ export default class ChannelHeader extends React.Component {
     searchMentions(e) {
         e.preventDefault();
 
-        const user = UserStore.getCurrentUser();
+        const user = this.props.user;
 
         let terms = '';
         if (user.notify_props && user.notify_props.mention_keys) {
-            const termKeys = UserStore.getCurrentMentionKeys();
+            const termKeys = UserStore.getMentionKeys(user.id);
 
             if (user.notify_props.all === 'true' && termKeys.indexOf('@all') !== -1) {
                 termKeys.splice(termKeys.indexOf('@all'), 1);
@@ -150,7 +147,7 @@ export default class ChannelHeader extends React.Component {
             </Popover>
         );
         let channelTitle = channel.display_name;
-        const currentId = UserStore.getCurrentId();
+        const currentId = this.prop.user.id;
         const isAdmin = Utils.isAdmin(this.state.memberChannel.roles) || Utils.isAdmin(this.state.memberTeam.roles);
         const isDirect = (this.state.channel.type === 'D');
 
@@ -474,3 +471,7 @@ export default class ChannelHeader extends React.Component {
         );
     }
 }
+
+ChannelHeader.propTypes = {
+    user: React.PropTypes.object.isRequired
+};

--- a/web/react/components/delete_post_modal.jsx
+++ b/web/react/components/delete_post_modal.jsx
@@ -68,7 +68,7 @@ export default class DeletePostModal extends React.Component {
 
                         AppDispatcher.handleServerAction({
                             type: ActionTypes.RECEIVED_POST_SELECTED,
-                            results: null
+                            postId: null
                         });
                     } else if (selectedPost.id === this.state.post.id && this.state.root_id) {
                         if (selectedPost.root_id && selectedPost.root_id.length > 0 && selectedList.posts[selectedPost.root_id]) {
@@ -77,7 +77,7 @@ export default class DeletePostModal extends React.Component {
 
                             AppDispatcher.handleServerAction({
                                 type: ActionTypes.RECEIVED_POST_SELECTED,
-                                post_list: selectedList
+                                postId: selectedPost.root_id
                             });
 
                             AppDispatcher.handleServerAction({

--- a/web/react/components/navbar.jsx
+++ b/web/react/components/navbar.jsx
@@ -90,7 +90,7 @@ export default class Navbar extends React.Component {
 
             AppDispatcher.handleServerAction({
                 type: ActionTypes.RECEIVED_POST_SELECTED,
-                results: null
+                postId: null
             });
 
             if (e.target.className !== 'navbar-toggle' && e.target.className !== 'icon-bar') {

--- a/web/react/components/post.jsx
+++ b/web/react/components/post.jsx
@@ -99,6 +99,10 @@ export default class Post extends React.Component {
             return true;
         }
 
+        if (nextProps.hasProfiles !== this.props.hasProfiles) {
+            return true;
+        }
+
         return false;
     }
     getCommentCount(props) {
@@ -223,6 +227,7 @@ export default class Post extends React.Component {
                                 posts={posts}
                                 handleCommentClick={this.handleCommentClick}
                                 retryPost={this.retryPost}
+                                hasProfiles={this.props.hasProfiles}
                             />
                         </div>
                     </div>
@@ -233,7 +238,7 @@ export default class Post extends React.Component {
 }
 
 Post.propTypes = {
-    post: React.PropTypes.object,
+    post: React.PropTypes.object.isRequired,
     posts: React.PropTypes.object,
     parentPost: React.PropTypes.object,
     sameUser: React.PropTypes.bool,
@@ -241,5 +246,6 @@ Post.propTypes = {
     hideProfilePic: React.PropTypes.bool,
     isLastComment: React.PropTypes.bool,
     shouldHighlight: React.PropTypes.bool,
-    displayNameType: React.PropTypes.string
+    displayNameType: React.PropTypes.string,
+    hasProfiles: React.PropTypes.bool
 };

--- a/web/react/components/post_body.jsx
+++ b/web/react/components/post_body.jsx
@@ -39,12 +39,10 @@ class PostBody extends React.Component {
         this.loadImg = this.loadImg.bind(this);
 
         const linkData = Utils.extractLinks(this.props.post.message);
-        const profiles = UserStore.getProfiles();
 
         this.state = {
             links: linkData.links,
-            post: this.props.post,
-            hasUserProfiles: profiles && Object.keys(profiles).length > 1
+            post: this.props.post
         };
     }
 

--- a/web/react/components/post_body.jsx
+++ b/web/react/components/post_body.jsx
@@ -33,7 +33,6 @@ class PostBody extends React.Component {
 
         this.isImgLoading = false;
 
-        this.handleUserChange = this.handleUserChange.bind(this);
         this.parseEmojis = this.parseEmojis.bind(this);
         this.createEmbed = this.createEmbed.bind(this);
         this.createImageEmbed = this.createImageEmbed.bind(this);
@@ -80,24 +79,10 @@ class PostBody extends React.Component {
 
     componentDidMount() {
         this.parseEmojis();
-
-        UserStore.addChangeListener(this.handleUserChange);
     }
 
     componentDidUpdate() {
         this.parseEmojis();
-    }
-
-    componentWillUnmount() {
-        UserStore.removeChangeListener(this.handleUserChange);
-    }
-
-    handleUserChange() {
-        if (!this.state.hasProfiles) {
-            const profiles = UserStore.getProfiles();
-
-            this.setState({hasProfiles: profiles && Object.keys(profiles).length > 1});
-        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -357,7 +342,8 @@ PostBody.propTypes = {
     post: React.PropTypes.object.isRequired,
     parentPost: React.PropTypes.object,
     retryPost: React.PropTypes.func.isRequired,
-    handleCommentClick: React.PropTypes.func.isRequired
+    handleCommentClick: React.PropTypes.func.isRequired,
+    hasProfiles: React.PropTypes.bool
 };
 
 export default injectIntl(PostBody);

--- a/web/react/components/post_deleted_modal.jsx
+++ b/web/react/components/post_deleted_modal.jsx
@@ -38,7 +38,7 @@ export default class PostDeletedModal extends React.Component {
 
         AppDispatcher.handleServerAction({
             type: ActionTypes.RECEIVED_POST_SELECTED,
-            results: null
+            postId: null
         });
 
         this.props.onHide();

--- a/web/react/components/post_header.jsx
+++ b/web/react/components/post_header.jsx
@@ -13,16 +13,17 @@ export default class PostHeader extends React.Component {
         this.state = {};
     }
     render() {
-        var post = this.props.post;
+        const post = this.props.post;
+        const user = this.props.user;
 
-        let userProfile = <UserProfile userId={post.user_id}/>;
+        let userProfile = <UserProfile user={user}/>;
         let botIndicator;
 
         if (post.props && post.props.from_webhook) {
             if (post.props.override_username && global.window.mm_config.EnablePostUsernameOverride === 'true') {
                 userProfile = (
                     <UserProfile
-                        userId={post.user_id}
+                        user={user}
                         overwriteName={post.props.override_username}
                         disablePopover={true}
                     />
@@ -33,7 +34,7 @@ export default class PostHeader extends React.Component {
         } else if (Utils.isSystemMessage(post)) {
             userProfile = (
                 <UserProfile
-                    userId={''}
+                    user={{}}
                     overwriteName={Constants.SYSTEM_MESSAGE_PROFILE_NAME}
                     overwriteImage={Constants.SYSTEM_MESSAGE_PROFILE_IMAGE}
                     disablePopover={true}
@@ -68,6 +69,7 @@ PostHeader.defaultProps = {
 };
 PostHeader.propTypes = {
     post: React.PropTypes.object,
+    user: React.PropTypes.object,
     commentCount: React.PropTypes.number,
     isLastComment: React.PropTypes.bool,
     handleCommentClick: React.PropTypes.func,

--- a/web/react/components/posts_view.jsx
+++ b/web/react/components/posts_view.jsx
@@ -28,6 +28,7 @@ export default class PostsView extends React.Component {
         this.handleResize = this.handleResize.bind(this);
         this.scrollToBottom = this.scrollToBottom.bind(this);
         this.scrollToBottomAnimated = this.scrollToBottomAnimated.bind(this);
+        this.onUserChange = this.onUserChange.bind(this);
 
         this.jumpToPostNode = null;
         this.wasAtBottom = true;
@@ -38,7 +39,8 @@ export default class PostsView extends React.Component {
         this.state = {
             displayNameType: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, 'name_format', 'false'),
             isScrolling: false,
-            topPostId: null
+            topPostId: null,
+            hasProfiles: false
         };
     }
     static get SCROLL_TYPE_FREE() {
@@ -242,6 +244,7 @@ export default class PostsView extends React.Component {
                     shouldHighlight={shouldHighlight}
                     onClick={() => EventHelpers.emitPostFocusEvent(post.id)} //eslint-disable-line no-loop-func
                     displayNameType={this.state.displayNameType}
+                    hasProfiles={this.state.hasProfiles}
                 />
             );
 
@@ -367,9 +370,11 @@ export default class PostsView extends React.Component {
         if (this.props.postList != null) {
             this.updateScrolling();
         }
+        UserStore.addChangeListener(this.onUserChange);
         window.addEventListener('resize', this.handleResize);
     }
     componentWillUnmount() {
+        UserStore.removeChangeListener(this.onUserChange);
         window.removeEventListener('resize', this.handleResize);
     }
     componentDidUpdate() {
@@ -413,8 +418,18 @@ export default class PostsView extends React.Component {
         if (this.state.isScrolling !== nextState.isScrolling) {
             return true;
         }
+        if (this.state.hasProfiles !== nextState.hasProfiles) {
+            return true;
+        }
 
         return false;
+    }
+    onUserChange() {
+        if (!this.state.hasProfiles) {
+            const profiles = UserStore.getProfiles();
+
+            this.setState({hasProfiles: profiles && Object.keys(profiles).length > 1});
+        }
     }
     render() {
         let posts = [];

--- a/web/react/components/posts_view_container.jsx
+++ b/web/react/components/posts_view_container.jsx
@@ -6,6 +6,7 @@ import LoadingScreen from './loading_screen.jsx';
 
 import ChannelStore from '../stores/channel_store.jsx';
 import PostStore from '../stores/post_store.jsx';
+import UserStore from '../stores/user_store.jsx';
 
 import * as Utils from '../utils/utils.jsx';
 import * as EventHelpers from '../dispatcher/event_helpers.jsx';
@@ -24,11 +25,13 @@ export default class PostsViewContainer extends React.Component {
         this.handlePostsViewScroll = this.handlePostsViewScroll.bind(this);
         this.loadMorePostsTop = this.loadMorePostsTop.bind(this);
         this.handlePostsViewJumpRequest = this.handlePostsViewJumpRequest.bind(this);
+        this.onUserChange = this.onUserChange.bind(this);
 
         const currentChannelId = ChannelStore.getCurrentId();
         const state = {
             scrollType: PostsView.SCROLL_TYPE_BOTTOM,
-            scrollPost: null
+            scrollPost: null,
+            profiles: JSON.parse(JSON.stringify(UserStore.getProfiles()))
         };
         if (currentChannelId) {
             Object.assign(state, {
@@ -54,12 +57,14 @@ export default class PostsViewContainer extends React.Component {
         ChannelStore.addLeaveListener(this.onChannelLeave);
         PostStore.addChangeListener(this.onPostsChange);
         PostStore.addPostsViewJumpListener(this.handlePostsViewJumpRequest);
+        UserStore.addChangeListener(this.onUserChange);
     }
     componentWillUnmount() {
         ChannelStore.removeChangeListener(this.onChannelChange);
         ChannelStore.removeLeaveListener(this.onChannelLeave);
         PostStore.removeChangeListener(this.onPostsChange);
         PostStore.removePostsViewJumpListener(this.handlePostsViewJumpRequest);
+        UserStore.removeChangeListener(this.onUserChange);
     }
     handlePostsViewJumpRequest(type, post) {
         switch (type) {
@@ -135,6 +140,9 @@ export default class PostsViewContainer extends React.Component {
         atTop[this.state.currentChannelIndex] = PostStore.getVisibilityAtTop(currentChannelId);
         this.setState({postLists, atTop});
     }
+    onUserChange() {
+        this.setState({profiles: JSON.parse(JSON.stringify(UserStore.getProfiles()))});
+    }
     getChannelPosts(id) {
         return PostStore.getVisiblePosts(id);
     }
@@ -180,6 +188,7 @@ export default class PostsViewContainer extends React.Component {
                     showMoreMessagesBottom={false}
                     introText={channel ? createChannelIntroMessage(channel) : null}
                     messageSeparatorTime={this.state.currentLastViewed}
+                    profiles={this.state.profiles}
                 />
             );
             if (!postLists[i] && isActive) {

--- a/web/react/components/rhs_comment.jsx
+++ b/web/react/components/rhs_comment.jsx
@@ -194,8 +194,16 @@ class RhsComment extends React.Component {
 
         var timestamp = UserStore.getCurrentUser().update_at;
 
-        var loading;
-        var postClass = '';
+        let loading;
+        let postClass = '';
+        let message = (
+            <div
+                ref='message_holder'
+                onClick={TextFormatting.handleClick}
+                dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message)}}
+            />
+        );
+
         if (post.state === Constants.POST_FAILED) {
             postClass += ' post-fail';
             loading = (
@@ -216,6 +224,13 @@ class RhsComment extends React.Component {
                 <img
                     className='post-loading-gif pull-right'
                     src='/static/images/load.gif'
+                />
+            );
+        } else if (this.props.post.state === Constants.POST_DELETED) {
+            message = (
+                <FormattedMessage
+                    id='post_body.deleted'
+                    defaultMessage='(message deleted)'
                 />
             );
         }
@@ -246,7 +261,7 @@ class RhsComment extends React.Component {
                     <div>
                         <ul className='post__header'>
                             <li className='col__name'>
-                                <strong><UserProfile userId={post.user_id}/></strong>
+                                <strong><UserProfile user={this.props.user}/></strong>
                             </li>
                             <li className='col'>
                                 <time className='post__time'>
@@ -268,11 +283,7 @@ class RhsComment extends React.Component {
                         <div className='post__body'>
                             <div className={postClass}>
                                 {loading}
-                                <div
-                                    ref='message_holder'
-                                    onClick={TextFormatting.handleClick}
-                                    dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message)}}
-                                />
+                                {message}
                             </div>
                             {fileAttachment}
                         </div>
@@ -288,7 +299,8 @@ RhsComment.defaultProps = {
 };
 RhsComment.propTypes = {
     intl: intlShape.isRequired,
-    post: React.PropTypes.object
+    post: React.PropTypes.object,
+    user: React.PropTypes.object
 };
 
 export default injectIntl(RhsComment);

--- a/web/react/components/rhs_header_post.jsx
+++ b/web/react/components/rhs_header_post.jsx
@@ -27,7 +27,7 @@ export default class RhsHeaderPost extends React.Component {
 
         AppDispatcher.handleServerAction({
             type: ActionTypes.RECEIVED_POST_SELECTED,
-            results: null
+            postId: null
         });
     }
     handleBack(e) {
@@ -42,7 +42,7 @@ export default class RhsHeaderPost extends React.Component {
 
         AppDispatcher.handleServerAction({
             type: ActionTypes.RECEIVED_POST_SELECTED,
-            results: null
+            postId: null
         });
     }
     render() {

--- a/web/react/components/rhs_root_post.jsx
+++ b/web/react/components/rhs_root_post.jsx
@@ -50,10 +50,10 @@ export default class RhsRootPost extends React.Component {
         this.parseEmojis();
     }
     render() {
-        var post = this.props.post;
-        var currentUser = UserStore.getCurrentUser();
-        var isOwner = currentUser.id === post.user_id;
-        var isAdmin = Utils.isAdmin(currentUser.roles);
+        const post = this.props.post;
+        const user = this.props.user;
+        var isOwner = user.id === post.user_id;
+        var isAdmin = Utils.isAdmin(user.roles);
         var timestamp = UserStore.getProfile(post.user_id).update_at;
         var channel = ChannelStore.get(post.channel_id);
 
@@ -62,9 +62,9 @@ export default class RhsRootPost extends React.Component {
             type = 'Comment';
         }
 
-        var currentUserCss = '';
+        var userCss = '';
         if (UserStore.getCurrentId() === post.user_id) {
-            currentUserCss = 'current--user';
+            userCss = 'current--user';
         }
 
         var systemMessageClass = '';
@@ -185,14 +185,14 @@ export default class RhsRootPost extends React.Component {
             );
         }
 
-        let userProfile = <UserProfile userId={post.user_id}/>;
+        let userProfile = <UserProfile user={user}/>;
         let botIndicator;
 
         if (post.props && post.props.from_webhook) {
             if (post.props.override_username && global.window.mm_config.EnablePostUsernameOverride === 'true') {
                 userProfile = (
                     <UserProfile
-                        userId={post.user_id}
+                        user={user}
                         overwriteName={post.props.override_username}
                         disablePopover={true}
                     />
@@ -203,7 +203,7 @@ export default class RhsRootPost extends React.Component {
         } else if (Utils.isSystemMessage(post)) {
             userProfile = (
                 <UserProfile
-                    userId={''}
+                    user={{}}
                     overwriteName={Constants.SYSTEM_MESSAGE_PROFILE_NAME}
                     overwriteImage={Constants.SYSTEM_MESSAGE_PROFILE_IMAGE}
                     disablePopover={true}
@@ -230,7 +230,7 @@ export default class RhsRootPost extends React.Component {
         );
 
         return (
-            <div className={'post post--root ' + currentUserCss + ' ' + systemMessageClass}>
+            <div className={'post post--root ' + userCss + ' ' + systemMessageClass}>
                 <div className='post-right-channel__name'>{channelName}</div>
                 <div className='post__content'>
                     <div className='post__img'>
@@ -278,10 +278,10 @@ export default class RhsRootPost extends React.Component {
 }
 
 RhsRootPost.defaultProps = {
-    post: null,
     commentCount: 0
 };
 RhsRootPost.propTypes = {
-    post: React.PropTypes.object,
+    post: React.PropTypes.object.isRequired,
+    user: React.PropTypes.object.isRequired,
     commentCount: React.PropTypes.number
 };

--- a/web/react/components/search_bar.jsx
+++ b/web/react/components/search_bar.jsx
@@ -87,7 +87,7 @@ class SearchBar extends React.Component {
 
         AppDispatcher.handleServerAction({
             type: ActionTypes.RECEIVED_POST_SELECTED,
-            results: null
+            postId: null
         });
     }
     handleUserInput(text) {

--- a/web/react/components/search_results_header.jsx
+++ b/web/react/components/search_results_header.jsx
@@ -32,7 +32,7 @@ export default class SearchResultsHeader extends React.Component {
 
         AppDispatcher.handleServerAction({
             type: ActionTypes.RECEIVED_POST_SELECTED,
-            results: null
+            postId: null
         });
     }
 

--- a/web/react/components/user_profile.jsx
+++ b/web/react/components/user_profile.jsx
@@ -2,7 +2,6 @@
 // See License.txt for license information.
 
 import * as Utils from '../utils/utils.jsx';
-import UserStore from '../stores/user_store.jsx';
 
 import {FormattedMessage} from 'mm-intl';
 
@@ -19,45 +18,15 @@ function nextId() {
 export default class UserProfile extends React.Component {
     constructor(props) {
         super(props);
-
         this.uniqueId = nextId();
-        this.onChange = this.onChange.bind(this);
-
-        this.state = this.getStateFromStores(this.props.userId);
-    }
-    getStateFromStores(userId) {
-        var profile = UserStore.getProfile(userId);
-
-        if (profile == null) {
-            return {profile: {id: '0', username: '...'}};
-        }
-
-        return {profile};
     }
     componentDidMount() {
-        UserStore.addChangeListener(this.onChange);
         if (!this.props.disablePopover) {
             $('body').tooltip({selector: '[data-toggle=tooltip]', trigger: 'hover click'});
         }
     }
-    componentWillUnmount() {
-        UserStore.removeChangeListener(this.onChange);
-    }
-    onChange(userId) {
-        if (!userId || userId === this.props.userId) {
-            var newState = this.getStateFromStores(this.props.userId);
-            if (!Utils.areObjectsEqual(newState, this.state)) {
-                this.setState(newState);
-            }
-        }
-    }
-    componentWillReceiveProps(nextProps) {
-        if (this.props.userId !== nextProps.userId) {
-            this.setState(this.getStateFromStores(nextProps.userId));
-        }
-    }
     render() {
-        var name = Utils.displayUsername(this.state.profile.id);
+        var name = Utils.displayUsername(this.props.user.id);
         if (this.props.overwriteName) {
             name = this.props.overwriteName;
         } else if (!name) {
@@ -68,7 +37,7 @@ export default class UserProfile extends React.Component {
             return <div>{name}</div>;
         }
 
-        var profileImg = '/api/v1/users/' + this.state.profile.id + '/image?time=' + this.state.profile.update_at + '&' + Utils.getSessionIndex();
+        var profileImg = '/api/v1/users/' + this.props.user.id + '/image?time=' + this.props.user.update_at + '&' + Utils.getSessionIndex();
         if (this.props.overwriteImage) {
             profileImg = this.props.overwriteImage;
         }
@@ -100,14 +69,14 @@ export default class UserProfile extends React.Component {
             dataContent.push(
                 <div
                     data-toggle='tooltip'
-                    title={this.state.profile.email}
+                    title={this.props.user.email}
                     key='user-popover-email'
                 >
                     <a
-                        href={'mailto:' + this.state.profile.email}
+                        href={'mailto:' + this.props.user.email}
                         className='text-nowrap text-lowercase user-popover__email'
                     >
-                        {this.state.profile.email}
+                        {this.props.user.email}
                     </a>
                 </div>
             );
@@ -139,13 +108,13 @@ export default class UserProfile extends React.Component {
 }
 
 UserProfile.defaultProps = {
-    userId: '',
+    user: {},
     overwriteName: '',
     overwriteImage: '',
     disablePopover: false
 };
 UserProfile.propTypes = {
-    userId: React.PropTypes.string,
+    user: React.PropTypes.object.isRequired,
     overwriteName: React.PropTypes.string,
     overwriteImage: React.PropTypes.string,
     disablePopover: React.PropTypes.bool

--- a/web/react/stores/user_store.jsx
+++ b/web/react/stores/user_store.jsx
@@ -17,50 +17,6 @@ const CHANGE_EVENT_STATUSES = 'change_statuses';
 class UserStoreClass extends EventEmitter {
     constructor() {
         super();
-
-        this.emitChange = this.emitChange.bind(this);
-        this.addChangeListener = this.addChangeListener.bind(this);
-        this.removeChangeListener = this.removeChangeListener.bind(this);
-        this.emitSessionsChange = this.emitSessionsChange.bind(this);
-        this.addSessionsChangeListener = this.addSessionsChangeListener.bind(this);
-        this.removeSessionsChangeListener = this.removeSessionsChangeListener.bind(this);
-        this.emitAuditsChange = this.emitAuditsChange.bind(this);
-        this.addAuditsChangeListener = this.addAuditsChangeListener.bind(this);
-        this.removeAuditsChangeListener = this.removeAuditsChangeListener.bind(this);
-        this.emitTeamsChange = this.emitTeamsChange.bind(this);
-        this.addTeamsChangeListener = this.addTeamsChangeListener.bind(this);
-        this.removeTeamsChangeListener = this.removeTeamsChangeListener.bind(this);
-        this.emitStatusesChange = this.emitStatusesChange.bind(this);
-        this.addStatusesChangeListener = this.addStatusesChangeListener.bind(this);
-        this.removeStatusesChangeListener = this.removeStatusesChangeListener.bind(this);
-        this.getCurrentId = this.getCurrentId.bind(this);
-        this.getCurrentUser = this.getCurrentUser.bind(this);
-        this.setCurrentUser = this.setCurrentUser.bind(this);
-        this.getLastEmail = this.getLastEmail.bind(this);
-        this.setLastEmail = this.setLastEmail.bind(this);
-        this.getLastUsername = this.getLastUsername.bind(this);
-        this.setLastUsername = this.setLastUsername.bind(this);
-        this.hasProfile = this.hasProfile.bind(this);
-        this.getProfile = this.getProfile.bind(this);
-        this.getProfileByUsername = this.getProfileByUsername.bind(this);
-        this.getProfilesUsernameMap = this.getProfilesUsernameMap.bind(this);
-        this.getProfiles = this.getProfiles.bind(this);
-        this.getActiveOnlyProfiles = this.getActiveOnlyProfiles.bind(this);
-        this.getActiveOnlyProfileList = this.getActiveOnlyProfileList.bind(this);
-        this.saveProfile = this.saveProfile.bind(this);
-        this.setSessions = this.setSessions.bind(this);
-        this.getSessions = this.getSessions.bind(this);
-        this.setAudits = this.setAudits.bind(this);
-        this.getAudits = this.getAudits.bind(this);
-        this.setTeams = this.setTeams.bind(this);
-        this.getTeams = this.getTeams.bind(this);
-        this.getCurrentMentionKeys = this.getCurrentMentionKeys.bind(this);
-        this.setStatuses = this.setStatuses.bind(this);
-        this.pSetStatuses = this.pSetStatuses.bind(this);
-        this.setStatus = this.setStatus.bind(this);
-        this.getStatuses = this.getStatuses.bind(this);
-        this.getStatus = this.getStatus.bind(this);
-
         this.profileCache = null;
     }
 
@@ -277,7 +233,11 @@ class UserStoreClass extends EventEmitter {
     }
 
     getCurrentMentionKeys() {
-        var user = this.getCurrentUser();
+        return this.getMentionKeys(this.getCurrentId());
+    }
+
+    getMentionKeys(id) {
+        var user = this.getProfile(id);
 
         var keys = [];
 

--- a/web/react/stores/user_store.jsx
+++ b/web/react/stores/user_store.jsx
@@ -290,7 +290,7 @@ class UserStoreClass extends EventEmitter {
 }
 
 var UserStore = new UserStoreClass();
-UserStore.setMaxListeners(0);
+UserStore.setMaxListeners(15);
 
 UserStore.dispatchToken = AppDispatcher.register((payload) => {
     var action = payload.action;

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -1417,3 +1417,7 @@ export function languages() {
 export function isPostEphemeral(post) {
     return post.type === Constants.POST_TYPE_EPHEMERAL || post.state === Constants.POST_DELETED;
 }
+
+export function getRootId(post) {
+    return post.root_id === '' ? post.id : post.root_id;
+}


### PR DESCRIPTION
This lets us avoid setting the max listeners for the UserStore to unlimited and is more inline with our design theory of top-level views/components propagating changes from the stores down through their children.

I also took the liberty of fixing PLT-1952 as the RHS thread code was rather horrendous. Now instead of doing some bizarre logic to handle which posts it should render, the rhs_thread just asks the post store for it, which also handles it better now.