### PR TITLE
PLT-1626/PLT-1424/PLT-1473/PLT-1483 Improved search highlighting

### DIFF
--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -47,7 +47,21 @@ class MattermostMarkdownRenderer extends marked.Renderer {
     }
 
     codespan(text) {
-        return '<span class="codespan__pre-wrap">' + super.codespan(text) + '</span>';
+        let output = text;
+
+        if (this.formattingOptions.searchTerm) {
+            const tokens = new Map();
+            output = TextFormatting.highlightSearchTerms(output, tokens, this.formattingOptions.searchTerm);
+            output = TextFormatting.replaceTokens(output, tokens);
+        }
+
+        return (
+            '<span class="codespan__pre-wrap">' +
+                '<code>' +
+                    output +
+                '</code>' +
+            '</span>'
+        );
     }
 
     br() {

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -43,7 +43,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
             usedLanguage = 'xml';
         }
 
-        return syntaxHightlighting.formatCode(usedLanguage, code);
+        return syntaxHightlighting.formatCode(usedLanguage, code, null, this.formattingOptions.searchTerm);
     }
 
     codespan(text) {

--- a/webapp/utils/syntax_hightlighting.jsx
+++ b/webapp/utils/syntax_hightlighting.jsx
@@ -123,10 +123,12 @@ hlJS.registerLanguage('yaml', hljsYaml);
 
 const HighlightedLanguages = Constants.HighlightedLanguages;
 
-export function formatCode(lang, data, filename) {
+export function formatCode(lang, data, filename, searchTerm) {
     const language = lang.toLowerCase() || '';
+
     let contents;
     let header = '';
+    let className = 'post-code';
 
     if (HighlightedLanguages[language]) {
         let name = HighlightedLanguages[language].name;
@@ -147,10 +149,13 @@ export function formatCode(lang, data, filename) {
         contents = TextFormatting.sanitizeHtml(data);
     }
 
-    let className = 'post-code';
     if (!language) {
         // wrap when no language is specified
         className += ' post-code--wrap';
+
+        const tokens = new Map();
+        contents = TextFormatting.highlightSearchTerms(contents, tokens, searchTerm);
+        contents = TextFormatting.replaceTokens(contents, tokens);
     }
 
     if (filename) {

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -11,6 +11,10 @@ import UserStore from 'stores/user_store.jsx';
 import twemoji from 'twemoji';
 import * as Utils from './utils.jsx';
 
+// pattern to detect the existance of a Chinese, Japanese, or Korean character in a string
+// http://stackoverflow.com/questions/15033196/using-javascript-to-check-whether-a-string-contains-japanese-characters-includi
+const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]/;
+
 // Performs formatting of user posts including highlighting mentions and search terms and converting urls, hashtags, and
 // @mentions to links by taking a user's message and returning a string of formatted html. Also takes a number of options
 // as part of the second parameter:
@@ -345,7 +349,11 @@ function parseSearchTerms(searchTerm) {
 
 function convertSearchTermToRegex(term) {
     let pattern;
-    if (term.endsWith('*')) {
+
+    if (cjkPattern.test(term)) {
+        // term contains Chinese, Japanese, or Korean characters so don't mark word boundaries
+        pattern = escapeRegex(term.replace(/\*/g,''));
+    } else if (term.endsWith('*')) {
         pattern = '\\b' + escapeRegex(term.substring(0, term.length - 1));
     } else {
         pattern = '\\b' + escapeRegex(term) + '\\b';

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -329,7 +329,7 @@ function parseSearchTerms(searchTerm) {
             termString = termString.substring(captured[0].length);
 
             // break the text up into words based on how the server splits them in SqlPostStore.SearchPosts and then discard empty terms
-            terms.push(...captured[0].split(/[ <>+\-\(\)~@]/).filter((term) => !!term));
+            terms.push(...captured[0].split(/[ <>+\(\)~@]/).filter((term) => !!term));
             continue;
         }
 

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -345,6 +345,7 @@ function parseSearchTerms(searchTerm) {
             terms.push(...captured[0].split(/[ <>+\(\)~@]/).filter((term) => !!term));
             continue;
         }
+
         // we should never reach this point since at least one of the regexes should match something in the remaining text
         throw new Error('Infinite loop in search term parsing: "' + termString + '"');
     }
@@ -360,12 +361,12 @@ function convertSearchTermToRegex(term) {
 
     if (cjkPattern.test(term)) {
         // term contains Chinese, Japanese, or Korean characters so don't mark word boundaries
-        pattern = '()(' + escapeRegex(term.replace(/\*/g,'')) + ')';
+        pattern = '()(' + escapeRegex(term.replace(/\*/g, '')) + ')';
     } else if (term.endsWith('*')) {
-        pattern = '\\b()(' + escapeRegex(term.substring(0, term.length - 1)) +')';
+        pattern = '\\b()(' + escapeRegex(term.substring(0, term.length - 1)) + ')';
     } else if (term.startsWith('@')) {
         // needs special handling of the first boundary because a word boundary doesn't work before an @ sign
-        pattern = '(\\W|^)(' + escapeRegex(term) + ')\\b'
+        pattern = '(\\W|^)(' + escapeRegex(term) + ')\\b';
     } else {
         pattern = '\\b()(' + escapeRegex(term) + ')\\b';
     }

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -379,7 +379,7 @@ function highlightSearchTerm(text, tokens, searchTerm) {
         // highlight existing tokens matching search terms
         var newTokens = new Map();
         for (const [alias, token] of tokens) {
-            if (token.originalText === term.replace(/\*$/, '')) {
+            if (token.originalText.toLowerCase() === term.replace(/\*$/, '').toLowerCase()) {
                 const index = tokens.size + newTokens.size;
                 const newAlias = `MM_SEARCHTERM${index}`;
 

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -65,7 +65,7 @@ export function doFormatText(text, options) {
     }
 
     if (options.searchTerm) {
-        output = highlightSearchTerm(output, tokens, options.searchTerm);
+        output = highlightSearchTerms(output, tokens, options.searchTerm);
     }
 
     if (!('mentionHighlight' in options) || options.mentionHighlight) {
@@ -362,7 +362,7 @@ function convertSearchTermToRegex(term) {
     return new RegExp(pattern, 'gi');
 }
 
-function highlightSearchTerm(text, tokens, searchTerm) {
+export function highlightSearchTerms(text, tokens, searchTerm) {
     const terms = parseSearchTerms(searchTerm);
 
     if (terms.length === 0) {
@@ -411,7 +411,7 @@ function highlightSearchTerm(text, tokens, searchTerm) {
     return output;
 }
 
-function replaceTokens(text, tokens) {
+export function replaceTokens(text, tokens) {
     let output = text;
 
     // iterate backwards through the map so that we do replacement in the opposite order that we added tokens


### PR DESCRIPTION
PLT-1626: Correctly highlight hyphenated hashtags
PLT-1424: Correctly highlight strings with CJK characters
PLT-1473: Correctly highlight search terms in code blocks without syntax highlighting
PLT-1483: Correctly highlight at mentions

Also, I fixed my pre-commit hook so I'll stop submitting stuff with ESLint errors