### PR TITLE
PLT-3073 Enterprise: Implement SAML/Okta Server side

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -40,6 +40,7 @@ func InitAdmin() {
 	BaseRoutes.Admin.Handle("/get_brand_image", ApiAppHandlerTrustRequester(getBrandImage)).Methods("GET")
 	BaseRoutes.Admin.Handle("/reset_mfa", ApiAdminSystemRequired(adminResetMfa)).Methods("POST")
 	BaseRoutes.Admin.Handle("/reset_password", ApiAdminSystemRequired(adminResetPassword)).Methods("POST")
+	BaseRoutes.Admin.Handle("/saml_metadata", ApiAppHandler(samlMetadata)).Methods("GET")
 }
 
 func getLogs(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -560,4 +561,23 @@ func adminResetPassword(c *Context, w http.ResponseWriter, r *http.Request) {
 	rdata := map[string]string{}
 	rdata["status"] = "ok"
 	w.Write([]byte(model.MapToJson(rdata)))
+}
+
+func samlMetadata(c *Context, w http.ResponseWriter, r *http.Request) {
+	samlInterface := einterfaces.GetSamlInterface()
+
+	if samlInterface == nil {
+		c.Err = model.NewLocAppError("loginWithSaml", "api.admin.saml.not_available.app_error", nil, "")
+		c.Err.StatusCode = http.StatusFound
+		return
+	}
+
+	if result, err := samlInterface.GetMetadata(); err != nil {
+		c.Err = model.NewLocAppError("loginWithSaml", "api.admin.saml.metadata.app_error", nil, "err="+err.Message)
+		return
+	} else {
+		w.Header().Set("Content-Type", "application/xml")
+		w.Header().Set("Content-Disposition", "attachment; filename=\"metadata.xml\"")
+		w.Write([]byte(result))
+	}
 }

--- a/api/context.go
+++ b/api/context.go
@@ -466,6 +466,11 @@ func RenderWebError(err *model.AppError, w http.ResponseWriter, r *http.Request)
 	link := "/"
 	linkMessage := T("api.templates.error.link")
 
+	status := http.StatusTemporaryRedirect
+	if err.StatusCode != http.StatusInternalServerError {
+		status = err.StatusCode
+	}
+
 	http.Redirect(
 		w,
 		r,
@@ -474,7 +479,7 @@ func RenderWebError(err *model.AppError, w http.ResponseWriter, r *http.Request)
 			"&details="+url.QueryEscape(details)+
 			"&link="+url.QueryEscape(link)+
 			"&linkmessage="+url.QueryEscape(linkMessage),
-		http.StatusTemporaryRedirect)
+		status)
 }
 
 func Handle404(w http.ResponseWriter, r *http.Request) {

--- a/api/saml.go
+++ b/api/saml.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api
+
+import (
+	"github.com/mattermost/platform/model"
+)
+
+func SaveCertificate(certificate string, certType int) *model.AppError {
+	saml := &model.SamlRecord{}
+	saml.Bytes = certificate
+	saml.Type = certType
+
+	rchan := Srv.Store.Saml().Save(saml)
+	if result := <-rchan; result.Err != nil {
+		return model.NewLocAppError("SaveCertificate", "api.saml.save_certificate.app_error", nil, "err="+result.Err.Error())
+	}
+
+	return nil
+}

--- a/config/config.json
+++ b/config/config.json
@@ -119,13 +119,13 @@
         "SupportEmail": "feedback@mattermost.com"
     },
     "GitLabSettings": {
-        "Enable": true,
-        "Secret": "44be6abdcc09c76cd336a48aec1d155fce48c120453d7f40667ede11c8af9a02",
-        "Id": "399bfdb2b96e5bc02578bf6fddbabf9c59faa03b7b7d6fa2c4c859216e6be8c2",
+        "Enable": false,
+        "Secret": "",
+        "Id": "",
         "Scope": "",
-        "AuthEndpoint": "http://parnasadev.com/oauth/authorize",
-        "TokenEndpoint": "http://parnasadev.com/oauth/token",
-        "UserApiEndpoint": "http://parnasadev.com/api/v3/user"
+        "AuthEndpoint": "",
+        "TokenEndpoint": "",
+        "UserApiEndpoint": ""
     },
     "GoogleSettings": {
         "Enable": false,

--- a/config/config.json
+++ b/config/config.json
@@ -119,13 +119,13 @@
         "SupportEmail": "feedback@mattermost.com"
     },
     "GitLabSettings": {
-        "Enable": false,
-        "Secret": "",
-        "Id": "",
+        "Enable": true,
+        "Secret": "44be6abdcc09c76cd336a48aec1d155fce48c120453d7f40667ede11c8af9a02",
+        "Id": "399bfdb2b96e5bc02578bf6fddbabf9c59faa03b7b7d6fa2c4c859216e6be8c2",
         "Scope": "",
-        "AuthEndpoint": "",
-        "TokenEndpoint": "",
-        "UserApiEndpoint": ""
+        "AuthEndpoint": "http://parnasadev.com/oauth/authorize",
+        "TokenEndpoint": "http://parnasadev.com/oauth/token",
+        "UserApiEndpoint": "http://parnasadev.com/api/v3/user"
     },
     "GoogleSettings": {
         "Enable": false,
@@ -165,5 +165,20 @@
         "DefaultServerLocale": "en",
         "DefaultClientLocale": "en",
         "AvailableLocales": ""
+    },
+    "SamlSettings": {
+        "Enable": false,
+        "Verify": false,
+        "Encrypt": false,
+        "IdpUrl": "",
+        "IdpDescriptorUrl": "",
+        "LoginButtonText": "",
+        "AssertionConsumerServiceURL": "",
+        "FirstNameAttribute": "",
+        "LastNameAttribute": "",
+        "EmailAttribute": "",
+        "UsernameAttribute": "",
+        "NicknameAttribute": "",
+        "LocaleAttribute": ""
     }
 }

--- a/einterfaces/saml.go
+++ b/einterfaces/saml.go
@@ -11,6 +11,7 @@ type SamlInterface interface {
 	ConfigureSP() *model.AppError
 	BuildRequest() (*model.SamlAuthRequest, *model.AppError)
 	DoLogin(encodedXML string) (*model.User, *model.AppError)
+	GetMetadata() (string, *model.AppError)
 }
 
 var theSamlInterface SamlInterface

--- a/einterfaces/saml.go
+++ b/einterfaces/saml.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package einterfaces
+
+import (
+	"github.com/mattermost/platform/model"
+)
+
+type SamlInterface interface {
+	ConfigureSP() *model.AppError
+	BuildRequest() (*model.SamlAuthRequest, *model.AppError)
+	DoLogin(encodedXML string) (*model.User, *model.AppError)
+}
+
+var theSamlInterface SamlInterface
+
+func RegisterSamlInterface(newInterface SamlInterface) {
+	theSamlInterface = newInterface
+}
+
+func GetSamlInterface() SamlInterface {
+	return theSamlInterface
+}

--- a/glide.lock
+++ b/glide.lock
@@ -42,6 +42,8 @@ imports:
   version: 9c19ed558d5df4da88e2ade9c8940d742aef0e7e
 - name: github.com/gorilla/websocket
   version: 1f512fc3f05332ba7117626cdfb4e07474e58e60
+  - name: github.com/kardianos/osext
+    version: 29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc
 - name: github.com/lib/pq
   version: ee1442bda7bd1b6a84e913bdb421cb1874ec629d
   subpackages:
@@ -61,6 +63,8 @@ imports:
   - i18n/bundle
   - i18n/language
   - i18n/translation
+- name: github.com/nu7hatch/gouuid
+  version: 179d4d0c4d8d407a32af483c2354df1d2c91e6c3
 - name: github.com/NYTimes/gziphandler
   version: 63027b26b87e2ae2ce3810393d4b81021cfd3a35
 - name: github.com/pborman/uuid

--- a/glide.yaml
+++ b/glide.yaml
@@ -39,3 +39,5 @@ import:
 - package: gopkg.in/throttled/throttled.v1
   subpackages:
   - store
+- package: github.com/kardianos/osext
+- package: github.com/nu7hatch/gouuid

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1100,6 +1100,10 @@
     "translation": "session.user_id={{.SessionUserId}}, preference.user_id={{.PreferenceUserId}}"
   },
   {
+    "id": "api.saml.save_certificate.app_error",
+    "translation": "Certificate did not save properly."
+  },
+  {
     "id": "api.server.new_server.init.info",
     "translation": "Server is initializing..."
   },
