### PR TITLE
PLT-2936 Fixed double joined channel messages upon /join

### DIFF
--- a/api/command_join.go
+++ b/api/command_join.go
@@ -53,7 +53,7 @@ func (me *JoinProvider) DoCommand(c *Context, channelId string, message string) 
 					return &model.CommandResponse{Text: c.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 				}
 
-				return &model.CommandResponse{GotoLocation: c.GetTeamURL() + "/channels/" + v.Name, Text: c.T("api.command_join.success"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+				return &model.CommandResponse{Text: c.T("api.command_join.success"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 		}
 	}


### PR DESCRIPTION
Previous: Joining a channel with /join sends two "X has joined the channel" messages
Expected: Joining a channel with /join sends one "X has joined the channel" message