### PR TITLE
PLT-3234 Reset password errors on Change Password Modal

### DIFF
--- a/webapp/components/user_settings/user_settings_security.jsx
+++ b/webapp/components/user_settings/user_settings_security.jsx
@@ -73,6 +73,15 @@ class SecurityTab extends React.Component {
         };
     }
 
+    componentWillUpdate() {
+        if ((this.state.passwordError !== '' || this.state.serverError) && (this.state.currentPassword !== '' || this.state.newPassword !== '' || this.state.confirmPassword !== '')) {
+            this.setState({
+                passwordError: '',
+                serverError: ''
+            });
+        }
+    }
+
     submitPassword(e) {
         e.preventDefault();
 


### PR DESCRIPTION
Previously, errors will persist in the password change modal until you press save. Now the errors disappear as soon as you type anything new.