### PR TITLE
PLT-2660 Fix cancelling in-progress uploads

### DIFF
--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -276,7 +276,7 @@ class FileUpload extends React.Component {
     }
 
     cancelUpload(clientId) {
-        const requests = JSON.parse(JSON.stringify(this.state.requests));
+        const requests = Object.assign({}, this.state.requests);
         const request = requests[clientId];
 
         if (request) {


### PR DESCRIPTION
It was turning Request instances into Objects causing .abort() to fail.