### PR TITLE
PLT-2321 Move the toggle icon next to the link being previewed

### DIFF
--- a/webapp/components/post_view/components/post_body.jsx
+++ b/webapp/components/post_view/components/post_body.jsx
@@ -136,7 +136,6 @@ export default class PostBody extends React.Component {
         }
 
         let message;
-        let additionalContent = null;
         if (this.props.post.state === Constants.POST_DELETED) {
             message = (
                 <FormattedMessage
@@ -151,9 +150,28 @@ export default class PostBody extends React.Component {
                     dangerouslySetInnerHTML={{__html: TextFormatting.formatText(this.props.post.message)}}
                 />
             );
+        }
 
-            additionalContent = (
-                <PostBodyAdditionalContent post={this.props.post}/>
+        let messageWrapper = (
+            <div
+                key={`${post.id}_message`}
+                id={`${post.id}_message`}
+                className={postClass}
+            >
+                {loading}
+                {message}
+            </div>
+        );
+
+        let messageWithAdditionalContent;
+        if (this.props.post.state === Constants.POST_DELETED) {
+            messageWithAdditionalContent = messageWrapper;
+        } else {
+            messageWithAdditionalContent = (
+                <PostBodyAdditionalContent
+                    post={this.props.post}
+                    message={messageWrapper}
+                />
             );
         }
 
@@ -161,16 +179,8 @@ export default class PostBody extends React.Component {
             <div>
                 {comment}
                 <div className='post__body'>
-                    <div
-                        key={`${post.id}_message`}
-                        id={`${post.id}_message`}
-                        className={postClass}
-                    >
-                        {loading}
-                        {message}
-                    </div>
+                    {messageWithAdditionalContent}
                     {fileAttachmentHolder}
-                    {additionalContent}
                 </div>
             </div>
         );

--- a/webapp/components/post_view/components/post_body_additional_content.jsx
+++ b/webapp/components/post_view/components/post_body_additional_content.jsx
@@ -152,7 +152,7 @@ export default class PostBodyAdditionalContent extends React.Component {
             );
         }
 
-        return null;
+        return this.props.message;
     }
 }
 

--- a/webapp/components/post_view/components/post_body_additional_content.jsx
+++ b/webapp/components/post_view/components/post_body_additional_content.jsx
@@ -117,21 +117,31 @@ export default class PostBodyAdditionalContent extends React.Component {
         const generateEmbed = this.generateEmbed();
 
         if (generateEmbed) {
-            let toggle;
+            let messageWithToggle = [];
             if (Utils.isFeatureEnabled(Constants.PRE_RELEASE_FEATURES.EMBED_TOGGLE)) {
-                toggle = (
+                // if message has only one line and starts with a link place toggle in this only line
+                // else - place it in new line between message and embed
+                const prependToggle = (/^\s*https?:\/\/.*$/).test(this.props.post.message);
+                messageWithToggle.push(
                     <a
-                        className='post__embed-visibility'
+                        className={`post__embed-visibility ${prependToggle ? 'pull-left' : ''}`}
                         data-expanded={this.state.embedVisible}
                         aria-label='Toggle Embed Visibility'
                         onClick={this.toggleEmbedVisibility}
                     />
                 );
+                if (prependToggle) {
+                    messageWithToggle.push(this.props.message);
+                } else {
+                    messageWithToggle.unshift(this.props.message);
+                }
+            } else {
+                messageWithToggle.push(this.props.message);
             }
 
             return (
                 <div>
-                    {toggle}
+                    {messageWithToggle}
                     <div
                         className='post__embed-container'
                         hidden={!this.state.embedVisible}
@@ -147,5 +157,6 @@ export default class PostBodyAdditionalContent extends React.Component {
 }
 
 PostBodyAdditionalContent.propTypes = {
-    post: React.PropTypes.object.isRequired
+    post: React.PropTypes.object.isRequired,
+    message: React.PropTypes.element.isRequired
 };

--- a/webapp/components/rhs_root_post.jsx
+++ b/webapp/components/rhs_root_post.jsx
@@ -210,6 +210,14 @@ export default class RhsRootPost extends React.Component {
             />
         );
 
+        const messageWrapper = (
+            <div
+                ref='message_holder'
+                onClick={TextFormatting.handleClick}
+                dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message)}}
+            />
+        );
+
         return (
             <div className={'post post--root ' + userCss + ' ' + systemMessageClass}>
                 <div className='post-right-channel__name'>{channelName}</div>
@@ -241,13 +249,9 @@ export default class RhsRootPost extends React.Component {
                             </li>
                         </ul>
                         <div className='post__body'>
-                            <div
-                                ref='message_holder'
-                                onClick={TextFormatting.handleClick}
-                                dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message)}}
-                            />
                             <PostBodyAdditionalContent
                                 post={post}
+                                message={messageWrapper}
                             />
                             {fileAttachment}
                         </div>

--- a/webapp/components/youtube_video.jsx
+++ b/webapp/components/youtube_video.jsx
@@ -144,9 +144,22 @@ export default class YoutubeVideo extends React.Component {
             return <div className='video-loading'/>;
         }
 
-        let header = 'Youtube';
+        let header;
         if (this.state.title) {
-            header = header + ' - ';
+            header = (
+                <h4>
+                    <span className='video-type'>{'Youtube - '}</span>
+                    <span className='video-title'>
+                        <a
+                            href={this.props.link}
+                            target='blank'
+                            rel='noopener noreferrer'
+                        >
+                            {this.state.title}
+                        </a>
+                    </span>
+                </h4>
+            );
         }
 
         let content;
