### PR TITLE
PLT-2127 Stopped setting Notification.permission

### DIFF
--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -156,10 +156,6 @@ export function notifyMe(title, body, channel) {
         requestedNotificationPermission = true;
 
         Notification.requestPermission((permission) => {
-            if (Notification.permission !== permission) {
-                Notification.permission = permission;
-            }
-
             if (permission === 'granted') {
                 try {
                     var notification = new Notification(title, {body, tag: body, icon: '/static/images/icon50x50.png'});


### PR DESCRIPTION
Notification.permission is supposed to be read only and I assume we were setting it from back when Chrome didn't support the field. Most of the time, I think the if statement prevents us from setting the property, but there must be some very rare cases where it doesn't which causes an error to be logged and might break the notifications