### PR TITLE
Various design fixes and improvements

### DIFF
--- a/webapp/sass/components/_dropdown.scss
+++ b/webapp/sass/components/_dropdown.scss
@@ -1,6 +1,8 @@
 @charset 'UTF-8';
 
 .dropdown-menu {
+    padding-top: 0;
+    padding-bottom: 0;
 
     &.colorpicker {
         z-index: 2500;
@@ -17,6 +19,8 @@
 
     > li > a {
         color: inherit;
+        padding-left: 10px;
+        padding-right: 10px;
 
         &:focus,
         &:hover {

--- a/webapp/sass/components/_modal.scss
+++ b/webapp/sass/components/_modal.scss
@@ -49,6 +49,10 @@
         table-layout: fixed;
     }
 
+    .modal-backdrop {
+        background: linear-gradient(to bottom, rgba(0, 0, 0 , 1) 0%, rgba(0, 0, 0, 0.7) 100%);
+    }
+
     .modal {
         color: alpha-color($black, .9);
         width: 100%;
@@ -76,7 +80,13 @@
 
             &.btn-default {
                 background: transparent;
-                border: none;
+                border: 1px solid currentColor;
+
+                &:hover,
+                &:focus,
+                &:active {
+                    background: rgba(0, 0, 0, 0.1);
+                }
             }
         }
 
@@ -122,7 +132,7 @@
         .modal-header {
             @include border-radius(0);
             @include clearfix;
-            background: $primary-color;
+            background: darken($primary-color, 20%);
             border: 1px solid $light-gray;
             color: $white;
             min-height: 56px;
@@ -146,18 +156,23 @@
             }
 
             .close {
+                @include border-radius($border-rad);
                 @include opacity(1);
-                @include single-transition(all, .25s, ease-in);
+                @include single-transition(all, .1s, ease-in);
+                border: 1px solid rgba(255, 255, 255, 0.5);
                 color: $white;
-                height: 30px;
-                line-height: 30px;
+                height: 32px;
+                line-height: 28px;
                 position: absolute;
                 right: 10px;
-                width: 30px;
+                width: 32px;
                 z-index: 5;
 
-                &:hover {
-                    @include alpha-property(background, $black, .1);
+                &:hover,
+                &:focus,
+                &:active {
+                    background: $white;
+                    color: rgba(102, 102, 102, 1);
                 }
 
                 span {
@@ -168,8 +183,9 @@
 
             .btn {
                 &.btn-primary {
+                    border: 1px solid rgba(255, 255, 255, 0.5);
                     float: right;
-                    margin: -4px 25px 0 0;
+                    margin: -2px 35px 0 0;
                     position: relative;
 
                     i {
@@ -194,8 +210,9 @@
         }
 
         .modal-content {
-            border-radius: 0;
-            box-shadow: none;
+            @include border-radius($border-rad);
+            border: none;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
         }
 
         .modal-chevron-icon {
@@ -504,7 +521,7 @@
     }
 
     .more-modal__image {
-        @include border-radius(60px);
+        @include border-radius(4px);
         flex-grow: 0;
         flex-shrink: 0;
         margin-right: 8px;

--- a/webapp/sass/components/_popover.scss
+++ b/webapp/sass/components/_popover.scss
@@ -2,7 +2,7 @@
 @import 'compass/css3/transition';
 
 .popover {
-    @include border-radius($border-rad);
+    @include border-radius($border-rad-dropdown);
     color: lighten($black, 25%);
 
     &.bottom,
@@ -179,7 +179,10 @@
 }
 
 .member-list__popover {
+    @include box-shadow(0 3px 8px -2px rgba(0, 0, 0, 0.3) !important);
     max-width: initial;
+    padding: 0;
+    top: 42px !important;
 
     .popover-content {
         max-height: 350px;

--- a/webapp/sass/components/_search.scss
+++ b/webapp/sass/components/_search.scss
@@ -17,7 +17,7 @@
 
 .search__clear {
     @include single-transition(all, .2s, linear);
-    @include translateX(60px);
+    @include translateX(70px);
     cursor: pointer;
     display: none;
     line-height: 45px;

--- a/webapp/sass/layout/_headers.scss
+++ b/webapp/sass/layout/_headers.scss
@@ -43,6 +43,10 @@
                 text-decoration: none;
             }
 
+            .dropdown-menu {
+                margin-top: -5px;
+            }
+
             .modal {
                 white-space: normal;
             }
@@ -94,7 +98,7 @@
         float: left;
 
         img {
-            @include border-radius(100px);
+            @include border-radius(4px);
         }
     }
 
@@ -172,7 +176,7 @@
             .dropdown-menu {
                 a {
                     overflow: hidden;
-                    padding: 3px 20px;
+                    padding: 3px 10px;
                     text-overflow: ellipsis;
                 }
             }

--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -1,8 +1,9 @@
 @charset 'UTF-8';
 
 .custom-textarea {
+    @include border-radius(2px);
     background: transparent;
-    border: 1px solid #cccccc;
+    border: 2px solid #cccccc;
     height: auto;
     line-height: 20px;
     min-height: 36px;
@@ -12,6 +13,7 @@
     word-wrap: break-word;
 
     &:focus {
+        @include alpha-property(background-color, $white, .05);
         border-color: #cccccc;
         box-shadow: none;
     }
@@ -62,7 +64,6 @@ body.ios {
 
     .help__text {
         bottom: -23px;
-        cursor: pointer;
         font-size: 13px;
         position: absolute;
         right: 0;
@@ -452,6 +453,9 @@ body.ios {
 
         .dropdown-menu {
             &.bottom {
+                @include box-shadow(0 0 10px rgba(0, 0, 0, 0.3));
+                @include border-radius($border-rad-dropdown);
+                border-color: rgba(51, 51, 51, 0.2);
                 bottom: 25px;
                 top: auto;
             }
@@ -476,6 +480,11 @@ body.ios {
 
         .permalink-icon {
             visibility: visible;
+        }
+
+        &.current--user .post__body {
+            border-radius: 2px;
+            box-shadow: inset 0 0 1px 0 rgba(0, 0, 0, .5);
         }
     }
 
@@ -807,7 +816,7 @@ body.ios {
         }
 
         img {
-            @include border-radius(50px);
+            @include border-radius(4px);
             height: 32px;
             vertical-align: inherit;
             width: 32px;
@@ -834,7 +843,7 @@ body.ios {
         .dropdown-menu {
             left: auto;
             min-width: 130px;
-            padding: 2px 0;
+            padding: 0;
             right: 0;
 
             li {
@@ -848,6 +857,15 @@ body.ios {
     }
 
     .post__dropdown {
+        @include opacity(.7);
+        text-decoration: none;
+
+        &:hover,
+        &:focus,
+        &:active {
+            @include opacity(1);
+        }
+
         &:after {
             content: '[...]';
             position: relative;
@@ -1045,9 +1063,16 @@ body.ios {
     }
 
     .comment-icon__container {
+        @include opacity(.7);
         display: inline-block;
         fill: $primary-color;
         visibility: hidden;
+
+        &:hover,
+        &:focus,
+        &:active {
+            @include opacity(1);
+        }
 
         &:focus {
             outline: none;

--- a/webapp/sass/layout/_sidebar-left.scss
+++ b/webapp/sass/layout/_sidebar-left.scss
@@ -40,11 +40,14 @@
     }
 
     .dropdown-menu {
+        @include box-shadow(0 3px 8px -2px rgba(0, 0, 0, 0.3) !important);
+        @include border-radius($border-rad-dropdown !important);
         max-height: 80vh;
-        max-width: 200px;
+        max-width: 300px;
         overflow-x: hidden;
         overflow-y: auto;
-        width: 200px;
+        right: -100px;
+        width: 300px;
     }
 
     .search__form {
@@ -132,8 +135,8 @@
         li {
             > h4 {
                 color: #aaaaaa;
-                font-size: 1em;
-                font-weight: 400;
+                font-size: 0.9em;
+                font-weight: 700;
                 letter-spacing: -.3px;
                 margin: 1.1em 0 .5em;
                 padding: 0 10px 0 15px;
@@ -188,6 +191,10 @@
                     font-weight: 600;
                 }
 
+                &.nav-more {
+                    text-decoration: none;
+                }
+
             }
 
             &.active {
@@ -220,6 +227,7 @@
     }
 
     .add-channel-btn {
+        @include single-transition(all, .1s, ease-in);
         color: #aaaaaa;
         float: right;
         font-size: 22px;

--- a/webapp/sass/layout/_sidebar-menu.scss
+++ b/webapp/sass/layout/_sidebar-menu.scss
@@ -1,6 +1,7 @@
 @charset 'UTF-8';
 
 .sidebar--menu {
+    @include box-shadow(inset 20px 0 30px -20px rgba(0, 0, 0, 0.5));
     background: #fafafa;
     border-right: $border-gray;
     display: none;
@@ -65,7 +66,7 @@
                 background: none !important;
                 color: inherit;
                 font-size: 15px;
-                line-height: 40px;
+                line-height: 45px;
                 padding: 0 15px;
 
                 .fa,

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -87,7 +87,7 @@
 
             .col__reply {
                 top: 0;
-                width: 65px;
+                width: 20px;
             }
 
             .col__name {
@@ -108,6 +108,10 @@
             }
         }
 
+        .comment-btn {
+            padding: 8px 15px;
+        }
+
         .post-list__content & {
             &:hover {
                 background: transparent;
@@ -121,6 +125,10 @@
         .dropdown,
         .post__reply {
             visibility: visible;
+        }
+
+        .dropdown .dropdown-menu a {
+            padding: 10px 15px;
         }
 
         .post__body {
@@ -286,6 +294,16 @@
         display: block;
     }
 
+    .signup-header {
+        line-height: 45px;
+        padding-bottom: 0;
+
+        a {
+            padding-top: 15px;
+            padding-bottom: 15px;
+        }
+    }
+
     .signup-team__container {
         font-size: .9em;
         margin-bottom: 30px;
@@ -300,6 +318,8 @@
         }
 
         .btn {
+            padding: 10px 30px;
+
             .icon,
             .fa {
                 margin-right: 6px;
@@ -318,6 +338,14 @@
             .info__label {
                 padding-bottom: 5px;
                 text-align: left;
+            }
+
+            form .btn {
+                padding: 8px 15px;
+            }
+
+            .filtered-user-list .more-modal__list {
+                padding-bottom: 30px;
             }
 
             .modal-image {
@@ -361,9 +389,23 @@
                     &.btn-primary {
                         display: block;
                         float: none;
-                        margin: 10px 0 6px;
+                        margin: 15px 0 6px;
+                        padding: 8px 15px;
                         width: 100%;
                     }
+                }
+            }
+
+            .modal-footer {
+                padding-bottom: 5px;
+
+                .btn {
+                    margin-bottom: 10px;
+                    padding: 8px 15px;
+                }
+
+                .btn+.btn {
+                    margin-left: 15px;
                 }
             }
 
@@ -402,12 +444,17 @@
                             z-index: 5;
 
                             .modal-title {
+                                margin-left: 30px;
+                                margin-right: 30px;
                                 text-align: center;
-                                width: 100%;
+                                width: auto;
                             }
                         }
 
                         .user-settings {
+                            padding-left: 0 !important;
+                            padding-right: 0 !important;
+
                             .tab-header {
                                 display: none;
                             }
@@ -433,15 +480,26 @@
                     }
 
                     .settings-content {
+                        padding-left: 0;
+                        padding-right: 0;
+
+                        .section-title {
+                            padding-right: 90px;
+                        }
+
                         .section-edit {
                             position: absolute;
                             top: 14px;
-                            right: 0;
+                            right: 15px;
                             padding-right: 0;
 
                             .fa {
                                 display: inline-block;
                             }
+                        }
+
+                        .setting-list-item .btn {
+                            padding: 8px 15px;
                         }
 
                         &.minimize-settings {
@@ -455,6 +513,12 @@
 
                         .section-min:hover {
                             background: none !important;
+                        }
+
+                        .user-settings .section-max {
+                            .section-title {
+                                padding-right: 15px;
+                            }
                         }
                     }
 
@@ -573,6 +637,15 @@
                     height: 16px;
                     width: 4px;
                 }
+
+                .dropdown-menu {
+                    left: 70px;
+                    right: 0;
+
+                    a {
+                        padding: 10px 15px;
+                    }
+                }
             }
 
             .navbar-toggle {
@@ -581,6 +654,11 @@
 
             .navbar-brand {
                 white-space: nowrap;
+
+                .description {
+                    margin-left: 0.5em;
+                    margin-right: 1em !important;
+                }
             }
         }
     }
@@ -596,14 +674,17 @@
     }
 
     .footer,
-    .footer-pane,
+    .footer-pane {
+        height: 240px;
+    }
+
     .footer-push {
-        height: 187px;
+        height: 90px;
     }
 
     .footer-pane {
         .footer-link {
-            line-height: 1.7;
+            line-height: 2.5;
             padding: 0;
             text-align: right;
             width: 100%;
@@ -645,7 +726,7 @@
             @include translateX(0);
             border: none;
             height: 45px;
-            padding: 7px 20px 0 49px;
+            padding: 7px 0 0 49px;
             position: relative;
 
             .glyphicon-refresh-animate {
@@ -665,7 +746,7 @@
     }
 
     .sidebar--menu {
-        @include single-transition(transform, .5s, ease);
+        @include single-transition(transform, .2s, ease-in-out);
         @include translate3d(290px, 0, 0);
         border: none;
         display: block;
@@ -677,7 +758,8 @@
     }
 
     .sidebar--left {
-        @include single-transition(transform, .5s, ease);
+        @include box-shadow(inset -20px 0 30px -20px rgba(0, 0, 0, 0.5));
+        @include single-transition(transform, .2s, ease-in-out);
         @include translate3d(-290px, 0, 0);
         width: 290px;
         border: none;
@@ -744,6 +826,8 @@
 
                 h4 {
                     margin: 16px 0 8px;
+                    padding-top: 5px;
+                    padding-bottom: 5px;
                 }
 
                 > a {
@@ -768,9 +852,15 @@
                 }
             }
         }
+
+        .add-channel-btn {
+            margin: -3px 0 0;
+            padding: 0 5px 0 15px;
+        }
     }
 
     .sidebar--right {
+        @include single-transition(transform, .2s, ease-in-out);
         @include translate3d(100%, 0, 0);
         right: 0;
         width: 100%;
@@ -795,7 +885,7 @@
     }
 
     .inner-wrap {
-        @include single-transition(all, .5s, ease);
+        @include single-transition(all, .2s, ease-in-out);
 
         .app__body & {
             &:before {
@@ -978,6 +1068,7 @@
                     .security-links {
                         display: block;
                         margin-bottom: 10px;
+                        padding-left: 15px;
 
                         &:last-child {
                             margin-bottom: 0;
@@ -1002,6 +1093,15 @@
             position: relative;
             right: 0;
             top: 0;
+
+            .member-menu {
+                right: 0;
+                top: 100%;
+
+                & > li > a {
+                    padding: 10px 15px;
+                }
+            }
         }
 
         .open > .dropdown-menu {
@@ -1019,6 +1119,24 @@
         &.move--right {
             @include translate3d(260px, 0, 0);
         }
+    }
+
+    .error-bar {
+        padding: 12px 40px 12px 5px;
+
+        a {
+            &.error-bar__close {
+                font-size: 30px;
+                margin-top: -21px;
+                padding: 0 15px;
+                top: 50%;
+            }
+        }
+    }
+
+    #archive-link-home a {
+        padding: 20px;
+        text-align: center;
     }
 }
 

--- a/webapp/sass/routes/_settings.scss
+++ b/webapp/sass/routes/_settings.scss
@@ -14,20 +14,24 @@
         width: 800px;
 
         .modal-back {
+            @include border-radius($border-rad);
+            @include single-transition(all, .1s, ease-in);
+            border: 1px solid rgba(255, 255, 255, 0.5);
             font-size: 27px;
             font-weight: normal;
-            height: 40px;
-            left: 0;
-            line-height: 32px;
+            height: 32px;
+            left: 10px;
+            line-height: 31px;
             position: absolute;
             text-align: center;
-            top: 12px;
-            width: 50px;
+            top: 13px;
+            width: 32px;
 
             .fa {
                 height: 100%;
                 left: 0;
                 line-height: inherit;
+                margin-left: -1px;
                 position: absolute;
                 width: 100%;
             }
@@ -307,6 +311,11 @@
 
                 .setting-list-item {
                     margin-top: 7px;
+
+                    .btn.theme {
+                        border-color: currentColor;
+                        margin-left: 10px;
+                    }
                 }
 
                 .has-error {
@@ -429,6 +438,10 @@
     .member-menu {
         right: 110%;
         top: -50%;
+
+        & > li > a {
+            padding: 10px 15px;
+        }
     }
 }
 

--- a/webapp/sass/routes/_signup.scss
+++ b/webapp/sass/routes/_signup.scss
@@ -7,7 +7,7 @@
     width: 100%;
 
     .fa {
-        margin-right: 5px;
+        margin-right: 10px;
     }
 }
 

--- a/webapp/sass/utils/_variables.scss
+++ b/webapp/sass/utils/_variables.scss
@@ -16,4 +16,5 @@ $dark-gray: rgba(0, 0, 0, .5);
 $border-gray: 1px solid #ddd;
 
 // Random variables
-$border-rad: 1px;
+$border-rad: 2px;
+$border-rad-dropdown: 4px;


### PR DESCRIPTION
Hello dear Mattermost community !

Here is a proposal for a few style changes. The main purpose was to make the interface more consistent and to improve the user experience by having more visible or intuitive elements.

Please feel free to try the changes and discuss about what can be included or not in Mattermost, i'd be very happy if it could enhance even a little the final user experience.
You can preview the changes through the following screenshots, and read right after them a list of what have been changed in the stylesheets.

# Screenshots

![sidebar-left](https://cloud.githubusercontent.com/assets/1526969/15966392/386f0bae-2f23-11e6-9795-964acb2d9e5f.png)
Left sidebar with updated headlines, consistent "more" links, and `+` buttons with hover effect

![sidebar-left-menu](https://cloud.githubusercontent.com/assets/1526969/15966388/3863767c-2f23-11e6-9911-28e7323afdec.png)
Left sidebar main menu with updated links padding, new box-shadow, consistent border-radius

![modal](https://cloud.githubusercontent.com/assets/1526969/15966387/38613fa6-2f23-11e6-8e0f-504275e36caf.png)
Modal with a box-shadow replacement of the border, updated "close" button, outline around secondary buttons

![modal-2](https://cloud.githubusercontent.com/assets/1526969/15966390/38681484-2f23-11e6-9f0f-e68fce1a97b0.png)
Modal with a darker header to improve the contrast with primary header buttons, better alignment of primary header buttons with the "close" button

![post](https://cloud.githubusercontent.com/assets/1526969/15966391/386bc110-2f23-11e6-939d-973b8f9515c7.png)
Post with inner shadow when hovering our own posts to improve visibility, stronger textarea to be more visible, consistent style for the post action icons with hovering effects and square profile images

![post-dropdown](https://cloud.githubusercontent.com/assets/1526969/15966389/3866516c-2f23-11e6-9860-e8b960c0f219.png)
Post actions dropdown made more consistent with the other dropdowns

![mobile-sidebar-left](https://cloud.githubusercontent.com/assets/1526969/15966394/387d53d0-2f23-11e6-91e6-3c52a6be660e.png)
Mobile - Left sidebar with bigger touch targets and inner shadow to emphasize the depth with the main content

![mobile-main](https://cloud.githubusercontent.com/assets/1526969/15966393/387be482-2f23-11e6-90e9-cb65c1083627.png)
Mobile - Main view with icons made further apart to improve visibility

![mobile-main-menu](https://cloud.githubusercontent.com/assets/1526969/15966395/38801994-2f23-11e6-8628-b5ad38a20391.png)
Mobile - Channel menu aligned with the channel name and with bigger touch targets

![mobile-sidebar-right](https://cloud.githubusercontent.com/assets/1526969/15966396/38857376-2f23-11e6-9006-e3dd37880ada.png)
Mobile - Right sidebar with bigger touch targets and inner shadow to emphasize the depth with the main content

![mobile-search-space](https://cloud.githubusercontent.com/assets/1526969/15966397/38863a36-2f23-11e6-8d72-f41d952fb0b4.png)
Mobile - Removed extra space at the right of the search box

![mobile-modal](https://cloud.githubusercontent.com/assets/1526969/15966399/3895fbe2-2f23-11e6-8317-eb2671cb0512.png)
Mobile - Modal with better use of the available horizontal space and updated "back" button

![mobile-modal-2](https://cloud.githubusercontent.com/assets/1526969/15966400/389c18ba-2f23-11e6-8cca-d27b36c4ef5c.png)
Mobile - Modal with a setting opened

![mobile-members](https://cloud.githubusercontent.com/assets/1526969/15966401/389ccbac-2f23-11e6-9e0a-83e2e2c509f8.png)
Mobile - Fixed placement of the dropdown on members list, with bigger touch targets

# Changes list

An exhaustive list of all the chances that were made to the original stylesheets, ordered by folder and by file.

## Components

- Dropdown : Removed the top and bottom extra space
- Dropdown : Reduced the horizontal padding
- Modal : Changed the opaque background with a subltle gradient
- Modal : Added a border on secondary/cancel buttons to improve their visibility, as well as a slight background on hover/focus
- Modal : Made the header background slightly darker for a better visibility of primary buttons
- Modal : Fixed the size and placement of the close button, added an outline border and an hover/focus state
- Modal : Fixed the alignment of header primary buttons with the close button
- Modal : Made the border-radius consistent with the rest of the UI
- Modal : Replaced the border with a box-shadow
- Modal : Made the modal profile images less rounded
- Popover : Made the border-radius consistent with the rest of the UI
- Popover : Added a box-shadow for better visibility
- Popover : Fixed the vertical position of the members list to prevent the overlapping with the members button
- Search : Fixed the cancel button shift when the search box isn't focused on mobile

## Layout

- Headers : Reduced the horizontal padding of left sidebar dropdown
- Headers : Fixed the position of the channel dropdown to be aligned with the left sidebar dropdown
- Headers : Made the profile images less rounded on the channel intro
- Post : Enhanced the visibility of the message writing area, made its radius consistent with the rest of the UI
- Post : Removed the pointer cursor while hovering the Markdown help text as it's not a link
- Post : Made the style of post actions dropdown consistent with the others dropdowns
- Post : Added a slight inner shadow while hovering our own posts to improve the contrast with the post background
- Post : Made the posts profile image less rounded
- Post : Removed the top and bottom extra space on post actions dropdown
- Post : Made the right-hand post icons with the same style
- Post : Added an opacity change while hovering the righ-hand post icons
- Sidebar left : Made the style of the main dropdown consistent with the others dropdowns
- Sidebar left : Increased the width of the main dropdown
- Sidebar left : Slightly changed the style of the sidebar headlines
- Sidebar left : Made the style of the "More" links of the sidebar consistent
- Sidebar left : Added an opacity transition while hovering the "add" buttons
- Sidebar menu : Added an inner shadow to emphasize the depth of the main container
- Sidebar menu : Increased the line-height of the list elements to have bigger touch targets on mobile

## Responsive

- Mobile : Increased the padding of the error bar, fixed the center alignment of its text and its close button
- Mobile : Increased the height of the top header on the "signup" pages
- Mobile : Increased the touch target of the back button of the top header on the "signup" pages
- Mobile : Increased the touch target of the signup/login form button
- Mobile : Reduced the height of the footer push
- Mobile : Increased the height of the footer and its links
- Mobile : Changed the transition animation and duration for the sidebars
- Mobile : Fixed the position of the channel dropdown, increased its width and its links touch target
- Mobile : Added some margin around the channel info icon on the header
- Mobile : Removed useless right padding on the search form
- Mobile : Added an inner shadow on the left sidebar to emphasize the depth of the main container
- Mobile : Increased the height of the channel headings of the left sidebar
- Mobile : Increased the touch target of the "add" buttons of the left sidebar
- Mobile : Increased the touch target of the links of the post dropdown menu
- Mobile : Increased the touch target of the post actions button
- Mobile : Increased the touch target of the primary button while commenting a post
- Mobile : Fixed the display of primary buttons on modals header and increased their touch target
- Mobile : Increased the touch target of buttons on modals footer as well as the margin between them
- Mobile : Fixed the display of the "Last name" field on the "Invite new member" modal
- Mobile : Removed useless side spacing on settings modals
- Mobile : Fixed titles inside settings modals that hadn't enough padding so they don't overlap over "edit" buttons
- Mobile : Slightly shifted the "edit" buttons of settings modals
- Mobile : Increased touch target of buttons inside settings modals
- Mobile : Reset the padding of titles inside settings modals when their section is extended
- Mobile : Fixed the header title of settings modals so they're correctly centered
- Mobile : Added some left padding to security links inside settings modals
- Mobile : Increased the touch target of buttons inside modals forms
- Mobile : Added extra bottom padding to users list inside modals so we don't have a scrollbar when opening a dropdown on the last user
- Mobile : Fixed the position of members dropdown inside modals, increased the touch target of their links
- Mobile : Increased the height of the "See more messages" message bar and centered its text

## Routes

- Settings : Changed the style and fixed the aligment of the "Back" button on settings modal header
- Settings : Changed style and fixed margin of secondary buttons inside settings modal forms
- Settings : Increased the touch target of links inside the members dropdown inside modals
- Signup : Added some margin on the icon of the top header on the "signup" pages

## Utils

- Variables : Added a variable defining the border-radius value for dropdowns