### PR TITLE
Fix typo

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3189,7 +3189,7 @@
   },
   {
     "id": "store.sql_user.save.max_accounts.app_error",
-    "translation": "This team has reached the maxmium number of allowed accounts. Contact your systems administrator to set a higher limit."
+    "translation": "This team has reached the maximum number of allowed accounts. Contact your systems administrator to set a higher limit."
   },
   {
     "id": "store.sql_user.save.member_count.app_error",


### PR DESCRIPTION
The word maximum was with a typo (maxmium).