### PR TITLE
PLT-2643 Fixed asynchronous autocomplete incorrectly replacing text

### DIFF
--- a/webapp/components/suggestion/at_mention_provider.jsx
+++ b/webapp/components/suggestion/at_mention_provider.jsx
@@ -1,20 +1,21 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import React from 'react';
+
 import SuggestionStore from 'stores/suggestion_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import * as Utils from 'utils/utils.jsx';
 import Client from 'utils/web_client.jsx';
 
 import {FormattedMessage} from 'react-intl';
+import Suggestion from './suggestion.jsx';
 
 const MaxUserSuggestions = 40;
 
-import React from 'react';
-
-class AtMentionSuggestion extends React.Component {
+class AtMentionSuggestion extends Suggestion {
     render() {
-        const {item, isSelection, onClick} = this.props;
+        const {item, isSelection} = this.props;
 
         let username;
         let description;
@@ -56,7 +57,7 @@ class AtMentionSuggestion extends React.Component {
         return (
             <div
                 className={className}
-                onClick={onClick}
+                onClick={this.handleClick}
             >
                 <div className='pull-left'>
                     {icon}
@@ -73,12 +74,6 @@ class AtMentionSuggestion extends React.Component {
         );
     }
 }
-
-AtMentionSuggestion.propTypes = {
-    item: React.PropTypes.object.isRequired,
-    isSelection: React.PropTypes.bool,
-    onClick: React.PropTypes.func
-};
 
 export default class AtMentionProvider {
     handlePretextChanged(suggestionId, pretext) {
@@ -112,8 +107,7 @@ export default class AtMentionProvider {
 
             const mentions = filtered.map((user) => '@' + user.username);
 
-            SuggestionStore.setMatchedPretext(suggestionId, captured[0]);
-            SuggestionStore.addSuggestions(suggestionId, mentions, filtered, AtMentionSuggestion);
+            SuggestionStore.addSuggestions(suggestionId, mentions, filtered, AtMentionSuggestion, captured[0]);
         }
     }
 }

--- a/webapp/components/suggestion/command_provider.jsx
+++ b/webapp/components/suggestion/command_provider.jsx
@@ -1,11 +1,13 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import * as AsyncClient from 'utils/async_client.jsx';
-
 import React from 'react';
 
-class CommandSuggestion extends React.Component {
+import * as AsyncClient from 'utils/async_client.jsx';
+
+import Suggestion from './suggestion.jsx';
+
+class CommandSuggestion extends Suggestion {
     render() {
         const {item, isSelection, onClick} = this.props;
 
@@ -30,16 +32,10 @@ class CommandSuggestion extends React.Component {
     }
 }
 
-CommandSuggestion.propTypes = {
-    item: React.PropTypes.object.isRequired,
-    isSelection: React.PropTypes.bool,
-    onClick: React.PropTypes.func
-};
-
 export default class CommandProvider {
     handlePretextChanged(suggestionId, pretext) {
         if (pretext.startsWith('/')) {
-            AsyncClient.getSuggestedCommands(pretext, suggestionId, CommandSuggestion);
+            AsyncClient.getSuggestedCommands(pretext, suggestionId, CommandSuggestion, pretext);
         }
     }
 }

--- a/webapp/components/suggestion/emoticon_provider.jsx
+++ b/webapp/components/suggestion/emoticon_provider.jsx
@@ -1,14 +1,16 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import SuggestionStore from 'stores/suggestion_store.jsx';
+import React from 'react';
+
 import * as Emoticons from 'utils/emoticons.jsx';
+import SuggestionStore from 'stores/suggestion_store.jsx';
+
+import Suggestion from './suggestion.jsx';
 
 const MAX_EMOTICON_SUGGESTIONS = 40;
 
-import React from 'react';
-
-class EmoticonSuggestion extends React.Component {
+class EmoticonSuggestion extends Suggestion {
     render() {
         const text = this.props.term;
         const emoticon = this.props.item;
@@ -38,13 +40,6 @@ class EmoticonSuggestion extends React.Component {
         );
     }
 }
-
-EmoticonSuggestion.propTypes = {
-    item: React.PropTypes.object.isRequired,
-    term: React.PropTypes.string.isRequired,
-    isSelection: React.PropTypes.bool,
-    onClick: React.PropTypes.func
-};
 
 export default class EmoticonProvider {
     handlePretextChanged(suggestionId, pretext) {
@@ -82,8 +77,7 @@ export default class EmoticonProvider {
             const terms = matched.map((emoticon) => ':' + emoticon.alias + ':');
 
             if (terms.length > 0) {
-                SuggestionStore.setMatchedPretext(suggestionId, text);
-                SuggestionStore.addSuggestions(suggestionId, terms, matched, EmoticonSuggestion);
+                SuggestionStore.addSuggestions(suggestionId, terms, matched, EmoticonSuggestion, text);
 
                 // force the selection to be cleared since the order of elements may have changed
                 SuggestionStore.clearSelection(suggestionId);

--- a/webapp/components/suggestion/search_channel_provider.jsx
+++ b/webapp/components/suggestion/search_channel_provider.jsx
@@ -1,13 +1,15 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import React from 'react';
+
 import ChannelStore from 'stores/channel_store.jsx';
 import Constants from 'utils/constants.jsx';
 import SuggestionStore from 'stores/suggestion_store.jsx';
 
-import React from 'react';
+import Suggestion from './suggestion.jsx';
 
-class SearchChannelSuggestion extends React.Component {
+class SearchChannelSuggestion extends Suggestion {
     render() {
         const {item, isSelection, onClick} = this.props;
 
@@ -26,12 +28,6 @@ class SearchChannelSuggestion extends React.Component {
         );
     }
 }
-
-SearchChannelSuggestion.propTypes = {
-    item: React.PropTypes.object.isRequired,
-    isSelection: React.PropTypes.bool,
-    onClick: React.PropTypes.func
-};
 
 export default class SearchChannelProvider {
     handlePretextChanged(suggestionId, pretext) {
@@ -62,10 +58,8 @@ export default class SearchChannelProvider {
             privateChannels.sort((a, b) => a.name.localeCompare(b.name));
             const privateChannelNames = privateChannels.map((channel) => channel.name);
 
-            SuggestionStore.setMatchedPretext(suggestionId, channelPrefix);
-
-            SuggestionStore.addSuggestions(suggestionId, publicChannelNames, publicChannels, SearchChannelSuggestion);
-            SuggestionStore.addSuggestions(suggestionId, privateChannelNames, privateChannels, SearchChannelSuggestion);
+            SuggestionStore.addSuggestions(suggestionId, publicChannelNames, publicChannels, SearchChannelSuggestion, channelPrefix);
+            SuggestionStore.addSuggestions(suggestionId, privateChannelNames, privateChannels, SearchChannelSuggestion, channelPrefix);
         }
     }
 }

--- a/webapp/components/suggestion/search_suggestion_list.jsx
+++ b/webapp/components/suggestion/search_suggestion_list.jsx
@@ -72,8 +72,10 @@ export default class SearchSuggestionList extends SuggestionList {
                     key={term}
                     ref={term}
                     item={item}
+                    term={term}
+                    matchedPretext={this.state.matchedPretext[i]}
                     isSelection={isSelection}
-                    onClick={this.handleItemClick.bind(this, term)}
+                    onClick={this.handleItemClick}
                 />
             );
         }

--- a/webapp/components/suggestion/search_user_provider.jsx
+++ b/webapp/components/suggestion/search_user_provider.jsx
@@ -1,13 +1,15 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import SuggestionStore from 'stores/suggestion_store.jsx';
-import UserStore from 'stores/user_store.jsx';
-import Client from 'utils/web_client.jsx';
-
 import React from 'react';
 
-class SearchUserSuggestion extends React.Component {
+import Client from 'utils/web_client.jsx';
+import SuggestionStore from 'stores/suggestion_store.jsx';
+import UserStore from 'stores/user_store.jsx';
+
+import Suggestion from './suggestion.jsx';
+
+class SearchUserSuggestion extends Suggestion {
     render() {
         const {item, isSelection, onClick} = this.props;
 
@@ -31,12 +33,6 @@ class SearchUserSuggestion extends React.Component {
     }
 }
 
-SearchUserSuggestion.propTypes = {
-    item: React.PropTypes.object.isRequired,
-    isSelection: React.PropTypes.bool,
-    onClick: React.PropTypes.func
-};
-
 export default class SearchUserProvider {
     handlePretextChanged(suggestionId, pretext) {
         const captured = (/\bfrom:\s*(\S*)$/i).exec(pretext);
@@ -58,8 +54,7 @@ export default class SearchUserProvider {
 
             const usernames = filtered.map((user) => user.username);
 
-            SuggestionStore.setMatchedPretext(suggestionId, usernamePrefix);
-            SuggestionStore.addSuggestions(suggestionId, usernames, filtered, SearchUserSuggestion);
+            SuggestionStore.addSuggestions(suggestionId, usernames, filtered, SearchUserSuggestion, usernamePrefix);
         }
     }
 }

--- a/webapp/components/suggestion/suggestion.jsx
+++ b/webapp/components/suggestion/suggestion.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import * as AsyncClient from 'utils/async_client.jsx';
-
 import React from 'react';
 
 export default class Suggestion extends React.Component {

--- a/webapp/components/suggestion/suggestion.jsx
+++ b/webapp/components/suggestion/suggestion.jsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import * as AsyncClient from 'utils/async_client.jsx';
+
+import React from 'react';
+
+export default class Suggestion extends React.Component {
+    static get propTypes() {
+        return {
+            item: React.PropTypes.object.isRequired,
+            term: React.PropTypes.string.isRequired,
+            matchedPretext: React.PropTypes.string.isRequired,
+            isSelection: React.PropTypes.bool,
+            onClick: React.PropTypes.func
+        };
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    handleClick(e) {
+        e.preventDefault();
+
+        this.props.onClick(this.props.term, this.props.matchedPretext);
+    }
+}

--- a/webapp/tests/suggestion_box.test.jsx
+++ b/webapp/tests/suggestion_box.test.jsx
@@ -1,0 +1,20 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import SuggestionBox from 'components/suggestion/suggestion_box.jsx';
+
+describe('SuggestionBox', function() {
+    it('findOverlap', function(done) {
+        assert.equal(SuggestionBox.findOverlap('', 'blue'), '');
+        assert.equal(SuggestionBox.findOverlap('red', ''), '');
+        assert.equal(SuggestionBox.findOverlap('red', 'blue'), '');
+        assert.equal(SuggestionBox.findOverlap('red', 'dog'), 'd');
+        assert.equal(SuggestionBox.findOverlap('red', 'education'), 'ed');
+        assert.equal(SuggestionBox.findOverlap('red', 'reduce'), 'red');
+        assert.equal(SuggestionBox.findOverlap('black', 'ack'), 'ack');
+
+        done();
+    });
+});


### PR DESCRIPTION
This should fix the case where autocompleting `/log` sometimes results in `/l/logout` instead of `/logout` due to incorrectly determining which text needed to be replaced. The important part of the code is in the handleCompleteWord method of the SuggestionBox component. 

I also went in and gave it the ability to have different autocomplete suggestions matching different parts of the text which didn't end up fixing the problem, but I left it there anyway in case it's used in the future.