### PR TITLE
PLT-2965 Reset channel top visibility correctly to fix intro message after tutorial

### DIFF
--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -260,7 +260,11 @@ class PostStoreClass extends EventEmitter {
     clearChannelVisibility(id, atBottom) {
         this.makePostsInfo(id);
         this.postsInfo[id].endVisible = Constants.POST_CHUNK_SIZE;
-        this.postsInfo[id].atTop = false;
+        if (this.postsInfo[id].postList) {
+            this.postsInfo[id].atTop = this.postsInfo[id].atTop && Constants.POST_CHUNK_SIZE >= this.postsInfo[id].postList.order.length;
+        } else {
+            this.postsInfo[id].atTop = false;
+        }
         this.postsInfo[id].atBottom = atBottom;
     }
 


### PR DESCRIPTION
It looks a bit confusing but basically I changed it from:
* When resetting channel visibility assume we're not at the top
to 
* When resetting visibility, check if we were previously at the top and if we have equal to or less messages than a standard chunk size to see if we're still at the top

This fixes the intro message not loading correctly after skipping the tutorial. It also fixes the PostView from getting initialized with the wrong value sometimes but that's a rare case since it would normally be offscreen.