@@ -1796,6 +1800,10 @@
     "translation": "Trying to reset password for user on wrong team."
   },
   {
+    "id": "api.user.saml.not_available.app_error",
+    "translation": "SAML is not configured or supported on this server."
+  },
+  {
     "id": "api.user.send_email_change_email_and_forget.error",
     "translation": "Failed to send email change notification email successfully err=%v"
   },
@@ -2154,6 +2162,62 @@
   {
     "id": "ent.mfa.validate_token.authenticate.app_error",
     "translation": "Error trying to authenticate MFA token"
+  },
+  {
+    "id": "ent.saml.build_request.app_error",
+    "translation": "An error ocurred while building the request"
+  },
+  {
+    "id": "ent.saml.build_request.encoding.app_error",
+    "translation": "An error ocurred while encoding the request"
+  },
+  {
+    "id": "ent.saml.build_request.encoding_signed.app_error",
+    "translation": "An error ocurred while encoding the signed request"
+  },
+  {
+    "id": "ent.saml.configure.app_error",
+    "translation": "An error ocurred while configuring SAML Service Provider, err=%v"
+  },
+  {
+    "id": "ent.saml.configure.load_idp_certificate.app_error",
+    "translation": "An error ocurred while trying to load the Identity Provider Certificate."
+  },
+  {
+    "id": "ent.saml.configure.load_private_key.app_error",
+    "translation": "An error ocurred while trying to load the Service Provider Private Key."
+  },
+  {
+    "id": "ent.saml.configure.save_fs_idp_certificate.app_error",
+    "translation": "An error ocurred while saving the Identity Provider Certificate to disk."
+  },
+  {
+    "id": "ent.saml.configure.save_fs_private_key.app_error",
+    "translation": "An error ocurred while saving the Service Provider Private Key to disk."
+  },
+  {
+    "id": "ent.saml.do_login.decrypt.app_error",
+    "translation": "An error ocurred while decrypting the response from the Identity Provider"
+  },
+  {
+    "id": "ent.saml.do_login.empty_response.app_error",
+    "translation": "We received an empty response from the Identity Provider"
+  },
+  {
+    "id": "ent.saml.do_login.parse.app_error",
+    "translation": "An error ocurred while parsing the response from the Identity Provider"
+  },
+  {
+    "id": "ent.saml.do_login.validate.app_error",
+    "translation": "An error ocurred while validating the response from the Identity Provider"
+  },
+  {
+    "id": "ent.saml.license_disable.app_error",
+    "translation": "Your license does not support using SAML authentication"
+  },
+  {
+    "id": "ent.saml.update_saml_user.unable_error",
+    "translation": "Unable to update existing SAML user. Allowing login anyway. err=%v"
   },
   {
     "id": "error.generic.link_message",
@@ -2544,6 +2608,22 @@
     "translation": "Invalid direct message restriction.  Must be 'any', or 'team'"
   },
   {
+    "id": "model.config.is_valid.saml_assertion_consumer_service_url.app_error",
+    "translation": "Invalid Assertion Consumer Service URL for SAML settings. Must be set."
+  },
+  {
+    "id": "model.config.is_valid.saml_email_attribute.app_error",
+    "translation": "Invalid Email attribute for SAML settings. Must be set."
+  },
+  {
+    "id": "model.config.is_valid.saml_idp_descriptor_url.app_error",
+    "translation": "Invalid Identity Provider Descriptor URL for SAML settings. Must be set."
+  },
+  {
+    "id": "model.config.is_valid.saml_idp_url.app_error",
+    "translation": "Invalid Identity Provider URL for SAML settings. Must be set."
+  },
+  {
     "id": "model.config.is_valid.sql_data_src.app_error",
     "translation": "Invalid data source for SQL settings.  Must be set."
   },
@@ -2774,6 +2854,22 @@
   {
     "id": "model.preference.is_valid.value.app_error",
     "translation": "Value is too long"
+  },
+  {
+    "id": "model.saml_record.is_valid.bytes.app_error",
+    "translation": "Bytes must be a valid certificate"
+  },
+  {
+    "id": "model.saml_record.is_valid.create_at.app_error",
+    "translation": "Create at must be a valid time"
+  },
+  {
+    "id": "model.saml_record.is_valid.id.app_error",
+    "translation": "Invalid Id"
+  },
+  {
+    "id": "model.saml_record.is_valid.type.app_error",
+    "translation": "Type must be a certificate or a private key"
   },
   {
     "id": "model.team.is_valid.characters.app_error",
@@ -3524,6 +3620,22 @@
     "translation": "We couldn't update the preference"
   },
   {
+    "id": "store.sql_saml.get.app_error",
+    "translation": "Unable to get the SAML certificate"
+  },
+  {
+    "id": "store.sql_saml.save.app_error",
+    "translation": "An error while saving the SAML certificate"
+  },
+  {
+    "id": "store.sql_saml.save.update.app_error",
+    "translation": "We couldn't update the SAML certificate"
+  },
+  {
+    "id": "store.sql_saml.save.updating.app_error",
+    "translation": "We encountered an error updating the SAML certificate"
+  },
+  {
     "id": "store.sql_session.analytics_session_count.app_error",
     "translation": "We couldn't count the sessions"
   },
@@ -3768,6 +3880,10 @@
     "translation": "This account does not use LDAP authentication. Please sign in using email and password."
   },
   {
+    "id": "store.sql_user.save.email_exists.saml_app_error",
+    "translation": "This account does not use SAML authentication. Please sign in using email and password."
+  },
+  {
     "id": "store.sql_user.save.existing.app_error",
     "translation": "Must call update for exisiting user"
   },
@@ -3785,6 +3901,10 @@
   },
   {
     "id": "store.sql_user.save.username_exists.ldap_app_error",
+    "translation": "An account with that username already exists. Please contact your Administrator."
+  },
+  {
+    "id": "store.sql_user.save.username_exists.saml_app_error",
     "translation": "An account with that username already exists. Please contact your Administrator."
   },
   {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -72,6 +72,10 @@
     "translation": "Attempting to recycle the database connection"
   },
   {
+    "id": "api.admin.saml.metadata.app_error",
+    "translation": "An error occurred while building Service Provider Metadata"
+  },
+  {
     "id": "api.admin.test_email.body",
     "translation": "<br/><br/><br/>It appears your Mattermost email is setup correctly!"
   },
