### PR TITLE
PLT-2756 Fixed error caused by new messages in channel indicator

### DIFF
--- a/webapp/action_creators/global_actions.jsx
+++ b/webapp/action_creators/global_actions.jsx
@@ -184,7 +184,7 @@ export function emitPostFocusRightHandSideFromSearch(post, isMentionSearch) {
             AppDispatcher.handleServerAction({
                 type: ActionTypes.RECEIVED_POST_SELECTED,
                 postId: Utils.getRootId(post),
-                from_search: SearchStore.getSearchTerm()
+                fromSearch: SearchStore.getSearchTerm()
             });
 
             AppDispatcher.handleServerAction({

--- a/webapp/components/posts_view.jsx
+++ b/webapp/components/posts_view.jsx
@@ -410,7 +410,11 @@ export default class PostsView extends React.Component {
     }
     componentWillReceiveProps(nextProps) {
         if (this.props.postList && this.props.postList.order.length) {
-            if (this.props.postList.order[0] !== nextProps.postList.order[0] && nextProps.scrollType !== PostsView.SCROLL_TYPE_BOTTOM && nextProps.scrollType !== PostsView.SCROLL_TYPE_NEW_MESSAGE && nextProps.postList.posts[nextProps.postList.order[0]].user_id !== nextProps.currentUser.id && this.props.postList.order[1] !== nextProps.postList.order[0]) { // new message from another user and not deleted
+            if (this.props.postList.order[0] !== nextProps.postList.order[0] && // if the most recent post has changed AND
+                nextProps.scrollType !== PostsView.SCROLL_TYPE_BOTTOM && // we're freely scrolling AND
+                nextProps.scrollType !== PostsView.SCROLL_TYPE_NEW_MESSAGE &&
+                nextProps.postList.posts[nextProps.postList.order[0]].user_id !== this.state.currentUser.id && // the new post isn't from the current user
+                this.props.postList.order[1] !== nextProps.postList.order[0]) { // and it isn't that the last message was deleted?
                 this.setState({showUnreadMessageAlert: true});
             } else if (nextProps.scrollType === PostsView.SCROLL_TYPE_BOTTOM) {
                 this.setState({showUnreadMessageAlert: false});

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -568,7 +568,7 @@ PostStore.dispatchToken = AppDispatcher.register((payload) => {
         break;
     case ActionTypes.RECEIVED_POST_SELECTED:
         PostStore.storeSelectedPostId(action.postId);
-        PostStore.emitSelectedPostChange(action.from_search);
+        PostStore.emitSelectedPostChange(action.fromSearch);
         break;
     default:
     }


### PR DESCRIPTION
I'm thinking that we might need to revert the "New Messages Below" indicator in the center channel. The logic driving it is rather funky and unreliable