### PR TITLE
PLT-2784 Fixing Channel Navigation Shortcuts

### DIFF
--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -1408,6 +1408,10 @@ export function localizeMessage(id, defaultMessage) {
     return id;
 }
 
+export function mod(a, b) {
+    return ((a % b) + b) % b;
+}
+
 export function getProfilePicSrcForPost(post, timestamp) {
     let src = Client.getUsersRoute() + '/' + post.user_id + '/image?time=' + timestamp;
     if (post.props && post.props.from_webhook && global.window.mm_config.EnablePostIconOverride === 'true') {


### PR DESCRIPTION
The shortcut to navigate between channels was wrong because of improper ordering of DM channels, and navigating to an unread channel produced JS errors. Also, many unnecessary things were retrieved from stores instead of state.

Changes made:
- Retrieved what can be retrieved from state instead of stores, the stores are used to get a list of all channels (this does not affect rendering, @jwilander okay'd it)
- User preferences on displayed DM channels are now taken into account
- Channeling sorting was simplified
- Navigation to the next unread channel was simplified
- All shortcuts now wrap around

