### PR TITLE
Allow posting of the encoded URL in the non-UTF-8

### DIFF
--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -124,7 +124,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         }
 
         try {
-            const unescaped = decodeURIComponent(unescape(href)).replace(/[^\w:]/g, '').toLowerCase();
+            const unescaped = unescape(href).replace(/[^\w:]/g, '').toLowerCase();
 
             if (unescaped.indexOf('javascript:') === 0 || unescaped.indexOf('vbscript:') === 0 || unescaped.indexOf('data:') === 0) { // eslint-disable-line no-script-url
                 return '';


### PR DESCRIPTION
Hello.

I'm using the Mattermost in the intranet.
URL of our in-house Wiki has been percent encoding other than UTF-8 (Specifically, EUC-JP).
Mattermost will sanitize the URL of our Wiki. So, we can not post the URL of the Wiki, we in trouble.

This is because it sanitized when Markdown renderer is an exception in the `decodeURIComponent ()` has occurred. `decodeURIComponent ()` accept only URI encoded in UTF-8.

I think in the post, percent-encoding of the URI is that it should be allowed also other than UTF-8.
