### PR TITLE
PLT-2259 Added target='_blank' to all attachment download links

### DIFF
--- a/web/react/components/file_attachment.jsx
+++ b/web/react/components/file_attachment.jsx
@@ -185,6 +185,7 @@ class FileAttachment extends React.Component {
                         data-toggle='tooltip'
                         title={this.props.intl.formatMessage(holders.download) + ' \"' + filenameString + '\"'}
                         className='post-image__name'
+                        target='_blank'
                     >
                         {trimmedFilename}
                     </a>
@@ -193,6 +194,7 @@ class FileAttachment extends React.Component {
                             href={fileUrl}
                             download={filenameString}
                             className='post-image__download'
+                            target='_blank'
                         >
                             <span
                                 className='fa fa-download'

--- a/web/react/components/view_image_popover_bar.jsx
+++ b/web/react/components/view_image_popover_bar.jsx
@@ -51,6 +51,7 @@ export default class ViewImagePopoverBar extends React.Component {
                         href={this.props.fileURL}
                         download={this.props.filename}
                         className='text'
+                        target='_blank'
                     >
                         <FormattedMessage
                             id='view_image_popover.download'


### PR DESCRIPTION
Causes IE11 to attempt to download the file in a new tab so that it won't start unloading the current tab and close the websockets