### PR TITLE
Added a warning message when AppDispatcher tries to dispatch without an action type

### DIFF
--- a/webapp/dispatcher/app_dispatcher.jsx
+++ b/webapp/dispatcher/app_dispatcher.jsx
@@ -8,6 +8,10 @@ const PayloadSources = Constants.PayloadSources;
 
 const AppDispatcher = Object.assign(new Flux.Dispatcher(), {
     handleServerAction: function performServerAction(action) {
+        if (!action.type) {
+            console.log('handleServerAction called with undefined action type'); // eslint-disable-line no-console
+        }
+
         var payload = {
             source: PayloadSources.SERVER_ACTION,
             action
@@ -16,6 +20,10 @@ const AppDispatcher = Object.assign(new Flux.Dispatcher(), {
     },
 
     handleViewAction: function performViewAction(action) {
+        if (!action.type) {
+            console.log('handleServerAction called with undefined action type'); // eslint-disable-line no-console
+        }
+
         var payload = {
             source: PayloadSources.VIEW_ACTION,
             action


### PR DESCRIPTION
This shouldn't reasonably happen unless we forget to add an action type to Constants. I'm adding a warning message because I've been caught multiple times by firing events with an undefined type which then trigger other events which also have an undefined type.