### PR TITLE
PLT-2138 Reordered theme field constants

### DIFF
--- a/web/react/utils/constants.jsx
+++ b/web/react/utils/constants.jsx
@@ -381,6 +381,21 @@ export default {
             uiName: 'Mention Highlight Link'
         },
         {
+            group: 'linkAndButtonElements',
+            id: 'linkColor',
+            uiName: 'Link Color'
+        },
+        {
+            group: 'linkAndButtonElements',
+            id: 'buttonBg',
+            uiName: 'Button BG'
+        },
+        {
+            group: 'linkAndButtonElements',
+            id: 'buttonColor',
+            uiName: 'Button Text'
+        },
+        {
             group: 'centerChannelElements',
             id: 'codeTheme',
             uiName: 'Code Theme',
@@ -402,21 +417,6 @@ export default {
                     uiName: 'Monokai'
                 }
             ]
-        },
-        {
-            group: 'linkAndButtonElements',
-            id: 'linkColor',
-            uiName: 'Link Color'
-        },
-        {
-            group: 'linkAndButtonElements',
-            id: 'buttonBg',
-            uiName: 'Button BG'
-        },
-        {
-            group: 'linkAndButtonElements',
-            id: 'buttonColor',
-            uiName: 'Button Text'
         }
     ],
     DEFAULT_CODE_THEME: 'github',


### PR DESCRIPTION
It was saving the fields of the theme string in a different order than it was loading them so the code theme was getting set to a colour and the fields following it were set to the following field's intended value