### PR TITLE
PLT-2981 Disabled Push Notifications section in Settings if disabled by admin

### DIFF
--- a/webapp/components/user_settings/user_settings_notifications.jsx
+++ b/webapp/components/user_settings/user_settings_notifications.jsx
@@ -263,71 +263,89 @@ class NotificationsTab extends React.Component {
             }
 
             let inputs = [];
+            let extraInfo = null;
+            let submit = null;
 
-            inputs.push(
-                <div key='userNotificationLevelOption'>
-                    <div className='radio'>
-                        <label>
-                            <input
-                                type='radio'
-                                name='pushNotificationLevel'
-                                checked={notifyActive[0]}
-                                onChange={this.handlePushRadio.bind(this, 'all')}
-                            />
-                            <FormattedMessage
-                                id='user.settings.push_notification.allActivity'
-                                defaultMessage='For all activity'
-                            />
-                        </label>
-                        <br/>
+            if (global.window.mm_config.SendPushNotifications === 'true') {
+                inputs.push(
+                    <div key='userNotificationLevelOption'>
+                        <div className='radio'>
+                            <label>
+                                <input
+                                    type='radio'
+                                    name='pushNotificationLevel'
+                                    checked={notifyActive[0]}
+                                    onChange={this.handlePushRadio.bind(this, 'all')}
+                                />
+                                <FormattedMessage
+                                    id='user.settings.push_notification.allActivity'
+                                    defaultMessage='For all activity'
+                                />
+                            </label>
+                            <br/>
+                        </div>
+                        <div className='radio'>
+                            <label>
+                                <input
+                                    type='radio'
+                                    name='pushNotificationLevel'
+                                    checked={notifyActive[1]}
+                                    onChange={this.handlePushRadio.bind(this, 'mention')}
+                                />
+                                <FormattedMessage
+                                    id='user.settings.push_notification.onlyMentions'
+                                    defaultMessage='For mentions and direct messages'
+                                />
+                            </label>
+                            <br/>
+                        </div>
+                        <div className='radio'>
+                            <label>
+                                <input
+                                    type='radio'
+                                    name='pushNotificationLevel'
+                                    checked={notifyActive[2]}
+                                    onChange={this.handlePushRadio.bind(this, 'none')}
+                                />
+                                <FormattedMessage
+                                    id='user.settings.push_notification.off'
+                                    defaultMessage='Off'
+                                />
+                            </label>
+                        </div>
                     </div>
-                    <div className='radio'>
-                        <label>
-                            <input
-                                type='radio'
-                                name='pushNotificationLevel'
-                                checked={notifyActive[1]}
-                                onChange={this.handlePushRadio.bind(this, 'mention')}
-                            />
-                            <FormattedMessage
-                                id='user.settings.push_notifications.onlyMentions'
-                                defaultMessage='For mentions and direct messages'
-                            />
-                        </label>
-                        <br/>
-                    </div>
-                    <div className='radio'>
-                        <label>
-                            <input
-                                type='radio'
-                                name='pushNotificationLevel'
-                                checked={notifyActive[2]}
-                                onChange={this.handlePushRadio.bind(this, 'none')}
-                            />
-                            <FormattedMessage
-                                id='user.settings.push_notifications.off'
-                                defaultMessage='Off'
-                            />
-                        </label>
-                    </div>
-                </div>
-            );
+                );
 
-            const extraInfo = (
-                <span>
-                    <FormattedMessage
-                        id='user.settings.push_notifications.info'
-                        defaultMessage='Notification alerts are pushed to your mobile device when there is activity in Mattermost.'
-                    />
-                </span>
-            );
+                extraInfo = (
+                    <span>
+                        <FormattedMessage
+                            id='user.settings.push_notification.info'
+                            defaultMessage='Notification alerts are pushed to your mobile device when there is activity in Mattermost.'
+                        />
+                    </span>
+                );
+
+                submit = this.handleSubmit();
+            } else {
+                inputs.push(
+                    <div
+                        key='oauthEmailInfo'
+                        className='form-group'
+                    >
+                        <FormattedMessage
+                            id='user.settings.push_notification.disabled_long'
+                            defaultMessage='Push notifications for mobile devices have been disabled by your System Administrator.'
+                        />
+                    </div>
+                );
+            }
 
             return (
                 <SettingItemMax
                     title={Utils.localizeMessage('user.settings.notifications.push', 'Mobile push notifications')}
                     extraInfo={extraInfo}
                     inputs={inputs}
-                    submit={this.handleSubmit}
+                    submit={submit}
                     server_error={this.state.serverError}
                     updateSection={this.handleCancel}
                 />
@@ -345,14 +363,21 @@ class NotificationsTab extends React.Component {
         } else if (this.state.notifyPushLevel === 'none') {
             describe = (
                 <FormattedMessage
-                    id='user.settings.push_notifications.off'
+                    id='user.settings.push_notification.off'
                     defaultMessage='Off'
+                />
+            );
+        } else if (global.window.mm_config.SendPushNotifications === 'false') {
+            describe = (
+                <FormattedMessage
+                    id='user.settings.push_notification.disabled'
+                    defaultMessage='Disabled by system administrator'
                 />
             );
         } else {
             describe = (
                 <FormattedMessage
-                    id='user.settings.push_notifications.onlyMentions'
+                    id='user.settings.push_notification.onlyMentions'
                     defaultMessage='For mentions and direct messages'
                 />
             );
@@ -364,7 +389,7 @@ class NotificationsTab extends React.Component {
 
         return (
             <SettingItemMin
-                title={Utils.localizeMessage('user.settings.notifications.push', 'Mobile push notifications')}
+                title={Utils.localizeMessage('user.settings.notification.push', 'Mobile push notifications')}
                 describe={describe}
                 updateSection={handleUpdateDesktopSection}
             />
@@ -911,10 +936,7 @@ class NotificationsTab extends React.Component {
             );
         }
 
-        let pushNotificationSection;
-        if (global.window.mm_config.SendPushNotifications === 'true') {
-            pushNotificationSection = this.createPushNotificationSection();
-        }
+        let pushNotificationSection = this.createPushNotificationSection();
 
         return (
             <div>

--- a/webapp/components/user_settings/user_settings_notifications.jsx
+++ b/webapp/components/user_settings/user_settings_notifications.jsx
@@ -936,7 +936,7 @@ class NotificationsTab extends React.Component {
             );
         }
 
-        let pushNotificationSection = this.createPushNotificationSection();
+        const pushNotificationSection = this.createPushNotificationSection();
 
         return (
             <div>

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1383,6 +1383,8 @@
   "user.settings.push_notification.info": "Notification alerts are pushed to your mobile device when there is activity in Mattermost.",
   "user.settings.push_notification.off": "Off",
   "user.settings.push_notification.onlyMentions": "For mentions and direct messages",
+  "user.settings.push_notification.disabled": "Disabled by system administrator",
+  "user.settings.push_notification.disabled_long": "Push notifications for mobile devices have been disabled by your System Administrator.",
   "user.settings.security.close": "Close",
   "user.settings.security.currentPassword": "Current Password",
   "user.settings.security.currentPasswordError": "Please enter your current password",


### PR DESCRIPTION
Changed the push notifications section in account settings to be disabled if it is disabled through the system console.

![image](https://cloud.githubusercontent.com/assets/5740966/15763110/a13a3ce2-28ef-11e6-98f3-07a962f078d3.png)

Also found out that i18n ids had a `s` in the code, but no `s` in `en.json`, fixed the situation below:

![image](https://cloud.githubusercontent.com/assets/5740966/15763055/50f86e34-28ef-11e6-8f9a-ed7e91d596ff.png)
