### PR TITLE
Scrolling fixes

### DIFF
--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -363,9 +363,8 @@ export default class PostList extends React.Component {
             }
         } else if (this.refs.postlist.scrollHeight !== this.prevScrollHeight) {
             window.requestAnimationFrame(() => {
-                // Only need to jump if we added posts to the top.
-                if (this.jumpToPostNode && (this.jumpToPostNode.offsetTop !== this.prevOffsetTop)) {
-                    this.refs.postlist.scrollTop += (this.refs.postlist.scrollHeight - this.prevScrollHeight);
+                if (this.jumpToPostNode) {
+                    this.refs.postlist.scrollTop += (this.jumpToPostNode.offsetTop - this.prevOffsetTop);
                 }
             });
         }

--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -68,7 +68,7 @@ export default class PostList extends React.Component {
         const childNodes = this.refs.postlistcontent.childNodes;
         for (let i = 0; i < childNodes.length; i++) {
             // If the node is 1/3 down the page
-            if (childNodes[i].offsetTop > (this.refs.postlist.scrollTop + (this.refs.postlist.offsetHeight / Constants.SCROLL_PAGE_FRACTION))) {
+            if (childNodes[i].offsetTop >= (this.refs.postlist.scrollTop + (this.refs.postlist.offsetHeight / Constants.SCROLL_PAGE_FRACTION))) {
                 this.jumpToPostNode = childNodes[i];
                 break;
             }

--- a/webapp/components/sidebar_right.jsx
+++ b/webapp/components/sidebar_right.jsx
@@ -10,8 +10,6 @@ import PostStore from 'stores/post_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-const SIDEBAR_SCROLL_DELAY = 500;
-
 import React from 'react';
 
 export default class SidebarRight extends React.Component {
@@ -55,8 +53,8 @@ export default class SidebarRight extends React.Component {
         const isOpen = this.state.searchVisible || this.state.postRightVisible;
         const willOpen = nextState.searchVisible || nextState.postRightVisible;
 
-        if (!isOpen && willOpen) {
-            setTimeout(() => PostStore.jumpPostsViewSidebarOpen(), SIDEBAR_SCROLL_DELAY);
+        if (isOpen !== willOpen) {
+            PostStore.jumpPostsViewSidebarOpen();
         }
     }
     doStrangeThings() {


### PR DESCRIPTION
* fix bad jumps on free scroll when somebody posts a new message (and old one disappears at top)
* add jump for compensation of resize on closing RHS (not only opening)
* fix scroll blinking on opening/closing RHS (caused by delay before resize compensation)