### PR TITLE
PLT-2970 Added BOT in RHS

### DIFF
--- a/webapp/components/post_header.jsx
+++ b/webapp/components/post_header.jsx
@@ -32,7 +32,7 @@ export default class PostHeader extends React.Component {
                 );
             }
 
-            botIndicator = <li className='col col__name bot-indicator'>{'BOT'}</li>;
+            botIndicator = <li className='col col__name bot-indicator'>{Constants.BOT_NAME}</li>;
         } else if (Utils.isSystemMessage(post)) {
             userProfile = (
                 <UserProfile

--- a/webapp/components/rhs_comment.jsx
+++ b/webapp/components/rhs_comment.jsx
@@ -151,6 +151,11 @@ export default class RhsComment extends React.Component {
 
         var timestamp = this.props.currentUser.update_at;
 
+        let botIndicator;
+
+        if (post.props && post.props.from_webhook) {
+            botIndicator = <li className='col col__name bot-indicator'>{Constants.BOT_NAME}</li>;
+        }
         let loading;
         let postClass = '';
         let message = (
@@ -206,9 +211,10 @@ export default class RhsComment extends React.Component {
                     </div>
                     <div>
                         <ul className='post__header'>
-                            <li className='col__name'>
+                            <li className='col col__name'>
                                 <strong><UserProfile user={this.props.user}/></strong>
                             </li>
+                            {botIndicator}
                             <li className='col'>
                                 <time className='post__time'>
                                     <FormattedDate

--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -67,6 +67,12 @@ export default class SearchResultsItem extends React.Component {
             disableProfilePopover = true;
         }
 
+        let botIndicator;
+
+        if (post.props && post.props.from_webhook) {
+            botIndicator = <li className='col col__name bot-indicator'>{Constants.BOT_NAME}</li>;
+        }
+
         return (
             <div className='search-item__container'>
                 <div className='date-separator'>
@@ -94,13 +100,14 @@ export default class SearchResultsItem extends React.Component {
                         </div>
                         <div>
                             <ul className='post__header'>
-                                <li className='col__name'><strong>
+                                <li className='col col__name'><strong>
                                     <UserProfile
                                         user={user}
                                         overwriteName={overrideUsername}
                                         disablePopover={disableProfilePopover}
                                     />
                                 </strong></li>
+                                {botIndicator}
                                 <li className='col'>
                                     <time className='search-item-time'>
                                         <FormattedDate

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -737,5 +737,6 @@ export default {
     EMOJI_PATH: '/static/emoji',
     DEFAULT_WEBHOOK_LOGO: logoWebhook,
     MHPNS: 'https://push.mattermost.com',
-    MTPNS: 'http://push-test.mattermost.com'
+    MTPNS: 'http://push-test.mattermost.com',
+    BOT_NAME: 'BOT'
 };


### PR DESCRIPTION
Previously, `BOT` does not show up in search results or replies. Now it does!

Also moved the string `BOT` to `constants.jsx` in case we want to rename bots in the future.

Examples:

![howdy1](https://cloud.githubusercontent.com/assets/5740966/15609637/312b3528-23ef-11e6-8933-45f7a2e72cd7.PNG)

![howdy2](https://cloud.githubusercontent.com/assets/5740966/15609638/343af140-23ef-11e6-95a2-f3404098abb5.PNG)


