### PR TITLE
PLT-3093 Fixed scrollbar endlessly scrolling up

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -169,6 +169,12 @@ export default class Sidebar extends React.Component {
             $('.sidebar--left .nav-pills__container').perfectScrollbar();
         }
 
+        // reset the scrollbar upon switching teams
+        if (this.state.currentTeam !== prevState.currentTeam) {
+            this.refs.container.scrollTop = 0;
+            $('.nav-pills__container').perfectScrollbar('update');
+        }
+
         // close the LHS on mobile when you change channels
         if (this.state.activeId !== prevState.activeId) {
             $('.app__body .inner-wrap').removeClass('move--right');


### PR DESCRIPTION
Previously, when the user switched teams the scrollbar could be caught in a feedback loop and continue to scroll down.
The first PR did not account for the team updating, scrolling up whenever the component is updated.
Now it only scrolls up when the team is updated.