### PR TITLE
Changed default AvailableLocales to include all locales

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 const (
@@ -34,6 +35,15 @@ const (
 
 	FAKE_SETTING = "********************************"
 )
+
+// should match the values in webapp/i18n/i18n.jsx
+var LOCALES = []string{
+	"en",
+	"es",
+	"fr",
+	"ja",
+	"pt-BR",
+}
 
 type ServiceSettings struct {
 	ListenAddress                     string
@@ -541,7 +551,7 @@ func (o *Config) SetDefaults() {
 
 	if o.LocalizationSettings.AvailableLocales == nil {
 		o.LocalizationSettings.AvailableLocales = new(string)
-		*o.LocalizationSettings.AvailableLocales = *o.LocalizationSettings.DefaultClientLocale
+		*o.LocalizationSettings.AvailableLocales = strings.Join(LOCALES, ",")
 	}
 }
 

--- a/webapp/i18n/i18n.jsx
+++ b/webapp/i18n/i18n.jsx
@@ -13,6 +13,7 @@ import frLocaleData from 'react-intl/locale-data/fr';
 import jaLocaleData from 'react-intl/locale-data/ja';
 import ptLocaleData from 'react-intl/locale-data/pt';
 
+// should match the values in model/config.go
 const languages = {
     en: {
         value: 'en',


### PR DESCRIPTION
I couldn't just pull the available locales from i18n.go because that introduced a circular dependency so they had to be manually specified