### PR TITLE
PLT-2998 Do not allow duplicated trigger words in slash commands and outgoing webhooks

### DIFF
--- a/api/command_test.go
+++ b/api/command_test.go
@@ -45,16 +45,28 @@ func TestCreateCommand(t *testing.T) {
 	}()
 	*utils.Cfg.ServiceSettings.EnableCommands = true
 
-	cmd := &model.Command{URL: "http://nowhere.com", Method: model.COMMAND_METHOD_POST, Trigger: "trigger"}
+	cmd1 := &model.Command{
+		CreatorId: user.Id,
+		TeamId:    team.Id,
+		URL:       "http://nowhere.com",
+		Method:    model.COMMAND_METHOD_POST,
+		Trigger:   "trigger"}
 
-	if _, err := Client.CreateCommand(cmd); err == nil {
+	if _, err := Client.CreateCommand(cmd1); err == nil {
 		t.Fatal("should have failed because not admin")
 	}
 
 	Client = th.SystemAdminClient
 
+	cmd2 := &model.Command{
+		CreatorId: user.Id,
+		TeamId:    team.Id,
+		URL:       "http://nowhere.com",
+		Method:    model.COMMAND_METHOD_POST,
+		Trigger:   "trigger"}
+
 	var rcmd *model.Command
-	if result, err := Client.CreateCommand(cmd); err != nil {
+	if result, err := Client.CreateCommand(cmd2); err != nil {
 		t.Fatal(err)
 	} else {
 		rcmd = result.Data.(*model.Command)
@@ -68,16 +80,19 @@ func TestCreateCommand(t *testing.T) {
 		t.Fatal("team ids didn't match")
 	}
 
-	cmd = &model.Command{CreatorId: "123", TeamId: "456", URL: "http://nowhere.com", Method: model.COMMAND_METHOD_POST, Trigger: "trigger"}
-	if result, err := Client.CreateCommand(cmd); err != nil {
-		t.Fatal(err)
-	} else {
-		if result.Data.(*model.Command).CreatorId != user.Id {
-			t.Fatal("bad user id wasn't overwritten")
-		}
-		if result.Data.(*model.Command).TeamId != team.Id {
-			t.Fatal("bad team id wasn't overwritten")
-		}
+	cmd3 := &model.Command{
+		CreatorId: "123",
+		TeamId:    "456",
+		URL:       "http://nowhere.com",
+		Method:    model.COMMAND_METHOD_POST,
+		Trigger:   "trigger"}
+	if _, err := Client.CreateCommand(cmd3); err == nil {
+		t.Fatal("trigger cannot be duplicated")
+	}
+
+	cmd4 := cmd3
+	if _, err := Client.CreateCommand(cmd4); err == nil {
+		t.Fatal("command cannot be duplicated")
 	}
 }
 

--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -262,6 +262,17 @@ func TestCreateOutgoingHook(t *testing.T) {
 		t.Fatal("team ids didn't match")
 	}
 
+	hook = &model.OutgoingWebhook{ChannelId: channel1.Id, TriggerWords: []string{"cats", "dogs"}, CallbackURLs: []string{"http://nowhere.com", "http://cats.com"}}
+	hook1 := &model.OutgoingWebhook{ChannelId: channel1.Id, TriggerWords: []string{"cats"}, CallbackURLs: []string{"http://nowhere.com"}}
+
+	if _, err := Client.CreateOutgoingWebhook(hook); err != nil {
+		t.Fatal("multiple trigger words and urls failed")
+	}
+
+	if _, err := Client.CreateOutgoingWebhook(hook1); err == nil {
+		t.Fatal("should have failed - duplicate trigger words and urls")
+	}
+
 	hook = &model.OutgoingWebhook{ChannelId: "junk", CallbackURLs: []string{"http://nowhere.com"}}
 	if _, err := Client.CreateOutgoingWebhook(hook); err == nil {
 		t.Fatal("should have failed - bad channel id")

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -284,6 +284,10 @@
     "translation": "Integrations have been limited to admins only."
   },
   {
+    "id": "api.command.duplicate_trigger.app_error",
+    "translation": "This trigger word is already in use. Please choose another word."
+  },
+  {
     "id": "api.command.delete.app_error",
     "translation": "Inappropriate permissions to delete command"
   },
@@ -1838,6 +1842,10 @@
   {
     "id": "api.webhook.create_outgoing.disabled.app_error",
     "translation": "Outgoing webhooks have been disabled by the system admin."
+  },
+  {
+    "id": "api.webhook.create_outgoing.intersect.app_error",
+    "translation": "Outgoing webhooks from the same channel cannot have the same trigger words/callback URLs."
   },
   {
     "id": "api.webhook.create_outgoing.not_open.app_error",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package utils
+
+func StringArrayIntersection(arr1, arr2 []string) []string {
+	arrMap := map[string]bool{}
+	result := []string{}
+
+	for _, value := range arr1 {
+		arrMap[value] = true
+	}
+
+	for _, value := range arr2 {
+		if arrMap[value] {
+			result = append(result, value)
+		}
+	}
+
+	return result
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestStringArrayIntersection(t *testing.T) {
+	a := []string{
+		"abc",
+		"def",
+		"ghi",
+	}
+	b := []string{
+		"jkl",
+	}
+	c := []string{
+		"def",
+	}
+
+	if len(StringArrayIntersection(a, b)) != 0 {
+		t.Fatal("should be 0")
+	}
+
+	if len(StringArrayIntersection(a, c)) != 1 {
+		t.Fatal("should be 1")
+	}
+}


### PR DESCRIPTION
All slash commands will have their triggers validated against all team commands and all built-in commands upon submission. Duplicated triggers will be rejected.

All outgoing webhooks will have their triggers and callback URLs validated against all existing outgoing webhooks. An outgoing webhook will be rejected if it:
- Shares a channel with an existing outgoing webhook,
- Shares trigger(s) with an existing outgoing webhook,
- And shares callback url(s) with an existing outgoing webhook