### PR TITLE
PLT-3070 Update GitLab SSO error message

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -306,8 +306,14 @@ func CreateOAuthUser(c *Context, w http.ResponseWriter, r *http.Request, service
 	}
 
 	if result := <-euchan; result.Err == nil {
-		c.Err = model.NewLocAppError("CreateOAuthUser", "api.user.create_oauth_user.already_attached.app_error",
-			map[string]interface{}{"Service": service}, "email="+user.Email)
+		authService := result.Data.(*model.User).AuthService
+		if authService == "" {
+			c.Err = model.NewLocAppError("CreateOAuthUser", "api.user.create_oauth_user.already_attached.app_error",
+				map[string]interface{}{"Service": service, "Auth": model.USER_AUTH_SERVICE_EMAIL}, "email="+user.Email)
+		} else {
+			c.Err = model.NewLocAppError("CreateOAuthUser", "api.user.create_oauth_user.already_attached.app_error",
+				map[string]interface{}{"Service": service, "Auth": authService}, "email="+user.Email)
+		}
 		return nil
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1561,7 +1561,7 @@
   },
   {
     "id": "api.user.create_oauth_user.already_attached.app_error",
-    "translation": "An existing user is already attached to your {{.Service}} account"
+    "translation": "There is already an account associated with that email address using a sign in method other than {{.Service}}. Please sign in using {{.Auth}}."
   },
   {
     "id": "api.user.create_oauth_user.already_used.app_error",


### PR DESCRIPTION
Updated the error message on `CreateOAuthUser` to reflect what the user's email is associated with.

Previous error message: `An existing user is already attached to your gitlab account`
Now: `There is already an account associated with that email address using a sign in method other than GitLab. Please sign in using [email or LDAP].`