### PR TITLE
PLT-3099 Fixed CTRL+UP to only work on empty input

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -225,11 +225,11 @@ class CreateComment extends React.Component {
         }
 
         if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && e.keyCode === KeyCodes.UP) {
-            e.preventDefault();
             const lastPost = PostStore.getCurrentUsersLatestPost(this.props.channelId, this.props.rootId);
-            if (!lastPost) {
+            if (!lastPost || this.state.messageText !== '') {
                 return;
             }
+            e.preventDefault();
             let message = lastPost.message;
             if (this.state.lastMessage !== '') {
                 message = this.state.lastMessage;

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -374,12 +374,12 @@ class CreatePost extends React.Component {
         }
 
         if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && e.keyCode === KeyCodes.UP) {
-            e.preventDefault();
             const channelId = ChannelStore.getCurrentId();
             const lastPost = PostStore.getCurrentUsersLatestPost(channelId);
-            if (!lastPost) {
+            if (!lastPost || this.state.messageText !== '') {
                 return;
             }
+            e.preventDefault();
             let message = lastPost.message;
             if (this.state.lastMessage !== '') {
                 message = this.state.lastMessage;


### PR DESCRIPTION
Previously, CMD+UP overrode system default shortcuts for going to the beginning/end of a message. Now it only works if the textbox is empty.