### PR TITLE
Update activity_log_modal.jsx help text to remove hard coded session length

### DIFF
--- a/web/react/components/activity_log_modal.jsx
+++ b/web/react/components/activity_log_modal.jsx
@@ -254,7 +254,7 @@ export default class ActivityLogModal extends React.Component {
                     <p className='session-help-text'>
                         <FormattedMessage
                             id='activity_log.sessionsDescription'
-                            defaultMessage="Sessions are created when you log in with your email and password to a new browser on a device. Sessions let you use Mattermost for up to 30 days without having to log in again. If you want to log out sooner, use the 'Logout' button below to end a session."
+                            defaultMessage="Sessions are created when you log in to a new browser on a device. Sessions let you use Mattermost without having to log in again for a time period specified by the System Admin. If you want to log out sooner, use the 'Logout' button below to end a session."
                         />
                     </p>
                     {content}

--- a/web/static/i18n/en.json
+++ b/web/static/i18n/en.json
@@ -17,7 +17,7 @@
   "activity_log.moreInfo": "More info",
   "activity_log.os": "OS: {os}",
   "activity_log.sessionId": "Session ID: {id}",
-  "activity_log.sessionsDescription": "Sessions are created when you log in with your email and password to a new browser on a device. Sessions let you use Mattermost for up to 30 days without having to log in again. If you want to log out sooner, use the 'Logout' button below to end a session.",
+  "activity_log.sessionsDescription": "Sessions are created when you log in to a new browser on a device. Sessions let you use Mattermost without having to log in again for a time period specified by the System Admin. If you want to log out sooner, use the 'Logout' button below to end a session.",
   "activity_log_modal.android": "Android",
   "activity_log_modal.androidNativeApp": "Android Native App",
   "activity_log_modal.iphoneNativeApp": "iPhone Native App",

--- a/web/static/i18n/es.json
+++ b/web/static/i18n/es.json
@@ -17,7 +17,6 @@
   "activity_log.moreInfo": "Mas información",
   "activity_log.os": "Sistema Operativo: {os}",
   "activity_log.sessionId": "Sesión ID: {id}",
-  "activity_log.sessionsDescription": "Las sesiones son creadas cuando inicias sesión con tus credenciales en un nuevo navegador desde cualquier dispositivo. Las sesiones te permiten utilizar Mattermost por un período de hasta 30 días sin tener que iniciar sesión nuevamente. Si quieres cerrar tu sesión antes de ese tiempo, utiliza el botón de 'Cerrar Sesión' en la parte de abajo.",
   "activity_log_modal.android": "Android",
   "activity_log_modal.androidNativeApp": "Android App Nativa",
   "activity_log_modal.iphoneNativeApp": "iPhone App Nativa",


### PR DESCRIPTION
Updated en.json and removed entry from es.json (needs to be re-translated)