### PR TITLE
PLT-1926/PLT-2247/PLT-2359 Updated our fork of marked

### DIFF
--- a/tests/test-links.md
+++ b/tests/test-links.md
@@ -1,70 +1,93 @@
-# Link Testing 
+# Link Testing
  
-Links in Mattermosts should render as specified below. 
+Links in Mattermosts should render as specified below.
 
-#### These strings should auto-link: 
+#### These strings should auto-link:
  
-http://example.com  
-https://example.com  
-www.example.com  
-www.example.com/index  
-www.example.com/index.html  
-www.example.com/index/sub  
-www.example.com/index?params=1  
-www.example.com/index?params=1&other=2  
-www.example.com/index?params=1;other=2  
-http://example.com:8065  
-http://www.example.com/_/page  
-www.example.com/_/page  
-https://en.wikipedia.org/wiki/🐬  
-https://en.wikipedia.org/wiki/Rendering_(computer_graphics)  
-http://127.0.0.1  
-http://192.168.1.1:4040  
-http://[::1]:80  
-http://[::1]:8065  
-https://[::1]:80  
-http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80  
-http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:8065  
-https://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:443  
-http://username:password@example.com  
-http://username:password@127.0.0.1  
-http://username:password@[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80  
-test@example.com  
- 
-#### These strings should not auto-link: 
- 
-example.com  
-readme.md  
-http://  
-@example.com  
-./make-compiled-client.sh  
-test.:test  
-https://<your-mattermost-url>/signup/gitlab  
+http://example.com
+https://example.com
+www.example.com
+www.example.com/index
+www.example.com/index.html
+www.example.com/index/sub
+www.example.com/index?params=1
+www.example.com/index?params=1&other=2
+www.example.com/index?params=1;other=2
+http://example.com:8065
+http://www.example.com/_/page
+www.example.com/_/page
+https://en.wikipedia.org/wiki/🐬
+https://en.wikipedia.org/wiki/Rendering_(computer_graphics)
+http://127.0.0.1
+http://192.168.1.1:4040
+http://[::1]:80
+http://[::1]:8065
+https://[::1]:80
+http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80
+http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:8065
+https://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:443
+http://username:password@example.com
+http://username:password@127.0.0.1
+http://username:password@[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80
+test@example.com
+http://example.com/more_(than)_one_(parens)
+http://example.com/(something)?after=parens
+http://foo.com/unicode_(✪)_in_parens
+http://✪df.ws/1234
+*https://example.com*
+_https://example.com_
+**https://example.com**
+__https://example.com__
+***https://example.com***
+___https://example.com___
+<https://example.com>
+<https://en.wikipedia.org/wiki/Rendering_(computer_graphics)>
+www1.example.com
+
+#### These strings should not auto-link:
+
+example.com
+readme.md
+@example.com
+./make-compiled-client.sh
+test.:test
+https://<your-mattermost-url>/signup/gitlab
+`https://example.com`
 
 #### Only the links within these sentences should auto-link:
 
