### PR TITLE
PLT-3002 Removed Auto-capitalization on Mobile Devices

### DIFF
--- a/webapp/components/login/login.jsx
+++ b/webapp/components/login/login.jsx
@@ -259,6 +259,7 @@ export default class Login extends React.Component {
                                 onChange={this.handleLoginIdChange}
                                 placeholder={this.createLoginPlaceholder(emailSigninEnabled, usernameSigninEnabled, ldapEnabled)}
                                 spellCheck='false'
+                                autoCapitalize='off'
                             />
                         </div>
                         <div className={'form-group' + errorClass}>

--- a/webapp/components/signup_user_complete.jsx
+++ b/webapp/components/signup_user_complete.jsx
@@ -373,6 +373,7 @@ export default class SignupUserComplete extends React.Component {
                             onChange={this.handleLdapIdChange}
                             placeholder={ldapIdPlaceholder}
                             spellCheck='false'
+                            autoCapitalize='off'
                         />
                     </div>
                     <div className={'form-group' + errorClass}>
@@ -513,6 +514,7 @@ export default class SignupUserComplete extends React.Component {
                         maxLength='128'
                         autoFocus={true}
                         spellCheck='false'
+                        autoCapitalize='off'
                     />
                     {emailError}
                     {emailHelpText}

--- a/webapp/components/signup_user_complete.jsx
+++ b/webapp/components/signup_user_complete.jsx
@@ -598,6 +598,7 @@ export default class SignupUserComplete extends React.Component {
                                     placeholder=''
                                     maxLength={Constants.MAX_USERNAME_LENGTH}
                                     spellCheck='false'
+                                    autoCapitalize='off'
                                 />
                                 {nameError}
                                 {nameHelpText}

--- a/webapp/components/user_settings/user_settings_general.jsx
+++ b/webapp/components/user_settings/user_settings_general.jsx
@@ -342,7 +342,7 @@ class UserSettingsGeneralTab extends React.Component {
                             <div className='col-sm-7'>
                                 <input
                                     className='form-control'
-                                    type='text'
+                                    type='email'
                                     onChange={this.updateEmail}
                                     value={this.state.email}
                                     autoCapitalize='off'
@@ -364,7 +364,7 @@ class UserSettingsGeneralTab extends React.Component {
                             <div className='col-sm-7'>
                                 <input
                                     className='form-control'
-                                    type='text'
+                                    type='email'
                                     onChange={this.updateConfirmEmail}
                                     value={this.state.confirmEmail}
                                     autoCapitalize='off'

--- a/webapp/components/user_settings/user_settings_general.jsx
+++ b/webapp/components/user_settings/user_settings_general.jsx
@@ -345,6 +345,7 @@ class UserSettingsGeneralTab extends React.Component {
                                     type='text'
                                     onChange={this.updateEmail}
                                     value={this.state.email}
+                                    autoCapitalize='off'
                                 />
                             </div>
                         </div>
@@ -366,6 +367,7 @@ class UserSettingsGeneralTab extends React.Component {
                                     type='text'
                                     onChange={this.updateConfirmEmail}
                                     value={this.state.confirmEmail}
+                                    autoCapitalize='off'
                                 />
                             </div>
                         </div>
@@ -681,6 +683,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 type='text'
                                 onChange={this.updateNickname}
                                 value={this.state.nickname}
+                                autoCapitalize='off'
                             />
                         </div>
                     </div>
@@ -764,6 +767,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 type='text'
                                 onChange={this.updateUsername}
                                 value={this.state.username}
+                                autoCapitalize='off'
                             />
                         </div>
                     </div>

--- a/webapp/components/user_settings/user_settings_general.jsx
+++ b/webapp/components/user_settings/user_settings_general.jsx
@@ -345,7 +345,6 @@ class UserSettingsGeneralTab extends React.Component {
                                     type='email'
                                     onChange={this.updateEmail}
                                     value={this.state.email}
-                                    autoCapitalize='off'
                                 />
                             </div>
                         </div>
@@ -367,7 +366,6 @@ class UserSettingsGeneralTab extends React.Component {
                                     type='email'
                                     onChange={this.updateConfirmEmail}
                                     value={this.state.confirmEmail}
-                                    autoCapitalize='off'
                                 />
                             </div>
                         </div>


### PR DESCRIPTION
Added `autoCapitalize='off` for mobile devices on:
 - Login
 - User creation
 - Changing
    - LDAP ID
    - Email
    - Nickname
    - Username

Tested on Android 5.0 and 6.0. Should work on iOS according to:
https://developers.google.com/web/updates/2015/04/autocapitalize?hl=en