### PR TITLE
PLT-3165 Close HTTP response bodies properly in golang driver (and some api functions)

### DIFF
--- a/api/command.go
+++ b/api/command.go
@@ -203,6 +203,7 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 								handleResponse(c, w, response, channelId, cmd, false)
 							}
 						} else {
+							defer resp.Body.Close()
 							body, _ := ioutil.ReadAll(resp.Body)
 							c.Err = model.NewLocAppError("command", "api.command.execute_command.failed_resp.app_error", map[string]interface{}{"Trigger": trigger, "Status": resp.Status}, string(body))
 						}

--- a/api/post.go
+++ b/api/post.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -428,6 +429,10 @@ func handleWebhookEvents(c *Context, post *model.Post, team *model.Team, channel
 					if resp, err := client.Do(req); err != nil {
 						l4g.Error(utils.T("api.post.handle_webhook_events_and_forget.event_post.error"), err.Error())
 					} else {
+						defer func() {
+							ioutil.ReadAll(resp.Body)
+							resp.Body.Close()
+						}()
 						respProps := model.MapFromJson(resp.Body)
 
 						// copy the context and create a mock session for posting the message


### PR DESCRIPTION
From #3145 

Response bodies were not being closed properly in `model/client.go`. I added a function to make sure the body is fully read and closed.

Some API functions that were making HTTP requests were not closing the response body properly. I fixed those.

This is not a worry for our API functions themselves since the [server automatically closes them](https://golang.org/pkg/net/http/#Request).