### PR TITLE
PLT-2755 Shortcut to upload file

### DIFF
--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -261,6 +261,13 @@ class FileUpload extends React.Component {
                 }
             }
         });
+
+        document.addEventListener('keydown', (e) => {
+            //CTRL+U or CMD+U for file uploads
+            if ((e.ctrlKey || e.metaKey) && e.keyCode === 85) {
+                $(this.refs.input).focus().trigger('click');
+            }
+        });
     }
 
     componentWillUnmount() {

--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -264,7 +264,7 @@ class FileUpload extends React.Component {
 
         document.addEventListener('keydown', (e) => {
             //CTRL+U or CMD+U for file uploads
-            if ((e.ctrlKey || e.metaKey) && e.keyCode === 85) {
+            if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.U) {
                 $(this.refs.input).focus().trigger('click');
             }
         });

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -544,7 +544,8 @@ export default {
         ENTER: 13,
         ESCAPE: 27,
         SPACE: 32,
-        TAB: 9
+        TAB: 9,
+        U: 85
     },
     CODE_PREVIEW_MAX_FILE_SIZE: 500000, // 500 KB
     HighlightedLanguages: {


### PR DESCRIPTION
Added code to use CTRL+U and CMD+U to open the file upload dialog.

Note: CTRL+U opens page source in the latest versions of Firefox and Chrome. CMD+U is currently untested, due to lack of a CMD button.