### PR TITLE
PLT-3229 Reset errors on invalid MFA token

### DIFF
--- a/webapp/components/user_settings/user_settings_security.jsx
+++ b/webapp/components/user_settings/user_settings_security.jsx
@@ -69,7 +69,8 @@ class SecurityTab extends React.Component {
             confirmPassword: '',
             authService: this.props.user.auth_service,
             mfaShowQr: false,
-            mfaToken: ''
+            mfaToken: '',
+            serverError: ''
         };
     }
 


### PR DESCRIPTION
Previously, errors would persist when the MFA section was closed or opened. Now errors go away!