### PR TITLE
PLT-2936 Fixed double join messages upon /join

### DIFF
--- a/api/command_join.go
+++ b/api/command_join.go
@@ -42,17 +42,9 @@ func (me *JoinProvider) DoCommand(c *Context, channelId string, message string) 
 
 			if v.Name == message {
 
-				if v.Type == model.CHANNEL_DIRECT {
+				if v.Type != model.CHANNEL_OPEN {
 					return &model.CommandResponse{Text: c.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 				}
-
-				JoinChannelById(c, c.Session.UserId, v.Id)
-
-				if c.Err != nil {
-					c.Err = nil
-					return &model.CommandResponse{Text: c.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-				}
-
 				return &model.CommandResponse{GotoLocation: c.GetTeamURL() + "/channels/" + v.Name, Text: c.T("api.command_join.success"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 		}

--- a/api/command_join_test.go
+++ b/api/command_join_test.go
@@ -41,18 +41,7 @@ func TestJoinCommands(t *testing.T) {
 
 	c1 := Client.Must(Client.GetChannels("")).Data.(*model.ChannelList)
 
-	if len(c1.Channels) != 6 { // 4 because of town-square, off-topic and direct
-		t.Fatal("didn't join channel")
-	}
-
-	found := false
-	for _, c := range c1.Channels {
-		if c.Name == channel2.Name {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if len(c1.Channels) != 5 {
 		t.Fatal("didn't join channel")
 	}
 }


### PR DESCRIPTION
When /join is used, two things happen:
- JoinChannelById is called
- GotoLocation is set to the URL of the channel

As the call is asynchronous, JoinChannelById usually finishes after GotoLocation. Navigating to an unjoined channel will attempt to join it. Then, another call to JoinChannel (in some form) will be made. Therefore two messages are printed.

Fix: Removed JoinChannelById call. This is doable as /join is only meant to join open channels.

In the unit tests, the number of channels was changed to 5: channel0, channel2, channel3, town-square, and off-topic. The comment was removed to prevent confusion.