### PR TITLE
Add <meta> tag to force latest version of IE

### DIFF
--- a/webapp/root.html
+++ b/webapp/root.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
     <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'>
     <meta name='robots' content='noindex, nofollow'>
     <meta name='referrer' content='no-referrer'>


### PR DESCRIPTION
Internet Explorer has a "Display intranet sites in Compatibility View" setting which makes sites with an intranet address use the IE7 engine by default.

In workplaces with locked-down workstations, this may be turned on by default and the user may be prevented from changing it, which results in them seeing a white screen by default when invited to join a Mattermost instance deployed on their intranet.

Adding this `<meta>` tag will override Intranet Mode to use a compatible, modern version of IE.