### PR TITLE
PLT-2049 Don't panic when Mattermost can't find config

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2020,6 +2020,10 @@
     "translation": "Loaded config file from %v"
   },
   {
+    "id": "mattermost.unable_to_load_config",
+    "translation": "Unable to load mattermost configuration file:"
+  },
+  {
     "id": "mattermost.current_version",
     "translation": "Current version is %v (%v/%v/%v)"
   },

--- a/mattermost.go
+++ b/mattermost.go
@@ -60,12 +60,25 @@ var flagTeamName string
 var flagRole string
 var flagRunCmds bool
 
+func doLoadConfig(filename string) (err string) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(string)
+		}
+	}()
+	utils.LoadConfig(filename)
+	return ""
+}
+
 func main() {
 
 	parseCmds()
 
 	utils.InitTranslations()
-	utils.LoadConfig(flagConfigFile)
+	if errstr := doLoadConfig(flagConfigFile); errstr != "" {
+		l4g.Exit(utils.T("mattermost.unable_to_load_config"), errstr)
+		return
+	}
 
 	if flagRunCmds {
 		utils.ConfigureCmdLineLog()
@@ -91,8 +104,7 @@ func main() {
 
 	if !utils.IsLicensed && len(utils.Cfg.SqlSettings.DataSourceReplicas) > 1 {
 		l4g.Critical(utils.T("store.sql.read_replicas_not_licensed.critical"))
-		time.Sleep(time.Second)
-		panic(fmt.Sprintf(utils.T("store.sql.read_replicas_not_licensed.critical")))
+		return
 	}
 
 	if flagRunCmds {


### PR DESCRIPTION
- Nice error message displayed instead.
- Also removed the panic when the licence was not found, replaced with return. 