### PR TITLE
Fix the Users.EmailVerified column value from '1' to true

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -265,7 +265,7 @@ func (us SqlUserStore) UpdatePassword(userId, hashedPassword string) StoreChanne
 
 		updateAt := model.GetMillis()
 
-		if _, err := us.GetMaster().Exec("UPDATE Users SET Password = :Password, LastPasswordUpdate = :LastPasswordUpdate, UpdateAt = :UpdateAt, AuthData = '', AuthService = '', EmailVerified = 1, FailedAttempts = 0 WHERE Id = :UserId", map[string]interface{}{"Password": hashedPassword, "LastPasswordUpdate": updateAt, "UpdateAt": updateAt, "UserId": userId}); err != nil {
+		if _, err := us.GetMaster().Exec("UPDATE Users SET Password = :Password, LastPasswordUpdate = :LastPasswordUpdate, UpdateAt = :UpdateAt, AuthData = '', AuthService = '', EmailVerified = true, FailedAttempts = 0 WHERE Id = :UserId", map[string]interface{}{"Password": hashedPassword, "LastPasswordUpdate": updateAt, "UpdateAt": updateAt, "UserId": userId}); err != nil {
 			result.Err = model.NewLocAppError("SqlUserStore.UpdatePassword", "store.sql_user.update_password.app_error", nil, "id="+userId+", "+err.Error())
 		} else {
 			result.Data = userId
@@ -722,7 +722,7 @@ func (us SqlUserStore) VerifyEmail(userId string) StoreChannel {
 	go func() {
 		result := StoreResult{}
 
-		if _, err := us.GetMaster().Exec("UPDATE Users SET EmailVerified = '1' WHERE Id = :UserId", map[string]interface{}{"UserId": userId}); err != nil {
+		if _, err := us.GetMaster().Exec("UPDATE Users SET EmailVerified = true WHERE Id = :UserId", map[string]interface{}{"UserId": userId}); err != nil {
 			result.Err = model.NewLocAppError("SqlUserStore.VerifyEmail", "store.sql_user.verify_email.app_error", nil, "userId="+userId+", "+err.Error())
 		}
 


### PR DESCRIPTION
Users.EmailVerified column type is bool.
but these queries were a string type and a number type.
this is ok in Mysql but cause errors in Postgresql.

like this(user_test.go:970).

```
[2016/05/02 23:20:47 KST] [EROR] /api/v3/users/reset_password:SqlUserStore.UpdatePassword code=500 rid=ezj4agkewibjzni3ptybq5knbh uid=9z53qbkxj7nq9m8r8jbb47enzr ip=::1 We couldn't update the user password [details: id=8bymugax77yhfff9zj4frthapc, pq: column "emailverified" is of type boolean but expression is of type integer]
--- FAIL: TestResetPassword (0.90s)
user_test.go:970: : We couldn't update the user password, id=8bymugax77yhfff9zj4frthapc, pq: column "emailverified" is of type boolean but expression is of type integer
```