### PR TITLE
PLT-3333 Changed Edit Header Title for DM Channels

### DIFF
--- a/webapp/components/edit_channel_header_modal.jsx
+++ b/webapp/components/edit_channel_header_modal.jsx
@@ -129,6 +129,26 @@ class EditChannelHeaderModal extends React.Component {
             serverError = <div className='form-group has-error'><br/><label className='control-label'>{this.state.serverError}</label></div>;
         }
 
+        let headerTitle = null;
+        if (this.props.channel.type === Constants.DM_CHANNEL) {
+            headerTitle = (
+                <FormattedMessage
+                    id='edit_channel_header_modal.title_dm'
+                    defaultMessage='Edit Header'
+                />
+            );
+        } else {
+            headerTitle = (
+                <FormattedMessage
+                    id='edit_channel_header_modal.title'
+                    defaultMessage='Edit Header for {channel}'
+                    values={{
+                        channel: this.props.channel.display_name
+                    }}
+                />
+            );
+        }
+
         return (
             <Modal
                 show={this.props.show}
@@ -136,13 +156,7 @@ class EditChannelHeaderModal extends React.Component {
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>
-                        <FormattedMessage
-                            id='edit_channel_header_modal.title'
-                            defaultMessage='Edit Header for {channel}'
-                            values={{
-                                channel: this.props.channel.display_name
-                            }}
-                        />
+                        {headerTitle}
                     </Modal.Title>
                 </Modal.Header>
                 <Modal.Body>

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -864,6 +864,7 @@
   "edit_channel_header_modal.error": "This channel header is too long, please enter a shorter one",
   "edit_channel_header_modal.save": "Save",
   "edit_channel_header_modal.title": "Edit Header for {channel}",
+  "edit_channel_header_modal.title_dm": "Edit Header",
   "edit_channel_purpose_modal.body": "Describe how this {type} should be used. This text appears in the channel list in the \"More...\" menu and helps others decide whether to join.",
   "edit_channel_purpose_modal.cancel": "Cancel",
   "edit_channel_purpose_modal.channel": "Channel",


### PR DESCRIPTION
Previously the title for the Edit Channel Header modal was `Edit Header for` for DM channels, this is due to DM channels not having a display_name. That is now changed to just `Edit Header` per spec.