### PR TITLE
PLT-2808 Removed english localization from Postgres queries

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -44,7 +44,8 @@
         "MaxIdleConns": 10,
         "MaxOpenConns": 10,
         "Trace": false,
-        "AtRestEncryptKey": "7rAh6iwQCkV4cA1Gsg3fgGOXJAQ43QVg"
+        "AtRestEncryptKey": "7rAh6iwQCkV4cA1Gsg3fgGOXJAQ43QVg",
+        "PostgresTextSearchConfig": "english"
     },
     "LogSettings": {
         "EnableConsole": true,

--- a/model/config.go
+++ b/model/config.go
@@ -73,13 +73,14 @@ type SSOSettings struct {
 }
 
 type SqlSettings struct {
-	DriverName         string
-	DataSource         string
-	DataSourceReplicas []string
-	MaxIdleConns       int
-	MaxOpenConns       int
-	Trace              bool
-	AtRestEncryptKey   string
+	DriverName               string
+	DataSource               string
+	DataSourceReplicas       []string
+	MaxIdleConns             int
+	MaxOpenConns             int
+	Trace                    bool
+	AtRestEncryptKey         string
+	PostgresTextSearchConfig *string
 }
 
 type LogSettings struct {
@@ -293,6 +294,10 @@ func (o *Config) SetDefaults() {
 
 	if len(o.EmailSettings.PasswordResetSalt) == 0 {
 		o.EmailSettings.PasswordResetSalt = NewRandomString(32)
+	}
+
+	if *o.SqlSettings.PostgresTextSearchConfig == "" {
+		*o.SqlSettings.PostgresTextSearchConfig = "en"
 	}
 
 	if o.ServiceSettings.EnableDeveloper == nil {

--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -732,7 +732,7 @@ func (s SqlPostStore) Search(teamId string, userId string, params *model.SearchP
 				terms = strings.Join(strings.Fields(terms), " & ")
 			}
 
-			searchClause := fmt.Sprintf("AND %s @@  to_tsquery(:Terms)", searchType)
+			searchClause := fmt.Sprintf("AND %s @@  to_tsquery(utils.Cfg.SqlSettings.PostgresTextSearchConfig, :Terms)", searchType)
 			searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
 		} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 			searchClause := fmt.Sprintf("AND MATCH (%s) AGAINST (:Terms IN BOOLEAN MODE)", searchType)

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -499,7 +499,7 @@ func (ss SqlStore) createIndexIfNotExists(indexName string, tableName string, co
 
 		query := ""
 		if indexType == INDEX_TYPE_FULL_TEXT {
-			query = "CREATE INDEX " + indexName + " ON " + tableName + " USING gin(to_tsvector('english', " + columnName + "))"
+			query = "CREATE INDEX " + indexName + " ON " + tableName + " USING gin(to_tsvector(utils.Cfg.SqlSettings.PostgresTextSearchConfig, " + columnName + "))"
 		} else {
 			query = "CREATE " + uniqueStr + "INDEX " + indexName + " ON " + tableName + " (" + columnName + ")"
 		}

--- a/webapp/components/admin_console/database_settings.jsx
+++ b/webapp/components/admin_console/database_settings.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import * as Utils from 'utils/utils.jsx';
+import * as I18n from 'i18n/i18n.jsx';
 
 import AdminSettings from './admin_settings.jsx';
 import BooleanSetting from './boolean_setting.jsx';
@@ -12,6 +13,7 @@ import GeneratedSetting from './generated_setting.jsx';
 import SettingsGroup from './settings_group.jsx';
 import TextSetting from './text_setting.jsx';
 import RecycleDbButton from './recycle_db.jsx';
+import DropdownSetting from './dropdown_setting.jsx';
 
 export default class DatabaseSettings extends AdminSettings {
     constructor(props) {
@@ -27,7 +29,8 @@ export default class DatabaseSettings extends AdminSettings {
             maxIdleConns: props.config.SqlSettings.MaxIdleConns,
             maxOpenConns: props.config.SqlSettings.MaxOpenConns,
             atRestEncryptKey: props.config.SqlSettings.AtRestEncryptKey,
-            trace: props.config.SqlSettings.Trace
+            trace: props.config.SqlSettings.Trace,
+            postgresTextSeachConfig: props.config.SqlSettings.PostgresTextSearchConfig
         });
     }
 
@@ -38,6 +41,7 @@ export default class DatabaseSettings extends AdminSettings {
         config.SqlSettings.MaxOpenConns = this.parseIntNonZero(this.state.maxOpenConns);
         config.SqlSettings.AtRestEncryptKey = this.state.atRestEncryptKey;
         config.SqlSettings.Trace = this.state.trace;
+        config.SqlSettings.PostgresTextSearchConfig = Utils.getI18nLanguage(this.state.postgresTextSeachConfig);
 
         return config;
     }
@@ -55,6 +59,35 @@ export default class DatabaseSettings extends AdminSettings {
 
     renderSettings() {
         const dataSource = '**********' + this.state.dataSource.substring(this.state.dataSource.indexOf('@'));
+
+        let textSearchConfig = null;
+        if (this.state.driverName === 'postgres') {
+            const locales = I18n.getAllLanguages();
+
+            const languages = Object.keys(locales).map((l) => {
+                return {value: locales[l].value, text: locales[l].name};
+            });
+            textSearchConfig = (
+                <DropdownSetting
+                    id='postgresTextSeachConfig'
+                    values={languages}
+                    label={
+                        <FormattedMessage
+                            id='admin.sql.postgresTextSeachConfig'
+                            defaultMessage='Postgres Text Search Localization:'
+                        />
+                    }
+                    value={this.state.postgresTextSeachConfig}
+                    onChange={this.handleChange}
+                    helpText={
+                        <FormattedMessage
+                            id='admin.sql.postgresTextSeachConfigDescription'
+                            defaultMessage='Language used to search the PostgreSQL database.'
+                        />
+                    }
+                />
+            );
+        }
 
         return (
             <SettingsGroup>
@@ -128,6 +161,7 @@ export default class DatabaseSettings extends AdminSettings {
                     value={this.state.maxOpenConns}
                     onChange={this.handleChange}
                 />
+                {textSearchConfig}
                 <GeneratedSetting
                     id='atRestEncryptKey'
                     label={

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -1372,3 +1372,19 @@ export function localizeMessage(id, defaultMessage) {
 export function mod(a, b) {
     return ((a % b) + b) % b;
 }
+
+export function getI18nLanguage(value) {
+    switch (value) {
+    case 'en':
+        return 'english';
+    case 'es':
+        return 'spanish';
+    case 'fr':
+        return 'french';
+    case 'ja':
+        return 'japanese';
+    case 'pt-BR':
+        return 'portuguese';
+    }
+    return 'english';
+}


### PR DESCRIPTION
Previously, all Postgres queries used English as a search parameter by default, now it is changed through the system console. The option only appears if Postgres is used. A helper function was written to translate the names of our currently supported languages to English, which is what Postgres uses.