@@ -190,18 +203,7 @@ export default class YoutubeVideo extends React.Component {
 
         return (
             <div>
-                <h4>
-                    <span className='video-type'>{header}</span>
-                    <span className='video-title'>
-                        <a
-                            href={this.props.link}
-                            target='blank'
-                            rel='noopener noreferrer'
-                        >
-                            {this.state.title}
-                        </a>
-                    </span>
-                </h4>
+                {header}
                 <div
                     className='video-div embed-responsive-item'
                     onClick={this.play}

--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -914,8 +914,12 @@ body.ios {
         cursor: pointer;
         display: inline-block;
         font: normal normal normal 14px/1 FontAwesome;
-        margin: 5px 0 10px;
+        margin: 0 0 10px;
         text-rendering: auto;
+
+        &.pull-left{
+            margin: 5px 5px 0 0;
+        }
 
         &:hover {
             text-decoration: none;

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -103,7 +103,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
             output += ' title="' + title + '"';
         }
 
-        output += '>' + text.replace(/\//g, '/<wbr />') + '</a>';
+        output += '>' + text + '</a>';
 
         return output;
     }

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -103,7 +103,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
             output += ' title="' + title + '"';
         }
 
-        output += '>' + text + '</a>';
+        output += '>' + text.replace(/\//g, '/<wbr />') + '</a>';
 
         return output;
     }

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -34,6 +34,8 @@ export function formatText(text, options = {}) {
         output = replaceNewlines(output);
     }
 
+    output = insertLongLinkWbr(output);
+
     return output;
 }
 
@@ -75,6 +77,9 @@ export function doFormatText(text, options) {
             }
         });
     }
+
+    //replace all "/" to "/<wbr />"
+    output = output.replace(/\//g, '/<wbr />');
 
     // reinsert tokens with formatted versions of the important words and phrases
     output = replaceTokens(output, tokens);
@@ -424,4 +429,11 @@ export function handleClick(e) {
     } else if (linkAttribute) {
         browserHistory.push(linkAttribute.value);
     }
+}
+
+//replace all "/" inside <a> tags to "/<wbr />"
+function insertLongLinkWbr(test) {
+    return test.replace(/\//g, (match, position, string) => {
+        return match + ((/a[^>]*>[^<]*$/).test(string.substr(0, position)) ? '<wbr />' : '');
+    });
 }

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -34,8 +34,6 @@ export function formatText(text, options = {}) {
         output = replaceNewlines(output);
     }
 
-    output = insertLongLinkWbr(output);
-
     return output;
 }
 
@@ -426,11 +424,4 @@ export function handleClick(e) {
     } else if (linkAttribute) {
         browserHistory.push(linkAttribute.value);
     }
-}
-
-//replace all "/" inside <a> tags to "/<wbr />"
-function insertLongLinkWbr(test) {
-    return test.replace(/\//g, (match, position, string) => {
-        return match + ((/a[^>]*>[^<]*$/).test(string.substr(0, position)) ? '<wbr />' : '');
-    });
 }

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -34,6 +34,8 @@ export function formatText(text, options = {}) {
         output = replaceNewlines(output);
     }
 
+    output = insertLongLinkWbr(output);
+
     return output;
 }
 
@@ -424,4 +426,11 @@ export function handleClick(e) {
     } else if (linkAttribute) {
         browserHistory.push(linkAttribute.value);
     }
+}
+
+//replace all "/" inside <a> tags to "/<wbr />"
+function insertLongLinkWbr(test) {
+    return test.replace(/\//g, (match, position, string) => {
+        return match + ((/a[^>]*>[^<]*$/).test(string.substr(0, position)) ? '<wbr />' : '');
+    });
 }


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/PLT-2321
this ticket became more complicated then I expect. As I understand, the main reason of this feature is saving space of extra line.
It is obvious how it should work in most common case of 
![image](https://cloud.githubusercontent.com/assets/11226228/15431031/b613971a-1eb0-11e6-9174-5a27eef36819.png)
I impliment it this way
![image](https://cloud.githubusercontent.com/assets/11226228/15431069/ec7c9590-1eb0-11e6-93ca-9e46eda3bcdb.png)
but what aboul more complex cases, messages that contain not only link, not start with a link, multiline messages or even messages with several links?
<img src="https://cloud.githubusercontent.com/assets/11226228/15431259/abf7ace8-1eb1-11e6-8908-e42f243ea8d9.png" width=300><img src="https://cloud.githubusercontent.com/assets/11226228/15431270/b7effaa0-1eb1-11e6-8e22-ed8974081d44.png" width=300><img src="https://cloud.githubusercontent.com/assets/11226228/15431280/c8605c72-1eb1-11e6-85c7-8a52a4fc50b4.png" width=300><img src="https://cloud.githubusercontent.com/assets/11226228/15431289/d5aad5a6-1eb1-11e6-966f-d714d585a48f.png" width=300>

I deside that the most common case with one line message starting with link covers most of cases with embed, so i implement feature only for this case, and leave mostly as is multiline case 

there is one thing wich may looks like werid - adding extra `<wbr/>` tags into links. i'll just illustrate this with screenshoot. without `<wbr/>`:
![image](https://cloud.githubusercontent.com/assets/11226228/15431644/8033fede-1eb3-11e6-8a86-d6d4c6c190a4.png)
with `<wbr/>`:
![image](https://cloud.githubusercontent.com/assets/11226228/15431675/9a5dec5c-1eb3-11e6-810b-6db556472e9f.png)

Also i've removed useless "Youtube" header