### PR TITLE
PLT-3066 Properly removed hashtags and at mentions inside of markdown links

### DIFF
--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -163,7 +163,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         }
 
         // remove any links added to the text by hashtag or mention parsing since they'll break this link
-        output += '>' + text.replace(/<\/?a[^>]*>/, '') + '</a>';
+        output += '>' + text.replace(/<\/?a[^>]*>/g, '') + '</a>';
 
         return output;
     }


### PR DESCRIPTION
The current code only removes the opening tag of any hashtags inside of the markdown link so it outputs invalid HTML