### PR TITLE
updated the 2.0 Dockerfile to include the proper location of mm gzip

### DIFF
--- a/docker/2.0/Dockerfile
+++ b/docker/2.0/Dockerfile
@@ -34,7 +34,7 @@ VOLUME /var/lib/mysql
 WORKDIR /mattermost
 
 # Copy over files
-ADD https://github.com/mattermost/platform/releases/download/v2.0.0-rc2/mattermost.tar.gz /
+ADD https://github.com/mattermost/platform/releases/download/v2.0.0/mattermost.tar.gz /
 RUN tar -zxvf /mattermost.tar.gz --strip-components=1 && rm /mattermost.tar.gz
 ADD config_docker.json /
 ADD docker-entry.sh /


### PR DESCRIPTION
The Dockerfile for 2.0 was pointing to an old location of the Mattermost gzip file.

I updated the location.