### PR TITLE
PLT-2940 Added validation for command triggers

### DIFF
--- a/model/command.go
+++ b/model/command.go
@@ -99,7 +99,7 @@ func (o *Command) IsValid() *AppError {
 		return NewLocAppError("Command.IsValid", "model.command.is_valid.team_id.app_error", nil, "")
 	}
 
-	if len(o.Trigger) == 0 || len(o.Trigger) > 128 {
+	if len(o.Trigger) == 0 || len(o.Trigger) > 128 || strings.contains(o.Trigger, "/") {
 		return NewLocAppError("Command.IsValid", "model.command.is_valid.trigger.app_error", nil, "")
 	}
 

--- a/model/command.go
+++ b/model/command.go
@@ -100,7 +100,7 @@ func (o *Command) IsValid() *AppError {
 		return NewLocAppError("Command.IsValid", "model.command.is_valid.team_id.app_error", nil, "")
 	}
 
-	if len(o.Trigger) == 0 || len(o.Trigger) > 128 || strings.contains(o.Trigger, "/") {
+	if len(o.Trigger) == 0 || len(o.Trigger) > 128 {
 		return NewLocAppError("Command.IsValid", "model.command.is_valid.trigger.app_error", nil, "")
 	}
 

--- a/model/command.go
+++ b/model/command.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 const (

--- a/model/command.go
+++ b/model/command.go
@@ -6,7 +6,6 @@ package model
 import (
 	"encoding/json"
 	"io"
-	"strings"
 )
 
 const (

--- a/model/command.go
+++ b/model/command.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 const (
@@ -99,7 +100,7 @@ func (o *Command) IsValid() *AppError {
 		return NewLocAppError("Command.IsValid", "model.command.is_valid.team_id.app_error", nil, "")
 	}
 
-	if len(o.Trigger) == 0 || len(o.Trigger) > 128 {
+	if len(o.Trigger) == 0 || len(o.Trigger) > 128 || strings.Contains(o.Trigger, "/") {
 		return NewLocAppError("Command.IsValid", "model.command.is_valid.trigger.app_error", nil, "")
 	}
 

--- a/webapp/components/backstage/add_command.jsx
+++ b/webapp/components/backstage/add_command.jsx
@@ -92,6 +92,20 @@ export default class AddCommand extends React.Component {
             return;
         }
 
+        if (command.trigger.indexOf('/') !== -1) {
+            this.setState({
+                saving: false,
+                clientError: (
+                    <FormattedMessage
+                        id='add_command.triggerInvalid'
+                        defaultMessage='A trigger word cannot contain /'
+                    />
+                )
+            });
+
+            return;
+        }
+
         if (!command.url) {
             this.setState({
                 saving: false,

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -50,6 +50,7 @@
   "add_command.trigger.help2": "Reserved: /echo, /join, /logout, /me, /shrug",
   "add_command.trigger.placeholder": "Command trigger e.g. \"hello\" not including the slash",
   "add_command.triggerRequired": "A trigger word is required",
+  "add_command.triggerInvalid": "A trigger word cannot contain /",
   "add_command.url": "Request URL",
   "add_command.url.help": "The callback URL to receive the HTTP POST or GET event request when the slash command is run.",
   "add_command.url.placeholder": "Must start with http:// or https://",


### PR DESCRIPTION
Command triggers containing a / can no longer be created. This prevents commands such as `//foo` causing server errors.

Future Todos:
- Validate commands server side (IsValid is not called on commands)
- Enforce restrictions on commands (e.g. letters and numbers only)