### PR TITLE
Appending "T0" to Team Edition in About

### DIFF
--- a/web/react/components/about_build_modal.jsx
+++ b/web/react/components/about_build_modal.jsx
@@ -22,7 +22,7 @@ export default class AboutBuildModal extends React.Component {
         let title = (
             <FormattedMessage
                 id='about.teamEdtion'
-                defaultMessage='Team Edition'
+                defaultMessage='Team Edition T0'
             />
         );
         let licensee;

--- a/web/static/i18n/en.json
+++ b/web/static/i18n/en.json
@@ -5,7 +5,7 @@
   "about.hash": "Build Hash:",
   "about.licensed": "Licensed by:",
   "about.number": "Build Number:",
-  "about.teamEdtion": "Team Edition",
+  "about.teamEdtion": "Team Edition T0",
   "about.title": "About Mattermost",
   "about.version": "Version:",
   "access_history.title": "Access History",

--- a/web/static/i18n/es.json
+++ b/web/static/i18n/es.json
@@ -5,7 +5,7 @@
   "about.hash": "Hash de compilación:",
   "about.licensed": "Licenciado por:",
   "about.number": "Número de compilación:",
-  "about.teamEdtion": "Edición Team",
+  "about.teamEdtion": "Edición Team T0",
   "about.title": "Acerca de Mattermost",
   "about.version": "Versión:",
   "access_history.title": "Historial de Acceso",

--- a/web/static/i18n/pt.json
+++ b/web/static/i18n/pt.json
@@ -5,7 +5,7 @@
   "about.hash": "Hash de Compilação:",
   "about.licensed": "Licenciado pela:",
   "about.number": "O Número De Compilação:",
-  "about.teamEdtion": "Team Edition",
+  "about.teamEdtion": "Team Edition T0",
   "about.title": "Sobre o Mattermost",
   "about.version": "Versão:",
   "access_history.title": "Histórico de Acesso",


### PR DESCRIPTION
Refining naming of Team Edition 

Mattermost Team Edition T0 - build from open source mattermost/platform repo
Mattermost Team Edition T1 - reserving this name for commercial build with the same features as T0, plus the ability to upgrade to Enterprise Edition