### PR TITLE
Patch to fix error message on leave channel

### DIFF
--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -106,6 +106,16 @@ func shouldSendEvent(webCon *WebConn, msg *model.Message) bool {
 		if msg.Action == model.ACTION_TYPING {
 			return false
 		}
+
+		// We have to make sure the user is in the channel. Otherwise system messages that
+		// post about users in channels they are not in trigger warnings.
+		if len(msg.ChannelId) > 0 {
+			allowed := webCon.HasPermissionsToChannel(msg.ChannelId)
+
+			if !allowed {
+				return false
+			}
+		}
 	} else {
 		// Don't share a user's view or preference events with other users
 		if msg.Action == model.ACTION_CHANNEL_VIEWED {


### PR DESCRIPTION
- Patch to fix the error message displayed to user.
- There is a deeper problem with leaving channels and system messages. Item queued for dev meeting to discuss. 