### PR TITLE
PLT-3028 Added CTRL+/ to show shortcuts

### DIFF
--- a/webapp/actions/channel_actions.jsx
+++ b/webapp/actions/channel_actions.jsx
@@ -4,7 +4,12 @@
 import {browserHistory} from 'react-router';
 
 import TeamStore from 'stores/team_store.jsx';
+import Client from 'utils/web_client.jsx';
 
 export function goToChannel(channel) {
     browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name);
+}
+
+export function executeCommand(channelId, message, suggest, success, error) {
+    Client.executeCommand(channelId, message, suggest, success, error);
 }

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -13,6 +13,7 @@ import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import Client from 'utils/web_client.jsx';
 import * as Utils from 'utils/utils.jsx';
+import * as ChannelActions from 'actions/channel_actions.jsx';
 
 import ChannelStore from 'stores/channel_store.jsx';
 import PostStore from 'stores/post_store.jsx';
@@ -69,6 +70,7 @@ class CreatePost extends React.Component {
         this.focusTextbox = this.focusTextbox.bind(this);
         this.showPostDeletedModal = this.showPostDeletedModal.bind(this);
         this.hidePostDeletedModal = this.hidePostDeletedModal.bind(this);
+        this.showShortcuts = this.showShortcuts.bind(this);
 
         PostStore.clearDraftUploads();
 
@@ -129,7 +131,7 @@ class CreatePost extends React.Component {
         this.setState({submitting: true, serverError: null});
         this.setState({lastMessage: this.state.messageText});
         if (post.message.indexOf('/') === 0) {
-            Client.executeCommand(
+            ChannelActions.executeCommand(
                 this.state.channelId,
                 post.message,
                 false,
@@ -311,6 +313,7 @@ class CreatePost extends React.Component {
         PreferenceStore.addChangeListener(this.onPreferenceChange);
 
         this.focusTextbox();
+        document.addEventListener('keydown', this.showShortcuts);
     }
     componentDidUpdate(prevProps, prevState) {
         if (prevState.channelId !== this.state.channelId) {
@@ -320,6 +323,24 @@ class CreatePost extends React.Component {
     componentWillUnmount() {
         ChannelStore.removeChangeListener(this.onChange);
         PreferenceStore.removeChangeListener(this.onPreferenceChange);
+        document.removeEventListener('keydown', this.showShortcuts);
+    }
+    showShortcuts(e) {
+        if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.FORWARD_SLASH) {
+            e.preventDefault();
+            ChannelActions.executeCommand(
+                this.state.channelId,
+                '/shortcuts ',
+                false,
+                null,
+                (err) => {
+                    const state = {};
+                    state.serverError = err.message;
+                    state.submitting = false;
+                    this.setState(state);
+                }
+            );
+        }
     }
     onChange() {
         const channelId = ChannelStore.getCurrentId();

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -334,10 +334,10 @@ class CreatePost extends React.Component {
                 false,
                 null,
                 (err) => {
-                    const state = {};
-                    state.serverError = err.message;
-                    state.submitting = false;
-                    this.setState(state);
+                    this.setState({
+                        serverError: err.message,
+                        submitting: false
+                    });
                 }
             );
         }


### PR DESCRIPTION
CTRL+/ now shows the shortcuts command. Using it does not affect what the user has typed into the textbox.

`executeCommand` was moved out of `create_post.jsx` to `actions/channel_actions.jsx` to reduce direct calls on Client.