### PR TITLE
PLT-2839 Forced sidebar to scroll to top on update

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -169,6 +169,9 @@ export default class Sidebar extends React.Component {
             $('.sidebar--left .nav-pills__container').perfectScrollbar();
         }
 
+        this.refs.container.scrollTop = 0;
+        $('.nav-pills__container').perfectScrollbar('update');
+
         // close the LHS on mobile when you change channels
         if (this.state.activeId !== prevState.activeId) {
             $('.app__body .inner-wrap').removeClass('move--right');


### PR DESCRIPTION
Previously, we can encounter endlessly scrolling sidebars by switching teams. Now the sidebar automatically scrolls to the top upon load.

Note: Only using jQuery for perfectScrollBar, that will be replaced with react-scrollbar later.