### PR TITLE
Allow autocorrection in textbox

### DIFF
--- a/webapp/components/textbox.jsx
+++ b/webapp/components/textbox.jsx
@@ -188,7 +188,6 @@ export default class Textbox extends React.Component {
                     type='textarea'
                     spellCheck='true'
                     autoComplete='off'
-                    autoCorrect='off'
                     maxLength={Constants.MAX_POST_LEN}
                     placeholder={this.props.createMessage}
                     value={this.props.messageText}

--- a/webapp/components/textbox.jsx
+++ b/webapp/components/textbox.jsx
@@ -187,7 +187,6 @@ export default class Textbox extends React.Component {
                     className={`form-control custom-textarea ${this.state.connection}`}
                     type='textarea'
                     spellCheck='true'
-                    autoComplete='off'
                     maxLength={Constants.MAX_POST_LEN}
                     placeholder={this.props.createMessage}
                     value={this.props.messageText}


### PR DESCRIPTION
remove autocorrect=off attribute from textbox, allowing word suggestion in android keyboards

<img src="https://cloud.githubusercontent.com/assets/11226228/14589701/5f617488-04f1-11e6-8f8e-e1a1992740da.png" alt="any site"  title="any site" width=200px/>   <img src="https://cloud.githubusercontent.com/assets/11226228/14589708/73ca6bfa-04f1-11e6-8aff-02a8a2fdafc5.png" alt="MM before this PR" title="MM before this PR" width=200px/>