### PR TITLE
Propose changing "Other teams" to "Outside this team"

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -514,7 +514,7 @@ export default class Sidebar extends React.Component {
                 <div className='sidebar__divider__text'>
                     <FormattedMessage
                         id='sidebar.otherMembers'
-                        defaultMessage='Other teams'
+                        defaultMessage='Outside this team:'
                     />
                 </div>
             </div>);

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1130,7 +1130,7 @@
   "sidebar.direct": "Direct Messages",
   "sidebar.more": "More",
   "sidebar.moreElips": "More...",
-  "sidebar.otherMembers": "Other teams",
+  "sidebar.otherMembers": "Outside this team",
   "sidebar.pg": "Private Groups",
   "sidebar.removeList": "Remove from list",
   "sidebar.tutorialScreen1": "<h4>Channels</h4><p><strong>Channels</strong> organize conversations across different topics. They’re open to everyone on your team. To send private communications use <strong>Direct Messages</strong> for a single person or <strong>Private Groups</strong> for multiple people.</p>",


### PR DESCRIPTION
Label seems confusing, propose text to make this more clear.

![image](https://cloud.githubusercontent.com/assets/177788/15188660/b28a1986-175b-11e6-8b13-1d57396b1e42.png)
