### PR TITLE
PLT-1993/PLT-1994 Stopped calling uploadFiles multiple times for a single upload

### DIFF
--- a/web/react/components/create_post.jsx
+++ b/web/react/components/create_post.jsx
@@ -262,9 +262,7 @@ class CreatePost extends React.Component {
             message = err.message;
         }
 
-        if (clientId === -1) {
-            this.setState({serverError: message});
-        } else {
+        if (clientId !== -1) {
             const draft = PostStore.getDraft(this.state.channelId);
 
             const index = draft.uploadsInProgress.indexOf(clientId);
@@ -274,8 +272,10 @@ class CreatePost extends React.Component {
 
             PostStore.storeDraft(this.state.channelId, draft);
 
-            this.setState({uploadsInProgress: draft.uploadsInProgress, serverError: message});
+            this.setState({uploadsInProgress: draft.uploadsInProgress});
         }
+
+        this.setState({serverError: message});
     }
     removePreview(id) {
         const previews = Object.assign([], this.state.previews);

--- a/web/react/components/file_upload.jsx
+++ b/web/react/components/file_upload.jsx
@@ -108,12 +108,12 @@ class FileUpload extends React.Component {
         }
     }
 
-    handleChange() {
-        var element = $(ReactDOM.findDOMNode(this.refs.fileInput));
+    handleChange(e) {
+        if (e.target.files.length > 0) {
+            this.uploadFiles(e.target.files);
 
-        this.uploadFiles(element.prop('files'));
-
-        Utils.clearFileInput(element[0]);
+            Utils.clearFileInput(e.target);
+        }
     }
 
     handleDrop(e) {


### PR DESCRIPTION
Only IE11 seemed to actually call the listener multiple times which caused it to overwrite the error message for any invalid uploads so that the user wouldn't see what went wrong