### PR TITLE
PLT-2529 Fixed updating mention keys when a user's username changes

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -186,13 +186,28 @@ func (u *User) SetDefaultNotifications() {
 	u.NotifyProps["desktop"] = USER_NOTIFY_ALL
 	u.NotifyProps["desktop_sound"] = "true"
 	u.NotifyProps["mention_keys"] = u.Username + ",@" + u.Username
-	u.NotifyProps["first_name"] = "false"
 	u.NotifyProps["all"] = "true"
 	u.NotifyProps["channel"] = "true"
-	splitName := strings.Split(u.Nickname, " ")
-	if len(splitName) > 0 && splitName[0] != "" {
+
+	if u.FirstName == "" {
+		u.NotifyProps["first_name"] = "false"
+	} else {
 		u.NotifyProps["first_name"] = "true"
-		u.NotifyProps["mention_keys"] += "," + splitName[0]
+	}
+}
+
+func (user *User) UpdateMentionKeysFromUsername(oldUsername string) {
+	nonUsernameKeys := []string{}
+	splitKeys := strings.Split(user.NotifyProps["mention_keys"], ",")
+	for _, key := range splitKeys {
+		if key != oldUsername && key != "@"+oldUsername {
+			nonUsernameKeys = append(nonUsernameKeys, key)
+		}
+	}
+
+	user.NotifyProps["mention_keys"] = user.Username + ",@" + user.Username
+	if len(nonUsernameKeys) > 0 {
+		user.NotifyProps["mention_keys"] += "," + strings.Join(nonUsernameKeys, ",")
 	}
 }
 

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -41,6 +41,33 @@ func TestUserPreUpdate(t *testing.T) {
 	user.PreUpdate()
 }
 
+func TestUserUpdateMentionKeysFromUsername(t *testing.T) {
+	user := User{Username: "user"}
+	user.SetDefaultNotifications()
+
+	if user.NotifyProps["mention_keys"] != "user,@user" {
+		t.Fatal("default mention keys are invalid: %v", user.NotifyProps["mention_keys"])
+	}
+
+	user.Username = "person"
+	user.UpdateMentionKeysFromUsername("user")
+	if user.NotifyProps["mention_keys"] != "person,@person" {
+		t.Fatal("mention keys are invalid after changing username: %v", user.NotifyProps["mention_keys"])
+	}
+
+	user.NotifyProps["mention_keys"] += ",mention"
+	user.UpdateMentionKeysFromUsername("person")
+	if user.NotifyProps["mention_keys"] != "person,@person,mention" {
+		t.Fatal("mention keys are invalid after adding extra mention keyword: %v", user.NotifyProps["mention_keys"])
+	}
+
+	user.Username = "user"
+	user.UpdateMentionKeysFromUsername("person")
+	if user.NotifyProps["mention_keys"] != "user,@user,mention" {
+		t.Fatal("mention keys are invalid after changing username with extra mention keyword: %v", user.NotifyProps["mention_keys"])
+	}
+}
+
 func TestUserIsValid(t *testing.T) {
 	user := User{}
 

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -141,14 +141,7 @@ func (us SqlUserStore) Update(user *model.User, allowActiveUpdate bool) StoreCha
 			}
 
 			if user.Username != oldUser.Username {
-				nonUsernameKeys := []string{}
-				splitKeys := strings.Split(user.NotifyProps["mention_keys"], ",")
-				for _, key := range splitKeys {
-					if key != oldUser.Username && key != "@"+oldUser.Username {
-						nonUsernameKeys = append(nonUsernameKeys, key)
-					}
-				}
-				user.NotifyProps["mention_keys"] = strings.Join(nonUsernameKeys, ",") + "," + user.Username + ",@" + user.Username
+				user.UpdateMentionKeysFromUsername(oldUser.Username)
 			}
 
 			if count, err := us.GetMaster().Update(user); err != nil {

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -213,7 +213,6 @@ function highlightCurrentMentions(text, tokens) {
     }
 
     for (const mention of UserStore.getCurrentMentionKeys()) {
-        // occasionally we get an empty mention which matches a bunch of empty strings
         if (!mention) {
             continue;
         }


### PR DESCRIPTION
Changing your username used to add an empty mention key if you had no other mention keys. This also fixes the default first name mention to actually be set off the first name and not the nickname