### PR TITLE
PLT-2719 Emails with underscores don't auto-link correctly

### DIFF
--- a/tests/test-links.md
+++ b/tests/test-links.md
@@ -67,3 +67,4 @@ https://en.wikipedia.org/wiki/URLs#Syntax links to the Syntax section of the Wik
 test@example.com links to `mailto:test@example.com`  
 [email link](mailto:test@example.com) links to `mailto:test@example.com` and not `http://mailto:test@example.com`  
 [other link](ts3server://example.com) links to `ts3server://example.com` and not `http://ts3server://example.com`  
+test_underscore@example.com links to `mailto:test_underscore@example.com`

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "autolinker": "0.24.1",
+    "autolinker": "mattermost/Autolinker.js#9689831109e104d7b545318e54199e6de8fd9b87",
     "bootstrap": "3.3.6",
     "bootstrap-colorpicker": "2.3.0",
     "chart.js": "1.0.2",


### PR DESCRIPTION
The bug is actually on the `Autolinker.js` dependency, just forked and fixed it until they apply the submitted PR.