@@ -2165,39 +2169,47 @@
   },
   {
     "id": "ent.saml.build_request.app_error",
-    "translation": "An error ocurred while building the request"
+    "translation": "An error occurred while building the request"
   },
   {
     "id": "ent.saml.build_request.encoding.app_error",
-    "translation": "An error ocurred while encoding the request"
+    "translation": "An error occurred while encoding the request"
   },
   {
     "id": "ent.saml.build_request.encoding_signed.app_error",
-    "translation": "An error ocurred while encoding the signed request"
+    "translation": "An error occurred while encoding the signed request"
   },
   {
     "id": "ent.saml.configure.app_error",
-    "translation": "An error ocurred while configuring SAML Service Provider, err=%v"
+    "translation": "An error occurred while configuring SAML Service Provider, err=%v"
   },
   {
     "id": "ent.saml.configure.load_idp_certificate.app_error",
-    "translation": "An error ocurred while trying to load the Identity Provider Certificate."
+    "translation": "An error occurred while trying to load the Identity Provider Certificate."
   },
   {
     "id": "ent.saml.configure.load_private_key.app_error",
-    "translation": "An error ocurred while trying to load the Service Provider Private Key."
+    "translation": "An error occurred while trying to load the Service Provider Private Key."
+  },
+  {
+    "id": "ent.saml.configure.load_pub_certificate.app_error",
+    "translation": "An error occurred while trying to load the Service Provider Certificate."
   },
   {
     "id": "ent.saml.configure.save_fs_idp_certificate.app_error",
-    "translation": "An error ocurred while saving the Identity Provider Certificate to disk."
+    "translation": "An error occurred while saving the Identity Provider Certificate to disk."
   },
   {
     "id": "ent.saml.configure.save_fs_private_key.app_error",
-    "translation": "An error ocurred while saving the Service Provider Private Key to disk."
+    "translation": "An error occurred while saving the Service Provider Private Key to disk."
+  },
+  {
+    "id": "ent.saml.configure.save_fs_pub_certificate.app_error",
+    "translation": "An error occurred while saving the Identity Service Certificate to disk."
   },
   {
     "id": "ent.saml.do_login.decrypt.app_error",
-    "translation": "An error ocurred while decrypting the response from the Identity Provider"
+    "translation": "An error occurred while decrypting the response from the Identity Provider"
   },
   {
     "id": "ent.saml.do_login.empty_response.app_error",
@@ -2205,15 +2217,19 @@
   },
   {
     "id": "ent.saml.do_login.parse.app_error",
-    "translation": "An error ocurred while parsing the response from the Identity Provider"
+    "translation": "An error occurred while parsing the response from the Identity Provider"
   },
   {
     "id": "ent.saml.do_login.validate.app_error",
-    "translation": "An error ocurred while validating the response from the Identity Provider"
+    "translation": "An error occurred while validating the response from the Identity Provider"
   },
   {
     "id": "ent.saml.license_disable.app_error",
     "translation": "Your license does not support using SAML authentication"
+  },
+  {
+    "id": "ent.saml.metadata.app_error",
+    "translation": "An error occurred while building Service Provider Metadata"
   },
   {
     "id": "ent.saml.update_saml_user.unable_error",

--- a/mattermost.go
+++ b/mattermost.go
@@ -58,8 +58,12 @@ var flagCmdResetDatabase bool
 var flagCmdRunLdapSync bool
 var flagUsername string
 var flagCmdUploadLicense bool
+var flagCmdUploadIdentityProviderCert bool
+var flagCmdUploadSamlPrivateKey bool
 var flagConfigFile string
 var flagLicenseFile string
+var flagCertificateFile string
+var flagPrivateKeyFile string
 var flagEmail string
 var flagPassword string
 var flagTeamName string
@@ -267,6 +271,8 @@ func parseCmds() {
 	flag.StringVar(&flagSiteURL, "site_url", "", "")
 	flag.StringVar(&flagConfirmBackup, "confirm_backup", "", "")
 	flag.StringVar(&flagRole, "role", "", "")
+	flag.StringVar(&flagCertificateFile, "certificate", "", "")
+	flag.StringVar(&flagPrivateKeyFile, "privkey", "", "")
 
 	flag.BoolVar(&flagCmdUpdateDb30, "upgrade_db_30", false, "")
 	flag.BoolVar(&flagCmdCreateTeam, "create_team", false, "")
@@ -285,6 +291,8 @@ func parseCmds() {
 	flag.BoolVar(&flagCmdResetDatabase, "reset_database", false, "")
 	flag.BoolVar(&flagCmdRunLdapSync, "ldap_sync", false, "")
 	flag.BoolVar(&flagCmdUploadLicense, "upload_license", false, "")
+	flag.BoolVar(&flagCmdUploadIdentityProviderCert, "idp_cert", false, "")
+	flag.BoolVar(&flagCmdUploadSamlPrivateKey, "saml_key", false, "")
 
 	flag.Parse()
 
@@ -303,7 +311,9 @@ func parseCmds() {
 		flagCmdPermanentDeleteAllUsers ||
 		flagCmdResetDatabase ||
 		flagCmdRunLdapSync ||
-		flagCmdUploadLicense)
+		flagCmdUploadLicense ||
+		flagCmdUploadIdentityProviderCert ||
+		flagCmdUploadSamlPrivateKey)
 }
 
 func runCmds() {
@@ -322,6 +332,8 @@ func runCmds() {
 	cmdResetDatabase()
 	cmdUploadLicense()
 	cmdRunLdapSync()
+	cmdUploadIdentityProviderCert()
+	cmdUploadSamlPrivateKey()
 }
 
 type TeamForUpgrade struct {
@@ -1216,6 +1228,68 @@ func cmdUploadLicense() {
 	}
 }
 
+func cmdUploadIdentityProviderCert() {
+	if flagCmdUploadIdentityProviderCert {
+		if model.BuildEnterpriseReady != "true" {
+			fmt.Fprintln(os.Stderr, "build must be enterprise ready")
+			os.Exit(1)
+		}
+
+		if len(flagCertificateFile) == 0 {
+			fmt.Fprintln(os.Stderr, "flag needs an argument: -certificate")
+			flag.Usage()
+			os.Exit(1)
+		}
+
+		var fileBytes []byte
+		var err error
+		if fileBytes, err = ioutil.ReadFile(flagCertificateFile); err != nil {
+			l4g.Error("%v", err)
+			flushLogAndExit(1)
+		}
+
+		if err := api.SaveCertificate(string(fileBytes), model.SAML_IDP_CERTIFICATE); err != nil {
+			l4g.Error("%v", err)
+			flushLogAndExit(1)
+		} else {
+			flushLogAndExit(0)
+		}
+
+		flushLogAndExit(0)
+	}
+}
+
+func cmdUploadSamlPrivateKey() {
+	if flagCmdUploadSamlPrivateKey {
+		if model.BuildEnterpriseReady != "true" {
+			fmt.Fprintln(os.Stderr, "build must be enterprise ready")
+			os.Exit(1)
+		}
+
+		if len(flagPrivateKeyFile) == 0 {
+			fmt.Fprintln(os.Stderr, "flag needs an argument: -privkey")
+			flag.Usage()
+			os.Exit(1)
+		}
+
+		var fileBytes []byte
+		var err error
+		if fileBytes, err = ioutil.ReadFile(flagPrivateKeyFile); err != nil {
+			l4g.Error("%v", err)
+			flushLogAndExit(1)
+		}
+
+		if err := api.SaveCertificate(string(fileBytes), model.SAML_PRIVATE_KEY); err != nil {
+			l4g.Error("%v", err)
+			flushLogAndExit(1)
+		} else {
+			flushLogAndExit(0)
+		}
+
+		flushLogAndExit(0)
+	}
+}
+
 func flushLogAndExit(code int) {
 	l4g.Close()
 	time.Sleep(time.Second)
@@ -1245,6 +1319,10 @@ FLAGS:
     -username="someuser"              Username used in other commands
 
     -license="ex.mattermost-license"  Path to your license file
+
+    -certificate="mattermost.crt"     Path to your certificate file
+
+    -privkey="mattermost.key"	      Path to your private key file
 
     -email="user@example.com"         Email address used in other commands
 
@@ -1332,6 +1410,18 @@ COMMANDS:
 
         Example:
             platform -upload_license -license="/path/to/license/example.mattermost-license"
+
+    -idp_cert			      Uploads a public certificate to be use for SAML authentication.
+    				      Requires the -certificate flag.
+
+     	Example:
+     	    platform -idp_cert -certificate="/path/to/public/certificate/mattermost.crt"
+
+    -saml_key			      Uploads a private key certificate to be use for SAML
+    				      authentication decryption. Requires the -privkey flag.
+
+     	Example:
+     	    platform -saml_key -privkey="/path/to/private/key/certificate/mattermost.key"
 
     -upgrade_db_30                   Upgrades the database from a version 2.x schema to version 3 see
                                       http://www.mattermost.org/upgrading-to-mattermost-3-0/

--- a/mattermost.go
+++ b/mattermost.go
@@ -141,6 +141,10 @@ func main() {
 			ldapI.StartLdapSyncJob()
 		}
 
+		if samlI := einterfaces.GetSamlInterface(); samlI != nil {
+			samlI.ConfigureSP()
+		}
+
 		// wait for kill signal before attempting to gracefully shutdown
 		// the running service
 		c := make(chan os.Signal)

--- a/model/config.go
+++ b/model/config.go
@@ -220,6 +220,25 @@ type LocalizationSettings struct {
 	AvailableLocales    *string
 }
 
+type SamlSettings struct {
+	// Basic
+	Enable                      *bool
+	Verify                      *bool
+	Encrypt                     *bool
+	IdpUrl                      *string
+	IdpDescriptorUrl            *string
+	LoginButtonText             *string
+	AssertionConsumerServiceURL *string
+
+	// User Mapping
+	FirstNameAttribute *string
+	LastNameAttribute  *string
+	EmailAttribute     *string
+	UsernameAttribute  *string
+	NicknameAttribute  *string
+	LocaleAttribute    *string
+}
+
 type Config struct {
 	ServiceSettings      ServiceSettings
 	TeamSettings         TeamSettings
@@ -235,6 +254,7 @@ type Config struct {
 	LdapSettings         LdapSettings
 	ComplianceSettings   ComplianceSettings
 	LocalizationSettings LocalizationSettings
+	SamlSettings         SamlSettings
 }
 
 func (o *Config) ToJson() string {
@@ -605,6 +625,66 @@ func (o *Config) SetDefaults() {
 		o.LocalizationSettings.AvailableLocales = new(string)
 		*o.LocalizationSettings.AvailableLocales = ""
 	}
+
+	if o.SamlSettings.Enable == nil {
+		o.SamlSettings.Enable = new(bool)
+		*o.SamlSettings.Enable = false
+	}
+
+	if o.SamlSettings.Verify == nil {
+		o.SamlSettings.Verify = new(bool)
+		*o.SamlSettings.Verify = false
+	}
+
+	if o.SamlSettings.Encrypt == nil {
+		o.SamlSettings.Encrypt = new(bool)
+		*o.SamlSettings.Encrypt = false
+	}
+
+	if o.SamlSettings.IdpUrl == nil {
+		o.SamlSettings.IdpUrl = new(string)
+		*o.SamlSettings.IdpUrl = ""
+	}
+
+	if o.SamlSettings.IdpDescriptorUrl == nil {
+		o.SamlSettings.IdpDescriptorUrl = new(string)
+		*o.SamlSettings.IdpDescriptorUrl = ""
+	}
+
+	if o.SamlSettings.AssertionConsumerServiceURL == nil {
+		o.SamlSettings.AssertionConsumerServiceURL = new(string)
+		*o.SamlSettings.AssertionConsumerServiceURL = ""
+	}
+
+	if o.SamlSettings.LoginButtonText == nil {
+		o.SamlSettings.LoginButtonText = new(string)
+		*o.SamlSettings.LoginButtonText = USER_AUTH_SERVICE_SAML_TEXT
+	}
+
+	if o.SamlSettings.FirstNameAttribute == nil {
+		o.SamlSettings.FirstNameAttribute = new(string)
+		*o.SamlSettings.FirstNameAttribute = ""
+	}
+
+	if o.SamlSettings.LastNameAttribute == nil {
+		o.SamlSettings.LastNameAttribute = new(string)
+		*o.SamlSettings.LastNameAttribute = ""
+	}
+
+	if o.SamlSettings.EmailAttribute == nil {
+		o.SamlSettings.EmailAttribute = new(string)
+		*o.SamlSettings.EmailAttribute = ""
+	}
+
+	if o.SamlSettings.NicknameAttribute == nil {
+		o.SamlSettings.NicknameAttribute = new(string)
+		*o.SamlSettings.NicknameAttribute = ""
+	}
+
+	if o.SamlSettings.LocaleAttribute == nil {
+		o.SamlSettings.LocaleAttribute = new(string)
+		*o.SamlSettings.LocaleAttribute = ""
+	}
 }
 
 func (o *Config) IsValid() *AppError {
@@ -707,6 +787,26 @@ func (o *Config) IsValid() *AppError {
 
 	if *o.LdapSettings.SyncIntervalMinutes <= 0 {
 		return NewLocAppError("Config.IsValid", "model.config.is_valid.ldap_sync_interval.app_error", nil, "")
+	}
+
+	if *o.SamlSettings.Enable {
+		if len(*o.SamlSettings.EmailAttribute) == 0 {
+			return NewLocAppError("Config.IsValid", "model.config.is_valid.saml_email_attribute.app_error", nil, "")
+		}
+
+		if len(*o.SamlSettings.IdpUrl) == 0 {
+			return NewLocAppError("Config.IsValid", "model.config.is_valid.saml_idp_url.app_error", nil, "")
+		}
+
+		if len(*o.SamlSettings.IdpDescriptorUrl) == 0 {
+			return NewLocAppError("Config.IsValid", "model.config.is_valid.saml_idp_descriptor_url.app_error", nil, "")
+		}
+
+		if *o.SamlSettings.Verify {
+			if len(*o.SamlSettings.AssertionConsumerServiceURL) == 0 {
+				return NewLocAppError("Config.IsValid", "model.config.is_valid.saml_assertion_consumer_service_url.app_error", nil, "")
+			}
+		}
 	}
 
 	return nil

--- a/model/license.go
+++ b/model/license.go
@@ -39,6 +39,7 @@ type Features struct {
 	Compliance     *bool `json:"compliance"`
 	CustomBrand    *bool `json:"custom_brand"`
 	MHPNS          *bool `json:"mhpns"`
+	SAML           *bool `json:"saml"`
 	FutureFeatures *bool `json:"future_features"`
 }
 
@@ -81,6 +82,11 @@ func (f *Features) SetDefaults() {
 	if f.MHPNS == nil {
 		f.MHPNS = new(bool)
 		*f.MHPNS = *f.FutureFeatures
+	}
+
+	if f.SAML == nil {
+		f.SAML = new(bool)
+		*f.SAML = *f.FutureFeatures
 	}
 }
 

--- a/model/saml.go
+++ b/model/saml.go
@@ -9,3 +9,38 @@ const (
 	SAML_IDP_CERTIFICATE        = 1
 	SAML_PRIVATE_KEY            = 2
 )
+
+type SamlRecord struct {
+	Id       string `json:"id"`
+	CreateAt int64  `json:"create_at"`
+	Bytes    string `json:"-"`
+	Type     int    `json:"type"`
+}
+
+func (sr *SamlRecord) IsValid() *AppError {
+	if len(sr.Id) != 26 {
+		return NewLocAppError("SamlRecord.IsValid", "model.saml_record.is_valid.id.app_error", nil, "")
+	}
+
+	if sr.CreateAt == 0 {
+		return NewLocAppError("SamlRecord.IsValid", "model.saml_record.is_valid.create_at.app_error", nil, "")
+	}
+
+	if len(sr.Bytes) == 0 || len(sr.Bytes) > 10000 {
+		return NewLocAppError("SamlRecord.IsValid", "model.saml_record.is_valid.bytes.app_error", nil, "")
+	}
+
+	if sr.Type != SAML_IDP_CERTIFICATE && sr.Type != SAML_PRIVATE_KEY {
+		return NewLocAppError("SamlRecord.IsValid", "model.saml_record.is_valid.type.app_error", nil, "")
+	}
+
+	return nil
+}
+
+func (sr *SamlRecord) PreSave() {
+	if sr.Id == "" {
+		sr.Id = NewId()
+	}
+
+	sr.CreateAt = GetMillis()
+}

--- a/model/saml.go
+++ b/model/saml.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+const (
+	USER_AUTH_SERVICE_SAML      = "saml"
+	USER_AUTH_SERVICE_SAML_TEXT = "With SAML"
+	SAML_IDP_CERTIFICATE        = 1
+	SAML_PRIVATE_KEY            = 2
+)

--- a/model/saml.go
+++ b/model/saml.go
@@ -10,6 +10,11 @@ const (
 	SAML_PRIVATE_KEY            = 2
 )
 
+type SamlAuthRequest struct {
+	Base64AuthRequest string
+	URL               string
+}
+
 type SamlRecord struct {
 	Id       string `json:"id"`
 	CreateAt int64  `json:"create_at"`

--- a/model/saml.go
+++ b/model/saml.go
@@ -8,6 +8,7 @@ const (
 	USER_AUTH_SERVICE_SAML_TEXT = "With SAML"
 	SAML_IDP_CERTIFICATE        = 1
 	SAML_PRIVATE_KEY            = 2
+	SAML_PUBLIC_CERT            = 3
 )
 
 type SamlAuthRequest struct {
@@ -35,7 +36,7 @@ func (sr *SamlRecord) IsValid() *AppError {
 		return NewLocAppError("SamlRecord.IsValid", "model.saml_record.is_valid.bytes.app_error", nil, "")
 	}
 
-	if sr.Type != SAML_IDP_CERTIFICATE && sr.Type != SAML_PRIVATE_KEY {
+	if sr.Type != SAML_IDP_CERTIFICATE && sr.Type != SAML_PRIVATE_KEY && sr.Type != SAML_PUBLIC_CERT {
 		return NewLocAppError("SamlRecord.IsValid", "model.saml_record.is_valid.type.app_error", nil, "")
 	}
 

--- a/store/sql_saml_store.go
+++ b/store/sql_saml_store.go
@@ -45,10 +45,13 @@ func (ss SqlSamlStore) Save(saml *model.SamlRecord) StoreChannel {
 
 		var oldRecord *model.SamlRecord
 		var certType string
-		if saml.Type == model.SAML_IDP_CERTIFICATE {
+		switch saml.Type {
+		case model.SAML_IDP_CERTIFICATE:
 			certType = "IDP CERTIFICATE"
-		} else {
+		case model.SAML_PRIVATE_KEY:
 			certType = "PRIVATE KEY"
+		default:
+			certType = "PUBLIC CERTIFICATE"
 		}
 
 		// Insert or update depending if it exists or not
@@ -85,10 +88,13 @@ func (ss SqlSamlStore) Get(certType int) StoreChannel {
 
 		var samlRecord *model.SamlRecord
 		var certTypeStr string
-		if certType == model.SAML_IDP_CERTIFICATE {
+		switch certType {
+		case model.SAML_IDP_CERTIFICATE:
 			certTypeStr = "SAML IDP CERTIFICATE"
-		} else {
+		case model.SAML_PRIVATE_KEY:
 			certTypeStr = "SAML PRIVATE KEY"
+		default:
+			certTypeStr = "SAML PUBLIC CERTIFICATE"
 		}
 
 		if err := ss.GetReplica().SelectOne(&samlRecord, "SELECT * FROM Saml WHERE Type = :Type", map[string]interface{}{"Type": certType}); err != nil {

--- a/store/sql_saml_store.go
+++ b/store/sql_saml_store.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package store
+
+import (
+	"github.com/mattermost/platform/model"
+)
+
+type SqlSamlStore struct {
+	*SqlStore
+}
+
+func NewSqlSamlStore(sqlStore *SqlStore) SamlStore {
+	ss := &SqlSamlStore{sqlStore}
+
+	for _, db := range sqlStore.GetAllConns() {
+		table := db.AddTableWithName(model.SamlRecord{}, "Saml").SetKeys(false, "Id")
+		table.ColMap("Id").SetMaxSize(26)
+		table.ColMap("Bytes").SetMaxSize(10000)
+	}
+
+	return ss
+}
+
+func (ss SqlSamlStore) UpgradeSchemaIfNeeded() {
+}
+
+func (ss SqlSamlStore) CreateIndexesIfNotExists() {
+}
+
+func (ss SqlSamlStore) Save(saml *model.SamlRecord) StoreChannel {
+
+	storeChannel := make(StoreChannel)
+
+	go func() {
+		result := StoreResult{}
+
+		saml.PreSave()
+		if result.Err = saml.IsValid(); result.Err != nil {
+			storeChannel <- result
+			close(storeChannel)
+			return
+		}
+
+		var oldRecord *model.SamlRecord
+
+		// Insert or update depending if it exists or not
+		if err := ss.GetReplica().SelectOne(&oldRecord, "SELECT * FROM Saml WHERE Type = :Type", map[string]interface{}{"Type": saml.Type}); err != nil {
+			if err := ss.GetMaster().Insert(saml); err != nil {
+				var certType string
+				if saml.Type == model.SAML_IDP_CERTIFICATE {
+					certType = "SAML IDP CERTIFICATE"
+				} else {
+					certType = "SAML PRIVATE KEY"
+				}
+				result.Err = model.NewLocAppError("SqlSamlStore.Save", "store.sql_saml.save.app_error", nil, "saml_type="+certType+", "+err.Error())
+			} else {
+				result.Data = saml
+			}
+		} else {
+			saml.Id = oldRecord.Id
+			if count, err := ss.GetMaster().Update(saml); err != nil {
+				result.Err = model.NewLocAppError("SqlSamlStore.Save", "store.sql_saml.update_app.updating.app_error", nil, "app_id="+saml.Id+", "+err.Error())
+			} else if count != 1 {
+				result.Err = model.NewLocAppError("SqlSamlStore.Save", "store.sql_saml.update_app.update.app_error", nil, "app_id="+saml.Id)
+			} else {
+				result.Data = saml
+			}
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (ss SqlSamlStore) Get(certType int) StoreChannel {
+
+	storeChannel := make(StoreChannel)
+
+	go func() {
+		result := StoreResult{}
+
+		var samlRecord *model.SamlRecord
+		var certTypeStr string
+		if certType == model.SAML_IDP_CERTIFICATE {
+			certTypeStr = "SAML IDP CERTIFICATE"
+		} else {
+			certTypeStr = "SAML PRIVATE KEY"
+		}
+
+		if err := ss.GetReplica().SelectOne(&samlRecord, "SELECT * FROM Saml WHERE Type = :Type", map[string]interface{}{"Type": certType}); err != nil {
+			result.Err = model.NewLocAppError("SqlSamlStore.Get", "store.sql_saml.get.app_error", nil, "cert="+certTypeStr+", "+err.Error())
+		} else {
+			result.Data = samlRecord
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+
+	}()
+
+	return storeChannel
+}

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -53,6 +53,7 @@ type SqlStore struct {
 	license       LicenseStore
 	recovery      PasswordRecoveryStore
 	emoji         EmojiStore
+	saml          SamlStore
 	SchemaVersion string
 }
 
@@ -129,6 +130,7 @@ func NewSqlStore() Store {
 	sqlStore.license = NewSqlLicenseStore(sqlStore)
 	sqlStore.recovery = NewSqlPasswordRecoveryStore(sqlStore)
 	sqlStore.emoji = NewSqlEmojiStore(sqlStore)
+	sqlStore.saml = NewSqlSamlStore(sqlStore)
 
 	err := sqlStore.master.CreateTablesIfNotExists()
 	if err != nil {
@@ -152,6 +154,7 @@ func NewSqlStore() Store {
 	sqlStore.license.(*SqlLicenseStore).UpgradeSchemaIfNeeded()
 	sqlStore.recovery.(*SqlPasswordRecoveryStore).UpgradeSchemaIfNeeded()
 	sqlStore.emoji.(*SqlEmojiStore).UpgradeSchemaIfNeeded()
+	sqlStore.saml.(*SqlSamlStore).UpgradeSchemaIfNeeded()
 
 	sqlStore.team.(*SqlTeamStore).CreateIndexesIfNotExists()
 	sqlStore.channel.(*SqlChannelStore).CreateIndexesIfNotExists()
@@ -168,6 +171,7 @@ func NewSqlStore() Store {
 	sqlStore.license.(*SqlLicenseStore).CreateIndexesIfNotExists()
 	sqlStore.recovery.(*SqlPasswordRecoveryStore).CreateIndexesIfNotExists()
 	sqlStore.emoji.(*SqlEmojiStore).CreateIndexesIfNotExists()
+	sqlStore.saml.(*SqlSamlStore).CreateIndexesIfNotExists()
 
 	sqlStore.preference.(*SqlPreferenceStore).DeleteUnusedFeatures()
 
@@ -694,6 +698,10 @@ func (ss SqlStore) PasswordRecovery() PasswordRecoveryStore {
 
 func (ss SqlStore) Emoji() EmojiStore {
 	return ss.emoji
+}
+
+func (ss SqlStore) Saml() SamlStore {
+	return ss.saml
 }
 
 func (ss SqlStore) DropAllTables() {

--- a/store/store.go
+++ b/store/store.go
@@ -43,6 +43,7 @@ type Store interface {
 	License() LicenseStore
 	PasswordRecovery() PasswordRecoveryStore
 	Emoji() EmojiStore
+	Saml() SamlStore
 	MarkSystemRanUnitTests()
 	Close()
 	DropAllTables()
@@ -262,4 +263,9 @@ type EmojiStore interface {
 	GetByName(name string) StoreChannel
 	GetAll() StoreChannel
 	Delete(id string, time int64) StoreChannel
+}
+
+type SamlStore interface {
+	Save(saml *model.SamlRecord) StoreChannel
+	Get(certType int) StoreChannel
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -272,6 +272,11 @@ func getClientConfig(c *model.Config) map[string]string {
 		if *License.Features.Compliance {
 			props["EnableCompliance"] = strconv.FormatBool(*c.ComplianceSettings.Enable)
 		}
+
+		if *License.Features.SAML {
+			props["EnableSaml"] = strconv.FormatBool(*c.SamlSettings.Enable)
+			props["SamlLoginButtonText"] = *c.SamlSettings.LoginButtonText
+		}
 	}
 
 	return props

--- a/vendor/github.com/kardianos/osext/LICENSE
+++ b/vendor/github.com/kardianos/osext/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/kardianos/osext/README.md
+++ b/vendor/github.com/kardianos/osext/README.md
@@ -1,0 +1,16 @@
+### Extensions to the "os" package.
+
+## Find the current Executable and ExecutableFolder.
+
+There is sometimes utility in finding the current executable file
+that is running. This can be used for upgrading the current executable
+or finding resources located relative to the executable file. Both
+working directory and the os.Args[0] value are arbitrary and cannot
+be relied on; os.Args[0] can be "faked".
+
+Multi-platform and supports:
+ * Linux
+ * OS X
+ * Windows
+ * Plan 9
+ * BSDs.

--- a/vendor/github.com/kardianos/osext/osext.go
+++ b/vendor/github.com/kardianos/osext/osext.go
@@ -1,0 +1,33 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Extensions to the standard "os" package.
+package osext // import "github.com/kardianos/osext"
+
+import "path/filepath"
+
+var cx, ce = executableClean()
+
+func executableClean() (string, error) {
+	p, err := executable()
+	return filepath.Clean(p), err
+}
+
+// Executable returns an absolute path that can be used to
+// re-invoke the current program.
+// It may not be valid after the current program exits.
+func Executable() (string, error) {
+	return cx, ce
+}
+
+// Returns same path as Executable, returns just the folder
+// path. Excludes the executable name and any trailing slash.
+func ExecutableFolder() (string, error) {
+	p, err := Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Dir(p), nil
+}

--- a/vendor/github.com/kardianos/osext/osext_plan9.go
+++ b/vendor/github.com/kardianos/osext/osext_plan9.go
@@ -1,0 +1,20 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package osext
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+func executable() (string, error) {
+	f, err := os.Open("/proc/" + strconv.Itoa(os.Getpid()) + "/text")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return syscall.Fd2path(int(f.Fd()))
+}

--- a/vendor/github.com/kardianos/osext/osext_procfs.go
+++ b/vendor/github.com/kardianos/osext/osext_procfs.go
@@ -1,0 +1,36 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux netbsd solaris dragonfly
+
+package osext
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+func executable() (string, error) {
+	switch runtime.GOOS {
+	case "linux":
+		const deletedTag = " (deleted)"
+		execpath, err := os.Readlink("/proc/self/exe")
+		if err != nil {
+			return execpath, err
+		}
+		execpath = strings.TrimSuffix(execpath, deletedTag)
+		execpath = strings.TrimPrefix(execpath, deletedTag)
+		return execpath, nil
+	case "netbsd":
+		return os.Readlink("/proc/curproc/exe")
+	case "dragonfly":
+		return os.Readlink("/proc/curproc/file")
+	case "solaris":
+		return os.Readlink(fmt.Sprintf("/proc/%d/path/a.out", os.Getpid()))
+	}
+	return "", errors.New("ExecPath not implemented for " + runtime.GOOS)
+}

--- a/vendor/github.com/kardianos/osext/osext_sysctl.go
+++ b/vendor/github.com/kardianos/osext/osext_sysctl.go
@@ -1,0 +1,126 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin freebsd openbsd
+
+package osext
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+var initCwd, initCwdErr = os.Getwd()
+
+func executable() (string, error) {
+	var mib [4]int32
+	switch runtime.GOOS {
+	case "freebsd":
+		mib = [4]int32{1 /* CTL_KERN */, 14 /* KERN_PROC */, 12 /* KERN_PROC_PATHNAME */, -1}
+	case "darwin":
+		mib = [4]int32{1 /* CTL_KERN */, 38 /* KERN_PROCARGS */, int32(os.Getpid()), -1}
+	case "openbsd":
+		mib = [4]int32{1 /* CTL_KERN */, 55 /* KERN_PROC_ARGS */, int32(os.Getpid()), 1 /* KERN_PROC_ARGV */}
+	}
+
+	n := uintptr(0)
+	// Get length.
+	_, _, errNum := syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, 0, uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+	buf := make([]byte, n)
+	_, _, errNum = syscall.Syscall6(syscall.SYS___SYSCTL, uintptr(unsafe.Pointer(&mib[0])), 4, uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&n)), 0, 0)
+	if errNum != 0 {
+		return "", errNum
+	}
+	if n == 0 { // This shouldn't happen.
+		return "", nil
+	}
+
+	var execPath string
+	switch runtime.GOOS {
+	case "openbsd":
+		// buf now contains **argv, with pointers to each of the C-style
+		// NULL terminated arguments.
+		var args []string
+		argv := uintptr(unsafe.Pointer(&buf[0]))
+	Loop:
+		for {
+			argp := *(**[1 << 20]byte)(unsafe.Pointer(argv))
+			if argp == nil {
+				break
+			}
+			for i := 0; uintptr(i) < n; i++ {
+				// we don't want the full arguments list
+				if string(argp[i]) == " " {
+					break Loop
+				}
+				if argp[i] != 0 {
+					continue
+				}
+				args = append(args, string(argp[:i]))
+				n -= uintptr(i)
+				break
+			}
+			if n < unsafe.Sizeof(argv) {
+				break
+			}
+			argv += unsafe.Sizeof(argv)
+			n -= unsafe.Sizeof(argv)
+		}
+		execPath = args[0]
+		// There is no canonical way to get an executable path on
+		// OpenBSD, so check PATH in case we are called directly
+		if execPath[0] != '/' && execPath[0] != '.' {
+			execIsInPath, err := exec.LookPath(execPath)
+			if err == nil {
+				execPath = execIsInPath
+			}
+		}
+	default:
+		for i, v := range buf {
+			if v == 0 {
+				buf = buf[:i]
+				break
+			}
+		}
+		execPath = string(buf)
+	}
+
+	var err error
+	// execPath will not be empty due to above checks.
+	// Try to get the absolute path if the execPath is not rooted.
+	if execPath[0] != '/' {
+		execPath, err = getAbs(execPath)
+		if err != nil {
+			return execPath, err
+		}
+	}
+	// For darwin KERN_PROCARGS may return the path to a symlink rather than the
+	// actual executable.
+	if runtime.GOOS == "darwin" {
+		if execPath, err = filepath.EvalSymlinks(execPath); err != nil {
+			return execPath, err
+		}
+	}
+	return execPath, nil
+}
+
+func getAbs(execPath string) (string, error) {
+	if initCwdErr != nil {
+		return execPath, initCwdErr
+	}
+	// The execPath may begin with a "../" or a "./" so clean it first.
+	// Join the two paths, trailing and starting slashes undetermined, so use
+	// the generic Join function.
+	return filepath.Join(initCwd, filepath.Clean(execPath)), nil
+}

--- a/vendor/github.com/kardianos/osext/osext_test.go
+++ b/vendor/github.com/kardianos/osext/osext_test.go
@@ -1,0 +1,203 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin linux freebsd netbsd windows openbsd
+
+package osext
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const (
+	executableEnvVar = "OSTEST_OUTPUT_EXECUTABLE"
+
+	executableEnvValueMatch  = "match"
+	executableEnvValueDelete = "delete"
+)
+
+func TestPrintExecutable(t *testing.T) {
+	ef, err := Executable()
+	if err != nil {
+		t.Fatalf("Executable failed: %v", err)
+	}
+	t.Log("Executable:", ef)
+}
+func TestPrintExecutableFolder(t *testing.T) {
+	ef, err := ExecutableFolder()
+	if err != nil {
+		t.Fatalf("ExecutableFolder failed: %v", err)
+	}
+	t.Log("Executable Folder:", ef)
+}
+func TestExecutableFolder(t *testing.T) {
+	ef, err := ExecutableFolder()
+	if err != nil {
+		t.Fatalf("ExecutableFolder failed: %v", err)
+	}
+	if ef[len(ef)-1] == filepath.Separator {
+		t.Fatal("ExecutableFolder ends with a trailing slash.")
+	}
+}
+func TestExecutableMatch(t *testing.T) {
+	ep, err := Executable()
+	if err != nil {
+		t.Fatalf("Executable failed: %v", err)
+	}
+
+	// fullpath to be of the form "dir/prog".
+	dir := filepath.Dir(filepath.Dir(ep))
+	fullpath, err := filepath.Rel(dir, ep)
+	if err != nil {
+		t.Fatalf("filepath.Rel: %v", err)
+	}
+	// Make child start with a relative program path.
+	// Alter argv[0] for child to verify getting real path without argv[0].
+	cmd := &exec.Cmd{
+		Dir:  dir,
+		Path: fullpath,
+		Env:  []string{fmt.Sprintf("%s=%s", executableEnvVar, executableEnvValueMatch)},
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("exec(self) failed: %v", err)
+	}
+	outs := string(out)
+	if !filepath.IsAbs(outs) {
+		t.Fatalf("Child returned %q, want an absolute path", out)
+	}
+	if !sameFile(outs, ep) {
+		t.Fatalf("Child returned %q, not the same file as %q", out, ep)
+	}
+}
+
+func TestExecutableDelete(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip()
+	}
+	fpath, err := Executable()
+	if err != nil {
+		t.Fatalf("Executable failed: %v", err)
+	}
+
+	r, w := io.Pipe()
+	stderrBuff := &bytes.Buffer{}
+	stdoutBuff := &bytes.Buffer{}
+	cmd := &exec.Cmd{
+		Path:   fpath,
+		Env:    []string{fmt.Sprintf("%s=%s", executableEnvVar, executableEnvValueDelete)},
+		Stdin:  r,
+		Stderr: stderrBuff,
+		Stdout: stdoutBuff,
+	}
+	err = cmd.Start()
+	if err != nil {
+		t.Fatalf("exec(self) start failed: %v", err)
+	}
+
+	tempPath := fpath + "_copy"
+	_ = os.Remove(tempPath)
+
+	err = copyFile(tempPath, fpath)
+	if err != nil {
+		t.Fatalf("copy file failed: %v", err)
+	}
+	err = os.Remove(fpath)
+	if err != nil {
+		t.Fatalf("remove running test file failed: %v", err)
+	}
+	err = os.Rename(tempPath, fpath)
+	if err != nil {
+		t.Fatalf("rename copy to previous name failed: %v", err)
+	}
+
+	w.Write([]byte{0})
+	w.Close()
+
+	err = cmd.Wait()
+	if err != nil {
+		t.Fatalf("exec wait failed: %v", err)
+	}
+
+	childPath := stderrBuff.String()
+	if !filepath.IsAbs(childPath) {
+		t.Fatalf("Child returned %q, want an absolute path", childPath)
+	}
+	if !sameFile(childPath, fpath) {
+		t.Fatalf("Child returned %q, not the same file as %q", childPath, fpath)
+	}
+}
+
+func sameFile(fn1, fn2 string) bool {
+	fi1, err := os.Stat(fn1)
+	if err != nil {
+		return false
+	}
+	fi2, err := os.Stat(fn2)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(fi1, fi2)
+}
+func copyFile(dest, src string) error {
+	df, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer df.Close()
+
+	sf, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sf.Close()
+
+	_, err = io.Copy(df, sf)
+	return err
+}
+
+func TestMain(m *testing.M) {
+	env := os.Getenv(executableEnvVar)
+	switch env {
+	case "":
+		os.Exit(m.Run())
+	case executableEnvValueMatch:
+		// First chdir to another path.
+		dir := "/"
+		if runtime.GOOS == "windows" {
+			dir = filepath.VolumeName(".")
+		}
+		os.Chdir(dir)
+		if ep, err := Executable(); err != nil {
+			fmt.Fprint(os.Stderr, "ERROR: ", err)
+		} else {
+			fmt.Fprint(os.Stderr, ep)
+		}
+	case executableEnvValueDelete:
+		bb := make([]byte, 1)
+		var err error
+		n, err := os.Stdin.Read(bb)
+		if err != nil {
+			fmt.Fprint(os.Stderr, "ERROR: ", err)
+			os.Exit(2)
+		}
+		if n != 1 {
+			fmt.Fprint(os.Stderr, "ERROR: n != 1, n == ", n)
+			os.Exit(2)
+		}
+		if ep, err := Executable(); err != nil {
+			fmt.Fprint(os.Stderr, "ERROR: ", err)
+		} else {
+			fmt.Fprint(os.Stderr, ep)
+		}
+	}
+	os.Exit(0)
+}

--- a/vendor/github.com/kardianos/osext/osext_windows.go
+++ b/vendor/github.com/kardianos/osext/osext_windows.go
@@ -1,0 +1,34 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package osext
+
+import (
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+var (
+	kernel                = syscall.MustLoadDLL("kernel32.dll")
+	getModuleFileNameProc = kernel.MustFindProc("GetModuleFileNameW")
+)
+
+// GetModuleFileName() with hModule = NULL
+func executable() (exePath string, err error) {
+	return getModuleFileName()
+}
+
+func getModuleFileName() (string, error) {
+	var n uint32
+	b := make([]uint16, syscall.MAX_PATH)
+	size := uint32(len(b))
+
+	r0, _, e1 := getModuleFileNameProc.Call(0, uintptr(unsafe.Pointer(&b[0])), uintptr(size))
+	n = uint32(r0)
+	if n == 0 {
+		return "", e1
+	}
+	return string(utf16.Decode(b[0:n])), nil
+}

--- a/vendor/github.com/nu7hatch/gouuid/.gitignore
+++ b/vendor/github.com/nu7hatch/gouuid/.gitignore
@@ -1,0 +1,11 @@
+_obj
+_test
+*.6
+*.out
+_testmain.go
+\#*
+.\#*
+*.log
+_cgo*
+*.o
+*.a

--- a/vendor/github.com/nu7hatch/gouuid/COPYING
+++ b/vendor/github.com/nu7hatch/gouuid/COPYING
@@ -1,0 +1,19 @@
+Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/nu7hatch/gouuid/README.md
+++ b/vendor/github.com/nu7hatch/gouuid/README.md
@@ -1,0 +1,21 @@
+# Pure Go UUID implementation
+
+This package provides immutable UUID structs and the functions
+NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+and 5 UUIDs as specified in [RFC 4122](http://www.ietf.org/rfc/rfc4122.txt).
+
+## Installation
+
+Use the `go` tool:
+
+	$ go get github.com/nu7hatch/gouuid
+
+## Usage
+
+See [documentation and examples](http://godoc.org/github.com/nu7hatch/gouuid)
+for more information.
+
+## Copyright
+
+Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>. See [COPYING](https://github.com/nu7hatch/gouuid/tree/master/COPYING)
+file for details.

--- a/vendor/github.com/nu7hatch/gouuid/example_test.go
+++ b/vendor/github.com/nu7hatch/gouuid/example_test.go
@@ -1,0 +1,33 @@
+package uuid_test
+
+import (
+	"fmt"
+	"github.com/nu7hatch/gouuid"
+)
+
+func ExampleNewV4() {
+	u4, err := uuid.NewV4()
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(u4)
+}
+
+func ExampleNewV5() {
+	u5, err := uuid.NewV5(uuid.NamespaceURL, []byte("nu7hat.ch"))
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(u5)
+}
+
+func ExampleParseHex() {
+	u, err := uuid.ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(u)
+}

--- a/vendor/github.com/nu7hatch/gouuid/uuid.go
+++ b/vendor/github.com/nu7hatch/gouuid/uuid.go
@@ -1,0 +1,173 @@
+// This package provides immutable UUID structs and the functions
+// NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+// and 5 UUIDs as specified in RFC 4122.
+//
+// Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
+package uuid
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"regexp"
+)
+
+// The UUID reserved variants.
+const (
+	ReservedNCS       byte = 0x80
+	ReservedRFC4122   byte = 0x40
+	ReservedMicrosoft byte = 0x20
+	ReservedFuture    byte = 0x00
+)
+
+// The following standard UUIDs are for use with NewV3() or NewV5().
+var (
+	NamespaceDNS, _  = ParseHex("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceURL, _  = ParseHex("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceOID, _  = ParseHex("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+	NamespaceX500, _ = ParseHex("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+)
+
+// Pattern used to parse hex string representation of the UUID.
+// FIXME: do something to consider both brackets at one time,
+// current one allows to parse string with only one opening
+// or closing bracket.
+const hexPattern = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-" +
+	"([1-5][a-z0-9]{3})-([a-z0-9]{4})-([a-z0-9]{12})\\}?$"
+
+var re = regexp.MustCompile(hexPattern)
+
+// A UUID representation compliant with specification in
+// RFC 4122 document.
+type UUID [16]byte
+
+// ParseHex creates a UUID object from given hex string
+// representation. Function accepts UUID string in following
+// formats:
+//
+//     uuid.ParseHex("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+//     uuid.ParseHex("{6ba7b814-9dad-11d1-80b4-00c04fd430c8}")
+//     uuid.ParseHex("urn:uuid:6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+//
+func ParseHex(s string) (u *UUID, err error) {
+	md := re.FindStringSubmatch(s)
+	if md == nil {
+		err = errors.New("Invalid UUID string")
+		return
+	}
+	hash := md[2] + md[3] + md[4] + md[5] + md[6]
+	b, err := hex.DecodeString(hash)
+	if err != nil {
+		return
+	}
+	u = new(UUID)
+	copy(u[:], b)
+	return
+}
+
+// Parse creates a UUID object from given bytes slice.
+func Parse(b []byte) (u *UUID, err error) {
+	if len(b) != 16 {
+		err = errors.New("Given slice is not valid UUID sequence")
+		return
+	}
+	u = new(UUID)
+	copy(u[:], b)
+	return
+}
+
+// Generate a UUID based on the MD5 hash of a namespace identifier
+// and a name.
+func NewV3(ns *UUID, name []byte) (u *UUID, err error) {
+	if ns == nil {
+		err = errors.New("Invalid namespace UUID")
+		return
+	}
+	u = new(UUID)
+	// Set all bits to MD5 hash generated from namespace and name.
+	u.setBytesFromHash(md5.New(), ns[:], name)
+	u.setVariant(ReservedRFC4122)
+	u.setVersion(3)
+	return
+}
+
+// Generate a random UUID.
+func NewV4() (u *UUID, err error) {
+	u = new(UUID)
+	// Set all bits to randomly (or pseudo-randomly) chosen values.
+	_, err = rand.Read(u[:])
+	if err != nil {
+		return
+	}
+	u.setVariant(ReservedRFC4122)
+	u.setVersion(4)
+	return
+}
+
+// Generate a UUID based on the SHA-1 hash of a namespace identifier
+// and a name.
+func NewV5(ns *UUID, name []byte) (u *UUID, err error) {
+	u = new(UUID)
+	// Set all bits to truncated SHA1 hash generated from namespace
+	// and name.
+	u.setBytesFromHash(sha1.New(), ns[:], name)
+	u.setVariant(ReservedRFC4122)
+	u.setVersion(5)
+	return
+}
+
+// Generate a MD5 hash of a namespace and a name, and copy it to the
+// UUID slice.
+func (u *UUID) setBytesFromHash(hash hash.Hash, ns, name []byte) {
+	hash.Write(ns[:])
+	hash.Write(name)
+	copy(u[:], hash.Sum([]byte{})[:16])
+}
+
+// Set the two most significant bits (bits 6 and 7) of the
+// clock_seq_hi_and_reserved to zero and one, respectively.
+func (u *UUID) setVariant(v byte) {
+	switch v {
+	case ReservedNCS:
+		u[8] = (u[8] | ReservedNCS) & 0xBF
+	case ReservedRFC4122:
+		u[8] = (u[8] | ReservedRFC4122) & 0x7F
+	case ReservedMicrosoft:
+		u[8] = (u[8] | ReservedMicrosoft) & 0x3F
+	}
+}
+
+// Variant returns the UUID Variant, which determines the internal
+// layout of the UUID. This will be one of the constants: RESERVED_NCS,
+// RFC_4122, RESERVED_MICROSOFT, RESERVED_FUTURE.
+func (u *UUID) Variant() byte {
+	if u[8]&ReservedNCS == ReservedNCS {
+		return ReservedNCS
+	} else if u[8]&ReservedRFC4122 == ReservedRFC4122 {
+		return ReservedRFC4122
+	} else if u[8]&ReservedMicrosoft == ReservedMicrosoft {
+		return ReservedMicrosoft
+	}
+	return ReservedFuture
+}
+
+// Set the four most significant bits (bits 12 through 15) of the
+// time_hi_and_version field to the 4-bit version number.
+func (u *UUID) setVersion(v byte) {
+	u[6] = (u[6] & 0xF) | (v << 4)
+}
+
+// Version returns a version number of the algorithm used to
+// generate the UUID sequence.
+func (u *UUID) Version() uint {
+	return uint(u[6] >> 4)
+}
+
+// Returns unparsed version of the generated UUID sequence.
+func (u *UUID) String() string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", u[0:4], u[4:6], u[6:8], u[8:10], u[10:])
+}

--- a/vendor/github.com/nu7hatch/gouuid/uuid_test.go
+++ b/vendor/github.com/nu7hatch/gouuid/uuid_test.go
@@ -1,0 +1,135 @@
+// This package provides immutable UUID structs and the functions
+// NewV3, NewV4, NewV5 and Parse() for generating versions 3, 4
+// and 5 UUIDs as specified in RFC 4122.
+//
+// Copyright (C) 2011 by Krzysztof Kowalik <chris@nu7hat.ch>
+package uuid
+
+import (
+	"regexp"
+	"testing"
+)
+
+const format = "^[a-z0-9]{8}-[a-z0-9]{4}-[1-5][a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12}$"
+
+func TestParse(t *testing.T) {
+	_, err := Parse([]byte{1, 2, 3, 4, 5})
+	if err == nil {
+		t.Errorf("Expected error due to invalid UUID sequence")
+	}
+	base, _ := NewV4()
+	u, err := Parse(base[:])
+	if err != nil {
+		t.Errorf("Expected to parse UUID sequence without problems")
+		return
+	}
+	if u.String() != base.String() {
+		t.Errorf("Expected parsed UUID to be the same as base, %s != %s", u.String(), base.String())
+	}
+}
+
+func TestParseString(t *testing.T) {
+	_, err := ParseHex("foo")
+	if err == nil {
+		t.Errorf("Expected error due to invalid UUID string")
+	}
+	base, _ := NewV4()
+	u, err := ParseHex(base.String())
+	if err != nil {
+		t.Errorf("Expected to parse UUID sequence without problems")
+		return
+	}
+	if u.String() != base.String() {
+		t.Errorf("Expected parsed UUID to be the same as base, %s != %s", u.String(), base.String())
+	}
+}
+
+func TestNewV3(t *testing.T) {
+	u, err := NewV3(NamespaceURL, []byte("golang.org"))
+	if err != nil {
+		t.Errorf("Expected to generate UUID without problems, error thrown: %d", err.Error())
+		return
+	}
+	if u.Version() != 3 {
+		t.Errorf("Expected to generate UUIDv3, given %d", u.Version())
+	}
+	if u.Variant() != ReservedRFC4122 {
+		t.Errorf("Expected to generate UUIDv3 RFC4122 variant, given %x", u.Variant())
+	}
+	re := regexp.MustCompile(format)
+	if !re.MatchString(u.String()) {
+		t.Errorf("Expected string representation to be valid, given %s", u.String())
+	}
+	u2, _ := NewV3(NamespaceURL, []byte("golang.org"))
+	if u2.String() != u.String() {
+		t.Errorf("Expected UUIDs generated of the same namespace and name to be the same")
+	}
+	u3, _ := NewV3(NamespaceDNS, []byte("golang.org"))
+	if u3.String() == u.String() {
+		t.Errorf("Expected UUIDs generated of different namespace and the same name to be different")
+	}
+	u4, _ := NewV3(NamespaceURL, []byte("code.google.com"))
+	if u4.String() == u.String() {
+		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
+	}
+}
+
+func TestNewV4(t *testing.T) {
+	u, err := NewV4()
+	if err != nil {
+		t.Errorf("Expected to generate UUID without problems, error thrown: %s", err.Error())
+		return
+	}
+	if u.Version() != 4 {
+		t.Errorf("Expected to generate UUIDv4, given %d", u.Version())
+	}
+	if u.Variant() != ReservedRFC4122 {
+		t.Errorf("Expected to generate UUIDv4 RFC4122 variant, given %x", u.Variant())
+	}
+	re := regexp.MustCompile(format)
+	if !re.MatchString(u.String()) {
+		t.Errorf("Expected string representation to be valid, given %s", u.String())
+	}
+}
+
+func TestNewV5(t *testing.T) {
+	u, err := NewV5(NamespaceURL, []byte("golang.org"))
+	if err != nil {
+		t.Errorf("Expected to generate UUID without problems, error thrown: %d", err.Error())
+		return
+	}
+	if u.Version() != 5 {
+		t.Errorf("Expected to generate UUIDv5, given %d", u.Version())
+	}
+	if u.Variant() != ReservedRFC4122 {
+		t.Errorf("Expected to generate UUIDv5 RFC4122 variant, given %x", u.Variant())
+	}
+	re := regexp.MustCompile(format)
+	if !re.MatchString(u.String()) {
+		t.Errorf("Expected string representation to be valid, given %s", u.String())
+	}
+	u2, _ := NewV5(NamespaceURL, []byte("golang.org"))
+	if u2.String() != u.String() {
+		t.Errorf("Expected UUIDs generated of the same namespace and name to be the same")
+	}
+	u3, _ := NewV5(NamespaceDNS, []byte("golang.org"))
+	if u3.String() == u.String() {
+		t.Errorf("Expected UUIDs generated of different namespace and the same name to be different")
+	}
+	u4, _ := NewV5(NamespaceURL, []byte("code.google.com"))
+	if u4.String() == u.String() {
+		t.Errorf("Expected UUIDs generated of the same namespace and different names to be different")
+	}
+}
+
+func BenchmarkParseHex(b *testing.B) {
+	s := "f3593cff-ee92-40df-4086-87825b523f13"
+	for i := 0; i < b.N; i++ {
+		_, err := ParseHex(s)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	b.ReportAllocs()
+}


### PR DESCRIPTION
This one covers:
* PLT-3137 Support for SAML configuration
* PLT-3410 SAML Database Store
* PLT-3411 CLI to add Identity Provider Certificate and Service Provider Private Key
* PLT-3409 SAML Interface for EE
* PLT-3139 Handle SAML authentication server side
* PLT-3443 SAML Obtain SP metadata


Each ticket is in his own commit

There is also an EE PR https://github.com/mattermost/enterprise/pull/32

TODO: Tests