### PR TITLE
Fix OAuth routes and link issues

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -29,11 +29,14 @@ func InitOAuth(r *mux.Router) {
 	sr.Handle("/authorize", ApiUserRequired(authorizeOAuth)).Methods("GET")
 	sr.Handle("/access_token", ApiAppHandler(getAccessToken)).Methods("POST")
 
-	// Also handle this a the old routes remove soon apiv2?
 	mr := Srv.Router
 	mr.Handle("/authorize", ApiUserRequired(authorizeOAuth)).Methods("GET")
 	mr.Handle("/access_token", ApiAppHandler(getAccessToken)).Methods("POST")
+
+	// Handle all the old routes, to be later removed
 	mr.Handle("/{service:[A-Za-z]+}/complete", AppHandlerIndependent(completeOAuth)).Methods("GET")
+	mr.Handle("/signup/{service:[A-Za-z]+}/complete", AppHandlerIndependent(completeOAuth)).Methods("GET")
+	mr.Handle("/login/{service:[A-Za-z]+}/complete", AppHandlerIndependent(completeOAuth)).Methods("GET")
 }
 
 func registerOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -185,7 +188,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	state := r.URL.Query().Get("state")
 
-	uri := c.GetSiteURL() + "/api/v1/oauth/" + service + "/complete"
+	uri := c.GetSiteURL() + "/signup/" + service + "/complete"
 
 	if body, team, props, err := AuthorizeOAuthUser(service, code, state, uri); err != nil {
 		c.Err = err

--- a/api/user.go
+++ b/api/user.go
@@ -1938,7 +1938,7 @@ func GetAuthorizationCode(c *Context, service, teamName string, props map[string
 	props["team"] = teamName
 	state := b64.StdEncoding.EncodeToString([]byte(model.MapToJson(props)))
 
-	redirectUri := c.GetSiteURL() + "/api/v1/oauth/" + service + "/complete"
+	redirectUri := c.GetSiteURL() + "/signup/" + service + "/complete"
 
 	authUrl := endpoint + "?response_type=code&client_id=" + clientId + "&redirect_uri=" + url.QueryEscape(redirectUri) + "&state=" + url.QueryEscape(state)
 

--- a/webapp/components/login.jsx
+++ b/webapp/components/login.jsx
@@ -60,10 +60,10 @@ export default class Login extends React.Component {
         let loginMessage = [];
         if (global.window.mm_config.EnableSignUpWithGitLab === 'true') {
             loginMessage.push(
-                <Link
+                <a
                     className='btn btn-custom-login gitlab'
                     key='gitlab'
-                    to={'/api/v1/oauth/gitlab/login?team=' + encodeURIComponent(teamName)}
+                    href={'/api/v1/oauth/gitlab/login?team=' + encodeURIComponent(teamName)}
                 >
                     <span className='icon'/>
                     <span>
@@ -72,16 +72,16 @@ export default class Login extends React.Component {
                             defaultMessage='with GitLab'
                         />
                     </span>
-                </Link>
+                </a>
             );
         }
 
         if (global.window.mm_config.EnableSignUpWithGoogle === 'true') {
             loginMessage.push(
-                <Link
+                <a
                     className='btn btn-custom-login google'
                     key='google'
-                    to={'/api/v1/oauth/google/login?team=' + encodeURIComponent(teamName)}
+                    href={'/api/v1/oauth/google/login?team=' + encodeURIComponent(teamName)}
                 >
                     <span className='icon'/>
                     <span>
@@ -90,7 +90,7 @@ export default class Login extends React.Component {
                             defaultMessage='with Google Apps'
                         />
                     </span>
-                </Link>
+                </a>
             );
         }
 

--- a/webapp/components/signup_user_complete.jsx
+++ b/webapp/components/signup_user_complete.jsx
@@ -317,10 +317,10 @@ class SignupUserComplete extends React.Component {
         var signupMessage = [];
         if (global.window.mm_config.EnableSignUpWithGitLab === 'true') {
             signupMessage.push(
-                <Link
+                <a
                     className='btn btn-custom-login gitlab'
                     key='gitlab'
-                    to={'/api/v1/oauth/gitlab/signup' + window.location.search + '&team=' + encodeURIComponent(this.state.teamName)}
+                    href={'/api/v1/oauth/gitlab/signup' + window.location.search + '&team=' + encodeURIComponent(this.state.teamName)}
                 >
                     <span className='icon'/>
                     <span>
@@ -329,16 +329,16 @@ class SignupUserComplete extends React.Component {
                             defaultMessage='with GitLab'
                         />
                     </span>
-                </Link>
+                </a>
             );
         }
 
         if (global.window.mm_config.EnableSignUpWithGoogle === 'true') {
             signupMessage.push(
-                <Link
+                <a
                     className='btn btn-custom-login google'
                     key='google'
-                    to={'/api/v1/oauth/google/signup' + window.location.search + '&team=' + encodeURIComponent(this.state.teamName)}
+                    href={'/api/v1/oauth/google/signup' + window.location.search + '&team=' + encodeURIComponent(this.state.teamName)}
                 >
                     <span className='icon'/>
                     <span>
@@ -347,7 +347,7 @@ class SignupUserComplete extends React.Component {
                             defaultMessage='with Google'
                         />
                     </span>
-                </Link>
+                </a>
            );
         }
 

--- a/webapp/components/team_signup_with_sso.jsx
+++ b/webapp/components/team_signup_with_sso.jsx
@@ -64,7 +64,7 @@ class SSOSignUpPage extends React.Component {
             this.props.service,
             (data) => {
                 if (data.follow_link) {
-                    browserHistory.push(data.follow_link);
+                    window.location.href = data.follow_link;
                 } else {
                     browserHistory.push('/' + team.name + '/channels/town-square');
                 }


### PR DESCRIPTION
We need to use proper html links for the SSO stuff as it requires a fresh page hit. We also cannot support both the new and old OAuth routes at the same time since we need to provide the OAuth provider with a redirect URI on the initial exchange and we have no way of knowing which redirect URIs (the old or new) the OAuth provider has registered.