### PR TITLE
PLT-3063 fix upgrade when user is a team admin

### DIFF
--- a/mattermost.go
+++ b/mattermost.go
@@ -483,6 +483,7 @@ func convertTeamTo30(primaryTeamName string, team *TeamForUpgrade, uniqueEmails 
 
 	for _, user := range users {
 		shouldUpdateUser := false
+		shouldUpdateRole := false
 		previousRole := user.Roles
 		previousEmail := user.Email
 		previousUsername := user.Username
@@ -495,7 +496,7 @@ func convertTeamTo30(primaryTeamName string, team *TeamForUpgrade, uniqueEmails 
 		if model.IsInRole(user.Roles, model.ROLE_TEAM_ADMIN) {
 			member.Roles = model.ROLE_TEAM_ADMIN
 			user.Roles = ""
-			shouldUpdateUser = true
+			shouldUpdateRole = true
 		}
 
 		exists := false
@@ -607,6 +608,25 @@ func convertTeamTo30(primaryTeamName string, team *TeamForUpgrade, uniqueEmails 
 					bodyPage.Render(),
 				)
 			}
+		}
+
+		if shouldUpdateRole {
+			if _, err := store.GetMaster().Exec(`
+				UPDATE Users 
+				SET 
+				    Roles = ''
+				WHERE
+				    Id = :Id
+				`,
+				map[string]interface{}{
+					"Id": user.Id,
+				},
+			); err != nil {
+				l4g.Error("Failed to update user role %v details=%v", user.Email, err)
+				flushLogAndExit(1)
+			}
+
+			l4g.Info("modified user_id=%v, changed roles from=%v to=%v", user.Id, previousRole, user.Roles)
 		}
 
 		uniqueEmails[user.Email] = true


### PR DESCRIPTION
This is a special case when upgrading users on the primary team who are team admins (not system admins) and have LDAP/Gitlab accounts.  It will remove the SSO link.