### PR TITLE
PLT-2023 Fixed mentions display with empty username

### DIFF
--- a/webapp/components/user_settings/user_settings_notifications.jsx
+++ b/webapp/components/user_settings/user_settings_notifications.jsx
@@ -906,7 +906,9 @@ class NotificationsTab extends React.Component {
 
             let describe = '';
             for (var i = 0; i < keys.length; i++) {
-                describe += '"' + keys[i] + '", ';
+                if (keys[i] !== '') {
+                    describe += '"' + keys[i] + '", ';
+                }
             }
 
             if (describe.length > 0) {


### PR DESCRIPTION
Previously, if you choose to be mentioned with your first name, and then later remove your first name, `""` shows up in the list of mentions. Now it does not.