### PR TITLE
PLT-2975 Removed check of email signup from creating a team

### DIFF
--- a/api/team.go
+++ b/api/team.go
@@ -222,11 +222,6 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func CreateTeam(c *Context, team *model.Team) *model.Team {
-	if !utils.Cfg.EmailSettings.EnableSignUpWithEmail {
-		c.Err = model.NewLocAppError("createTeam", "api.team.create_team.email_disabled.app_error", nil, "")
-		c.Err.StatusCode = http.StatusForbidden
-		return nil
-	}
 
 	if team == nil {
 		c.SetInvalidParam("createTeam", "team")


### PR DESCRIPTION
Tested this with LDAP login instead of Gitlab, but it works fine. This seems to have been left over from when you created a team without being logged in