### PR TITLE
PLT-3101 Added message history

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -11,6 +11,7 @@ import UserStore from 'stores/user_store.jsx';
 import PostDeletedModal from './post_deleted_modal.jsx';
 import PostStore from 'stores/post_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
+import MessageHistoryStore from 'stores/message_history_store.jsx';
 import Textbox from './textbox.jsx';
 import MsgTyping from './msg_typing.jsx';
 import FileUpload from './file_upload.jsx';
@@ -68,11 +69,11 @@ class CreateComment extends React.Component {
         this.hidePostDeletedModal = this.hidePostDeletedModal.bind(this);
 
         PostStore.clearCommentDraftUploads();
+        MessageHistoryStore.resetAllHistoryIndex();
 
         const draft = PostStore.getCommentDraft(this.props.rootId);
         this.state = {
             messageText: draft.message,
-            lastMessage: '',
             uploadsInProgress: draft.uploadsInProgress,
             previews: draft.previews,
             submitting: false,
@@ -80,18 +81,22 @@ class CreateComment extends React.Component {
             showPostDeletedModal: false
         };
     }
+
     componentDidMount() {
         PreferenceStore.addChangeListener(this.onPreferenceChange);
         this.focusTextbox();
     }
+
     componentWillUnmount() {
         PreferenceStore.removeChangeListener(this.onPreferenceChange);
     }
+
     onPreferenceChange() {
         this.setState({
             ctrlSend: PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter')
         });
     }
+
     componentDidUpdate(prevProps, prevState) {
         if (prevState.uploadsInProgress < this.state.uploadsInProgress) {
             $('.post-right__scroll').scrollTop($('.post-right__scroll')[0].scrollHeight);
@@ -101,6 +106,7 @@ class CreateComment extends React.Component {
             this.focusTextbox();
         }
     }
+
     handleSubmit(e) {
         e.preventDefault();
 
@@ -124,6 +130,8 @@ class CreateComment extends React.Component {
             this.setState({postError: this.props.intl.formatMessage(holders.commentLength, {max: Constants.CHARACTER_LIMIT})});
             return;
         }
+
+        MessageHistoryStore.storeMessageInHistory(this.state.messageText);
 
         const userId = UserStore.getCurrentId();
 
@@ -173,13 +181,13 @@ class CreateComment extends React.Component {
 
         this.setState({
             messageText: '',
-            lastMessage: this.state.messageText,
             submitting: false,
             postError: null,
             previews: [],
             serverError: null
         });
     }
+
     commentMsgKeyPress(e) {
         if (this.state.ctrlSend && e.ctrlKey || !this.state.ctrlSend) {
             if (e.which === KeyCodes.ENTER && !e.shiftKey && !e.altKey) {
@@ -191,6 +199,7 @@ class CreateComment extends React.Component {
 
         GlobalActions.emitLocalUserTypingEvent(this.props.channelId, this.props.rootId);
     }
+
     handleUserInput(messageText) {
         const draft = PostStore.getCommentDraft(this.props.rootId);
         draft.message = messageText;
@@ -199,6 +208,7 @@ class CreateComment extends React.Component {
         $('.post-right__scroll').parent().scrollTop($('.post-right__scroll')[0].scrollHeight);
         this.setState({messageText: messageText});
     }
+
     handleKeyDown(e) {
         if (this.state.ctrlSend && e.keyCode === KeyCodes.ENTER && e.ctrlKey === true) {
             this.commentMsgKeyPress(e);
@@ -224,22 +234,21 @@ class CreateComment extends React.Component {
             });
         }
 
-        if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && e.keyCode === KeyCodes.UP) {
-            const lastPost = PostStore.getCurrentUsersLatestPost(this.props.channelId, this.props.rootId);
-            if (!lastPost || this.state.messageText !== '') {
-                return;
+        if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
+            const lastMessage = MessageHistoryStore.nextMessageInHistory(e.keyCode, this.state.messageText, 'comment');
+            if (lastMessage !== '') {
+                e.preventDefault();
+                this.setState({
+                    messageText: lastMessage
+                });
             }
-            e.preventDefault();
-            let message = lastPost.message;
-            if (this.state.lastMessage !== '') {
-                message = this.state.lastMessage;
-            }
-            this.setState({messageText: message});
         }
     }
+
     handleUploadClick() {
         this.focusTextbox();
     }
+
     handleUploadStart(clientIds) {
         const draft = PostStore.getCommentDraft(this.props.rootId);
 
@@ -252,6 +261,7 @@ class CreateComment extends React.Component {
         // but this also resets the focus after a drag and drop
         this.focusTextbox();
     }
+
     handleFileUploadComplete(filenames, clientIds) {
         const draft = PostStore.getCommentDraft(this.props.rootId);
 
@@ -269,6 +279,7 @@ class CreateComment extends React.Component {
 
         this.setState({uploadsInProgress: draft.uploadsInProgress, previews: draft.previews});
     }
+
     handleUploadError(err, clientId) {
         if (clientId === -1) {
             this.setState({serverError: err});
@@ -285,6 +296,7 @@ class CreateComment extends React.Component {
             this.setState({uploadsInProgress: draft.uploadsInProgress, serverError: err});
         }
     }
+
     removePreview(id) {
         const previews = this.state.previews;
         const uploadsInProgress = this.state.uploadsInProgress;
@@ -309,30 +321,36 @@ class CreateComment extends React.Component {
 
         this.setState({previews: previews, uploadsInProgress: uploadsInProgress});
     }
+
     componentWillReceiveProps(newProps) {
         if (newProps.rootId !== this.props.rootId) {
             const draft = PostStore.getCommentDraft(newProps.rootId);
             this.setState({messageText: draft.message, uploadsInProgress: draft.uploadsInProgress, previews: draft.previews});
         }
     }
+
     getFileCount() {
         return this.state.previews.length + this.state.uploadsInProgress.length;
     }
+
     focusTextbox() {
         if (!Utils.isMobile()) {
             this.refs.textbox.focus();
         }
     }
+
     showPostDeletedModal() {
         this.setState({
             showPostDeletedModal: true
         });
     }
+
     hidePostDeletedModal() {
         this.setState({
             showPostDeletedModal: false
         });
     }
+
     render() {
         let serverError = null;
         if (this.state.serverError) {

--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -69,7 +69,7 @@ class CreateComment extends React.Component {
         this.hidePostDeletedModal = this.hidePostDeletedModal.bind(this);
 
         PostStore.clearCommentDraftUploads();
-        MessageHistoryStore.resetAllHistoryIndex();
+        MessageHistoryStore.resetHistoryIndex('comment');
 
         const draft = PostStore.getCommentDraft(this.props.rootId);
         this.state = {

--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -236,7 +236,7 @@ class CreateComment extends React.Component {
 
         if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
             const lastMessage = MessageHistoryStore.nextMessageInHistory(e.keyCode, this.state.messageText, 'comment');
-            if (lastMessage !== this.state.messageText) {
+            if (lastMessage !== null) {
                 e.preventDefault();
                 this.setState({
                     messageText: lastMessage

--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -236,7 +236,7 @@ class CreateComment extends React.Component {
 
         if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
             const lastMessage = MessageHistoryStore.nextMessageInHistory(e.keyCode, this.state.messageText, 'comment');
-            if (lastMessage !== '') {
+            if (lastMessage !== this.state.messageText) {
                 e.preventDefault();
                 this.setState({
                     messageText: lastMessage

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -396,7 +396,7 @@ class CreatePost extends React.Component {
 
         if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
             const lastMessage = MessageHistoryStore.nextMessageInHistory(e.keyCode, this.state.messageText, 'post');
-            if (lastMessage !== '') {
+            if (lastMessage !== this.state.messageText) {
                 e.preventDefault();
                 this.setState({
                     messageText: lastMessage

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -396,7 +396,7 @@ class CreatePost extends React.Component {
 
         if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
             const lastMessage = MessageHistoryStore.nextMessageInHistory(e.keyCode, this.state.messageText, 'post');
-            if (lastMessage !== this.state.messageText) {
+            if (lastMessage !== null) {
                 e.preventDefault();
                 this.setState({
                     messageText: lastMessage

--- a/webapp/components/edit_post_modal.jsx
+++ b/webapp/components/edit_post_modal.jsx
@@ -9,6 +9,7 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 import Textbox from './textbox.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
 import PostStore from 'stores/post_store.jsx';
+import MessageHistoryStore from 'stores/message_history_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 
 import Constants from 'utils/constants.jsx';
@@ -48,6 +49,8 @@ class EditPostModal extends React.Component {
             $('#edit_post').modal('hide');
             return;
         }
+
+        MessageHistoryStore.storeMessageInHistory(updatedPost.message);
 
         if (updatedPost.message.length === 0) {
             var tempState = this.state;

--- a/webapp/stores/message_history_store.jsx
+++ b/webapp/stores/message_history_store.jsx
@@ -15,7 +15,7 @@ class MessageHistoryStoreClass {
     }
 
     getMessageInHistory(type) {
-        if (this.index[type] > this.messageHistory.length - 1 || this.index[type] < 0) {
+        if (this.index[type] >= this.messageHistory.length || this.index[type] < 0) {
             return '';
         }
         return this.messageHistory[this.index[type]];
@@ -52,7 +52,7 @@ class MessageHistoryStoreClass {
     nextMessageInHistory(keyCode, messageText, type) {
         if (messageText !== '' && messageText !== this.getMessageInHistory(type)) {
             this.resetHistoryIndex(type);
-            return '';
+            return messageText;
         }
 
         if (keyCode === Constants.KeyCodes.UP) {

--- a/webapp/stores/message_history_store.jsx
+++ b/webapp/stores/message_history_store.jsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import Constants from 'utils/constants.jsx';
+
+const TYPE_POST = 'post';
+const TYPE_COMMENT = 'comment';
+
+class MessageHistoryStoreClass {
+    constructor() {
+        this.messageHistory = [];
+        this.index = [];
+        this.index[TYPE_POST] = 0;
+        this.index[TYPE_COMMENT] = 0;
+    }
+
+    getMessageInHistory(type) {
+        if (this.index[type] > this.messageHistory.length - 1 || this.index[type] < 0) {
+            return '';
+        }
+        return this.messageHistory[this.index[type]];
+    }
+
+    getHistoryLength() {
+        if (this.messageHistory === null) {
+            return 0;
+        }
+        return this.messageHistory.length;
+    }
+
+    storeMessageInHistory(message) {
+        this.messageHistory.push(message);
+        this.resetAllHistoryIndex();
+        if (this.messageHistory.length > Constants.MAX_PREV_MSGS) {
+            this.messageHistory = this.messageHistory.slice(1, Constants.MAX_PREV_MSGS + 1);
+        }
+    }
+
+    storeMessageInHistoryByIndex(index, message) {
+        this.messageHistory[index] = message;
+    }
+
+    resetAllHistoryIndex() {
+        this.index[TYPE_POST] = this.messageHistory.length;
+        this.index[TYPE_COMMENT] = this.messageHistory.length;
+    }
+
+    resetHistoryIndex(type) {
+        this.index[type] = this.messageHistory.length;
+    }
+
+    nextMessageInHistory(keyCode, messageText, type) {
+        if (messageText !== '' && messageText !== this.getMessageInHistory(type)) {
+            this.resetHistoryIndex(type);
+            return '';
+        }
+
+        if (keyCode === Constants.KeyCodes.UP) {
+            this.index[type]--;
+        } else if (keyCode === Constants.KeyCodes.DOWN) {
+            this.index[type]++;
+        }
+
+        if (this.index[type] < 0) {
+            this.index[type] = 0;
+        } else if (this.index[type] >= this.getHistoryLength()) {
+            this.index[type] = this.getHistoryLength();
+        }
+
+        return this.getMessageInHistory(type);
+    }
+}
+
+var MessageHistoryStore = new MessageHistoryStoreClass();
+
+export default MessageHistoryStore;

--- a/webapp/stores/message_history_store.jsx
+++ b/webapp/stores/message_history_store.jsx
@@ -51,7 +51,6 @@ class MessageHistoryStoreClass {
 
     nextMessageInHistory(keyCode, messageText, type) {
         if (messageText !== '' && messageText !== this.getMessageInHistory(type)) {
-            this.resetHistoryIndex(type);
             return messageText;
         }
 

--- a/webapp/stores/message_history_store.jsx
+++ b/webapp/stores/message_history_store.jsx
@@ -15,9 +15,12 @@ class MessageHistoryStoreClass {
     }
 
     getMessageInHistory(type) {
-        if (this.index[type] >= this.messageHistory.length || this.index[type] < 0) {
+        if (this.index[type] >= this.messageHistory.length) {
             return '';
+        } else if (this.index[type] < 0) {
+            return null;
         }
+
         return this.messageHistory[this.index[type]];
     }
 
@@ -51,7 +54,7 @@ class MessageHistoryStoreClass {
 
     nextMessageInHistory(keyCode, messageText, type) {
         if (messageText !== '' && messageText !== this.getMessageInHistory(type)) {
-            return messageText;
+            return null;
         }
 
         if (keyCode === Constants.KeyCodes.UP) {
@@ -62,6 +65,7 @@ class MessageHistoryStoreClass {
 
         if (this.index[type] < 0) {
             this.index[type] = 0;
+            return null;
         } else if (this.index[type] >= this.getHistoryLength()) {
             this.index[type] = this.getHistoryLength();
         }

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -752,6 +752,7 @@ export default {
     MHPNS: 'https://push.mattermost.com',
     MTPNS: 'http://push-test.mattermost.com',
     BOT_NAME: 'BOT',
+    MAX_PREV_MSGS: 100,
     POST_COLLAPSE_TIMEOUT: 1000 * 60 * 5, // five minutes
     LICENSE_EXPIRY_NOTIFICATION: 1000 * 60 * 60 * 24 * 15, // 15 days
     LICENSE_GRACE_PERIOD: 1000 * 60 * 60 * 24 * 15 // 15 days

--- a/webapp/utils/post_utils.jsx
+++ b/webapp/utils/post_utils.jsx
@@ -2,7 +2,6 @@
 // See License.txt for license information.
 
 import Client from 'utils/web_client.jsx';
-
 import Constants from 'utils/constants.jsx';
 
 export function isSystemMessage(post) {


### PR DESCRIPTION
You can now browse through the last 100 messages (practically unlimited if really needed) you typed in using CTRL/CMD+Up/Down.
Browsing through history in the RHS is independent of browsing through history in the main textbox, but both share the same history. History is reset upon enter. Will only work on empty text box, or if you're already browsing history with 0 changes.

Works just like a typical command line.

Both normal messages and slash commands work.
History is wiped every session.