### PR TITLE
PLT-2098/PLT-1895 Refactor to handle 10k users

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -832,8 +832,13 @@ func searchChannelExtraInfo(c *Context, w http.ResponseWriter, r *http.Request) 
 		memberCount := ccmresult.Data.(int64)
 		extraMembers := ecmresult.Data.(map[string]*model.ExtraMember)
 
-		data := model.ChannelExtra{Id: id, Members: extraMembers, MemberCount: memberCount}
-		w.Write([]byte(data.ToJson()))
+		extra := model.ChannelExtra{Id: id, Members: extraMembers, MemberCount: memberCount}
+
+		if HandleEtag(extra.Etag(), w, r) {
+			return
+		}
+
+		w.Write([]byte(extra.ToJson()))
 	}
 }
 

--- a/api/command_loadtest.go
+++ b/api/command_loadtest.go
@@ -267,7 +267,7 @@ func (me *LoadTestProvider) PostsCommand(c *Context, channelId string, message s
 
 	var usernames []string
 	if result := <-Srv.Store.User().GetProfiles(c.Session.TeamId, 1000, 0); result.Err == nil {
-		profileUsers := result.Data.(map[string]*model.User)
+		profileUsers := result.Data.(model.UserMap)
 		usernames = make([]string, len(profileUsers))
 		i := 0
 		for _, userprof := range profileUsers {

--- a/api/command_loadtest.go
+++ b/api/command_loadtest.go
@@ -266,7 +266,7 @@ func (me *LoadTestProvider) PostsCommand(c *Context, channelId string, message s
 	}
 
 	var usernames []string
-	if result := <-Srv.Store.User().GetProfiles(c.Session.TeamId); result.Err == nil {
+	if result := <-Srv.Store.User().GetProfiles(c.Session.TeamId, 1000, 0); result.Err == nil {
 		profileUsers := result.Data.(map[string]*model.User)
 		usernames = make([]string, len(profileUsers))
 		i := 0

--- a/api/command_loadtest.go
+++ b/api/command_loadtest.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"path"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	l4g "github.com/alecthomas/log4go"
+	"github.com/gorilla/websocket"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 )
@@ -49,6 +51,11 @@ var usage = `Mattermost load testing commands to help configure the system
 		Example:
 			/loadtest http://www.example.com/sample_file.md
 
+    WebSocket - Open a specified number of websocket connections
+		/loadtest websocket [close] <Num Connections>
+		
+		Example:
+			/loadtest websocket 10
 
 `
 
@@ -104,6 +111,10 @@ func (me *LoadTestProvider) DoCommand(c *Context, channelId string, message stri
 
 	if strings.HasPrefix(message, "url") {
 		return me.UrlCommand(c, channelId, message)
+	}
+
+	if strings.HasPrefix(message, "websocket") {
+		return me.SocketCommand(c, channelId, message)
 	}
 
 	return me.HelpCommand(c, channelId, message)
@@ -328,6 +339,44 @@ func (me *LoadTestProvider) UrlCommand(c *Context, channelId string, message str
 	}
 
 	return &model.CommandResponse{Text: "Loading data...", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+}
+
+var conns []*websocket.Conn
+
+func (me *LoadTestProvider) SocketCommand(c *Context, channelId string, message string) *model.CommandResponse {
+	if strings.Contains(message, "close") {
+		if conns != nil {
+			for _, c := range conns {
+				c.Close()
+			}
+			conns = nil
+		}
+		return &model.CommandResponse{Text: "Closed all test WebSocket connections.", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	}
+
+	numConns, _ := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(message, "websocket")))
+
+	url := "ws://localhost" + utils.Cfg.ServiceSettings.ListenAddress + "/api/v1/websocket"
+	header := http.Header{}
+	header.Set(model.HEADER_AUTH, "BEARER "+c.Session.Token)
+
+	start := 0
+	if conns == nil {
+		conns = make([]*websocket.Conn, numConns)
+	} else {
+		start = len(conns)
+		conns = append(conns, make([]*websocket.Conn, numConns)...)
+	}
+
+	var err error
+	for i := start; i < len(conns); i++ {
+		conns[i], _, err = websocket.DefaultDialer.Dial(url, header)
+		if err != nil {
+			l4g.Error(err.Error())
+		}
+	}
+
+	return &model.CommandResponse{Text: fmt.Sprintf("Created %d WebSocket connections.", numConns), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }
 
 func parseRange(command string, cmd string) (utils.Range, bool) {

--- a/api/post.go
+++ b/api/post.go
@@ -958,7 +958,7 @@ func setProfilesForPostList(c *Context, postList *model.PostList) {
 				options["email"] = true
 			}
 
-			(&profiles).ClearNonProfileFields(options)
+			profiles.ClearNonProfileFields(options)
 
 			postList.Profiles = profiles
 		}

--- a/api/post.go
+++ b/api/post.go
@@ -233,7 +233,7 @@ func handlePostEventsAndForget(c *Context, post *model.Post, triggerWebhooks boo
 		tchan := Srv.Store.Team().Get(c.Session.TeamId)
 		cchan := Srv.Store.Channel().Get(post.ChannelId)
 		uchan := Srv.Store.User().Get(post.UserId)
-		pchan := Srv.Store.User().GetProfiles(c.Session.TeamId)
+		pchan := Srv.Store.User().GetProfiles(c.Session.TeamId, 1000000, 0)
 		mchan := Srv.Store.Channel().GetMembers(post.ChannelId)
 
 		var team *model.Team

--- a/api/post.go
+++ b/api/post.go
@@ -233,7 +233,7 @@ func handlePostEventsAndForget(c *Context, post *model.Post, triggerWebhooks boo
 		tchan := Srv.Store.Team().Get(c.Session.TeamId)
 		cchan := Srv.Store.Channel().Get(post.ChannelId)
 		uchan := Srv.Store.User().Get(post.UserId)
-		pchan := Srv.Store.User().GetProfiles(c.Session.TeamId, 1000000, 0)
+		pchan := Srv.Store.User().GetProfiles(c.Session.TeamId, 1000000, 0) // large limit number so that we get all profiles
 		mchan := Srv.Store.Channel().GetMembers(post.ChannelId)
 
 		var team *model.Team
@@ -951,14 +951,7 @@ func setProfilesForPostList(c *Context, postList *model.PostList) {
 		} else {
 			profiles := result.Data.(model.UserMap)
 
-			options := utils.Cfg.GetSanitizeOptions()
-			options["passwordupdate"] = false
-			if c.IsSystemAdmin() {
-				options["fullname"] = true
-				options["email"] = true
-			}
-
-			profiles.ClearNonProfileFields(options)
+			profiles.ClearNonProfileFields(getSanitizeProfileOptions(c))
 
 			postList.Profiles = profiles
 		}

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -883,7 +883,7 @@ func TestGetOutOfChannelMentions(t *testing.T) {
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
 
 	var allProfiles map[string]*model.User
-	if result := <-Srv.Store.User().GetProfiles(team1.Id); result.Err != nil {
+	if result := <-Srv.Store.User().GetProfiles(team1.Id, 100000, 0); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		allProfiles = result.Data.(map[string]*model.User)
@@ -934,7 +934,7 @@ func TestGetOutOfChannelMentions(t *testing.T) {
 	channel2 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team2.Id}
 	channel2 = Client.Must(Client.CreateChannel(channel2)).Data.(*model.Channel)
 
-	if result := <-Srv.Store.User().GetProfiles(team2.Id); result.Err != nil {
+	if result := <-Srv.Store.User().GetProfiles(team2.Id, 100000, 0); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		allProfiles = result.Data.(map[string]*model.User)

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -882,11 +882,11 @@ func TestGetOutOfChannelMentions(t *testing.T) {
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team1.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).Data.(*model.Channel)
 
-	var allProfiles map[string]*model.User
+	var allProfiles model.UserMap
 	if result := <-Srv.Store.User().GetProfiles(team1.Id, 100000, 0); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
-		allProfiles = result.Data.(map[string]*model.User)
+		allProfiles = result.Data.(model.UserMap)
 	}
 
 	var members []model.ChannelMember
@@ -937,7 +937,7 @@ func TestGetOutOfChannelMentions(t *testing.T) {
 	if result := <-Srv.Store.User().GetProfiles(team2.Id, 100000, 0); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
-		allProfiles = result.Data.(map[string]*model.User)
+		allProfiles = result.Data.(model.UserMap)
 	}
 
 	if result := <-Srv.Store.Channel().GetMembers(channel2.Id); result.Err != nil {

--- a/api/slackimport.go
+++ b/api/slackimport.go
@@ -93,12 +93,12 @@ func SlackParsePosts(data io.Reader) []SlackPost {
 	return posts
 }
 
-func SlackAddUsers(teamId string, slackusers []SlackUser, log *bytes.Buffer) map[string]*model.User {
+func SlackAddUsers(teamId string, slackusers []SlackUser, log *bytes.Buffer) model.UserMap {
 	// Log header
 	log.WriteString(utils.T("api.slackimport.slack_add_users.created"))
 	log.WriteString("===============\r\n\r\n")
 
-	addedUsers := make(map[string]*model.User)
+	addedUsers := model.UserMap{}
 	for _, sUser := range slackusers {
 		firstName := ""
 		lastName := ""
@@ -131,7 +131,7 @@ func SlackAddUsers(teamId string, slackusers []SlackUser, log *bytes.Buffer) map
 	return addedUsers
 }
 
-func SlackAddPosts(channel *model.Channel, posts []SlackPost, users map[string]*model.User) {
+func SlackAddPosts(channel *model.Channel, posts []SlackPost, users model.UserMap) {
 	for _, sPost := range posts {
 		switch {
 		case sPost.Type == "message" && (sPost.SubType == "" || sPost.SubType == "file_share"):
@@ -174,7 +174,7 @@ func SlackAddPosts(channel *model.Channel, posts []SlackPost, users map[string]*
 	}
 }
 
-func SlackAddChannels(teamId string, slackchannels []SlackChannel, posts map[string][]SlackPost, users map[string]*model.User, log *bytes.Buffer) map[string]*model.Channel {
+func SlackAddChannels(teamId string, slackchannels []SlackChannel, posts map[string][]SlackPost, users model.UserMap, log *bytes.Buffer) map[string]*model.Channel {
 	// Write Header
 	log.WriteString(utils.T("api.slackimport.slack_add_channels.added"))
 	log.WriteString("=================\r\n\r\n")

--- a/api/user.go
+++ b/api/user.go
@@ -58,8 +58,9 @@ func InitUser(r *mux.Router) {
 
 	sr.Handle("/me", ApiAppHandler(getMe)).Methods("GET")
 	sr.Handle("/status", ApiUserRequiredActivity(getStatuses, false)).Methods("POST")
-	sr.Handle("/profiles", ApiUserRequired(getProfiles)).Methods("GET")
-	sr.Handle("/profiles/{id:[A-Za-z0-9]+}", ApiUserRequired(getProfiles)).Methods("GET")
+	sr.Handle("/profiles/{offset:[0-9]+}/{num:[0-9]+}", ApiUserRequired(getProfiles)).Methods("GET")
+	sr.Handle("/profiles/{id:[A-Za-z0-9]+}/{offset:[0-9]+}/{num:[0-9]+}", ApiUserRequired(getProfiles)).Methods("GET")
+	sr.Handle("/profile/{id:[A-Za-z0-9]+}", ApiUserRequired(getProfile)).Methods("GET")
 	sr.Handle("/{id:[A-Za-z0-9]+}", ApiUserRequired(getUser)).Methods("GET")
 	sr.Handle("/{id:[A-Za-z0-9]+}/sessions", ApiUserRequired(getSessions)).Methods("GET")
 	sr.Handle("/{id:[A-Za-z0-9]+}/audits", ApiUserRequired(getAudits)).Methods("GET")
@@ -341,7 +342,7 @@ func sendWelcomeEmailAndForget(c *Context, userId, email, teamName, teamDisplayN
 func addDirectChannelsAndForget(user *model.User) {
 	go func() {
 		var profiles map[string]*model.User
-		if result := <-Srv.Store.User().GetProfiles(user.TeamId); result.Err != nil {
+		if result := <-Srv.Store.User().GetProfiles(user.TeamId, 10, 0); result.Err != nil {
 			l4g.Error(utils.T("api.user.add_direct_channels_and_forget.failed.error"), user.Id, user.TeamId, result.Err.Error())
 			return
 		} else {
@@ -923,6 +924,38 @@ func getUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func getProfile(c *Context, w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	id := params["id"]
+
+	if !c.HasPermissionsToTeam(id, "getProfile") {
+		return
+	}
+
+	if result := <-Srv.Store.User().Get(id); result.Err != nil {
+		c.Err = result.Err
+		return
+	} else if HandleEtag(result.Data.(*model.User).Etag(), w, r) {
+		return
+	} else {
+		profile := result.Data.(*model.User)
+		etag := profile.Etag()
+
+		options := utils.Cfg.GetSanitizeOptions()
+		options["passwordupdate"] = false
+		if c.IsSystemAdmin() {
+			options["fullname"] = true
+			options["email"] = true
+		}
+
+		profile.Sanitize(options)
+		profile.ClearNonProfileFields()
+		w.Header().Set(model.HEADER_ETAG_SERVER, etag)
+		w.Write([]byte(result.Data.(*model.User).ToJson()))
+		return
+	}
+}
+
 func getProfiles(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	id, ok := params["id"]
@@ -933,17 +966,28 @@ func getProfiles(c *Context, w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-
 	} else {
 		id = c.Session.TeamId
 	}
 
-	etag := (<-Srv.Store.User().GetEtagForProfiles(id)).Data.(string)
+	numProfiles, err := strconv.Atoi(params["num"])
+	if err != nil || numProfiles <= 0 {
+		c.SetInvalidParam("getProfiles", "num")
+		return
+	}
+
+	offset, err := strconv.Atoi(params["offset"])
+	if err != nil || offset < 0 {
+		c.SetInvalidParam("getProfiles", "offset")
+		return
+	}
+
+	etag := (<-Srv.Store.User().GetEtagForProfiles(id, numProfiles, offset)).Data.(string)
 	if HandleEtag(etag, w, r) {
 		return
 	}
 
-	if result := <-Srv.Store.User().GetProfiles(id); result.Err != nil {
+	if result := <-Srv.Store.User().GetProfiles(id, numProfiles, offset); result.Err != nil {
 		c.Err = result.Err
 		return
 	} else {
@@ -1402,19 +1446,11 @@ func UpdateRoles(c *Context, user *model.User, roles string) *model.User {
 
 	if !model.IsInRole(roles, model.ROLE_SYSTEM_ADMIN) {
 		if model.IsInRole(user.Roles, model.ROLE_TEAM_ADMIN) && !model.IsInRole(roles, model.ROLE_TEAM_ADMIN) {
-			if result := <-Srv.Store.User().GetProfiles(user.TeamId); result.Err != nil {
+			if result := <-Srv.Store.User().GetRoleCount(user.TeamId, model.ROLE_TEAM_ADMIN); result.Err != nil {
 				c.Err = result.Err
 				return nil
 			} else {
-				activeAdmins := -1
-				profileUsers := result.Data.(map[string]*model.User)
-				for _, profileUser := range profileUsers {
-					if profileUser.DeleteAt == 0 && model.IsInRole(profileUser.Roles, model.ROLE_TEAM_ADMIN) {
-						activeAdmins = activeAdmins + 1
-					}
-				}
-
-				if activeAdmins <= 0 {
+				if result.Data.(int64) <= 0 {
 					c.Err = model.NewLocAppError("updateRoles", "api.user.update_roles.one_admin.app_error", nil, "")
 					return nil
 				}
@@ -1467,20 +1503,12 @@ func updateActive(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// make sure there is at least 1 other active admin
 	if !active && model.IsInRole(user.Roles, model.ROLE_TEAM_ADMIN) {
-		if result := <-Srv.Store.User().GetProfiles(user.TeamId); result.Err != nil {
+		if result := <-Srv.Store.User().GetRoleCount(user.TeamId, model.ROLE_TEAM_ADMIN); result.Err != nil {
 			c.Err = result.Err
 			return
 		} else {
-			activeAdmins := -1
-			profileUsers := result.Data.(map[string]*model.User)
-			for _, profileUser := range profileUsers {
-				if profileUser.DeleteAt == 0 && model.IsInRole(profileUser.Roles, model.ROLE_TEAM_ADMIN) {
-					activeAdmins = activeAdmins + 1
-				}
-			}
-
-			if activeAdmins <= 0 {
-				c.Err = model.NewLocAppError("updateRoles", "api.user.update_roles.one_admin.app_error", nil, "userId="+user_id)
+			if result.Data.(int64) <= 0 {
+				c.Err = model.NewLocAppError("updateActive", "api.user.update_roles.one_admin.app_error", nil, "")
 				return
 			}
 		}
@@ -1869,7 +1897,7 @@ func getStatuses(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if result := <-Srv.Store.User().GetProfiles(c.Session.TeamId); result.Err != nil {
+	if result := <-Srv.Store.User().GetProfiles(c.Session.TeamId, 1000, 0); result.Err != nil {
 		c.Err = result.Err
 		return
 	} else {

--- a/api/user.go
+++ b/api/user.go
@@ -1003,10 +1003,10 @@ func getProfiles(c *Context, w http.ResponseWriter, r *http.Request) {
 			options["email"] = true
 		}
 
-		(&profiles).ClearNonProfileFields(options)
+		profiles.ClearNonProfileFields(options)
 
 		w.Header().Set(model.HEADER_ETAG_SERVER, etag)
-		w.Write([]byte((&profiles).ToJson()))
+		w.Write([]byte(profiles.ToJson()))
 		return
 	}
 }
@@ -1033,9 +1033,9 @@ func searchProfiles(c *Context, w http.ResponseWriter, r *http.Request) {
 			options["email"] = true
 		}
 
-		(&profiles).ClearNonProfileFields(options)
+		profiles.ClearNonProfileFields(options)
 
-		w.Write([]byte((&profiles).ToJson()))
+		w.Write([]byte(profiles.ToJson()))
 		return
 	}
 }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -317,17 +317,17 @@ func TestGetUser(t *testing.T) {
 
 	if userMap, err := Client.GetProfiles(rteam.Data.(*model.Team).Id, 0, 1000, ""); err != nil {
 		t.Fatal(err)
-	} else if len(userMap.Data.(map[string]*model.User)) != 2 {
+	} else if len(userMap.Data.(model.UserMap)) != 2 {
 		t.Fatal("should have been 2")
-	} else if userMap.Data.(map[string]*model.User)[rId].Id != rId {
+	} else if userMap.Data.(model.UserMap)[rId].Id != rId {
 		t.Fatal("should have been valid")
 	} else {
 
 		// test etag caching
 		if cache_result, err := Client.GetProfiles(rteam.Data.(*model.Team).Id, 0, 1000, userMap.Etag); err != nil {
 			t.Fatal(err)
-		} else if cache_result.Data.(map[string]*model.User) != nil {
-			t.Log(model.UserMapToJson(cache_result.Data.(map[string]*model.User)))
+		} else if cache_result.Data.(model.UserMap) != nil {
+			t.Log(model.UserMapToJson(cache_result.Data.(model.UserMap)))
 			t.Fatal("cache should be empty")
 		}
 	}

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1292,6 +1292,8 @@ func TestGetProfile(t *testing.T) {
 func TestSearchProfiles(t *testing.T) {
 	Setup()
 
+	Client.Logout()
+
 	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1262,3 +1262,68 @@ func TestSwitchToEmail(t *testing.T) {
 		t.Fatal("should have failed - wrong user")
 	}
 }
+
+func TestGetProfile(t *testing.T) {
+	Setup()
+
+	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	rteam, _ := Client.CreateTeam(&team)
+
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "pwd"}
+	ruser, _ := Client.CreateUser(&user, "")
+	store.Must(Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+
+	if _, err := Client.GetProfile(ruser.Data.(*model.User).Id, ""); err == nil {
+		t.Fatal("should have failed")
+	}
+
+	Client.LoginByEmail(team.Name, user.Email, user.Password)
+
+	if result, err := Client.GetProfile(ruser.Data.(*model.User).Id, ""); err != nil {
+		t.Fatal(err.Error())
+	} else {
+		if result.Data.(*model.User).Id != ruser.Data.(*model.User).Id {
+			t.Fatal("invalid user returned")
+		}
+	}
+
+}
+
+func TestSearchProfiles(t *testing.T) {
+	Setup()
+
+	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	rteam, _ := Client.CreateTeam(&team)
+
+	user := model.User{TeamId: rteam.Data.(*model.Team).Id, Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "pwd"}
+	r1, _ := Client.CreateUser(&user, "")
+	ruser := r1.Data.(*model.User)
+	store.Must(Srv.Store.User().VerifyEmail(ruser.Id))
+
+	data := map[string]string{}
+	data["term"] = ruser.Username
+
+	if _, err := Client.SearchProfiles(data); err == nil {
+		t.Fatal("should have failed")
+	}
+
+	Client.LoginByEmail(team.Name, user.Email, user.Password)
+
+	if result, err := Client.SearchProfiles(data); err != nil {
+		t.Fatal(err.Error())
+	} else {
+		if len(result.Data.(model.UserMap)) != 1 {
+			t.Fatal("invalid results returned")
+		}
+	}
+
+	data["term"] = "junk"
+	if result, err := Client.SearchProfiles(data); err != nil {
+		t.Fatal(err.Error())
+	} else {
+		if len(result.Data.(model.UserMap)) != 0 {
+			t.Fatal("invalid results returned")
+		}
+	}
+
+}

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -315,7 +315,7 @@ func TestGetUser(t *testing.T) {
 		t.Fatal("shouldn't have accss")
 	}
 
-	if userMap, err := Client.GetProfiles(rteam.Data.(*model.Team).Id, ""); err != nil {
+	if userMap, err := Client.GetProfiles(rteam.Data.(*model.Team).Id, 0, 1000, ""); err != nil {
 		t.Fatal(err)
 	} else if len(userMap.Data.(map[string]*model.User)) != 2 {
 		t.Fatal("should have been 2")
@@ -324,15 +324,15 @@ func TestGetUser(t *testing.T) {
 	} else {
 
 		// test etag caching
-		if cache_result, err := Client.GetProfiles(rteam.Data.(*model.Team).Id, userMap.Etag); err != nil {
+		if cache_result, err := Client.GetProfiles(rteam.Data.(*model.Team).Id, 0, 1000, userMap.Etag); err != nil {
 			t.Fatal(err)
 		} else if cache_result.Data.(map[string]*model.User) != nil {
-			t.Log(cache_result.Data)
+			t.Log(model.UserMapToJson(cache_result.Data.(map[string]*model.User)))
 			t.Fatal("cache should be empty")
 		}
 	}
 
-	if _, err := Client.GetProfiles(rteam2.Data.(*model.Team).Id, ""); err == nil {
+	if _, err := Client.GetProfiles(rteam2.Data.(*model.Team).Id, 0, 1000, ""); err == nil {
 		t.Fatal("shouldn't have access")
 	}
 
@@ -348,7 +348,7 @@ func TestGetUser(t *testing.T) {
 
 	Client.LoginByEmail(team.Name, user.Email, "pwd")
 
-	if _, err := Client.GetProfiles(rteam2.Data.(*model.Team).Id, ""); err != nil {
+	if _, err := Client.GetProfiles(rteam2.Data.(*model.Team).Id, 0, 1000, ""); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -327,7 +327,6 @@ func TestGetUser(t *testing.T) {
 		if cache_result, err := Client.GetProfiles(rteam.Data.(*model.Team).Id, 0, 1000, userMap.Etag); err != nil {
 			t.Fatal(err)
 		} else if cache_result.Data.(model.UserMap) != nil {
-			t.Log(model.UserMapToJson(cache_result.Data.(model.UserMap)))
 			t.Fatal("cache should be empty")
 		}
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1624,6 +1624,10 @@
     "translation": "Couldn't upload profile image"
   },
   {
+    "id": "api.user.get_profile.bad_permissions.app_error",
+    "translation": "You do not have the appropriate permissions"
+  },
+  {
     "id": "api.web_conn.new_web_conn.last_activity.error",
     "translation": "Failed to update LastActivityAt for user_id=%v and session_id=%v, err=%v"
   },
@@ -2540,6 +2544,10 @@
     "translation": "We couldn't get the extra info for channel members"
   },
   {
+    "id": "store.sql_channel.search_extra_members.app_error",
+    "translation": "We couldn't search the extra info for channel members"
+  },
+  {
     "id": "store.sql_channel.get_for_export.app_error",
     "translation": "We couldn't get all the channels"
   },
@@ -3082,6 +3090,14 @@
   {
     "id": "store.sql_user.get_profiles.app_error",
     "translation": "We encountered an error while finding user profiles"
+  },
+  {
+    "id": "store.sql_user.get_profiles_from_list.app_error",
+    "translation": "We encountered an error while finding user profiles from the provided list"
+  },
+  {
+    "id": "store.sql_user.search_profiles.app_error",
+    "translation": "We encountered an error while searching user profiles"
   },
   {
     "id": "store.sql_user.get_sysadmin_profiles.app_error",

--- a/model/channel_extra.go
+++ b/model/channel_extra.go
@@ -23,9 +23,9 @@ func (o *ExtraMember) Sanitize(options map[string]bool) {
 }
 
 type ChannelExtra struct {
-	Id          string        `json:"id"`
-	Members     []ExtraMember `json:"members"`
-	MemberCount int64         `json:"member_count"`
+	Id          string                  `json:"id"`
+	Members     map[string]*ExtraMember `json:"members"`
+	MemberCount int64                   `json:"member_count"`
 }
 
 func (o *ChannelExtra) ToJson() string {

--- a/model/channel_extra.go
+++ b/model/channel_extra.go
@@ -4,8 +4,13 @@
 package model
 
 import (
+	"crypto/md5"
 	"encoding/json"
+	"fmt"
 	"io"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 type ExtraMember struct {
@@ -46,4 +51,18 @@ func ChannelExtraFromJson(data io.Reader) *ChannelExtra {
 	} else {
 		return nil
 	}
+}
+
+func (ce *ChannelExtra) Etag() string {
+	ids := []string{}
+
+	for _, m := range ce.Members {
+		ids = append(ids, m.Id)
+	}
+
+	sort.Strings(ids)
+
+	md5Ids := fmt.Sprintf("%x", md5.Sum([]byte(strings.Join(ids, ""))))
+
+	return fmt.Sprintf("%v.%v.%v.%v", CurrentVersion, ce.Id, strconv.FormatInt(ce.MemberCount, 10), md5Ids)
 }

--- a/model/client.go
+++ b/model/client.go
@@ -256,8 +256,8 @@ func (c *Client) GetMe(etag string) (*Result, *AppError) {
 	}
 }
 
-func (c *Client) GetProfiles(teamId string, etag string) (*Result, *AppError) {
-	if r, err := c.DoApiGet("/users/profiles/"+teamId, "", etag); err != nil {
+func (c *Client) GetProfiles(teamId string, offset int, limit int, etag string) (*Result, *AppError) {
+	if r, err := c.DoApiGet(fmt.Sprintf("/users/profiles/%s/%d/%d", teamId, offset, limit), "", etag); err != nil {
 		return nil, err
 	} else {
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),

--- a/model/client.go
+++ b/model/client.go
@@ -265,6 +265,24 @@ func (c *Client) GetProfiles(teamId string, offset int, limit int, etag string) 
 	}
 }
 
+func (c *Client) GetProfile(userId string, etag string) (*Result, *AppError) {
+	if r, err := c.DoApiGet(fmt.Sprintf("/users/profile/%s", userId), "", etag); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), UserFromJson(r.Body)}, nil
+	}
+}
+
+func (c *Client) SearchProfiles(m map[string]string) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/users/profiles/search", MapToJson(m)); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), UserMapFromJson(r.Body)}, nil
+	}
+}
+
 func (c *Client) LoginById(id string, password string) (*Result, *AppError) {
 	m := make(map[string]string)
 	m["id"] = id
@@ -664,6 +682,15 @@ func (c *Client) UpdateLastViewedAt(channelId string) (*Result, *AppError) {
 
 func (c *Client) GetChannelExtraInfo(id string, memberLimit int, etag string) (*Result, *AppError) {
 	if r, err := c.DoApiGet("/channels/"+id+"/extra_info/"+strconv.FormatInt(int64(memberLimit), 10), "", etag); err != nil {
+		return nil, err
+	} else {
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), ChannelExtraFromJson(r.Body)}, nil
+	}
+}
+
+func (c *Client) SearchChannelExtraInfo(id string, m map[string]string) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/channels/"+id+"/extra_info/search", MapToJson(m)); err != nil {
 		return nil, err
 	} else {
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),

--- a/model/post_list.go
+++ b/model/post_list.go
@@ -9,8 +9,9 @@ import (
 )
 
 type PostList struct {
-	Order []string         `json:"order"`
-	Posts map[string]*Post `json:"posts"`
+	Order    []string         `json:"order"`
+	Posts    map[string]*Post `json:"posts"`
+	Profiles UserMap          `json:"profiles"`
 }
 
 func (o *PostList) ToJson() string {

--- a/model/user.go
+++ b/model/user.go
@@ -56,6 +56,8 @@ type User struct {
 	Locale             string    `json:"locale"`
 }
 
+type UserMap map[string]*User
+
 // IsValid validates the user and returns an error if it isn't configured
 // correctly.
 func (u *User) IsValid() *AppError {
@@ -374,26 +376,6 @@ func UserFromJson(data io.Reader) *User {
 	}
 }
 
-func UserMapToJson(u map[string]*User) string {
-	b, err := json.Marshal(u)
-	if err != nil {
-		return ""
-	} else {
-		return string(b)
-	}
-}
-
-func UserMapFromJson(data io.Reader) map[string]*User {
-	decoder := json.NewDecoder(data)
-	var users map[string]*User
-	err := decoder.Decode(&users)
-	if err == nil {
-		return users
-	} else {
-		return nil
-	}
-}
-
 // HashPassword generates a hash using the bcrypt.GenerateFromPassword
 func HashPassword(password string) string {
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), 10)
@@ -465,4 +447,31 @@ func CleanUsername(s string) string {
 	}
 
 	return s
+}
+
+func (um *UserMap) ToJson() string {
+	b, err := json.Marshal(um)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func UserMapFromJson(data io.Reader) *UserMap {
+	decoder := json.NewDecoder(data)
+	var users UserMap
+	err := decoder.Decode(&users)
+	if err == nil {
+		return &users
+	} else {
+		return nil
+	}
+}
+
+func (um *UserMap) ClearNonProfileFields(sanitizeOptions map[string]bool) {
+	for _, p := range *um {
+		p.Sanitize(sanitizeOptions)
+		p.ClearNonProfileFields()
+	}
 }

--- a/model/user.go
+++ b/model/user.go
@@ -458,12 +458,12 @@ func (um *UserMap) ToJson() string {
 	}
 }
 
-func UserMapFromJson(data io.Reader) *UserMap {
+func UserMapFromJson(data io.Reader) UserMap {
 	decoder := json.NewDecoder(data)
 	var users UserMap
 	err := decoder.Decode(&users)
 	if err == nil {
-		return &users
+		return users
 	} else {
 		return nil
 	}

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -611,7 +611,7 @@ func (s SqlChannelStore) GetExtraMembers(channelId string, limit int) StoreChann
 	go func() {
 		result := StoreResult{}
 
-		var members []model.ExtraMember
+		var members []*model.ExtraMember
 		var err error
 
 		if limit != -1 {
@@ -650,10 +650,56 @@ func (s SqlChannelStore) GetExtraMembers(channelId string, limit int) StoreChann
 		if err != nil {
 			result.Err = model.NewLocAppError("SqlChannelStore.GetExtraMembers", "store.sql_channel.get_extra_members.app_error", nil, "channel_id="+channelId+", "+err.Error())
 		} else {
+			memberMap := map[string]*model.ExtraMember{}
 			for i := range members {
 				members[i].Sanitize(utils.Cfg.GetSanitizeOptions())
+				memberMap[members[i].Id] = members[i]
 			}
-			result.Data = members
+			result.Data = memberMap
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlChannelStore) SearchExtraMembers(channelId, term string) StoreChannel {
+	storeChannel := make(StoreChannel)
+
+	go func() {
+		result := StoreResult{}
+
+		var members []*model.ExtraMember
+		var err error
+
+		_, err = s.GetReplica().Select(&members, `
+			SELECT
+				Id,
+				Nickname,
+				Email,
+				ChannelMembers.Roles,
+				Username
+			FROM
+				ChannelMembers,
+				Users
+			WHERE
+				ChannelMembers.UserId = Users.Id
+				AND Users.DeleteAt = 0
+				AND ChannelId = :ChannelId
+				AND (Users.Username LIKE :Term
+					OR Users.Nickname LIKE :Term)`, map[string]interface{}{"ChannelId": channelId, "Term": "%" + term + "%"})
+
+		if err != nil {
+			result.Err = model.NewLocAppError("SqlChannelStore.GetExtraMembers", "store.sql_channel.get_extra_members.app_error", nil, "channel_id="+channelId+", "+err.Error())
+		} else {
+			memberMap := map[string]*model.ExtraMember{}
+			for i := range members {
+				members[i].Sanitize(utils.Cfg.GetSanitizeOptions())
+				memberMap[members[i].Id] = members[i]
+			}
+			result.Data = memberMap
 		}
 
 		storeChannel <- result

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -692,7 +692,7 @@ func (s SqlChannelStore) SearchExtraMembers(channelId, term string) StoreChannel
 					OR Users.Nickname LIKE :Term)`, map[string]interface{}{"ChannelId": channelId, "Term": "%" + term + "%"})
 
 		if err != nil {
-			result.Err = model.NewLocAppError("SqlChannelStore.GetExtraMembers", "store.sql_channel.get_extra_members.app_error", nil, "channel_id="+channelId+", "+err.Error())
+			result.Err = model.NewLocAppError("SqlChannelStore.SearchExtraMembers", "store.sql_channel.search_extra_members.app_error", nil, "channel_id="+channelId+", "+err.Error())
 		} else {
 			memberMap := map[string]*model.ExtraMember{}
 			for i := range members {

--- a/store/sql_user_store_test.go
+++ b/store/sql_user_store_test.go
@@ -258,7 +258,7 @@ func TestUserStoreGetProfiles(t *testing.T) {
 	if r1 := <-store.User().GetProfiles(u1.TeamId, 60, 0); r1.Err != nil {
 		t.Fatal(r1.Err)
 	} else {
-		users := r1.Data.(map[string]*model.User)
+		users := r1.Data.(model.UserMap)
 		if len(users) != 2 {
 			t.Fatal("invalid returned users")
 		}
@@ -271,8 +271,65 @@ func TestUserStoreGetProfiles(t *testing.T) {
 	if r2 := <-store.User().GetProfiles("123", 60, 0); r2.Err != nil {
 		t.Fatal(r2.Err)
 	} else {
-		if len(r2.Data.(map[string]*model.User)) != 0 {
+		if len(r2.Data.(model.UserMap)) != 0 {
 			t.Fatal("should have returned empty map")
+		}
+	}
+}
+
+func TestUserStoreGetProfilesFromList(t *testing.T) {
+	Setup()
+
+	u1 := model.User{}
+	u1.TeamId = model.NewId()
+	u1.Email = model.NewId()
+	Must(store.User().Save(&u1))
+
+	u2 := model.User{}
+	u2.TeamId = u1.TeamId
+	u2.Email = model.NewId()
+	Must(store.User().Save(&u2))
+
+	ids := []string{u1.Id, u2.Id}
+
+	if r1 := <-store.User().GetProfilesFromList(ids); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		users := r1.Data.(model.UserMap)
+		if len(users) != 2 {
+			t.Fatal("invalid returned users")
+		}
+
+		if users[u1.Id].Id != u1.Id {
+			t.Fatal("invalid returned user")
+		}
+	}
+}
+
+func TestUserStoreSearchProfiles(t *testing.T) {
+	Setup()
+
+	u1 := model.User{}
+	u1.TeamId = model.NewId()
+	u1.Email = model.NewId()
+	u1.Username = model.NewId()
+	Must(store.User().Save(&u1))
+
+	u2 := model.User{}
+	u2.TeamId = u1.TeamId
+	u2.Email = model.NewId()
+	Must(store.User().Save(&u2))
+
+	if r1 := <-store.User().SearchProfiles(u1.TeamId, u1.Username); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		users := r1.Data.(model.UserMap)
+		if len(users) != 1 {
+			t.Fatal("invalid returned users")
+		}
+
+		if users[u1.Id].Id != u1.Id {
+			t.Fatal("invalid returned user")
 		}
 	}
 }

--- a/store/sql_user_store_test.go
+++ b/store/sql_user_store_test.go
@@ -255,7 +255,7 @@ func TestUserStoreGetProfiles(t *testing.T) {
 	u2.Email = model.NewId()
 	Must(store.User().Save(&u2))
 
-	if r1 := <-store.User().GetProfiles(u1.TeamId); r1.Err != nil {
+	if r1 := <-store.User().GetProfiles(u1.TeamId, 60, 0); r1.Err != nil {
 		t.Fatal(r1.Err)
 	} else {
 		users := r1.Data.(map[string]*model.User)
@@ -268,7 +268,7 @@ func TestUserStoreGetProfiles(t *testing.T) {
 		}
 	}
 
-	if r2 := <-store.User().GetProfiles("123"); r2.Err != nil {
+	if r2 := <-store.User().GetProfiles("123", 60, 0); r2.Err != nil {
 		t.Fatal(r2.Err)
 	} else {
 		if len(r2.Data.(map[string]*model.User)) != 0 {
@@ -418,6 +418,24 @@ func TestUserStoreUpdateAuthData(t *testing.T) {
 		}
 		if user.Password != "" {
 			t.Fatal("Password was not cleared properly")
+		}
+	}
+}
+
+func TestUserStoreGetRoleCount(t *testing.T) {
+	Setup()
+
+	u1 := model.User{}
+	u1.TeamId = model.NewId()
+	u1.Email = model.NewId()
+	u1.Roles = "role"
+	Must(store.User().Save(&u1))
+
+	if r1 := <-store.User().GetRoleCount(u1.TeamId, u1.Roles); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		if r1.Data.(int64) != 1 {
+			t.Fatal("invalid returned count")
 		}
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -80,6 +80,7 @@ type ChannelStore interface {
 	RemoveMember(channelId string, userId string) StoreChannel
 	PermanentDeleteMembersByUser(userId string) StoreChannel
 	GetExtraMembers(channelId string, limit int) StoreChannel
+	SearchExtraMembers(channelId, term string) StoreChannel
 	CheckPermissionsTo(teamId string, channelId string, userId string) StoreChannel
 	CheckOpenChannelPermissions(teamId string, channelId string) StoreChannel
 	CheckPermissionsToByName(teamId string, channelName string, userId string) StoreChannel
@@ -122,6 +123,7 @@ type UserStore interface {
 	GetByEmail(teamId string, email string) StoreChannel
 	GetByAuth(teamId string, authData string, authService string) StoreChannel
 	GetByUsername(teamId string, username string) StoreChannel
+	SearchProfiles(teamId, term string) StoreChannel
 	VerifyEmail(userId string) StoreChannel
 	GetEtagForProfiles(teamId string, limit, offset int) StoreChannel
 	UpdateFailedPasswordAttempts(userId string, attempts int) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -118,6 +118,7 @@ type UserStore interface {
 	UpdateAuthData(userId, service, authData, email string) StoreChannel
 	Get(id string) StoreChannel
 	GetProfiles(teamId string, limit, offset int) StoreChannel
+	GetProfilesFromList(userIds []string) StoreChannel
 	GetByEmail(teamId string, email string) StoreChannel
 	GetByAuth(teamId string, authData string, authService string) StoreChannel
 	GetByUsername(teamId string, username string) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -117,12 +117,12 @@ type UserStore interface {
 	UpdatePassword(userId, newPassword string) StoreChannel
 	UpdateAuthData(userId, service, authData, email string) StoreChannel
 	Get(id string) StoreChannel
-	GetProfiles(teamId string) StoreChannel
+	GetProfiles(teamId string, limit, offset int) StoreChannel
 	GetByEmail(teamId string, email string) StoreChannel
 	GetByAuth(teamId string, authData string, authService string) StoreChannel
 	GetByUsername(teamId string, username string) StoreChannel
 	VerifyEmail(userId string) StoreChannel
-	GetEtagForProfiles(teamId string) StoreChannel
+	GetEtagForProfiles(teamId string, limit, offset int) StoreChannel
 	UpdateFailedPasswordAttempts(userId string, attempts int) StoreChannel
 	GetForExport(teamId string) StoreChannel
 	GetTotalUsersCount() StoreChannel
@@ -130,6 +130,7 @@ type UserStore interface {
 	GetSystemAdminProfiles() StoreChannel
 	PermanentDelete(userId string) StoreChannel
 	AnalyticsUniqueUserCount(teamId string) StoreChannel
+	GetRoleCount(teamId, role string) StoreChannel
 }
 
 type SessionStore interface {

--- a/web/react/components/channel_header.jsx
+++ b/web/react/components/channel_header.jsx
@@ -52,10 +52,14 @@ export default class ChannelHeader extends React.Component {
     getStateFromStores() {
         const extraInfo = ChannelStore.getCurrentExtraInfo();
 
+        const users = $.map(extraInfo.members, (el) => {
+            return el;
+        });
+
         return {
             channel: ChannelStore.getCurrent(),
             memberChannel: ChannelStore.getCurrentMember(),
-            users: extraInfo.members,
+            users,
             userCount: extraInfo.member_count,
             searchVisible: SearchStore.getSearchResults() !== null
         };

--- a/web/react/components/channel_invite_modal.jsx
+++ b/web/react/components/channel_invite_modal.jsx
@@ -10,6 +10,7 @@ import ChannelStore from '../stores/channel_store.jsx';
 import * as Utils from '../utils/utils.jsx';
 import * as Client from '../utils/client.jsx';
 import * as AsyncClient from '../utils/async_client.jsx';
+import Constants from '../utils/constants.jsx';
 
 import {FormattedMessage} from 'mm-intl';
 
@@ -77,6 +78,7 @@ export default class ChannelInviteModal extends React.Component {
             ChannelStore.addChangeListener(this.onListenerChange);
             UserStore.addChangeListener(this.onListenerChange);
             this.onListenerChange();
+            AsyncClient.getProfiles(0, Constants.USER_CHUNK_SIZE);
         } else if (this.props.show && !nextProps.show) {
             ChannelStore.removeExtraInfoChangeListener(this.onListenerChange);
             ChannelStore.removeChangeListener(this.onListenerChange);

--- a/web/react/components/channel_invite_modal.jsx
+++ b/web/react/components/channel_invite_modal.jsx
@@ -142,6 +142,9 @@ export default class ChannelInviteModal extends React.Component {
                     style={{maxHeight}}
                     users={this.state.nonmembers}
                     actions={[this.createInviteButton]}
+                    search={(term) => {
+                        AsyncClient.searchProfiles(term);
+                    }}
                 />
             );
         }

--- a/web/react/components/channel_invite_modal.jsx
+++ b/web/react/components/channel_invite_modal.jsx
@@ -53,21 +53,11 @@ export default class ChannelInviteModal extends React.Component {
             };
         }
 
-        // make sure we have all members of this channel before rendering
         const extraInfo = ChannelStore.getCurrentExtraInfo();
-        if (extraInfo.member_count !== extraInfo.members.length) {
-            AsyncClient.getChannelExtraInfo(this.props.channel.id, -1);
-
-            return {
-                loading: true
-            };
-        }
-
-        const memberIds = extraInfo.members.map((user) => user.id);
 
         var nonmembers = [];
         for (var id in users) {
-            if (memberIds.indexOf(id) === -1) {
+            if (!(id in extraInfo.members)) {
                 nonmembers.push(users[id]);
             }
         }

--- a/web/react/components/channel_members_modal.jsx
+++ b/web/react/components/channel_members_modal.jsx
@@ -44,18 +44,9 @@ export default class ChannelMembersModal extends React.Component {
     }
     getStateFromStores() {
         const extraInfo = ChannelStore.getCurrentExtraInfo();
-        const profiles = UserStore.getActiveOnlyProfiles();
 
-        if (extraInfo.member_count !== extraInfo.members.length) {
-            AsyncClient.getChannelExtraInfo(this.props.channel.id, -1);
-
-            return {
-                loading: true
-            };
-        }
-
-        const memberList = extraInfo.members.map((member) => {
-            return profiles[member.id];
+        const memberList = $.map(extraInfo.members, (el) => {
+            return el;
         });
 
         function compareByUsername(a, b) {
@@ -151,6 +142,7 @@ export default class ChannelMembersModal extends React.Component {
                     style={{maxHeight}}
                     users={this.state.memberList}
                     actions={[this.createRemoveMemberButton]}
+                    isChannelMembers={true}
                 />
             );
         }

--- a/web/react/components/channel_members_modal.jsx
+++ b/web/react/components/channel_members_modal.jsx
@@ -142,7 +142,9 @@ export default class ChannelMembersModal extends React.Component {
                     style={{maxHeight}}
                     users={this.state.memberList}
                     actions={[this.createRemoveMemberButton]}
-                    isChannelMembers={true}
+                    search={(term) => {
+                        AsyncClient.searchChannelExtraInfo(term);
+                    }}
                 />
             );
         }

--- a/web/react/components/filtered_user_list.jsx
+++ b/web/react/components/filtered_user_list.jsx
@@ -3,12 +3,8 @@
 
 import UserList from './user_list.jsx';
 
-import ChannelStore from '../stores/channel_store.jsx';
-
-import * as Client from '../utils/client.jsx';
-import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import Constants from '../utils/constants.jsx';
-const ActionTypes = Constants.ActionTypes;
+const KeyCodes = Constants.KeyCodes;
 
 import {intlShape, injectIntl, defineMessages, FormattedMessage} from 'mm-intl';
 
@@ -28,6 +24,7 @@ class FilteredUserList extends React.Component {
         super(props);
 
         this.searchProfiles = this.searchProfiles.bind(this);
+        this.keyPress = this.keyPress.bind(this);
 
         this.state = {
             filter: ''
@@ -45,45 +42,20 @@ class FilteredUserList extends React.Component {
     }
 
     searchProfiles() {
-        const rdata = {};
-        rdata.term = this.refs.filter.value;
+        const filter = this.refs.filter.value;
 
-        if (!rdata.term || rdata.term.length === 0) {
+        if (!filter || filter.length === 0) {
             this.setState({filter: ''});
             return;
         }
 
-        if (this.props.isChannelMembers) {
-            Client.searchChannelExtraInfo(
-                ChannelStore.getCurrentId(),
-                rdata,
-                (data) => {
-                    AppDispatcher.handleServerAction({
-                        type: ActionTypes.RECEIVED_CHANNEL_EXTRA_INFO,
-                        extra_info: data
-                    });
+        this.setState({filter});
+        this.props.search(filter);
+    }
 
-                    this.setState({filter: rdata.term});
-                },
-                () => {
-                    this.setState({filter: ''});
-                }
-            );
-        } else {
-            Client.searchProfiles(
-                rdata,
-                (data) => {
-                    AppDispatcher.handleServerAction({
-                        type: ActionTypes.RECEIVED_PROFILES,
-                        profiles: data
-                    });
-
-                    this.setState({filter: rdata.term});
-                },
-                () => {
-                    this.setState({filter: ''});
-                }
-            );
+    keyPress(e) {
+        if (e.which === KeyCodes.ENTER) {
+            this.searchProfiles();
         }
     }
 
@@ -92,7 +64,6 @@ class FilteredUserList extends React.Component {
 
         let users = this.props.users;
 
-        // this logic might be better placed in UserStore
         if (this.state.filter) {
             const filter = this.state.filter.toLowerCase();
 
@@ -145,6 +116,7 @@ class FilteredUserList extends React.Component {
                             ref='filter'
                             className='form-control filter-textbox'
                             placeholder={formatMessage(holders.search)}
+                            onKeyPress={this.keyPress}
                         />
                     </div>
                     <div className='col-sm-2'>
@@ -178,8 +150,7 @@ class FilteredUserList extends React.Component {
 
 FilteredUserList.defaultProps = {
     users: [],
-    actions: [],
-    isChannelMembers: false
+    actions: []
 };
 
 FilteredUserList.propTypes = {
@@ -187,7 +158,7 @@ FilteredUserList.propTypes = {
     users: React.PropTypes.arrayOf(React.PropTypes.object),
     actions: React.PropTypes.arrayOf(React.PropTypes.func),
     style: React.PropTypes.object,
-    isChannelMembers: React.PropTypes.bool
+    search: React.PropTypes.bool.isRequired
 };
 
 export default injectIntl(FilteredUserList);

--- a/web/react/components/member_list_team.jsx
+++ b/web/react/components/member_list_team.jsx
@@ -55,6 +55,9 @@ export default class MemberListTeam extends React.Component {
                 style={this.props.style}
                 users={this.state.users}
                 actions={[TeamMembersDropdown]}
+                search={(term) => {
+                    AsyncClient.searchProfiles(term);
+                }}
             />
         );
     }

--- a/web/react/components/member_list_team.jsx
+++ b/web/react/components/member_list_team.jsx
@@ -3,7 +3,11 @@
 
 import FilteredUserList from './filtered_user_list.jsx';
 import TeamMembersDropdown from './team_members_dropdown.jsx';
+
 import UserStore from '../stores/user_store.jsx';
+
+import * as AsyncClient from '../utils/async_client.jsx';
+import Constants from '../utils/constants.jsx';
 
 export default class MemberListTeam extends React.Component {
     constructor(props) {
@@ -18,6 +22,7 @@ export default class MemberListTeam extends React.Component {
     }
 
     componentDidMount() {
+        AsyncClient.getProfiles(0, Constants.USER_CHUNK_SIZE);
         UserStore.addChangeListener(this.onChange);
     }
 

--- a/web/react/components/more_direct_channels.jsx
+++ b/web/react/components/more_direct_channels.jsx
@@ -1,10 +1,14 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-const Modal = ReactBootstrap.Modal;
 import FilteredUserList from './filtered_user_list.jsx';
+
 import UserStore from '../stores/user_store.jsx';
+
+import * as AsyncClient from '../utils/async_client.jsx';
 import * as Utils from '../utils/utils.jsx';
+
+const Modal = ReactBootstrap.Modal;
 
 import {FormattedMessage} from 'mm-intl';
 
@@ -128,6 +132,9 @@ export default class MoreDirectChannels extends React.Component {
                         style={{maxHeight}}
                         users={this.state.users}
                         actions={[this.createJoinDirectChannelButton]}
+                        search={(term) => {
+                            AsyncClient.searchProfiles(term);
+                        }}
                     />
                 </Modal.Body>
                 <Modal.Footer>

--- a/web/react/components/navbar.jsx
+++ b/web/react/components/navbar.jsx
@@ -53,10 +53,18 @@ export default class Navbar extends React.Component {
         this.state = state;
     }
     getStateFromStores() {
+        let users;
+        const extraInfo = ChannelStore.getCurrentExtraInfo();
+        if (extraInfo && extraInfo.members) {
+            users = $.map(extraInfo.members, (el) => {
+                return el;
+            });
+        }
+
         return {
             channel: ChannelStore.getCurrent(),
             member: ChannelStore.getCurrentMember(),
-            users: ChannelStore.getCurrentExtraInfo().members
+            users
         };
     }
     componentDidMount() {

--- a/web/react/components/search_bar.jsx
+++ b/web/react/components/search_bar.jsx
@@ -121,6 +121,13 @@ class SearchBar extends React.Component {
                         results: data,
                         is_mention_search: isMentionSearch
                     });
+
+                    if (data.profiles) {
+                        AppDispatcher.handleServerAction({
+                            type: ActionTypes.RECEIVED_PROFILES,
+                            profiles: data.profiles
+                        });
+                    }
                 },
                 (err) => {
                     this.setState({isSearching: false});

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -140,6 +140,12 @@ export default class Sidebar extends React.Component {
         TeamStore.addChangeListener(this.onChange);
         PreferenceStore.addChangeListener(this.onChange);
 
+        // move when React Router goes in
+        const preferences = PreferenceStore.getCategory(Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW);
+        preferences.forEach((p) => {
+            AsyncClient.getProfile(p.name);
+        });
+
         this.updateTitle();
         this.updateUnreadIndicators();
 

--- a/web/react/components/sidebar.jsx
+++ b/web/react/components/sidebar.jsx
@@ -145,6 +145,7 @@ export default class Sidebar extends React.Component {
         preferences.forEach((p) => {
             AsyncClient.getProfile(p.name);
         });
+        AsyncClient.getProfiles(0, Constants.USER_CHUNK_SIZE);
 
         this.updateTitle();
         this.updateUnreadIndicators();
@@ -545,7 +546,7 @@ export default class Sidebar extends React.Component {
                     >
                         <FormattedMessage
                             id='sidebar.more'
-                            defaultMessage='More ({count})'
+                            defaultMessage='More ({count}+)'
                             values={{
                                 count: this.state.hiddenDirectChannelCount
                             }}

--- a/web/react/components/team_members_dropdown.jsx
+++ b/web/react/components/team_members_dropdown.jsx
@@ -41,7 +41,7 @@ export default class TeamMembersDropdown extends React.Component {
             };
             Client.updateRoles(data,
                 () => {
-                    AsyncClient.getProfiles();
+                    AsyncClient.getProfile(this.props.user.id);
                 },
                 (err) => {
                     this.setState({serverError: err.message});
@@ -52,7 +52,7 @@ export default class TeamMembersDropdown extends React.Component {
     handleMakeActive() {
         Client.updateActive(this.props.user.id, true,
             () => {
-                AsyncClient.getProfiles();
+                AsyncClient.getProfile(this.props.user.id);
                 AsyncClient.getChannelExtraInfo(ChannelStore.getCurrentId());
             },
             (err) => {
@@ -63,7 +63,7 @@ export default class TeamMembersDropdown extends React.Component {
     handleMakeNotActive() {
         Client.updateActive(this.props.user.id, false,
             () => {
-                AsyncClient.getProfiles();
+                AsyncClient.getProfile(this.props.user.id);
                 AsyncClient.getChannelExtraInfo(ChannelStore.getCurrentId());
             },
             (err) => {
@@ -83,7 +83,7 @@ export default class TeamMembersDropdown extends React.Component {
 
             Client.updateRoles(data,
                 () => {
-                    AsyncClient.getProfiles();
+                    AsyncClient.getProfile(this.props.user.id);
                 },
                 (err) => {
                     this.setState({serverError: err.message});

--- a/web/react/dispatcher/event_helpers.jsx
+++ b/web/react/dispatcher/event_helpers.jsx
@@ -17,6 +17,10 @@ export function emitChannelClickEvent(channel) {
     AsyncClient.updateLastViewedAt(channel.id);
     AsyncClient.getPosts(channel.id);
 
+    if (channel.type === Constants.DM_CHANNEL) {
+        AsyncClient.getProfile(Utils.getDirectTeammateId(channel.name));
+    }
+
     AppDispatcher.handleViewAction({
         type: ActionTypes.CLICK_CHANNEL,
         name: channel.name,

--- a/web/react/stores/analytics_store.jsx
+++ b/web/react/stores/analytics_store.jsx
@@ -40,6 +40,14 @@ class AnalyticsStoreClass extends EventEmitter {
         return {};
     }
 
+    getTeamStat(id, statName) {
+        if (id in this.teamStats) {
+            return this.teamStats[id][statName];
+        }
+
+        return null;
+    }
+
     storeSystemStats(newStats) {
         for (const stat in newStats) {
             if (!newStats.hasOwnProperty(stat)) {

--- a/web/react/stores/channel_store.jsx
+++ b/web/react/stores/channel_store.jsx
@@ -20,29 +20,6 @@ class ChannelStoreClass extends EventEmitter {
 
         this.setMaxListeners(15);
 
-        this.emitChange = this.emitChange.bind(this);
-        this.addChangeListener = this.addChangeListener.bind(this);
-        this.removeChangeListener = this.removeChangeListener.bind(this);
-        this.emitMoreChange = this.emitMoreChange.bind(this);
-        this.addMoreChangeListener = this.addMoreChangeListener.bind(this);
-        this.removeMoreChangeListener = this.removeMoreChangeListener.bind(this);
-        this.emitExtraInfoChange = this.emitExtraInfoChange.bind(this);
-        this.addExtraInfoChangeListener = this.addExtraInfoChangeListener.bind(this);
-        this.removeExtraInfoChangeListener = this.removeExtraInfoChangeListener.bind(this);
-        this.emitLeave = this.emitLeave.bind(this);
-        this.addLeaveListener = this.addLeaveListener.bind(this);
-        this.removeLeaveListener = this.removeLeaveListener.bind(this);
-        this.findFirstBy = this.findFirstBy.bind(this);
-        this.get = this.get.bind(this);
-        this.getMember = this.getMember.bind(this);
-        this.getByName = this.getByName.bind(this);
-        this.setPostMode = this.setPostMode.bind(this);
-        this.getPostMode = this.getPostMode.bind(this);
-        this.setUnreadCount = this.setUnreadCount.bind(this);
-        this.setUnreadCounts = this.setUnreadCounts.bind(this);
-        this.getUnreadCount = this.getUnreadCount.bind(this);
-        this.getUnreadCounts = this.getUnreadCounts.bind(this);
-
         this.currentId = null;
         this.postMode = this.POST_MODE_CHANNEL;
         this.channels = [];
@@ -231,8 +208,29 @@ class ChannelStoreClass extends EventEmitter {
     getMoreChannels() {
         return this.moreChannels;
     }
-    storeExtraInfos(extraInfos) {
-        this.extraInfos = extraInfos;
+    storeExtraInfo(extraInfo) {
+        if (this.extraInfos == null) {
+            this.extraInfos = {};
+        }
+
+        if (this.extraInfos[extraInfo.id] == null) {
+            this.extraInfos[extraInfo.id] = extraInfo;
+            return;
+        }
+
+        if (this.extraInfos[extraInfo.id].members == null) {
+            this.extraInfos[extraInfo.id].members = {};
+        }
+
+        for (const id in extraInfo.members) {
+            if (!extraInfo.members.hasOwnProperty(id)) {
+                continue;
+            }
+
+            this.extraInfos[extraInfo.id].members[id] = extraInfo.members[id];
+        }
+
+        this.extraInfos[extraInfo.id].member_count = extraInfo.member_cound;
     }
     getExtraInfos() {
         return this.extraInfos;
@@ -334,9 +332,7 @@ ChannelStore.dispatchToken = AppDispatcher.register((payload) => {
         break;
 
     case ActionTypes.RECEIVED_CHANNEL_EXTRA_INFO:
-        var extraInfos = ChannelStore.getExtraInfos();
-        extraInfos[action.extra_info.id] = action.extra_info;
-        ChannelStore.storeExtraInfos(extraInfos);
+        ChannelStore.storeExtraInfo(action.extra_info);
         ChannelStore.emitExtraInfoChange();
         break;
 

--- a/web/react/stores/socket_store.jsx
+++ b/web/react/stores/socket_store.jsx
@@ -217,6 +217,11 @@ function handleNewPostEvent(msg, translations) {
         AsyncClient.getChannel(msg.channel_id);
     }
 
+    // Get profile if it's missing
+    if (UserStore.getProfile(post.user_id) == null) {
+        AsyncClient.getProfile(post.user_id);
+    }
+
     // Send desktop notification
     if ((UserStore.getCurrentId() !== msg.user_id || post.props.from_webhook === 'true') && !Utils.isSystemMessage(post)) {
         const msgProps = msg.props;

--- a/web/react/stores/socket_store.jsx
+++ b/web/react/stores/socket_store.jsx
@@ -300,7 +300,7 @@ function handlePostDeleteEvent(msg) {
 }
 
 function handleNewUserEvent() {
-    AsyncClient.getProfiles();
+    AsyncClient.getProfiles(0, Constants.USER_CHUNK_SIZE);
     AsyncClient.getChannelExtraInfo();
 }
 

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -209,14 +209,14 @@ export function getChannelExtraInfo(id, memberLimit) {
 }
 
 export function getProfile(id) {
-    if (isCallInProgress('getProfile')) {
+    if (isCallInProgress('getProfile' + id)) {
         return;
     }
 
-    callTracker.getProfile = utils.getTimestamp();
+    callTracker['getProfile' + id] = utils.getTimestamp();
     client.getProfile(id,
         (data, textStatus, xhr) => {
-            callTracker.getProfile = 0;
+            callTracker['getProfile' + id] = 0;
 
             if (xhr.status === 304 || !data) {
                 return;
@@ -227,11 +227,11 @@ export function getProfile(id) {
 
             AppDispatcher.handleServerAction({
                 type: ActionTypes.RECEIVED_PROFILES,
-                profiles: profiles
+                profiles
             });
         },
         (err) => {
-            callTracker.getProfile = 0;
+            callTracker['getProfile' + id] = 0;
             dispatchError(err, 'getProfile');
         }
     );
@@ -444,6 +444,13 @@ export function search(terms) {
                 type: ActionTypes.RECEIVED_SEARCH,
                 results: data
             });
+
+            if (data.profiles) {
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_PROFILES,
+                    profiles: data.profiles
+                });
+            }
         },
         function searchFailure(err) {
             callTracker['search_' + String(terms)] = 0;
@@ -499,6 +506,13 @@ export function getPostsPage(id, maxPosts) {
                     numRequested: numPosts,
                     post_list: data
                 });
+
+                if (data.profiles) {
+                    AppDispatcher.handleServerAction({
+                        type: ActionTypes.RECEIVED_PROFILES,
+                        profiles: data.profiles
+                    });
+                }
             },
             (err) => {
                 dispatchError(err, 'getPostsPage');
@@ -554,6 +568,13 @@ export function getPosts(id) {
                 numRequested: 0,
                 post_list: data
             });
+
+            if (data.profiles) {
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_PROFILES,
+                    profiles: data.profiles
+                });
+            }
         },
         (err) => {
             dispatchError(err, 'getPosts');
@@ -591,6 +612,13 @@ export function getPostsBefore(postId, offset, numPost) {
                 numRequested: numPost,
                 post_list: data
             });
+
+            if (data.profiles) {
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_PROFILES,
+                    profiles: data.profiles
+                });
+            }
         },
         (err) => {
             dispatchError(err, 'getPostsBefore');
@@ -628,6 +656,13 @@ export function getPostsAfter(postId, offset, numPost) {
                 numRequested: numPost,
                 post_list: data
             });
+
+            if (data.profiles) {
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_PROFILES,
+                    profiles: data.profiles
+                });
+            }
         },
         (err) => {
             dispatchError(err, 'getPostsAfter');

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -208,28 +208,31 @@ export function getChannelExtraInfo(id, memberLimit) {
     }
 }
 
-export function getProfiles() {
-    if (isCallInProgress('getProfiles')) {
+export function getProfile(id) {
+    if (isCallInProgress('getProfile')) {
         return;
     }
 
-    callTracker.getProfiles = utils.getTimestamp();
-    client.getProfiles(
-        function getProfilesSuccess(data, textStatus, xhr) {
-            callTracker.getProfiles = 0;
+    callTracker.getProfile = utils.getTimestamp();
+    client.getProfile(id,
+        (data, textStatus, xhr) => {
+            callTracker.getProfile = 0;
 
             if (xhr.status === 304 || !data) {
                 return;
             }
 
+            const profiles = {};
+            profiles[data.id] = data;
+
             AppDispatcher.handleServerAction({
                 type: ActionTypes.RECEIVED_PROFILES,
-                profiles: data
+                profiles: profiles
             });
         },
-        function getProfilesFailure(err) {
-            callTracker.getProfiles = 0;
-            dispatchError(err, 'getProfiles');
+        (err) => {
+            callTracker.getProfile = 0;
+            dispatchError(err, 'getProfile');
         }
     );
 }
@@ -496,8 +499,6 @@ export function getPostsPage(id, maxPosts) {
                     numRequested: numPosts,
                     post_list: data
                 });
-
-                getProfiles();
             },
             (err) => {
                 dispatchError(err, 'getPostsPage');
@@ -553,8 +554,6 @@ export function getPosts(id) {
                 numRequested: 0,
                 post_list: data
             });
-
-            getProfiles();
         },
         (err) => {
             dispatchError(err, 'getPosts');
@@ -592,8 +591,6 @@ export function getPostsBefore(postId, offset, numPost) {
                 numRequested: numPost,
                 post_list: data
             });
-
-            getProfiles();
         },
         (err) => {
             dispatchError(err, 'getPostsBefore');
@@ -631,8 +628,6 @@ export function getPostsAfter(postId, offset, numPost) {
                 numRequested: numPost,
                 post_list: data
             });
-
-            getProfiles();
         },
         (err) => {
             dispatchError(err, 'getPostsAfter');

--- a/web/react/utils/async_client.jsx
+++ b/web/react/utils/async_client.jsx
@@ -237,6 +237,34 @@ export function getProfile(id) {
     );
 }
 
+export function getProfiles(offset, limit) {
+    if (isCallInProgress('getProfiles')) {
+        return;
+    }
+
+    callTracker.getProfiles = utils.getTimestamp();
+    client.getProfiles(
+        offset,
+        limit,
+        (data, textStatus, xhr) => {
+            callTracker.getProfiles = 0;
+
+            if (xhr.status === 304 || !data) {
+                return;
+            }
+
+            AppDispatcher.handleServerAction({
+                type: ActionTypes.RECEIVED_PROFILES,
+                profiles: data
+            });
+        },
+        (err) => {
+            callTracker.getProfiles = 0;
+            dispatchError(err, 'getProfiles');
+        }
+    );
+}
+
 export function getSessions() {
     if (isCallInProgress('getSessions')) {
         return;

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -914,6 +914,21 @@ export function getChannelExtraInfo(id, memberLimit, success, error) {
     });
 }
 
+export function searchChannelExtraInfo(id, data, success, error) {
+    $.ajax({
+        url: '/api/v1/channels/' + id + '/extra_info/search',
+        dataType: 'json',
+        contentType: 'application/json',
+        type: 'POST',
+        data: JSON.stringify(data),
+        success,
+        error: function onError(xhr, status, err) {
+            var e = handleError('searchChannelExtraInfo', xhr, status, err);
+            error(e);
+        }
+    });
+}
+
 export function executeCommand(channelId, command, suggest, success, error) {
     $.ajax({
         url: '/api/v1/commands/execute',
@@ -1248,6 +1263,23 @@ export function getProfilesForTeam(teamId, offset, limit, success, error) {
             error(e);
         }
     });
+}
+
+export function searchProfiles(data, success, error) {
+    $.ajax({
+        url: '/api/v1/users/profiles/search',
+        dataType: 'json',
+        contentType: 'application/json',
+        type: 'POST',
+        data: JSON.stringify(data),
+        success,
+        error: function onError(xhr, status, err) {
+            var e = handleError('searchProfiles', xhr, status, err);
+            error(e);
+        }
+    });
+
+    track('api', 'api_users_search_profiles');
 }
 
 export function uploadFile(formData, success, error) {

--- a/web/react/utils/client.jsx
+++ b/web/react/utils/client.jsx
@@ -1203,10 +1203,26 @@ export function removeChannelMember(id, data, success, error) {
     track('api', 'api_channels_remove_member');
 }
 
-export function getProfiles(success, error) {
+export function getProfile(id, success, error) {
     $.ajax({
         cache: false,
-        url: '/api/v1/users/profiles',
+        url: '/api/v1/users/profile/' + id,
+        dataType: 'json',
+        contentType: 'application/json',
+        type: 'GET',
+        success,
+        ifModified: true,
+        error: function onError(xhr, status, err) {
+            var e = handleError('getProfile', xhr, status, err);
+            error(e);
+        }
+    });
+}
+
+export function getProfiles(offset, limit, success, error) {
+    $.ajax({
+        cache: false,
+        url: '/api/v1/users/profiles/' + offset + '/' + limit,
         dataType: 'json',
         contentType: 'application/json',
         type: 'GET',
@@ -1219,10 +1235,10 @@ export function getProfiles(success, error) {
     });
 }
 
-export function getProfilesForTeam(teamId, success, error) {
+export function getProfilesForTeam(teamId, offset, limit, success, error) {
     $.ajax({
         cache: false,
-        url: '/api/v1/users/profiles/' + teamId,
+        url: '/api/v1/users/profiles/' + teamId + '/' + offset + '/' + limit,
         dataType: 'json',
         contentType: 'application/json',
         type: 'GET',

--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -143,6 +143,7 @@ export default {
     EMAIL_SERVICE: 'email',
     SIGNIN_CHANGE: 'signin_change',
     SIGNIN_VERIFIED: 'verified',
+    USER_CHUNK_SIZE: 60,
     POST_CHUNK_SIZE: 60,
     MAX_POST_CHUNKS: 3,
     POST_FOCUS_CONTEXT_RADIUS: 10,

--- a/web/react/utils/utils.jsx
+++ b/web/react/utils/utils.jsx
@@ -965,17 +965,28 @@ export function isComment(post) {
 }
 
 export function getDirectTeammate(channelId) {
-    var userIds = ChannelStore.get(channelId).name.split('__');
-    var curUserId = UserStore.getCurrentId();
-    var teammate = {};
+    let teammate = {};
+
+    const teammateId = getDirectTeammateId(ChannelStore.get(channelId).name);
+    if (teammateId.length !== 0) {
+        teammate = UserStore.getProfile(teammateId);
+    }
+
+    return teammate;
+}
+
+export function getDirectTeammateId(channelName) {
+    const userIds = channelName.split('__');
+    const curUserId = UserStore.getCurrentId();
+    let teammate = '';
 
     if (userIds.length !== 2 || userIds.indexOf(curUserId) === -1) {
         return teammate;
     }
 
-    for (var idx in userIds) {
+    for (const idx in userIds) {
         if (userIds[idx] !== curUserId) {
-            teammate = UserStore.getProfile(userIds[idx]);
+            teammate = userIds[idx];
             break;
         }
     }

--- a/web/static/i18n/en.json
+++ b/web/static/i18n/en.json
@@ -671,6 +671,7 @@
   "file_upload.filesAbove": "Files above {max}MB could not be uploaded: {filenames}",
   "file_upload.limited": "Uploads limited to {count} files maximum. Please use additional posts for more files.",
   "file_upload.pasted": "Image Pasted at ",
+  "filtered_user_list.searchProfiles": "Search",
   "filtered_user_list.count": "{count, number} {count, plural, one {member} other {members}}",
   "filtered_user_list.countTotal": "{count, number} {count, plural, one {member} other {members}} of {total} Total",
   "filtered_user_list.search": "Search members",

--- a/web/static/i18n/en.json
+++ b/web/static/i18n/en.json
@@ -918,7 +918,7 @@
   "sidebar.createChannel": "Create new channel",
   "sidebar.createGroup": "Create new group",
   "sidebar.direct": "Direct Messages",
-  "sidebar.more": "More ({count})",
+  "sidebar.more": "More ({count}+)",
   "sidebar.moreElips": "More...",
   "sidebar.pg": "Private Groups",
   "sidebar.removeList": "Remove from list",

--- a/web/static/i18n/en.json
+++ b/web/static/i18n/en.json
@@ -411,6 +411,7 @@
   "admin.team.userCreationTitle": "Enable User Creation: ",
   "admin.team_analytics.activeUsers": "Active Users With Posts",
   "admin.team_analytics.totalPosts": "Total Posts",
+  "admin.userList.loadMore": "Load more users",
   "admin.userList.title": "Users for {team}",
   "admin.userList.title2": "Users for {team} ({count})",
   "admin.user_item.confirmDemoteDescription": "If you demote yourself from the System Admin role and there is not another user with System Admin privileges, you'll need to re-assign a System Admin by accessing the Mattermost server through a terminal and running the following command.",

--- a/web/static/i18n/es.json
+++ b/web/static/i18n/es.json
@@ -917,7 +917,7 @@
   "sidebar.createChannel": "Crear un nuevo canal",
   "sidebar.createGroup": "Crear un nuevo grupo",
   "sidebar.direct": "Mensajes Directos",
-  "sidebar.more": "Más ({count})",
+  "sidebar.more": "Más ({count}+)",
   "sidebar.moreElips": "Más...",
   "sidebar.pg": "Grupos Privados",
   "sidebar.removeList": "Remover de la lista",

--- a/web/static/i18n/es.json
+++ b/web/static/i18n/es.json
@@ -670,6 +670,7 @@
   "file_upload.filesAbove": "No se pueden subir archivos de más de {max}MB: {filenames}",
   "file_upload.limited": "Se pueden subir un máximo de {count} archivos. Por favor envía otros mensajes para adjuntar más archivos.",
   "file_upload.pasted": "Imagen Pegada el ",
+  "filtered_user_list.searchProfiles": "Buscar",
   "filtered_user_list.count": "{count, number} {count, plural, one {Miembro} other {Miembros}}",
   "filtered_user_list.countTotal": "{count, number} {count, plural, one {Miembro} other {Miembros}} de {total} Total",
   "filtered_user_list.search": "Buscar miembros",

--- a/web/static/i18n/pt.json
+++ b/web/static/i18n/pt.json
@@ -672,6 +672,7 @@
   "file_upload.pasted": "Imagem Colada em ",
   "filtered_user_list.count": "{count, number} {count, plural, one {membro} other {membros}}",
   "filtered_user_list.countTotal": "{count, number} {count, plural, one {membro} other {membros}} de {total} Total",
+  "filtered_user_list.searchProfiles": "Procurar",
   "filtered_user_list.search": "Procurar membros",
   "find_team.email": "E-mail",
   "find_team.findDescription": "Foi enviado um e-mail com links para todas as equipes do qual você é membro.",

--- a/web/static/i18n/pt.json
+++ b/web/static/i18n/pt.json
@@ -917,7 +917,7 @@
   "sidebar.createChannel": "Criar novo canal",
   "sidebar.createGroup": "Criar um novo grupo",
   "sidebar.direct": "Mensagens Diretas",
-  "sidebar.more": "Mais ({count})",
+  "sidebar.more": "Mais ({count}+)",
   "sidebar.moreElips": "Mais...",
   "sidebar.pg": "Grupos Privados",
   "sidebar.removeList": "Remover da lista",


### PR DESCRIPTION
Brief overview of the refactoring in this PR:
* Added  a loadtest command to open/close websocket connections
* System console user page now has paging
* PostList now contains a profiles field
* Every time a list of posts is returned from the server, the related profiles are returned as well
* Added profile and channel member search APIs
* Updated filtered user lists to search with a button

Known issues:
* Member counts in the manage team/channel members modals don't count all users (they only count users the client has profiles for)
* "..." for usernames on first page load until scroll or channel switch (will be fixed in an upcoming PR)