### PR TITLE
Fix default Browser locale

### DIFF
--- a/webapp/action_creators/global_actions.jsx
+++ b/webapp/action_creators/global_actions.jsx
@@ -265,7 +265,8 @@ export function newLocalizationSelected(locale) {
 }
 
 export function loadBrowserLocale() {
-    let locale = (navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage)).split('-')[0];
+    let locale = (navigator.languages && navigator.languages.length > 0 ? navigator.languages[0] :
+        (navigator.language || navigator.userLanguage)).split('-')[0];
     if (!I18n.getLanguages()[locale]) {
         locale = 'en';
     }


### PR DESCRIPTION
I didn't thought the desktop and mobile apps had `navigator.languages` as an empty array