### PR TITLE
Fix heavy regression on GitLab for version 3.0.0

### DIFF
--- a/model/gitlab/gitlab.go
+++ b/model/gitlab/gitlab.go
@@ -47,7 +47,8 @@ func userFromGitLabUser(glu *GitLabUser) *model.User {
 	}
 	strings.TrimSpace(user.Email)
 	user.Email = glu.Email
-	*user.AuthData = strconv.FormatInt(glu.Id, 10)
+	userId := strconv.FormatInt(glu.Id, 10)
+	user.AuthData = &userId
 	user.AuthService = model.USER_AUTH_SERVICE_GITLAB
 
 	return user


### PR DESCRIPTION
Hello there, 
First, thanks for the work made on mattermost.

I found on new release 3.0.0 an heavy regression on SSO with gitlab, when I was trying to connect to it i get this stacktrace:

```
2016/05/14 16:25:54 runtime error: invalid memory address or nil pointer dereference
goroutine 16 [running]:
runtime/debug.Stack(0x0, 0x0, 0x0)
/usr/local/go/src/runtime/debug/stack.go:24 +0x80
runtime/debug.PrintStack()
/usr/local/go/src/runtime/debug/stack.go:16 +0x18
github.com/gorilla/handlers.recoveryHandler.log(0x7f064598d840, 0xc8202bfbc0, 0x0, 0x1, 0xca20c0, 0xc82000a0b0)
/var/lib/jenkins/jobs/mattermost-platform-release/workspace/src/github.com/mattermost/platform/Godeps/_workspace/src/github.com/gorilla/handlers/recovery.go:84 +0xb8
github.com/gorilla/handlers.recoveryHandler.ServeHTTP.func1(0x7f06459d4710, 0xc820323c70, 0x7f064598d840, 0xc8202bfbc0, 0x0, 0xc82038c101)
/var/lib/jenkins/jobs/mattermost-platform-release/workspace/src/github.com/mattermost/platform/Godeps/_workspace/src/github.com/gorilla/handlers/recovery.go:69 +0x9b
panic(0xca20c0, 0xc82000a0b0)
/usr/local/go/src/runtime/panic.go:443 +0x4e9
github.com/mattermost/platform/model/gitlab.userFromGitLabUser(0xc8207f87d0, 0xc82026d9c0)
/var/lib/jenkins/jobs/mattermost-platform-release/workspace/src/github.com/mattermost/platform/model/gitlab/gitlab.go:50 +0x2a9
github.com/mattermost/platform/model/gitlab.(*GitLabProvider).GetUserFromJson(0x11eb358, 0x7f06459a0a40, 0xc82026d9c0, 0x6)
/var/lib/jenkins/jobs/mattermost-platform-release/workspace/src/github.com/mattermost/platform/model/gitlab/gitlab.go:90 +0x4c
```

This stack trace is relative how the code deal with pointer.
And what I found is that you trying to pass a value to a pointer which is not initialized, so the compiler is not complaining because it doesn't check if pointers are initialized in a struct.

So, I did a small fix for a small bug which break everything. I hope it will help