### PR TITLE
PLT-2170 Send payload in application/json for outgoing webhooks

### DIFF
--- a/model/outgoing_webhook.go
+++ b/model/outgoing_webhook.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
+	"strconv"
 )
 
 type OutgoingWebhook struct {
@@ -22,6 +24,47 @@ type OutgoingWebhook struct {
 	CallbackURLs StringArray `json:"callback_urls"`
 	DisplayName  string      `json:"display_name"`
 	Description  string      `json:"description"`
+	ContentType  string      `json:"content_type"`
+}
+
+type OutgoingWebhookPayload struct {
+	Token       string `json:"token"`
+	TeamId      string `json:"team_id"`
+	TeamDomain  string `json:"team_domain"`
+	ChannelId   string `json:"channel_id"`
+	ChannelName string `json:"channel_name"`
+	Timestamp   int64  `json:"timestamp"`
+	UserId      string `json:"user_id"`
+	UserName    string `json:"user_name"`
+	PostId      string `json:"post_id"`
+	Text        string `json:"text"`
+	TriggerWord string `json:"trigger_word"`
+}
+
+func (o *OutgoingWebhookPayload) ToJSON() string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func (o *OutgoingWebhookPayload) ToFormValues() string {
+	v := url.Values{}
+	v.Set("token", o.Token)
+	v.Set("team_id", o.TeamId)
+	v.Set("team_domain", o.TeamDomain)
+	v.Set("channel_id", o.ChannelId)
+	v.Set("channel_name", o.ChannelName)
+	v.Set("timestamp", strconv.FormatInt(o.Timestamp/1000, 10))
+	v.Set("user_id", o.UserId)
+	v.Set("user_name", o.UserName)
+	v.Set("post_id", o.PostId)
+	v.Set("text", o.Text)
+	v.Set("trigger_word", o.TriggerWord)
+
+	return v.Encode()
 }
 
 func (o *OutgoingWebhook) ToJson() string {
@@ -122,6 +165,10 @@ func (o *OutgoingWebhook) IsValid() *AppError {
 
 	if len(o.Description) > 128 {
 		return NewLocAppError("OutgoingWebhook.IsValid", "model.outgoing_hook.is_valid.description.app_error", nil, "")
+	}
+
+	if len(o.ContentType) > 64 {
+		return NewLocAppError("OutgoingWebhook.IsValid", "model.outgoing_hook.is_valid.content_type.app_error", nil, "")
 	}
 
 	return nil

--- a/model/outgoing_webhook.go
+++ b/model/outgoing_webhook.go
@@ -167,7 +167,7 @@ func (o *OutgoingWebhook) IsValid() *AppError {
 		return NewLocAppError("OutgoingWebhook.IsValid", "model.outgoing_hook.is_valid.description.app_error", nil, "")
 	}
 
-	if len(o.ContentType) > 64 {
+	if len(o.ContentType) > 128 {
 		return NewLocAppError("OutgoingWebhook.IsValid", "model.outgoing_hook.is_valid.content_type.app_error", nil, "")
 	}
 

--- a/model/outgoing_webhook_test.go
+++ b/model/outgoing_webhook_test.go
@@ -4,6 +4,8 @@
 package model
 
 import (
+	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -107,7 +109,48 @@ func TestOutgoingWebhookIsValid(t *testing.T) {
 
 	o.Description = strings.Repeat("1", 128)
 	if err := o.IsValid(); err != nil {
+		t.Fatal("should be invalid")
+	}
+
+	o.ContentType = strings.Repeat("1", 65)
+	if err := o.IsValid(); err == nil {
 		t.Fatal(err)
+	}
+
+	o.ContentType = strings.Repeat("1", 64)
+	if err := o.IsValid(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOutgoingWebhookPayloadToFormValues(t *testing.T) {
+	p := &OutgoingWebhookPayload{
+		Token:       "Token",
+		TeamId:      "TeamId",
+		TeamDomain:  "TeamDomain",
+		ChannelId:   "ChannelId",
+		ChannelName: "ChannelName",
+		Timestamp:   123000,
+		UserId:      "UserId",
+		UserName:    "UserName",
+		PostId:      "PostId",
+		Text:        "Text",
+		TriggerWord: "TriggerWord",
+	}
+	v := url.Values{}
+	v.Set("token", "Token")
+	v.Set("team_id", "TeamId")
+	v.Set("team_domain", "TeamDomain")
+	v.Set("channel_id", "ChannelId")
+	v.Set("channel_name", "ChannelName")
+	v.Set("timestamp", "123")
+	v.Set("user_id", "UserId")
+	v.Set("user_name", "UserName")
+	v.Set("post_id", "PostId")
+	v.Set("text", "Text")
+	v.Set("trigger_word", "TriggerWord")
+	if got, want := p.ToFormValues(), v.Encode(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Got %+v, wanted %+v", got, want)
 	}
 }
 

--- a/model/outgoing_webhook_test.go
+++ b/model/outgoing_webhook_test.go
@@ -112,12 +112,12 @@ func TestOutgoingWebhookIsValid(t *testing.T) {
 		t.Fatal("should be invalid")
 	}
 
-	o.ContentType = strings.Repeat("1", 65)
+	o.ContentType = strings.Repeat("1", 129)
 	if err := o.IsValid(); err == nil {
 		t.Fatal(err)
 	}
 
-	o.ContentType = strings.Repeat("1", 64)
+	o.ContentType = strings.Repeat("1", 128)
 	if err := o.IsValid(); err != nil {
 		t.Fatal(err)
 	}

--- a/store/sql_webhook_store.go
+++ b/store/sql_webhook_store.go
@@ -33,6 +33,7 @@ func NewSqlWebhookStore(sqlStore *SqlStore) WebhookStore {
 		tableo.ColMap("CallbackURLs").SetMaxSize(1024)
 		tableo.ColMap("DisplayName").SetMaxSize(64)
 		tableo.ColMap("Description").SetMaxSize(128)
+		tableo.ColMap("ContentType").SetMaxSize(128)
 	}
 
 	return s
@@ -44,7 +45,7 @@ func (s SqlWebhookStore) UpgradeSchemaIfNeeded() {
 
 	s.CreateColumnIfNotExists("OutgoingWebhooks", "DisplayName", "varchar(64)", "varchar(64)", "")
 	s.CreateColumnIfNotExists("OutgoingWebhooks", "Description", "varchar(128)", "varchar(128)", "")
-	s.CreateColumnIfNotExists("OutgoingWebhooks", "ContentType", "varchar(64)", "varchar(64)", "")
+	s.CreateColumnIfNotExists("OutgoingWebhooks", "ContentType", "varchar(128)", "varchar(128)", "")
 }
 
 func (s SqlWebhookStore) CreateIndexesIfNotExists() {

--- a/store/sql_webhook_store.go
+++ b/store/sql_webhook_store.go
@@ -44,6 +44,7 @@ func (s SqlWebhookStore) UpgradeSchemaIfNeeded() {
 
 	s.CreateColumnIfNotExists("OutgoingWebhooks", "DisplayName", "varchar(64)", "varchar(64)", "")
 	s.CreateColumnIfNotExists("OutgoingWebhooks", "Description", "varchar(128)", "varchar(128)", "")
+	s.CreateColumnIfNotExists("OutgoingWebhooks", "ContentType", "varchar(64)", "varchar(64)", "")
 }
 
 func (s SqlWebhookStore) CreateIndexesIfNotExists() {

--- a/webapp/components/backstage/add_outgoing_webhook.jsx
+++ b/webapp/components/backstage/add_outgoing_webhook.jsx
@@ -21,6 +21,7 @@ export default class AddOutgoingWebhook extends React.Component {
 
         this.updateDisplayName = this.updateDisplayName.bind(this);
         this.updateDescription = this.updateDescription.bind(this);
+        this.updateContentType = this.updateContentType.bind(this);
         this.updateChannelId = this.updateChannelId.bind(this);
         this.updateTriggerWords = this.updateTriggerWords.bind(this);
         this.updateCallbackUrls = this.updateCallbackUrls.bind(this);
@@ -28,6 +29,7 @@ export default class AddOutgoingWebhook extends React.Component {
         this.state = {
             displayName: '',
             description: '',
+            contentType: 'application/x-www-form-urlencoded',
             channelId: '',
             triggerWords: '',
             callbackUrls: '',
@@ -103,6 +105,7 @@ export default class AddOutgoingWebhook extends React.Component {
             trigger_words: triggerWords,
             callback_urls: callbackUrls,
             display_name: this.state.displayName,
+            content_type: this.state.contentType,
             description: this.state.description
         };
 
@@ -129,6 +132,12 @@ export default class AddOutgoingWebhook extends React.Component {
     updateDescription(e) {
         this.setState({
             description: e.target.value
+        });
+    }
+
+    updateContentType(e) {
+        this.setState({
+            contentType: e.target.value
         });
     }
 
@@ -207,6 +216,31 @@ export default class AddOutgoingWebhook extends React.Component {
                                     value={this.state.description}
                                     onChange={this.updateDescription}
                                 />
+                            </div>
+                        </div>
+                        <div className='form-group'>
+                            <label
+                                className='control-label col-sm-4'
+                                htmlFor='contentType'
+                            >
+                                <FormattedMessage
+                                    id='add_outgoing_webhook.content_Type'
+                                    defaultMessage='Content Type'
+                                />
+                            </label>
+                            <div className='col-md-5 col-sm-8'>
+                                <select
+                                  className='form-control'
+                                  value={this.state.contentType}
+                                  onChange={this.updateContentType}
+                                >
+                                  <option value='application/x-www-form-urlencoded'>
+                                    application/x-www-form-urlencoded
+                                  </option>
+                                  <option value='application/json'>
+                                    application/json
+                                  </option>
+                                </select>
                             </div>
                         </div>
                         <div className='form-group'>

--- a/webapp/components/backstage/add_outgoing_webhook.jsx
+++ b/webapp/components/backstage/add_outgoing_webhook.jsx
@@ -160,6 +160,8 @@ export default class AddOutgoingWebhook extends React.Component {
     }
 
     render() {
+        const contentTypeOption1 = 'application/x-www-form-urlencoded';
+        const contentTypeOption2 = 'application/json';
         return (
             <div className='backstage-content'>
                 <BackstageHeader>
@@ -230,16 +232,20 @@ export default class AddOutgoingWebhook extends React.Component {
                             </label>
                             <div className='col-md-5 col-sm-8'>
                                 <select
-                                  className='form-control'
-                                  value={this.state.contentType}
-                                  onChange={this.updateContentType}
+                                    className='form-control'
+                                    value={this.state.contentType}
+                                    onChange={this.updateContentType}
                                 >
-                                  <option value='application/x-www-form-urlencoded'>
-                                    application/x-www-form-urlencoded
-                                  </option>
-                                  <option value='application/json'>
-                                    application/json
-                                  </option>
+                                    <option
+                                        value={contentTypeOption1}
+                                    >
+                                        {contentTypeOption1}
+                                    </option>
+                                    <option
+                                        value={contentTypeOption2}
+                                    >
+                                        {contentTypeOption2}
+                                    </option>
                                 </select>
                             </div>
                         </div>

--- a/webapp/components/backstage/installed_outgoing_webhook.jsx
+++ b/webapp/components/backstage/installed_outgoing_webhook.jsx
@@ -113,17 +113,17 @@ export default class InstalledOutgoingWebhook extends React.Component {
         }
 
         let urls = (
-          <div className='item-details__row'>
-              <span className='item-details__url'>
-                  <FormattedMessage
-                      id='installed_integrations.callback_urls'
-                      defaultMessage='Callback URLs: {urls}'
-                      values={{
-                          urls: outgoingWebhook.callback_urls.join(', ')
-                      }}
-                  />
-              </span>
-          </div>
+            <div className='item-details__row'>
+                <span className='item-details__url'>
+                    <FormattedMessage
+                        id='installed_integrations.callback_urls'
+                        defaultMessage='Callback URLs: {urls}'
+                        values={{
+                            urls: outgoingWebhook.callback_urls.join(', ')
+                        }}
+                    />
+                </span>
+            </div>
         );
 
         return (
@@ -141,7 +141,7 @@ export default class InstalledOutgoingWebhook extends React.Component {
                                 id='installed_integrations.content_type'
                                 defaultMessage='Content-Type: {contentType}'
                                 values={{
-                                    contentType: outgoingWebhook.content_type || "application/x-www-form-urlencoded"
+                                    contentType: outgoingWebhook.content_type || 'application/x-www-form-urlencoded'
                                 }}
                             />
                         </span>

--- a/webapp/components/backstage/installed_outgoing_webhook.jsx
+++ b/webapp/components/backstage/installed_outgoing_webhook.jsx
@@ -112,22 +112,19 @@ export default class InstalledOutgoingWebhook extends React.Component {
             );
         }
 
-        const urls = [];
-        for (const url of outgoingWebhook.callback_urls) {
-            urls.push(
-                <div
-                    key={url}
-                    className='item-details__url'
-                >
-                    {url}
-                </div>
-            );
-            urls.push(
-                <br
-                    key={'BR' + url}
-                />
-            );
-        }
+        let urls = (
+          <div className='item-details__row'>
+              <span className='item-details__url'>
+                  <FormattedMessage
+                      id='installed_integrations.callback_urls'
+                      defaultMessage='Callback URLs: {urls}'
+                      values={{
+                          urls: outgoingWebhook.callback_urls.join(', ')
+                      }}
+                  />
+              </span>
+          </div>
+        );
 
         return (
             <div className='backstage-list__item'>
@@ -138,6 +135,17 @@ export default class InstalledOutgoingWebhook extends React.Component {
                         </span>
                     </div>
                     {description}
+                    <div className='item-details__row'>
+                        <span className='item-details__content_type'>
+                            <FormattedMessage
+                                id='installed_integrations.content_type'
+                                defaultMessage='Content-Type: {contentType}'
+                                values={{
+                                    contentType: outgoingWebhook.content_type || "application/x-www-form-urlencoded"
+                                }}
+                            />
+                        </span>
+                    </div>
                     {triggerWords}
                     <div className='item-details__row'>
                         <span className='item-details__token'>
@@ -162,11 +170,7 @@ export default class InstalledOutgoingWebhook extends React.Component {
                             />
                         </span>
                     </div>
-                    <div className='item-details__row'>
-                        <span className='item-details__urls'>
-                            {urls}
-                        </span>
-                    </div>
+                    {urls}
                 </div>
                 <div className='item-actions'>
                     <a

--- a/webapp/sass/routes/_backstage.scss
+++ b/webapp/sass/routes/_backstage.scss
@@ -220,6 +220,7 @@ body {
     }
 
     .item-details__description,
+    .item-details__content_type,
     .item-details__token,
     .item-details__trigger-words,
     .item-details__url,


### PR DESCRIPTION
The Add outgoing webhook UI now has a 'Content-Type' field that allows
to choose between application/x-www-form-urlencoded and
application/json. All outgoing webhooks created before this change will
be considered as x-www-form-urlencoded. There's also a minor change in
the way the outgoing webhook summary is displayed: the 'Callback URLs'
label was missing.