-(http://example.com)  
-(test@example.com)  
-This is a sentence with a http://example.com in it.  
-This is a sentence with a [link](http://example.com) in it.  
-This is a sentence with a http://example.com/_/underscore in it.  
-This is a sentence with a link (http://example.com) in it.  
-This is a sentence with a (https://en.wikipedia.org/wiki/Rendering_(computer_graphics)) in it.  
-This is a sentence with a http://192.168.1.1:4040 in it.  
-This is a sentence with a https://[::1]:80 in it.  
-This is a link to http://example.com.  
+(http://example.com)
+(see http://example.com)
+(http://example.com watch this)
+(test@example.com)
+This is a sentence with a http://example.com in it.
+This is a sentence with a [link](http://example.com) in it.
+This is a sentence with a http://example.com/_/underscore in it.
+This is a sentence with a link (http://example.com) in it.
+This is a sentence with a (https://en.wikipedia.org/wiki/Rendering_(computer_graphics)) in it.
+This is a sentence with a http://192.168.1.1:4040 in it.
+This is a sentence with a https://[::1]:80 in it.
+This is a link to http://example.com.
+This is a link containing http://example.com/something?with,commas,in,url, but not at end
 
-#### These links should auto-link to the specified location:  
+#### These links should auto-link to the specified location:
 
-[example link](example.com) links to `http://example.com`  
-[example.com](example.com) links to `http://example.com`  
-[example.com/other](example.com) links to `http://example.com`  
-[example.com/other_link](example.com/example) links to `http://example.com/example`  
-www.example.com links to `http://www.example.com`  
-https://example.com links to `https://example.com` and not `http://example.com`  
-https://en.wikipedia.org/wiki/🐬 links to the Wikipedia article on dolphins  
-https://en.wikipedia.org/wiki/URLs#Syntax links to the Syntax section of the Wikipedia article on URLs  
-test@example.com links to `mailto:test@example.com`  
-[email link](mailto:test@example.com) links to `mailto:test@example.com` and not `http://mailto:test@example.com`  
-[other link](ts3server://example.com) links to `ts3server://example.com` and not `http://ts3server://example.com`  
+[example link](example.com) links to `http://example.com`
+[example.com](example.com) links to `http://example.com`
+[example.com/other](example.com) links to `http://example.com`
+[example.com/other_link](example.com/example) links to `http://example.com/example`
+www.example.com links to `http://www.example.com`
+https://example.com links to `https://example.com` and not `http://example.com`
+https://en.wikipedia.org/wiki/🐬 links to the Wikipedia article on dolphins
+https://en.wikipedia.org/wiki/URLs#Syntax links to the Syntax section of the Wikipedia article on URLs
+test@example.com links to `mailto:test@example.com`
+mailto:test@example.com links to `mailto:test@example.com`
+[email link](mailto:test@example.com) links to `mailto:test@example.com` and not `http://mailto:test@example.com`
+[other link](ts3server://example.com) links to `ts3server://example.com` and not `http://ts3server://example.com`
 test_underscore@example.com links to `mailto:test_underscore@example.com`
+[link with spaces](example.com/ spaces in the url) links to either `http://example.com/ spaces in the url` or `http://example.com/%20spaces%20in%20the%20url`
+
+#### These links should have tooltips when you hover over them
+[link](example.com "catch phrase!") should have the tooltip `catch phrase!`
+[link](example.com "title with "quotes"") should have the tooltip `title with "quotes"`
+[link with spaces](example.com/ spaces in the url "and a title") should have the tooltip `and a title`

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -16,7 +16,7 @@
     "jasny-bootstrap": "3.1.3",
     "jquery": "2.2.3",
     "keymirror": "0.1.1",
-    "marked": "mattermost/marked#cb85e5cc81bc7937dbb73c3c53d9532b1b97e3ca",
+    "marked": "mattermost/marked#43e7e590944ea308a4d36f21917118d51a261e74",
     "mattermost": "mattermost/mattermost-javascript#master",
     "match-at": "0.1.0",
     "object-assign": "4.1.0",

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -13,40 +13,6 @@ function markdownImageLoaded(image) {
 }
 window.markdownImageLoaded = markdownImageLoaded;
 
-class MattermostInlineLexer extends marked.InlineLexer {
-    constructor(links, options) {
-        super(links, options);
-
-        this.rules = Object.assign({}, this.rules);
-
-        // modified version of the regex that allows for links starting with www and those surrounded by parentheses
-        // the original is /^[\s\S]+?(?=[\\<!\[_*`~]|https?:\/\/| {2,}\n|$)/
-        this.rules.text = /^[\s\S]+?(?=[\\<!\[_*`~]|https?:\/\/|www\.|\(| {2,}\n|$)/;
-
-        // modified version of the regex that allows links starting with www and those surrounded by parentheses
-        // the original is /^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/
-        this.rules.url = /^(\(?(?:https?:\/\/|www\.)[^\s<.][^\s<]*[^<.,:;"'\]\s])/;
-
-        // modified version of the regex that allows <links> starting with www.
-        // the original is /^<([^ >]+(@|:\/)[^ >]+)>/
-        this.rules.autolink = /^<((?:[^ >]+(@|:\/)|www\.)[^ >]+)>/;
-    }
-}
-
-class MattermostParser extends marked.Parser {
-    parse(src) {
-        this.inline = new MattermostInlineLexer(src.links, this.options, this.renderer);
-        this.tokens = src.reverse();
-
-        var out = '';
-        while (this.next()) {
-            out += this.tok();
-        }
-
-        return out;
-    }
-}
-
 class MattermostMarkdownRenderer extends marked.Renderer {
     constructor(options, formattingOptions = {}) {
         super(options);
@@ -109,18 +75,6 @@ class MattermostMarkdownRenderer extends marked.Renderer {
 
     link(href, title, text) {
         let outHref = href;
-        let outText = text;
-        let prefix = '';
-        let suffix = '';
-
-        // some links like https://en.wikipedia.org/wiki/Rendering_(computer_graphics) contain brackets
-        // and we try our best to differentiate those from ones just wrapped in brackets when autolinking
-        if (outHref.startsWith('(') && outHref.endsWith(')') && text === outHref) {
-            prefix = '(';
-            suffix = ')';
-            outText = text.substring(1, text.length - 1);
-            outHref = outHref.substring(1, outHref.length - 1);
-        }
 
         try {
             const unescaped = decodeURIComponent(unescape(href)).replace(/[^\w:]/g, '').toLowerCase();
@@ -149,9 +103,9 @@ class MattermostMarkdownRenderer extends marked.Renderer {
             output += ' title="' + title + '"';
         }
 
-        output += '>' + outText + '</a>';
+        output += '>' + text + '</a>';
 
-        return prefix + output + suffix;
+        return output;
     }
 
     paragraph(text) {
@@ -486,7 +440,7 @@ export function format(text, options) {
 
     const tokens = new MattermostLexer(markdownOptions).lex(text);
 
-    return new MattermostParser(markdownOptions).parse(tokens);
+    return new marked.Parser(markdownOptions).parse(tokens);
 }
 
 // Marked helper functions that should probably just be exported


### PR DESCRIPTION
The changes to the markdown regexes can be viewed [here](https://github.com/mattermost/marked/pull/1/files) although I don't imagine that'll be super useful since they're kind of horrifying. They mostly match the ones found [here](http://daringfireball.net/2010/07/improved_regex_for_matching_urls) with some small tweaks to make them fit with the rest of the markdown regexes. You'll just have to take my word that they pass all of marked's unit tests unless you want to run them yourself.

I also got rid of the modified regexes that I had in markdown.jsx since the changes I made to marked made those obsolete.