### PR TITLE
PLT-1951 Require indentation for multiline list items

### DIFF
--- a/tests/test-markdown-lists.md
+++ b/tests/test-markdown-lists.md
@@ -162,7 +162,7 @@ Verify that all list types render as expected.
 
 ### Ordered Lists Separated by Carriage Returns
 
-**Expected:*
+**Expected:**
 ```
 1. One
   • Two
@@ -176,7 +176,6 @@ Verify that all list types render as expected.
 1. One
   - Two
 
-
 1. One
 2. Two
 
@@ -185,15 +184,15 @@ Verify that all list types render as expected.
 **Expected:**
 ```
 1. One
- - Two
+- Two
 This text should be on a new line.
 ```
 
 **Actual:**
 
 1. One
- - Two
-This text should be on a new line.
+- Two
+ This text should be on a new line.
 
 **Expected:**
 ```

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -16,7 +16,7 @@
     "jasny-bootstrap": "3.1.3",
     "jquery": "2.2.3",
     "keymirror": "0.1.1",
-    "marked": "mattermost/marked#2d92082cd542dc0adc175a1407194f6a4c3cb621",
+    "marked": "mattermost/marked#662c0d2997215f328eaa55eb33aaa445838b4479",
     "match-at": "0.1.0",
     "mattermost": "mattermost/mattermost-javascript#master",
     "object-assign": "4.1.0",


### PR DESCRIPTION
Made some changes so that:
```
1. foo
text
```
renders as expected with the text on a new line. It's not 100%, but the cases that don't work are incredibly specific and I don't know if anyone actually uses the functionality that triggers them to render funny.

Marked changes here: https://github.com/mattermost/marked/commit/662c0d2997215f328eaa55eb33aaa445838b4479