### PR TITLE
Path in docker differs for CD

### DIFF
--- a/docker/2.1/docker-entry.sh
+++ b/docker/2.1/docker-entry.sh
@@ -107,5 +107,5 @@ sleep 5
 # ------------------------
 
 echo starting platform
-cd /mattermost/bin
+cd /mattermost/mattermost/bin
 ./platform -config=/config_docker.json


### PR DESCRIPTION
Running docker will fail because it can't CD into the mattermost directory