### PR TITLE
Fixed runtime error panic in api/post.go

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -493,7 +493,9 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 		// Find out who is a member of the channel, only keep those profiles
 		tempProfileMap := make(map[string]*model.User)
 		for _, member := range members {
-			tempProfileMap[member.UserId] = profileMap[member.UserId]
+			if _, ok := profileMap[member.UserId]; ok {
+				tempProfileMap[member.UserId] = profileMap[member.UserId]
+			}
 		}
 
 		profileMap = tempProfileMap


### PR DESCRIPTION
This issue occurs when you remove user directly from database (Users table). I know that it should not happen but I guess we have to add extra check.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0xd8 pc=0x6047cb]

goroutine 435 [running]:
panic(0xcf8ac0, 0xc82000a110)
        /usr/lib/go-1.6/src/runtime/panic.go:464 +0x3e6
github.com/mattermost/platform/api.sendNotifications(0xc8202dcc60, 0xc8209d89a0, 0xc8207d4500, 0xc82076a4d0, 0xc8208ddad0, 0xc82054c840, 0x8, 0x8)
        /opt/platform/gopath/src/github.com/mattermost/platform/api/post.go:506 +0x1f3b
created by github.com/mattermost/platform/api.handlePostEvents
        /opt/platform/gopath/src/github.com/mattermost/platform/api/post.go:282 +0x121d
```