### PR TITLE
PLT-2525: Render attachment fields similar to Slack

### DIFF
--- a/tests/test-slack-attachments.json
+++ b/tests/test-slack-attachments.json
@@ -1,0 +1,56 @@
+{
+    "message": "Hello world",
+    "props": {
+        "attachments": [
+            {
+                "color": "#7CD197",
+                "fields": [
+                    {
+                        "short": false,
+                        "title": "Area",
+                        "value": "Testing with a very long piece of text that will take up the whole width of the table. This is one more sentence to really make it a long field."
+                    },
+                    {
+                        "short": true,
+                        "title": "Iteration",
+                        "value": "Testing"
+                    },
+                    {
+                        "short": true,
+                        "title": "State",
+                        "value": "New"
+                    },
+                    {
+                        "short": false,
+                        "title": "Reason",
+                        "value": "New defect reported"
+                    },
+                    {
+                        "short": false,
+                        "title": "Random field",
+                        "value": "This is a field which is not marked as short so it should be rendered on a separate row"
+                    },
+                    {
+                        "short": true,
+                        "title": "Short 1",
+                        "value": "Short field"
+                    },
+                    {
+                        "short": true,
+                        "title": "Short 2",
+                        "value": "Another one"
+                    }
+                ],
+                "mrkdwn_in": [
+                    "pretext"
+                ],
+                "pretext": "Some text here",
+                "text": "This is the text of the attachment. It should appear just above the image",
+                "thumb_url": "https://slack.global.ssl.fastly.net/7bf4/img/services/jenkins-ci_128.png",
+                "title": "A slack attachment",
+                "title_link": "https://www.google.com"
+            }
+        ]
+    },
+    "type": "slack_attachment"
+}

--- a/webapp/components/post_attachment.jsx
+++ b/webapp/components/post_attachment.jsx
@@ -87,75 +87,82 @@ class PostAttachment extends React.Component {
             return '';
         }
 
-        const compactTable = fields.filter((field) => field.short).length > 0;
-        let tHead;
-        let tBody;
+        let fieldTables = [];
 
-        if (compactTable) {
-            let headerCols = [];
-            let bodyCols = [];
+        let headerCols = [];
+        let bodyCols = [];
+        let rowPos = 0;
+        let lastWasLong = false;
+        let nrTables = 0;
 
-            fields.forEach((field, i) => {
-                headerCols.push(
-                    <th
-                        className='attachment___field-caption'
-                        key={'attachment__field-caption-' + i}
+        fields.forEach((field, i) => {
+            if (rowPos === 2 || !(field.short === true) || lastWasLong) {
+                fieldTables.push(
+                    <table
+                        className='attachment___fields'
+                        key={'attachment__table__' + nrTables}
                     >
-                        {field.title}
-                    </th>
+                        <thead>
+                            <tr>
+                            {headerCols}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                {bodyCols}
+                            </tr>
+                        </tbody>
+                    </table>
                 );
-                bodyCols.push(
-                    <td
-                        className='attachment___field'
-                        key={'attachment__field-' + i}
-                        dangerouslySetInnerHTML={{__html: TextFormatting.formatText(field.value || '')}}
+                headerCols = [];
+                bodyCols = [];
+                rowPos = 0;
+                nrTables += 1;
+                lastWasLong = false;
+            }
+            headerCols.push(
+                <th
+                    className='attachment___field-caption'
+                    key={'attachment__field-caption-' + i + '__' + nrTables}
+                    width='50%'
+                >
+                    {field.title}
+                </th>
+            );
+            bodyCols.push(
+                <td
+                    className='attachment___field'
+                    key={'attachment__field-' + i + '__' + nrTables}
+                    dangerouslySetInnerHTML={{__html: TextFormatting.formatText(field.value || '')}}
+                >
+                </td>
+            );
+            rowPos += 1;
+            lastWasLong = !(field.short === true);
+        });
+        if (headerCols.length > 0) { // Flush last fields
+            fieldTables.push(
+                    <table
+                        className='attachment___fields'
+                        key={'attachment__table__' + nrTables}
                     >
-                    </td>
+                        <thead>
+                            <tr>
+                            {headerCols}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                {bodyCols}
+                            </tr>
+                        </tbody>
+                    </table>
                 );
-            });
-
-            tHead = (
-                <tr>
-                    {headerCols}
-                </tr>
-            );
-            tBody = (
-                <tr>
-                    {bodyCols}
-                </tr>
-            );
-        } else {
-            tBody = [];
-
-            fields.forEach((field, i) => {
-                tBody.push(
-                    <tr key={'attachment__field-' + i}>
-                        <td
-                            className='attachment___field-caption'
-                        >
-                            {field.title}
-                        </td>
-                        <td
-                            className='attachment___field'
-                            dangerouslySetInnerHTML={{__html: TextFormatting.formatText(field.value || '')}}
-                        >
-                        </td>
-                    </tr>
-                );
-            });
         }
-
         return (
-            <table
-                className='attachment___fields'
-            >
-                <thead>
-                    {tHead}
-                </thead>
-                <tbody>
-                    {tBody}
-                </tbody>
-            </table>
+            <div>
+                {fieldTables}
+            </div>
         );
     }
 


### PR DESCRIPTION
The original implementation compacted all attachment fields when just a single field specified it was short. This PR reimplements the logic so at most 2 short fields are rendered side by side, as observed in Slack. In addition a non-short field will always get the full width.
This dramatically improves the rendering of existing Slack integrations with attachments in Mattermost.