### PR TITLE
Fix incorrect postgres keys.

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -77,9 +77,9 @@ func (us SqlUserStore) Save(user *model.User) StoreChannel {
 		}
 
 		if err := us.GetMaster().Insert(user); err != nil {
-			if IsUniqueConstraintError(err.Error(), "Email", "users_email_teamid_key") {
+			if IsUniqueConstraintError(err.Error(), "Email", "users_email_key") {
 				result.Err = model.NewLocAppError("SqlUserStore.Save", "store.sql_user.save.email_exists.app_error", nil, "user_id="+user.Id+", "+err.Error())
-			} else if IsUniqueConstraintError(err.Error(), "Username", "users_username_teamid_key") {
+			} else if IsUniqueConstraintError(err.Error(), "Username", "users_username_key") {
 				result.Err = model.NewLocAppError("SqlUserStore.Save", "store.sql_user.save.username_exists.app_error", nil, "user_id="+user.Id+", "+err.Error())
 			} else {
 				result.Err = model.NewLocAppError("SqlUserStore.Save", "store.sql_user.save.app_error", nil, "user_id="+user.Id+", "+err.Error())


### PR DESCRIPTION
The test had errors in postgres because of incorrect postgres keys.

```
[2016/05/03 10:19:15 KST] [EROR] /api/v3/users/create:SqlUserStore.Save code=500 rid=6h5gz1fuxids9ytzimzbgwno3e uid= ip=::1 We couldn't save the account. [details: user_id=3o8aod7uapnxzmngn3rz1rm48r, pq: duplicate key value violates unique constraint "users_email_key"]
--- FAIL: TestCreateUser (0.12s)
	user_test.go:59: : We couldn't save the account., user_id=3o8aod7uapnxzmngn3rz1rm48r, pq: duplicate key value violates unique constraint "users_email_key"
```

```
[2016/05/03 10:26:06 KST] [EROR] /api/v3/users/create:SqlUserStore.Save code=500 rid=tetdakekgffzu8muhrrxuzc9ae uid= ip=::1 We couldn't save the account. [details: user_id=izifcscu5igpzb48ey1gmi5wjw, pq: duplicate key value violates unique constraint "users_username_key"]
--- FAIL: TestCreateUser (0.12s)
	user_test.go:67: : We couldn't save the account., user_id=izifcscu5igpzb48ey1gmi5wjw, pq: duplicate key value violates unique constraint "users_username_key"
```