### PR TITLE
Update client license etag to handle new features

### DIFF
--- a/api/license.go
+++ b/api/license.go
@@ -153,20 +153,13 @@ func removeLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getClientLicenceConfig(c *Context, w http.ResponseWriter, r *http.Request) {
-	config := utils.ClientLicense
-
-	var etag string
-	if config["IsLicensed"] == "false" {
-		etag = model.Etag(config["IsLicensed"])
-	} else {
-		etag = model.Etag(config["IsLicensed"], config["IssuedAt"])
-	}
-
+	etag := utils.GetClientLicenseEtag()
 	if HandleEtag(etag, w, r) {
 		return
 	}
 
-	w.Header().Set(model.HEADER_ETAG_SERVER, etag)
+	clientLicense := utils.ClientLicense
 
-	w.Write([]byte(model.MapToJson(config)))
+	w.Header().Set(model.HEADER_ETAG_SERVER, etag)
+	w.Write([]byte(model.MapToJson(clientLicense)))
 }

--- a/api/license_test.go
+++ b/api/license_test.go
@@ -4,13 +4,14 @@
 package api
 
 import (
+	"github.com/mattermost/platform/utils"
 	"testing"
 )
 
 func TestGetLicenceConfig(t *testing.T) {
 	Setup()
 
-	if result, err := Client.GetClientLicenceConfig(); err != nil {
+	if result, err := Client.GetClientLicenceConfig(""); err != nil {
 		t.Fatal(err)
 	} else {
 		cfg := result.Data.(map[string]string)
@@ -18,5 +19,31 @@ func TestGetLicenceConfig(t *testing.T) {
 		if _, ok := cfg["IsLicensed"]; !ok {
 			t.Fatal(cfg)
 		}
+
+		// test etag caching
+		if cache_result, err := Client.GetClientLicenceConfig(result.Etag); err != nil {
+			t.Fatal(err)
+		} else if len(cache_result.Data.(map[string]string)) != 0 {
+			t.Log(cache_result.Data)
+			t.Fatal("cache should be empty")
+		}
+
+		utils.ClientLicense["IsLicensed"] = "true"
+
+		if cache_result, err := Client.GetClientLicenceConfig(result.Etag); err != nil {
+			t.Fatal(err)
+		} else if len(cache_result.Data.(map[string]string)) == 0 {
+			t.Fatal("result should not be empty")
+		}
+
+		utils.ClientLicense["SomeFeature"] = "true"
+
+		if cache_result, err := Client.GetClientLicenceConfig(result.Etag); err != nil {
+			t.Fatal(err)
+		} else if len(cache_result.Data.(map[string]string)) == 0 {
+			t.Fatal("result should not be empty")
+		}
+
+		utils.ClientLicense = map[string]string{"IsLicensed": "false"}
 	}
 }

--- a/model/client.go
+++ b/model/client.go
@@ -1125,8 +1125,8 @@ func (c *Client) MockSession(sessionToken string) {
 	c.AuthType = HEADER_BEARER
 }
 
-func (c *Client) GetClientLicenceConfig() (*Result, *AppError) {
-	if r, err := c.DoApiGet("/license/client_config", "", ""); err != nil {
+func (c *Client) GetClientLicenceConfig(etag string) (*Result, *AppError) {
+	if r, err := c.DoApiGet("/license/client_config", "", etag); err != nil {
 		return nil, err
 	} else {
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),

--- a/utils/license.go
+++ b/utils/license.go
@@ -5,11 +5,13 @@ package utils
 
 import (
 	"crypto"
+	"crypto/md5"
 	"crypto/rsa"
 	"crypto/sha512"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -128,4 +130,14 @@ func getClientLicense(l *model.License) map[string]string {
 	}
 
 	return props
+}
+
+func GetClientLicenseEtag() string {
+	value := ""
+
+	for k, v := range ClientLicense {
+		value += fmt.Sprintf("%s:%s;", k, v)
+	}
+
+	return model.Etag(fmt.Sprintf("%x", md5.Sum([]byte(value))))
 }

--- a/utils/license_test.go
+++ b/utils/license_test.go
@@ -48,3 +48,21 @@ func TestValidateLicense(t *testing.T) {
 		t.Fatal("should have failed - bad license")
 	}
 }
+
+func TestClientLicenseEtag(t *testing.T) {
+	etag1 := GetClientLicenseEtag()
+
+	ClientLicense["SomeFeature"] = "true"
+
+	etag2 := GetClientLicenseEtag()
+	if etag1 == etag2 {
+		t.Fatal("etags should not match")
+	}
+
+	ClientLicense["SomeFeature"] = "false"
+
+	etag3 := GetClientLicenseEtag()
+	if etag2 == etag3 {
+		t.Fatal("etags should not match")
+	}
+}

--- a/webapp/components/admin_console/team_settings.jsx
+++ b/webapp/components/admin_console/team_settings.jsx
@@ -102,7 +102,10 @@ class TeamSettings extends React.Component {
         config.TeamSettings.EnableUserCreation = this.refs.EnableUserCreation.checked;
         config.TeamSettings.RestrictTeamNames = this.refs.RestrictTeamNames.checked;
         config.TeamSettings.EnableTeamListing = this.refs.EnableTeamListing.checked;
-        config.TeamSettings.EnableCustomBrand = this.refs.EnableCustomBrand.checked;
+
+        if (this.refs.EnableCustomBrand) {
+            config.TeamSettings.EnableCustomBrand = this.refs.EnableCustomBrand.checked;
+        }
 
         if (this.refs.CustomBrandText) {
             config.TeamSettings.CustomBrandText = this.refs.CustomBrandText.value;


### PR DESCRIPTION
When we added new features the client license etag wasn't catching that since the license itself didn't change. I just updated it to md5 the entire client license to make sure nothing has changed.