### PR TITLE
PLT-2826 JS Error on Cancelling Change Notification Preferences

### DIFF
--- a/webapp/components/channel_notifications_modal.jsx
+++ b/webapp/components/channel_notifications_modal.jsx
@@ -182,7 +182,6 @@ export default class ChannelNotificationsModal extends React.Component {
 
             const handleUpdateSection = function updateSection(e) {
                 this.updateSection('');
-                this.onListenerChange();
                 e.preventDefault();
             }.bind(this);
 
@@ -312,7 +311,6 @@ export default class ChannelNotificationsModal extends React.Component {
 
             const handleUpdateSection = function handleUpdateSection(e) {
                 this.updateSection('');
-                this.onListenerChange();
                 e.preventDefault();
             }.bind(this);
 


### PR DESCRIPTION
Calls to `this.onListenerChange()` was removed, as `onListenerChange` did not exist inside this scope. This did not affect functionality, notification settings still save as expected.