### PR TITLE
PLT-2989 Incoming webhooks available to all channels user is member of

### DIFF
--- a/webapp/components/backstage/add_incoming_webhook.jsx
+++ b/webapp/components/backstage/add_incoming_webhook.jsx
@@ -172,6 +172,8 @@ export default class AddIncomingWebhook extends React.Component {
                                     id='channelId'
                                     value={this.state.channelId}
                                     onChange={this.updateChannelId}
+                                    selectOpen={true}
+                                    selectPrivate={true}
                                 />
                             </div>
                         </div>

--- a/webapp/components/backstage/add_outgoing_webhook.jsx
+++ b/webapp/components/backstage/add_outgoing_webhook.jsx
@@ -224,6 +224,7 @@ export default class AddOutgoingWebhook extends React.Component {
                                     id='channelId'
                                     value={this.state.channelId}
                                     onChange={this.updateChannelId}
+                                    selectOpen={true}
                                 />
                             </div>
                         </div>

--- a/webapp/components/channel_select.jsx
+++ b/webapp/components/channel_select.jsx
@@ -11,7 +11,10 @@ export default class ChannelSelect extends React.Component {
     static get propTypes() {
         return {
             onChange: React.PropTypes.func,
-            value: React.PropTypes.string
+            value: React.PropTypes.string,
+            selectOpen: React.PropTypes.bool.isRequired,
+            selectPrivate: React.PropTypes.bool.isRequired,
+            selectDm: React.PropTypes.bool.isRequired
         };
     }
 
@@ -54,7 +57,25 @@ export default class ChannelSelect extends React.Component {
         ];
 
         this.state.channels.forEach((channel) => {
-            if (channel.type !== Constants.DM_CHANNEL) {
+            if (channel.type === Constants.OPEN_CHANNEL && this.props.selectOpen) {
+                options.push(
+                    <option
+                        key={channel.id}
+                        value={channel.id}
+                    >
+                        {channel.display_name}
+                    </option>
+                );
+            } else if (channel.type === Constants.PRIVATE_CHANNEL && this.props.selectPrivate) {
+                options.push(
+                    <option
+                        key={channel.id}
+                        value={channel.id}
+                    >
+                        {channel.display_name}
+                    </option>
+                );
+            } else if (channel.type === Constants.DM_CHANNEL && this.props.selectDm) {
                 options.push(
                     <option
                         key={channel.id}
@@ -77,3 +98,9 @@ export default class ChannelSelect extends React.Component {
         );
     }
 }
+
+ChannelSelect.defaultProps = {
+    selectOpen: false,
+    selectPrivate: false,
+    selectDm: false
+};

--- a/webapp/components/channel_select.jsx
+++ b/webapp/components/channel_select.jsx
@@ -33,26 +33,19 @@ export default class ChannelSelect extends React.Component {
         this.handleChannelChange = this.handleChannelChange.bind(this);
         this.compareByDisplayName = this.compareByDisplayName.bind(this);
 
+        AsyncClient.getMoreChannels(true);
+
         this.state = {
-            channels: []
+            channels: ChannelStore.getAll().sort(this.compareByDisplayName)
         };
     }
 
-    componentWillMount() {
-        AsyncClient.getMoreChannels(true);
-        this.setState({
-            channels: ChannelStore.getAll().sort(this.compareByDisplayName)
-        });
-
+    componentDidMount() {
         ChannelStore.addChangeListener(this.handleChannelChange);
     }
 
     componentWillUnmount() {
         ChannelStore.removeChangeListener(this.handleChannelChange);
-    }
-
-    shouldComponentUpdate(nextProps, nextState) {
-        return !Utils.areObjectsEqual(nextState.channels, this.state.channels);
     }
 
     handleChannelChange() {

--- a/webapp/components/channel_select.jsx
+++ b/webapp/components/channel_select.jsx
@@ -54,7 +54,7 @@ export default class ChannelSelect extends React.Component {
         ];
 
         this.state.channels.forEach((channel) => {
-            if (channel.type === Constants.OPEN_CHANNEL) {
+            if (channel.type !== Constants.DM_CHANNEL) {
                 options.push(
                     <option
                         key={channel.id}


### PR DESCRIPTION
Removed the check for OPEN_CHANNEL, now incoming/outgoing webhooks can be directed at any channel that is not a DM channel.

Can also change the check to allow DM channels.