### PR TITLE
PLT-2245 Change tutorial text from "Team Invite" to "Invite teammates"

### DIFF
--- a/webapp/components/tutorial/tutorial_intro_screens.jsx
+++ b/webapp/components/tutorial/tutorial_intro_screens.jsx
@@ -132,7 +132,7 @@ export default class TutorialIntroScreens extends React.Component {
                 >
                     <FormattedMessage
                         id='tutorial_intro.teamInvite'
-                        defaultMessage='Team Invite'
+                        defaultMessage='Invite teammates'
                     />
                 </a>
             );

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1232,7 +1232,7 @@
   "tutorial_intro.screenTwo": "<h3>How Mattermost works:</h3><p>Communication happens in public discussion channels, private groups and direct messages.</p><p>Everything is archived and searchable from any web-enabled desktop, laptop or phone.</p>",
   "tutorial_intro.skip": "Skip tutorial",
   "tutorial_intro.support": "Need anything, just email us at ",
-  "tutorial_intro.teamInvite": "Team Invite",
+  "tutorial_intro.teamInvite": "Invite teammates",
   "tutorial_intro.whenReady": " when you’re ready.",
   "tutorial_tip.next": "Next",
   "tutorial_tip.ok": "Okay",

--- a/webapp/i18n/es.json
+++ b/webapp/i18n/es.json
@@ -1193,7 +1193,7 @@
   "tutorial_intro.screenTwo": "<h3>Cómo funciona Mattermost:</h3> <p>Las comunicaciones ocurren en los canales de discusión los cuales son públicos, o en grupos privados e incluso con mensajes privados.</p> <p>Todo lo que ocurre es archivado y se puede buscar en cualquier momento desde cualquier dispositivo con acceso a Mattermost.</p>",
   "tutorial_intro.skip": "Saltar el tutorial",
   "tutorial_intro.support": "Necesitas algo, escribemos a ",
-  "tutorial_intro.teamInvite": "Invitar a tu Equipo",
+  "tutorial_intro.teamInvite": "Invitar compañeros",
   "tutorial_intro.whenReady": " cuando estés listo(a).",
   "tutorial_tip.next": "Siguiente",
   "tutorial_tip.ok": "Aceptar",

--- a/webapp/i18n/fr.json
+++ b/webapp/i18n/fr.json
@@ -1094,7 +1094,7 @@
   "tutorial_intro.screenTwo": "<h3>Comment fonctionne Mattermost :</h3><p>Vous pouvez échanger dans des canaux publics, des groupes privés ou des messages privés.</p><p>Tout est archivé et peut être recherché depuis n'importe quel navigateur web de bureau, tablette ou mobile.</p>",
   "tutorial_intro.skip": "Passer le tutoriel",
   "tutorial_intro.support": "Besoin de quoi que ce soit, envoyez-nous un courriel à :",
-  "tutorial_intro.teamInvite": "Invitation à l'équipe",
+  "tutorial_intro.teamInvite": "Inviter des membres",
   "tutorial_intro.whenReady": "quand vous serez prêt.",
   "tutorial_tip.next": "Suivant",
   "tutorial_tip.ok": "D'accord",

--- a/webapp/i18n/ja.json
+++ b/webapp/i18n/ja.json
@@ -1198,7 +1198,7 @@
   "tutorial_intro.screenTwo": "<h3>Mattermostの使い方</h3><p>公開チャンネル、プライベートグループ、ダイレクトメッセージでコミュニケーションします。</p><p>全てがアーカイブされ、ウェブにアクセスできるデスクトップ、ラップトップ、スマートフォンのいずれからでも検索できます。</p>",
   "tutorial_intro.skip": "チュートリアルをスキップする",
   "tutorial_intro.support": "必要なことがあったら、電子メールを出してください: ",
-  "tutorial_intro.teamInvite": "チーム招待",
+  "tutorial_intro.teamInvite": "チームメイトを招待する",
   "tutorial_intro.whenReady": " 用意ができた時に。",
   "tutorial_tip.next": "次へ",
   "tutorial_tip.ok": "OK",

--- a/webapp/i18n/pt.json
+++ b/webapp/i18n/pt.json
@@ -1193,7 +1193,7 @@
   "tutorial_intro.screenTwo": "<h3>Como Mattermost funciona:</h3><p>A comunicação acontece em canais de discussão pública, grupos privados e mensagens diretas.</p><p>Tudo é arquivado e pesquisável a partir de qualquer desktop, laptop ou telefone com suporte a web.</p>",
   "tutorial_intro.skip": "Pular o tutorial",
   "tutorial_intro.support": "Precisa de alguma coisa, envie um e-mail para nós no ",
-  "tutorial_intro.teamInvite": "Convide sua Equipe",
+  "tutorial_intro.teamInvite": "Convidar pessoas para equipe",
   "tutorial_intro.whenReady": " quando você estiver pronto.",
   "tutorial_tip.next": "Próximo",
   "tutorial_tip.ok": "Ok",


### PR DESCRIPTION
I updated the localization files as well since the expected text for tutorial_intro.teamInvite was the exact same as tutorial_intro.invite, but I can remove that if people prefer. 