### PR TITLE
PLT-3234 Reset password errors upon submission

### DIFF
--- a/webapp/components/user_settings/user_settings_security.jsx
+++ b/webapp/components/user_settings/user_settings_security.jsx
@@ -68,10 +68,11 @@ class SecurityTab extends React.Component {
             currentPassword: '',
             newPassword: '',
             confirmPassword: '',
+            passwordError: '',
+            serverError: '',
             authService: this.props.user.auth_service,
             mfaShowQr: false,
-            mfaToken: '',
-            serverError: ''
+            mfaToken: ''
         };
     }
 


### PR DESCRIPTION
Previously, password errors were not cleared upon form saving/cancelling. Now they are!

This was done by changing `getDefaultState`