### PR TITLE
Reposition search highlighting for code blocks

### DIFF
--- a/webapp/sass/layout/_markdown.scss
+++ b/webapp/sass/layout/_markdown.scss
@@ -81,6 +81,8 @@
 
 .post-code__search-highlighting {
     color: transparent;
+    right: 6.5px;
+    left: 6.5px;
     pointer-events: none;
     position: absolute;
     @include user-select(none);


### PR DESCRIPTION
Certain code bocks will have the search highlighting wrap differently than the code itself so they become out of sync