### PR TITLE
Email check shouldn't be case-sensitive #3349

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -190,7 +190,7 @@ func CheckUserDomain(user *model.User, domains string) bool {
 
 	matched := false
 	for _, d := range domainArray {
-		if strings.HasSuffix(user.Email, "@"+d) {
+		if strings.HasSuffix(strings.ToLower(user.Email), "@"+d) {
 			matched = true
 			break
 		}


### PR DESCRIPTION
The email address "allowed domains" check appears to be case-sensitive which is incorrectly blocking valid registrations, Please see #3349
I was unable to bring up a dev instance locally on RHEL 7.1 due to Gopath issues(spent an hour or so) and hence couldn't test this fix. Assuming that this is a simple change that can be tested easily by someone from the team, Please reject and fix this on your own if this fix is invalid.