### PR TITLE
PLT-3058 Respect CTRL+ENTER for all modals

### DIFF
--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -82,7 +82,7 @@ class CreatePost extends React.Component {
             previews: draft.previews,
             submitting: false,
             initialText: draft.messageText,
-            ctrlSend: false,
+            ctrlSend: PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
             centerTextbox: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_CENTERED,
             showTutorialTip: false,
             showPostDeletedModal: false

--- a/webapp/components/edit_post_modal.jsx
+++ b/webapp/components/edit_post_modal.jsx
@@ -82,6 +82,10 @@ class EditPostModal extends React.Component {
             e.preventDefault();
             ReactDOM.findDOMNode(this.refs.editbox).blur();
             this.handleEdit(e);
+        } else if (this.state.ctrlSend && e.ctrlKey && e.which === KeyCodes.ENTER) {
+            e.preventDefault();
+            ReactDOM.findDOMNode(this.refs.editbox).blur();
+            this.handleSubmit(e);
         }
     }
     handleEditPostEvent(options) {

--- a/webapp/stores/preference_store.jsx
+++ b/webapp/stores/preference_store.jsx
@@ -16,6 +16,8 @@ class PreferenceStoreClass extends EventEmitter {
         this.dispatchToken = AppDispatcher.register(this.handleEventPayload);
 
         this.preferences = new Map();
+
+        this.setMaxListeners(15);
     }
 
     getKey(category, name) {


### PR DESCRIPTION
Previously, CTRL+ENTER was not used on 3 modals:
- Edit post
- Change channel header
- Change channel purpose

Now it is!

`maxListeners` had to be increased on `PreferenceStore` to account for the different modals checking for changes.