### PR TITLE
Fix postgres case-sensitive errors

### DIFF
--- a/vendor/github.com/go-gorp/gorp/dialect_postgres.go
+++ b/vendor/github.com/go-gorp/gorp/dialect_postgres.go
@@ -78,7 +78,7 @@ func (d PostgresDialect) AutoIncrBindValue() string {
 }
 
 func (d PostgresDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
-	return " returning " + d.QuoteField(col.ColumnName)
+	return " returning " + col.ColumnName
 }
 
 // Returns suffix
@@ -123,7 +123,7 @@ func (d PostgresDialect) InsertAutoIncrToTarget(exec SqlExecutor, insertSql stri
 }
 
 func (d PostgresDialect) QuoteField(f string) string {
-	return `"` + f + `"`
+	return `"` + strings.ToLower(f) + `"`
 }
 
 func (d PostgresDialect) QuotedTableForQuery(schema string, table string) string {


### PR DESCRIPTION
release-3.0 has postgres case-sensitive errors
like this

```
create table if not exists "Users" ("Id" varchar(26) not null primary key, "CreateAt" bigint, "UpdateAt" bigint, "DeleteAt" bigint, "Username" varchar(64) unique, "Password" varchar(128), "AuthData" varchar(128) unique, "AuthService" varchar(32), "Email" varchar(128) unique, "EmailVerified" boolean, "Nickname" varchar(64), "FirstName" varchar(64), "LastName" varchar(64), "Roles" varchar(64), "LastActivityAt" bigint, "LastPingAt" bigint, "AllowMarketing" boolean, "Props" varchar(4000), "NotifyProps" varchar(2000), "ThemeProps" varchar(2000), "LastPasswordUpdate" bigint, "LastPictureUpdate" bigint, "FailedAttempts" integer, "Locale" varchar(5), "MfaActive" boolean, "MfaSecret" varchar(128)) ;
```

before release-3.0 :
```
create table if not exists "users" ("id" varchar(26) not null primary key, "createat" bigint, "updateat" bigint, "deleteat" bigint, "username" varchar(64) unique, "password" varchar(128), "authdata" varchar(128), "authservice" varchar(32), "email" varchar(128) unique, "emailverified" boolean, "nickname" varchar(64), "firstname" varchar(64), "lastname" varchar(64), "roles" varchar(64), "lastactivityat" bigint, "lastpingat" bigint, "allowmarketing" boolean, "props" varchar(4000), "notifyprops" varchar(2000), "themeprops" varchar(2000), "lastpasswordupdate" bigint, "lastpictureupdate" bigint, "failedattempts" integer, "locale" varchar(5), "mfaactive" boolean, "mfasecret" varchar(128)) ;
```

I think you had fixed this error once before but while #2949 was fixed,  the previous code that occured error was overwritten over the fixed code.