### PR TITLE
PLT-3101 Added Message History

### DIFF
--- a/webapp/components/edit_post_modal.jsx
+++ b/webapp/components/edit_post_modal.jsx
@@ -49,6 +49,8 @@ class EditPostModal extends React.Component {
             return;
         }
 
+        PostStore.storeMessageInHistory(updatedPost.message);
+
         if (updatedPost.message.length === 0) {
             var tempState = this.state;
             Reflect.deleteProperty(tempState, 'editText');

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -23,6 +23,7 @@ class PostStoreClass extends EventEmitter {
         this.selectedPostId = null;
         this.postsInfo = {};
         this.currentFocusedPostId = null;
+        this.messageHistory = [];
     }
     emitChange() {
         this.emit(CHANGE_EVENT);
@@ -537,6 +538,27 @@ class PostStoreClass extends EventEmitter {
         }
 
         return commentCount;
+    }
+    getMessageInHistory(index) {
+        if (index < 0 || index >= this.messageHistory.length) {
+            return '';
+        }
+        return this.messageHistory[index % this.messageHistory.length];
+    }
+    getHistoryLength() {
+        if (this.messageHistory === null) {
+            return 0;
+        }
+        return this.messageHistory.length;
+    }
+    storeMessageInHistory(message) {
+        this.messageHistory.push(message);
+        if (this.messageHistory.length > Constants.MAX_PREV_MSGS) {
+            this.messageHistory = this.messageHistory.slice(1, Constants.MAX_PREV_MSGS + 1);
+        }
+    }
+    storeMessageInHistoryByIndex(index, message) {
+        this.messageHistory[index] = message;
     }
 }
 

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -750,6 +750,7 @@ export default {
     MHPNS: 'https://push.mattermost.com',
     MTPNS: 'http://push-test.mattermost.com',
     BOT_NAME: 'BOT',
+    MAX_PREV_MSGS: 100,
     POST_COLLAPSE_TIMEOUT: 1000 * 60 * 5, // five minutes
     LICENSE_EXPIRY_NOTIFICATION: 1000 * 60 * 60 * 24 * 15, // 15 days
     LICENSE_GRACE_PERIOD: 1000 * 60 * 60 * 24 * 15 // 15 days

--- a/webapp/utils/post_utils.jsx
+++ b/webapp/utils/post_utils.jsx
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 
 import Client from 'utils/web_client.jsx';
-
+import PostStore from 'stores/post_store.jsx';
 import Constants from 'utils/constants.jsx';
 
 export function isSystemMessage(post) {
@@ -29,4 +29,33 @@ export function getProfilePicSrcForPost(post, timestamp) {
     }
 
     return src;
+}
+
+export function messageHistoryHandler(e) {
+    if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
+        if (this.state.messageText !== '' && this.currentLastMsgIndex === PostStore.getHistoryLength()) {
+            return;
+        }
+
+        e.preventDefault();
+
+        if (this.currentMsgHistoryLength !== PostStore.getHistoryLength()) {
+            this.currentLastMsgIndex = PostStore.getHistoryLength();
+            this.currentMsgHistoryLength = this.currentLastMsgIndex;
+        }
+
+        if (e.keyCode === Constants.KeyCodes.UP) {
+            this.currentLastMsgIndex--;
+        } else if (e.keyCode === Constants.KeyCodes.DOWN) {
+            this.currentLastMsgIndex++;
+        }
+
+        if (this.currentLastMsgIndex < 0) {
+            this.currentLastMsgIndex = 0;
+        } else if (this.currentLastMsgIndex >= PostStore.getHistoryLength()) {
+            this.currentLastMsgIndex = PostStore.getHistoryLength();
+        }
+
+        this.setState({messageText: PostStore.getMessageInHistory(this.currentLastMsgIndex)});
+    }
 }

--- a/webapp/utils/post_utils.jsx
+++ b/webapp/utils/post_utils.jsx
@@ -33,7 +33,9 @@ export function getProfilePicSrcForPost(post, timestamp) {
 
 export function messageHistoryHandler(e) {
     if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
-        if (this.state.messageText !== '' && this.currentLastMsgIndex === PostStore.getHistoryLength()) {
+        if (this.state.messageText !== '' && this.state.messageText !== PostStore.getMessageInHistory(this.currentLastMsgIndex)) {
+            this.currentLastMsgIndex = PostStore.getHistoryLength();
+            this.currentMsgHistoryLength = this.currentLastMsgIndex;
             return;
         }
 


### PR DESCRIPTION
You can now browse through the last 20 messages you typed in using CTRL/CMD+Up/Down.
Browsing through history in the RHS is independent of browsing through history in the main textbox, but both share the same history.

Works just like a typical command line, but only 20 messages are saved instead of practically unlimited. 

Both normal messages and slash commands work.
History is wiped every session. 

@jwilander test server?