### PR TITLE
PLT-3150 Added check for code theme name changes

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -47,7 +47,10 @@ func NewSqlUserStore(sqlStore *SqlStore) UserStore {
 }
 
 func (us SqlUserStore) UpgradeSchemaIfNeeded() {
-	// ADDED for 3.2 remove for 3.6
+	// ADDED for 2.0 REMOVE for 2.4
+	us.CreateColumnIfNotExists("Users", "Locale", "varchar(5)", "character varying(5)", model.DEFAULT_LOCALE)
+
+	// ADDED for 3.2 REMOVE for 3.6
 	var data []*model.User
 	shouldUpdate := false
 	if _, err := us.GetReplica().Select(&data, "SELECT * FROM Users WHERE ThemeProps LIKE '%solaris%'"); err == nil {
@@ -65,6 +68,7 @@ func (us SqlUserStore) UpgradeSchemaIfNeeded() {
 					return
 				}
 			}
+			shouldUpdate = false
 		}
 	}
 }

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -53,7 +53,7 @@ func (us SqlUserStore) UpgradeSchemaIfNeeded() {
 	// ADDED for 3.2 REMOVE for 3.6
 	var data []*model.User
 	shouldUpdate := false
-	if _, err := us.GetReplica().Select(&data, "SELECT * FROM Users WHERE ThemeProps LIKE '%solaris%'"); err == nil {
+	if _, err := us.GetReplica().Select(&data, "SELECT * FROM Users WHERE ThemeProps LIKE '%solarized%'"); err == nil {
 		for _, user := range data {
 			if user.ThemeProps["codetheme"] == "solarized_dark" {
 				user.ThemeProps["codetheme"] = "solarized-dark"


### PR DESCRIPTION
`solaris_dark` and `solaris_light` had their `_`s changed to `-`. This checks for any users with the themes upon server start, and changes them as needed.

Also deleted `remove for 2.4` code