### PR TITLE
PLT-2142 Increased the maximum size of image uploads to 24 megapixels

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -52,7 +52,7 @@ const (
 	RotatedCCWMirrored = 7
 	RotatedCW          = 8
 
-	MaxImageSize = 4096 * 2160 // 4k resolution
+	MaxImageSize = 6048 * 4032 // 24 megapixels, roughly 36MB as a raw image
 )
 
 var fileInfoCache *utils.Cache = utils.NewLru(1000)


### PR DESCRIPTION
According to [this page](http://www.disturbancesinthewash.net/journal/how-many-megapixels-do-i-need), this will be about 36MB in memory as a raw image while we're making the thumbnail. This is large enough that photos from all camera phones and most cameras will still be able to be uploaded while still preventing any zip bombs. 