### PR TITLE
Changed mention parser to ignore empty string mentions

### DIFF
--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -213,6 +213,11 @@ function highlightCurrentMentions(text, tokens) {
     }
 
     for (const mention of UserStore.getCurrentMentionKeys()) {
+        // occasionally we get an empty mention which matches a bunch of empty strings
+        if (!mention) {
+            continue;
+        }
+
         output = output.replace(new RegExp(`(^|\\W)(${escapeRegex(mention)})\\b`, 'gi'), replaceCurrentMentionWithToken);
     }
 


### PR DESCRIPTION
This is the cause of the strange escaped html entities in messages that people are getting occasionally. I'd like to know why we're getting empty strings as potential mentions, but I can't find anything obvious that would cause it