### PR TITLE
PLT-3205 Stopped Youtube videos playing when collapsed

### DIFF
--- a/webapp/components/post_view/components/post_body_additional_content.jsx
+++ b/webapp/components/post_view/components/post_body_additional_content.jsx
@@ -81,6 +81,7 @@ export default class PostBodyAdditionalContent extends React.Component {
                 <YoutubeVideo
                     channelId={this.props.post.channel_id}
                     link={link}
+                    show={this.state.embedVisible}
                 />
             );
         }

--- a/webapp/components/youtube_video.jsx
+++ b/webapp/components/youtube_video.jsx
@@ -46,6 +46,10 @@ export default class YoutubeVideo extends React.Component {
             return;
         }
 
+        if (props.show === false) {
+            this.stop();
+        }
+
         this.setState({
             videoId: match[2],
             time: this.handleYoutubeTime(link)
@@ -221,5 +225,6 @@ export default class YoutubeVideo extends React.Component {
 
 YoutubeVideo.propTypes = {
     channelId: React.PropTypes.string.isRequired,
-    link: React.PropTypes.string.isRequired
+    link: React.PropTypes.string.isRequired,
+    show: React.PropTypes.bool.isRequired
 };


### PR DESCRIPTION
Previously, Youtube videos would continue playing when they are collapsed, which sometimes caused unexplainable noises to come out. Now it's fixed!