### PR TITLE
PLT-2058 Debugging incoming web hook content

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -4,9 +4,7 @@
 package api
 
 import (
-	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -384,17 +382,19 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		payload = r.Body
 	}
 
-	l4g.Debug(func() string {
-		body, err := ioutil.ReadAll(payload)
-		if err != nil {
-			return utils.T("api.webhook.incoming.debug.error") + err.Error()
-		}
-
-		// Create a new payload io.Reader, as the old one was read into body
-		payload = bytes.NewReader(body)
-
-		return utils.T("api.webhook.incoming.debug") + string(body)
-	})
+	payload, err := utils.DebugReader(
+		payload,
+		utils.T("api.webhook.incoming.debug"),
+	)
+	if err != nil {
+		c.Err = model.NewLocAppError(
+			"incomingWebhook",
+			"api.webhook.incoming.debug.error",
+			nil,
+			err.Error(),
+		)
+		return
+	}
 
 	parsedRequest := model.IncomingWebhookRequestFromJson(payload)
 	if parsedRequest == nil {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1904,6 +1904,14 @@
     "translation": "Outgoing webhooks have been disabled by the system admin."
   },
   {
+    "id": "api.webhook.incoming.debug",
+    "translation": "Incoming webhook received. Content="
+  },
+  {
+    "id": "api.webhook.incoming.debug.error",
+    "translation": "Could not read payload of incoming webhook. Error="
+  },
+  {
     "id": "api.webhook.init.debug",
     "translation": "Initializing webhook api routes"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1909,7 +1909,7 @@
   },
   {
     "id": "api.webhook.incoming.debug.error",
-    "translation": "Could not read payload of incoming webhook. Error="
+    "translation": "Could not read payload of incoming webhook."
   },
   {
     "id": "api.webhook.init.debug",

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package utils
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+
+	l4g "github.com/alecthomas/log4go"
+)
+
+// DebugReader logs the content of the io.Reader and returns a new io.Reader
+// with the same content as the received io.Reader.
+// If you pass reader by reference, it won't be re-created unless the loglevel
+// includes Debug.
+// If an error is returned, the reader is consumed an cannot be read again.
+func DebugReader(reader io.Reader, message string) (io.Reader, error) {
+	var err error
+	l4g.Debug(func() string {
+		content, err := ioutil.ReadAll(reader)
+		if err != nil {
+			return ""
+		}
+
+		reader = bytes.NewReader(content)
+
+		return message + string(content)
+	})
+
+	return reader, err
+}

--- a/utils/log.go
+++ b/utils/log.go
@@ -5,7 +5,6 @@ package utils
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"io/ioutil"
 


### PR DESCRIPTION
# Pull Request PLT-2058
This change debugs contents of incoming webhooks using l4g.

The problem is that in order to debug the request body, it needs to be
read. And a Reader can only be read once. Hence, the body is only read
for Debugging if it is actually enabled. Furthermore, a new reader is
created from the content of the old reader in order for the rest of the
method to work as usual (with or without debugging).

The debug statement is wrapped in a closure, so that the content is
only copied if Debug is actually enabled.

It is not possible to return (string, string) from the closure to
l4g.Debug(). That is the reason the debugging is not done with =%v,
but the translations strings end with a space.

I tested the change with a application/json HTTP header as well as
payload=

I will create an accompanying pull request at `mattermost/docs`.

NOTE: The tests failed for me on a fresh clone of `mattermost/platform` as well as on my commit.

## Existing #2835
I was not able to re-open the existing pull-request #2835. From the discussion there:
I extracted debugging into a separate utility method to debug `io.Reader`s.

@crspeller wrote:
> @apheleia Sorry for the delay. We were a bit busy with the 3.0 release.
Looks good!
I am wondering, since the default logging level would include the messages, maybe this should have it's own configuration setting? Regardless of the logging level? That way you can have debugging messages without dumping all your incoming webhooks (which could be quite a lot of text)

I think `DEBUG` is the perfect fit for this kind of output, as it is intended for debugging. Adding flags outside the common l4g debug level will only confuse a user and make it unnecessarily complex, in my opinion.