### PR TITLE
PLT-3229 Reset MFA error upon update

### DIFF
--- a/webapp/components/user_settings/user_settings_security.jsx
+++ b/webapp/components/user_settings/user_settings_security.jsx
@@ -306,7 +306,7 @@ class SecurityTab extends React.Component {
 
             updateSectionStatus = function resetSection(e) {
                 this.props.updateSection('');
-                this.setState({mfaToken: '', mfaShowQr: false, mfaError: null});
+                this.setState({mfaToken: '', mfaShowQr: false, mfaError: null, serverError: null});
                 e.preventDefault();
             }.bind(this);
 


### PR DESCRIPTION
Previously MFA errors did not clear upon cancel, now they do!

Also found out that `mfaError` is never used, instead we use `serverError`.