### PR TITLE
Fix occasional visual hiccup when posting/replying to messages

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -146,8 +146,13 @@ class CreateComment extends React.Component {
         GlobalActions.emitUserCommentedEvent(post);
         Client.createPost(
             post,
-            () => {
+            (data) => {
                 PostStore.removePendingPost(post.channel_id, post.pending_post_id);
+
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_POST,
+                    post: data
+                });
             },
             (err) => {
                 if (err.id === 'api.post.create_post.root_id.app_error') {

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -179,8 +179,13 @@ class CreatePost extends React.Component {
         this.setState({messageText: '', submitting: false, postError: null, previews: [], serverError: null});
 
         Client.createPost(post,
-            () => {
+            (data) => {
                 PostStore.removePendingPost(post.pending_post_id);
+
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_POST,
+                    post: data
+                });
             },
             (err) => {
                 if (err.id === 'api.post.create_post.root_id.app_error') {


### PR DESCRIPTION
This was being caused by the pending post being removed before the websocket had a chance to give the client the proper post.