### PR TITLE
Focus search text input when opening "Direct Messages" modal

### DIFF
--- a/webapp/components/filtered_user_list.jsx
+++ b/webapp/components/filtered_user_list.jsx
@@ -52,6 +52,10 @@ class FilteredUserList extends React.Component {
         }
     }
 
+    componentDidMount() {
+        ReactDOM.findDOMNode(this.refs.filter).focus();
+    }
+
     componentDidUpdate(prevProps, prevState) {
         if (prevState.filter !== this.state.filter) {
             $(ReactDOM.findDOMNode(this.refs.userList)).scrollTop(0);


### PR DESCRIPTION
Focus the search field when the filtered user list is shown.

Most of the time, if you have more than 10 users, you will have to search for the user you want to act on. This removes an extra click and allows you to start typing directly.

Affected views: 
- Channel invite modal
- Channel members list
- Team members list
- Direct message "more" modal