### PR TITLE
PLT-2786 Open Account Settings/Recent Mentions Shortcuts

### DIFF
--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -47,6 +47,7 @@ export default class ChannelHeader extends React.Component {
         this.searchMentions = this.searchMentions.bind(this);
         this.showRenameChannelModal = this.showRenameChannelModal.bind(this);
         this.hideRenameChannelModal = this.hideRenameChannelModal.bind(this);
+        this.openRecentMentions = this.openRecentMentions.bind(this);
 
         const state = this.getStateFromStores();
         state.showEditChannelPurposeModal = false;
@@ -82,6 +83,7 @@ export default class ChannelHeader extends React.Component {
         PreferenceStore.addChangeListener(this.onListenerChange);
         UserStore.addChangeListener(this.onListenerChange);
         $('.sidebar--left .dropdown-menu').perfectScrollbar();
+        document.addEventListener('keydown', this.openRecentMentions);
     }
     componentWillUnmount() {
         ChannelStore.removeChangeListener(this.onListenerChange);
@@ -89,6 +91,7 @@ export default class ChannelHeader extends React.Component {
         SearchStore.removeSearchChangeListener(this.onListenerChange);
         PreferenceStore.removeChangeListener(this.onListenerChange);
         UserStore.removeChangeListener(this.onListenerChange);
+        document.removeEventListener('keydown', this.openRecentMentions);
     }
     onListenerChange() {
         const newState = this.getStateFromStores();
@@ -138,6 +141,11 @@ export default class ChannelHeader extends React.Component {
             do_search: true,
             is_mention_search: true
         });
+    }
+    openRecentMentions(e) {
+        if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.keyCode === Constants.KeyCodes.M) {
+            this.searchMentions(e);
+        }
     }
     showRenameChannelModal(e) {
         e.preventDefault();

--- a/webapp/components/navbar_dropdown.jsx
+++ b/webapp/components/navbar_dropdown.jsx
@@ -28,6 +28,7 @@ export default class NavbarDropdown extends React.Component {
         this.handleAboutModal = this.handleAboutModal.bind(this);
         this.aboutModalDismissed = this.aboutModalDismissed.bind(this);
         this.onTeamChange = this.onTeamChange.bind(this);
+        this.openAccountSettings = this.openAccountSettings.bind(this);
 
         this.state = {
             showUserSettingsModal: false,
@@ -53,6 +54,7 @@ export default class NavbarDropdown extends React.Component {
         });
 
         TeamStore.addChangeListener(this.onTeamChange);
+        document.addEventListener('keydown', this.openAccountSettings);
     }
 
     onTeamChange() {
@@ -65,8 +67,13 @@ export default class NavbarDropdown extends React.Component {
     componentWillUnmount() {
         $(ReactDOM.findDOMNode(this.refs.dropdown)).off('hide.bs.dropdown');
         TeamStore.removeChangeListener(this.onTeamChange);
+        document.removeEventListener('keydown', this.openAccountSettings);
     }
-
+    openAccountSettings(e) {
+        if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.keyCode === Constants.KeyCodes.A) {
+            this.setState({showUserSettingsModal: true});
+        }
+    }
     render() {
         var teamLink = '';
         var inviteLink = '';

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -549,7 +549,9 @@ export default {
         ESCAPE: 27,
         SPACE: 32,
         TAB: 9,
-        U: 85
+        U: 85,
+        A: 65,
+        M: 77
     },
     CODE_PREVIEW_MAX_FILE_SIZE: 500000, // 500 KB
     HighlightedLanguages: {


### PR DESCRIPTION
CTRL+SHIFT+A or CMD+SHIFT+A: Open account settings
CTRL+SHIFT+M or CMD+SHIFT+M: Open recent mentions

Tested on Mac/Chrome/Firefox/Safari and Windows/Chrome/Firefox/Edge