### PR TITLE
PLT-2817 Made all settings save on enter

### DIFF
--- a/webapp/components/admin_console/admin_settings.jsx
+++ b/webapp/components/admin_console/admin_settings.jsx
@@ -8,6 +8,7 @@ import Client from 'utils/web_client.jsx';
 
 import FormError from 'components/form_error.jsx';
 import SaveButton from 'components/admin_console/save_button.jsx';
+import Constants from 'utils/constants.jsx';
 
 export default class AdminSettings extends React.Component {
     static get propTypes() {
@@ -21,6 +22,7 @@ export default class AdminSettings extends React.Component {
 
         this.handleChange = this.handleChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
+        this.onKeyDown = this.onKeyDown.bind(this);
 
         this.state = {
             saveNeeded: false,
@@ -34,6 +36,20 @@ export default class AdminSettings extends React.Component {
             saveNeeded: true,
             [id]: value
         });
+    }
+
+    componentDidMount() {
+        document.addEventListener('keydown', this.onKeyDown);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.onKeyDown);
+    }
+
+    onKeyDown(e) {
+        if (e.keyCode === Constants.KeyCodes.ENTER) {
+            this.handleSubmit(e);
+        }
     }
 
     handleSubmit(e) {

--- a/webapp/components/setting_item_max.jsx
+++ b/webapp/components/setting_item_max.jsx
@@ -2,10 +2,32 @@
 // See License.txt for license information.
 
 import {FormattedMessage} from 'react-intl';
+import * as Utils from 'utils/utils.jsx';
+import Constants from 'utils/constants.jsx';
 
 import React from 'react';
 
 export default class SettingItemMax extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.onKeyDown = this.onKeyDown.bind(this);
+    }
+
+    onKeyDown(e) {
+        if (e.keyCode === Constants.KeyCodes.ENTER) {
+            this.props.submit(e);
+        }
+    }
+
+    componentDidMount() {
+        document.addEventListener('keydown', this.onKeyDown);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.onKeyDown);
+    }
+
     render() {
         var clientError = null;
         if (this.props.client_error) {
@@ -25,16 +47,14 @@ export default class SettingItemMax extends React.Component {
         var submit = '';
         if (this.props.submit) {
             submit = (
-                <a
+                <input
+                    type='submit'
                     className='btn btn-sm btn-primary'
                     href='#'
                     onClick={this.props.submit}
+                    value={Utils.localizeMessage('setting_item_max.save', 'Save')}
                 >
-                    <FormattedMessage
-                        id='setting_item_max.save'
-                        defaultMessage='Save'
-                    />
-                </a>
+                </input>
             );
         }
 


### PR DESCRIPTION
All settings in either Account Settings or Admin Console now save on hitting enter!

`e.preventDefault()` is called in the props, which is why I did not call it inside.