### PR TITLE
Removed placeholder text on channel switch modal

### DIFF
--- a/webapp/components/channel_switch_modal.jsx
+++ b/webapp/components/channel_switch_modal.jsx
@@ -110,7 +110,6 @@ export default class SwitchChannelModal extends React.Component {
                         type='input'
                         onUserInput={this.onUserInput}
                         value={this.state.text}
-                        placeholder={Utils.localizeMessage('channel_switch_modal.hint', 'Type the name of a channel')}
                         onKeyDown={this.handleKeyDown}
                         listComponent={SuggestionList}
                         maxLength='64'

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -720,7 +720,6 @@
   "channel_notifications.unreadInfo": "The channel name is bolded in the sidebar when there are unread messages. Selecting \"Only for mentions\" will bold the channel only when you are mentioned.",
   "channel_select.placeholder": "--- Select a channel ---",
   "channel_switch_modal.help": "Type channel name. Use ↑↓ to browse, TAB to select, ↵ to confirm, ESC to dismiss",
-  "channel_switch_modal.hint": "Type the name of a channel",
   "channel_switch_modal.not_found": "No matches found.",
   "channel_switch_modal.submit": "Switch",
   "channel_switch_modal.title": "Switch Channels",

--- a/webapp/i18n/es.json
+++ b/webapp/i18n/es.json
@@ -718,7 +718,6 @@
   "channel_notifications.unreadInfo": "El nombre del canal está en negritas en la barra lateral cuando hay mensajes sin leer. Al elegir \"Sólo para menciones\" sólo lo dejará en negritas cuando seas mencionado.",
   "channel_select.placeholder": "--- Selecciona un canal ---",
   "channel_switch_modal.help": "↑↓ para navegar, TAB para seleccionar, ↵ para confirmar, ESC para descartar",
-  "channel_switch_modal.hint": "Escribe el nombre de un canal",
   "channel_switch_modal.not_found": "No se encontró ninguna coincidencia.",
   "channel_switch_modal.submit": "Cambiar",
   "channel_switch_modal.title": "Cambiar Canales",

--- a/webapp/i18n/fr.json
+++ b/webapp/i18n/fr.json
@@ -718,7 +718,6 @@
   "channel_notifications.unreadInfo": "Le nom du canal est en gras dans la barre latérale lorsqu'il y a des messages non-plus. Choisir \"Seulement pour les mentions\" mettra en gras le canal seulement si vous être mentionné.",
   "channel_select.placeholder": "--- Sélectionnez un canal ---",
   "channel_switch_modal.help": "↑↓ to browse, TAB to select, ↵ to confirm, ESC to dismiss",
-  "channel_switch_modal.hint": "Type the name of a channel",
   "channel_switch_modal.not_found": "No matches found.",
   "channel_switch_modal.submit": "Switch",
   "channel_switch_modal.title": "Switch Channels",

--- a/webapp/i18n/ja.json
+++ b/webapp/i18n/ja.json
@@ -718,7 +718,6 @@
   "channel_notifications.unreadInfo": "チャンネル名は未読のメッセージがある場合、サイドバーで太字で表示されます。「あなたについての投稿のみ」を選択することで、あなたについての投稿がある場合のみ太字で表示されます。",
   "channel_select.placeholder": "--- チャンネルを選択してください ---",
   "channel_switch_modal.help": "↑↓ to browse, TAB to select, ↵ to confirm, ESC to dismiss",
-  "channel_switch_modal.hint": "Type the name of a channel",
   "channel_switch_modal.not_found": "No matches found.",
   "channel_switch_modal.submit": "Switch",
   "channel_switch_modal.title": "Switch Channels",

--- a/webapp/i18n/pt-BR.json
+++ b/webapp/i18n/pt-BR.json
@@ -718,7 +718,6 @@
   "channel_notifications.unreadInfo": "O nome do canal fica em negrito na barra lateral quando houver mensagens não lidas. Selecionando \"Apenas menções\" o canal vai ficar em negrito apenas quando você for mencionado.",
   "channel_select.placeholder": "--- Selecione um canal ---",
   "channel_switch_modal.help": "↑↓ to browse, TAB to select, ↵ to confirm, ESC to dismiss",
-  "channel_switch_modal.hint": "Type the name of a channel",
   "channel_switch_modal.not_found": "No matches found.",
   "channel_switch_modal.submit": "Switch",
   "channel_switch_modal.title": "Switch Channels",


### PR DESCRIPTION
Manual revert of https://github.com/mattermost/platform/pull/3232
Text is already covered through https://github.com/mattermost/platform/pull/3256

The reverted PR had text in the `input` as a placeholder. The other PR placed the text in the instructions. We want to keep the other PR.