### PR TITLE
PLT-2981 Fixed typo in Push Notification Settings

### DIFF
--- a/webapp/components/user_settings/user_settings_notifications.jsx
+++ b/webapp/components/user_settings/user_settings_notifications.jsx
@@ -325,7 +325,7 @@ class NotificationsTab extends React.Component {
                     </span>
                 );
 
-                submit = this.handleSubmit();
+                submit = this.handleSubmit;
             } else {
                 inputs.push(
                     <div


### PR DESCRIPTION
Fixed typo in `submit = this.handleSubmit;` to fixed the Push Notifications section not opening if it was enabled in the system console.