### PR TITLE
PLT-3332 Removed multiple change channel header messages

### DIFF
--- a/webapp/components/edit_channel_header_modal.jsx
+++ b/webapp/components/edit_channel_header_modal.jsx
@@ -34,11 +34,10 @@ class EditChannelHeaderModal extends React.Component {
 
         this.ctrlSend = PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter');
 
-        this.submitted = false;
-
         this.state = {
             header: props.channel.header,
-            serverError: ''
+            serverError: '',
+            submitted: false
         };
     }
 
@@ -57,16 +56,15 @@ class EditChannelHeaderModal extends React.Component {
     componentWillReceiveProps(nextProps) {
         if (this.props !== nextProps) {
             this.setState({
-                header: nextProps.channel.header
+                header: nextProps.channel.header,
+                submitted: false
             });
-            this.submitted = false;
         }
     }
 
     componentDidUpdate(prevProps) {
         if (this.props.show && !prevProps.show) {
             this.onShow();
-            this.submitted = false;
         }
     }
 
@@ -81,11 +79,7 @@ class EditChannelHeaderModal extends React.Component {
     }
 
     handleSubmit() {
-        if (this.submitted === true) {
-            return;
-        }
-
-        this.submitted = true;
+        this.setState({submitted: true});
 
         Client.updateChannelHeader(
             this.props.channel.id,
@@ -187,7 +181,7 @@ class EditChannelHeaderModal extends React.Component {
                         />
                     </button>
                     <button
-                        disabled={this.submitted}
+                        disabled={this.state.submitted}
                         type='button'
                         className='btn btn-primary'
                         onClick={this.handleSubmit}

--- a/webapp/components/edit_channel_header_modal.jsx
+++ b/webapp/components/edit_channel_header_modal.jsx
@@ -34,6 +34,8 @@ class EditChannelHeaderModal extends React.Component {
 
         this.ctrlSend = PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter');
 
+        this.submitted = false;
+
         this.state = {
             header: props.channel.header,
             serverError: ''
@@ -57,12 +59,14 @@ class EditChannelHeaderModal extends React.Component {
             this.setState({
                 header: nextProps.channel.header
             });
+            this.submitted = false;
         }
     }
 
     componentDidUpdate(prevProps) {
         if (this.props.show && !prevProps.show) {
             this.onShow();
+            this.submitted = false;
         }
     }
 
@@ -77,6 +81,12 @@ class EditChannelHeaderModal extends React.Component {
     }
 
     handleSubmit() {
+        if (this.submitted === true) {
+            return;
+        }
+
+        this.submitted = true;
+
         Client.updateChannelHeader(
             this.props.channel.id,
             this.state.header,
@@ -102,6 +112,7 @@ class EditChannelHeaderModal extends React.Component {
     onShow() {
         const textarea = ReactDOM.findDOMNode(this.refs.textarea);
         Utils.placeCaretAtEnd(textarea);
+        this.submitted = false;
     }
 
     onHide() {
@@ -176,6 +187,7 @@ class EditChannelHeaderModal extends React.Component {
                         />
                     </button>
                     <button
+                        disabled={this.submitted}
                         type='button'
                         className='btn btn-primary'
                         onClick={this.handleSubmit}

--- a/webapp/components/edit_channel_purpose_modal.jsx
+++ b/webapp/components/edit_channel_purpose_modal.jsx
@@ -30,10 +30,9 @@ export default class EditChannelPurposeModal extends React.Component {
 
         this.ctrlSend = PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter');
 
-        this.submitted = false;
-
         this.state = {
-            serverError: ''
+            serverError: '',
+            submitted: false
         };
     }
 
@@ -48,7 +47,6 @@ export default class EditChannelPurposeModal extends React.Component {
     componentDidUpdate() {
         if (this.props.show) {
             $(ReactDOM.findDOMNode(this.refs.purpose)).focus();
-            this.submitted = false;
         }
     }
 
@@ -79,11 +77,7 @@ export default class EditChannelPurposeModal extends React.Component {
             return;
         }
 
-        if (this.submitted === true) {
-            return;
-        }
-
-        this.submitted = true;
+        this.setState({submitted: true});
 
         Client.updateChannelPurpose(
             this.props.channel.id,
@@ -199,7 +193,7 @@ export default class EditChannelPurposeModal extends React.Component {
                     <button
                         type='button'
                         className='btn btn-primary'
-                        disabled={this.submitted}
+                        disabled={this.state.submitted}
                         onClick={this.handleSave}
                     >
                         <FormattedMessage

--- a/webapp/components/edit_channel_purpose_modal.jsx
+++ b/webapp/components/edit_channel_purpose_modal.jsx
@@ -30,6 +30,8 @@ export default class EditChannelPurposeModal extends React.Component {
 
         this.ctrlSend = PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter');
 
+        this.submitted = false;
+
         this.state = {
             serverError: ''
         };
@@ -46,6 +48,7 @@ export default class EditChannelPurposeModal extends React.Component {
     componentDidUpdate() {
         if (this.props.show) {
             $(ReactDOM.findDOMNode(this.refs.purpose)).focus();
+            this.submitted = false;
         }
     }
 
@@ -75,6 +78,13 @@ export default class EditChannelPurposeModal extends React.Component {
         if (!this.props.channel) {
             return;
         }
+
+        if (this.submitted === true) {
+            return;
+        }
+
+        this.submitted = true;
+
         Client.updateChannelPurpose(
             this.props.channel.id,
             ReactDOM.findDOMNode(this.refs.purpose).value.trim(),
@@ -189,6 +199,7 @@ export default class EditChannelPurposeModal extends React.Component {
                     <button
                         type='button'
                         className='btn btn-primary'
+                        disabled={this.submitted}
                         onClick={this.handleSave}
                     >
                         <FormattedMessage


### PR DESCRIPTION
Previously, a user with a slow connection or fast fingers can press submit multiple times on a modal (changing channel header/purpose, for this PR) and cause multiple system messages to appear. Now the submit function is disabled upon first submission.