### PR TITLE
Fix parsing attachment field links into markdown (#2958)

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -200,10 +200,10 @@ func CreateWebhookPost(c *Context, channelId, text, overrideUsername, overrideIc
 								// parse attachment field links into Markdown format
 								for j, fInt := range fields {
 									field := fInt.(map[string]interface{})
-									if _, ok := field["text"]; ok {
-										fText := field["text"].(string)
-										fText = linkWithTextRegex.ReplaceAllString(fText, "[${2}](${1})")
-										field["text"] = fText
+									if _, ok := field["value"]; ok {
+										fValue := field["value"].(string)
+										fValue = linkWithTextRegex.ReplaceAllString(fValue, "[${2}](${1})")
+										field["value"] = fValue
 										fields[j] = field
 									}
 								}

--- a/tests/test-slack-attachments.json
+++ b/tests/test-slack-attachments.json
@@ -39,6 +39,11 @@
                         "short": true,
                         "title": "Short 2",
                         "value": "Another one"
+                    },
+                    {
+                        "short": true,
+                        "title": "Field with link",
+                        "value": "<http://example.com|Link>"
                     }
                 ],
                 "mrkdwn_in": [


### PR DESCRIPTION
Field contents are stored in 'value' not 'text'.