### PR TITLE
PLT-2585 Removed private channels as an option for outgoing webhooks

### DIFF
--- a/webapp/components/channel_select.jsx
+++ b/webapp/components/channel_select.jsx
@@ -54,7 +54,7 @@ export default class ChannelSelect extends React.Component {
         ];
 
         this.state.channels.forEach((channel) => {
-            if (channel.type !== Constants.DM_CHANNEL) {
+            if (channel.type === Constants.OPEN_CHANNEL) {
                 options.push(
                     <option
                         key={channel.id}


### PR DESCRIPTION
Server code already prevented them from being added to private channels, but the UI still gave them as an option