### PR TITLE
Remove more items and use the headers for these kind of links

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -539,20 +539,6 @@ export default class Sidebar extends React.Component {
             head.appendChild(link);
         }
 
-        var directMessageMore = (
-            <li key='more'>
-                <a
-                    href='#'
-                    onClick={this.showMoreDirectChannelsModal}
-                >
-                    <FormattedMessage
-                        id='sidebar.more'
-                        defaultMessage='More'
-                    />
-                </a>
-            </li>
-        );
-
         let showChannelModal = false;
         if (this.state.newChannelModalType !== '') {
             showChannelModal = true;
@@ -566,11 +552,27 @@ export default class Sidebar extends React.Component {
                 />
             </Tooltip>
         );
+        const browseChannelTootlip = (
+            <Tooltip id='browse-channel-tooltip' >
+                <FormattedMessage
+                    id='sidebar.browseChannel'
+                    defaultMessage='Browse all channels'
+                />
+            </Tooltip>
+        );
         const createGroupTootlip = (
             <Tooltip id='new-group-tooltip'>
                 <FormattedMessage
                     id='sidebar.createGroup'
                     defaultMessage='Create new group'
+                />
+            </Tooltip>
+        );
+        const openDirectMessageTootlip = (
+            <Tooltip id='open-directmessage-tooltip'>
+                <FormattedMessage
+                    id='sidebar.openDirectMessage'
+                    defaultMessage='Open a direct message'
                 />
             </Tooltip>
         );
@@ -631,10 +633,21 @@ export default class Sidebar extends React.Component {
                     <ul className='nav nav-pills nav-stacked'>
                         <li>
                             <h4>
-                                <FormattedMessage
-                                    id='sidebar.channels'
-                                    defaultMessage='Channels'
-                                />
+                                <OverlayTrigger
+                                    delayShow={500}
+                                    placement='top'
+                                    overlay={browseChannelTootlip}
+                                >
+                                    <a
+                                        href='#'
+                                        onClick={this.showMoreChannelsModal}
+                                    >
+                                        <FormattedMessage
+                                            id='sidebar.channels'
+                                            defaultMessage='Channels'
+                                        />
+                                    </a>
+                                </OverlayTrigger>
                                 <OverlayTrigger
                                     delayShow={500}
                                     placement='top'
@@ -651,18 +664,6 @@ export default class Sidebar extends React.Component {
                             </h4>
                         </li>
                         {publicChannelItems}
-                        <li>
-                            <a
-                                href='#'
-                                className='nav-more'
-                                onClick={this.showMoreChannelsModal}
-                            >
-                                <FormattedMessage
-                                    id='sidebar.moreElips'
-                                    defaultMessage='More...'
-                                />
-                            </a>
-                        </li>
                     </ul>
 
                     <ul className='nav nav-pills nav-stacked'>
@@ -692,16 +693,26 @@ export default class Sidebar extends React.Component {
                     <ul className='nav nav-pills nav-stacked'>
                         <li>
                             <h4>
-                                <FormattedMessage
-                                    id='sidebar.direct'
-                                    defaultMessage='Direct Messages'
-                                />
+                                <OverlayTrigger
+                                    delayShow={500}
+                                    placement='top'
+                                    overlay={openDirectMessageTootlip}
+                                >
+                                    <a
+                                        href='#'
+                                        onClick={this.showMoreDirectChannelsModal}
+                                    >
+                                        <FormattedMessage
+                                            id='sidebar.direct'
+                                            defaultMessage='Direct Messages'
+                                        />
+                                    </a>
+                                </OverlayTrigger>
                             </h4>
                         </li>
                         {directMessageItems}
                         {directDivider}
                         {directMessageNonTeamItems}
-                        {directMessageMore}
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Hey everybody,

this aims to get rid of the "More" links from Direct Messages and Channels. The links are moved to the "category headers" namedly "DIRECT MESSAGES" and "CHANNELS".

Which makes the UX way better, as you don't have to scroll down to the end of the menu, to start a new direct message chat for example.

Fair warning, this is untested, as I only have access to windows systems and it seems like there is no way to build on windows. And nobody in the Contributers chat could think of how to build it any other way.