### PR TITLE
PLT-3156 Typo in 'Edit Nickname' message when nickname is set through login provider

### DIFF
--- a/webapp/components/user_settings/user_settings_general.jsx
+++ b/webapp/components/user_settings/user_settings_general.jsx
@@ -596,7 +596,7 @@ class UserSettingsGeneralTab extends React.Component {
                     <span>
                         <FormattedMessage
                             id='user.settings.general.field_handled_externally'
-                            defaultMessage='This field is handled through your login provider. If you want to change it, you need to do so though your login provider.'
+                            defaultMessage='This field is handled through your login provider. If you want to change it, you need to do so through your login provider.'
                         />
                     </span>
                 );

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1310,6 +1310,7 @@
   "user.settings.general.emailMatch": "The new emails you entered do not match.",
   "user.settings.general.emptyName": "Click 'Edit' to add your full name",
   "user.settings.general.emptyNickname": "Click 'Edit' to add a nickname",
+  "user.settings.general.field_handled_externally": "This field is handled through your login provider. If you want to change it, you need to do so through your login provider.",
   "user.settings.general.firstName": "First Name",
   "user.settings.general.fullName": "Full Name",
   "user.settings.general.imageTooLarge": "Unable to upload profile image. File is too large.",


### PR DESCRIPTION
Text should say "you need to do so through your login provider". Notice that the typo says "though" instead of "through".