### PR TITLE
Move away from the "andForget" style of function

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -636,5 +636,5 @@ func CompleteSwitchWithOAuth(c *Context, w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	sendSignInChangeEmailAndForget(c, user.Email, c.GetSiteURL(), strings.Title(service)+" SSO")
+	go sendSignInChangeEmail(c, user.Email, c.GetSiteURL(), strings.Title(service)+" SSO")
 }


### PR DESCRIPTION
As suggested by @crspeller here:
https://github.com/mattermost/platform/pull/3022#issuecomment-220004020

I went ahead and modified all the _AndForget_ functions in `api/user.go`.

There are still 37 occurrences of _AndForget_ in the project, does that help if I go through the list and modify the functions so they do not start a go routine? Or do you prefer I leave it like that for the moment?

Please let me know.