### PR TITLE
User filter modal's filter text box doesn't operate on email addresses

### DIFF
--- a/webapp/components/filtered_user_list.jsx
+++ b/webapp/components/filtered_user_list.jsx
@@ -111,6 +111,7 @@ class FilteredUserList extends React.Component {
                 return user.username.toLowerCase().indexOf(filter) !== -1 ||
                     (user.first_name && user.first_name.toLowerCase().indexOf(filter) !== -1) ||
                     (user.last_name && user.last_name.toLowerCase().indexOf(filter) !== -1) ||
+                    (user.email && user.email.toLowerCase().indexOf(filter) !== -1) ||
                     (user.nickname && user.nickname.toLowerCase().indexOf(filter) !== -1);
             });
         }


### PR DESCRIPTION
The user filter modal(Eg: the screen for choosing a user to direct-message by selecting "More" under Direct messages) doesnt appear to filter against listed email addresses.

The email address and usernames are displayed on the modal, but the filter appears to take first name, last name and nicknames behind the scenes (which are not actually displayed on the modal and might be counter-intuitive). Adding the email address makes it more predictable to filter what is displayed on the screen (and in our installation, easier for our users to find folks with weird usernames, but known email addresses).