### PR TITLE
PLT-2755 Shortcut to upload file

### DIFF
--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -285,7 +285,9 @@ class FileUpload extends React.Component {
     keyUpload(e) {
         if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.U) {
             e.preventDefault();
-            $(this.refs.fileInput).focus().trigger('click');
+            if (this.props.postType === 'post' && document.activeElement.id === 'post_textbox' || this.props.postType === 'comment' && document.activeElement.id === 'reply_textbox') {
+                $(this.refs.fileInput).focus().trigger('click');
+            }
         }
     }
 
@@ -344,7 +346,7 @@ FileUpload.propTypes = {
     onUploadStart: React.PropTypes.func,
     onTextDrop: React.PropTypes.func,
     channelId: React.PropTypes.string,
-    postType: React.PropTypes.string
+    postType: React.PropTypes.string,
 };
 
 export default injectIntl(FileUpload, {withRef: true});

--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -283,8 +283,8 @@ class FileUpload extends React.Component {
     }
 
     keyUpload(e) {
-        if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.U) {
-            $(this.refs.input).focus().trigger('click');
+        if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.K) {
+            $(this.refs.fileInput).focus().trigger('click');
         }
     }
 

--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -346,7 +346,7 @@ FileUpload.propTypes = {
     onUploadStart: React.PropTypes.func,
     onTextDrop: React.PropTypes.func,
     channelId: React.PropTypes.string,
-    postType: React.PropTypes.string,
+    postType: React.PropTypes.string
 };
 
 export default injectIntl(FileUpload, {withRef: true});

--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -283,7 +283,8 @@ class FileUpload extends React.Component {
     }
 
     keyUpload(e) {
-        if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.K) {
+        if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.U) {
+            e.preventDefault();
             $(this.refs.fileInput).focus().trigger('click');
         }
     }

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -549,8 +549,7 @@ export default {
         ESCAPE: 27,
         SPACE: 32,
         TAB: 9,
-        U: 85,
-        K: 75
+        U: 85
     },
     CODE_PREVIEW_MAX_FILE_SIZE: 500000, // 500 KB
     HighlightedLanguages: {

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -549,7 +549,8 @@ export default {
         ESCAPE: 27,
         SPACE: 32,
         TAB: 9,
-        U: 85
+        U: 85,
+        K: 75
     },
     CODE_PREVIEW_MAX_FILE_SIZE: 500000, // 500 KB
     HighlightedLanguages: {


### PR DESCRIPTION
Shortcut to upload file implemented as CTRL+K instead of CTRL+U, as CTRL+U opens page source on most browsers.

Tested on Windows/Chrome and Mac/Chrome

Open to suggestions on CTRL+key :)