### PR TITLE
PLT-3105 Moved file attachments to be stored in data/channels

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -149,7 +149,7 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		path := "teams/" + c.TeamId + "/channels/" + channelId + "/users/" + c.Session.UserId + "/" + uid + "/" + filename
+		path := "channels/" + channelId + "/users/" + c.Session.UserId + "/" + uid + "/" + filename
 
 		if err := WriteFile(buf.Bytes(), path); err != nil {
 			c.Err = err
@@ -172,7 +172,7 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func handleImages(filenames []string, fileData [][]byte, teamId, channelId, userId string) {
-	dest := "teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/"
+	dest := "channels/" + channelId + "/users/" + userId + "/"
 
 	for i, filename := range filenames {
 		name := filename[:strings.LastIndex(filename, ".")]
@@ -318,18 +318,21 @@ func getFileInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cchan := Srv.Store.Channel().CheckPermissionsTo(c.TeamId, channelId, c.Session.UserId)
+	cchan := Srv.Store.Channel().CheckPermissionsToNoTeam(channelId, c.Session.UserId)
 
-	path := "teams/" + c.TeamId + "/channels/" + channelId + "/users/" + userId + "/" + filename
+	path := "channels/" + channelId + "/users/" + userId + "/" + filename
 	var info *model.FileInfo
 
 	if cached, ok := fileInfoCache.Get(path); ok {
 		info = cached.(*model.FileInfo)
 	} else {
-		fileData := make(chan []byte)
-		go readFile(path, fileData)
+		err, bytes := getFileData(c.TeamId, channelId, userId, filename)
+		if err != nil {
+			c.Err = err
+			return
+		}
 
-		newInfo, err := model.GetInfoForBytes(filename, <-fileData)
+		newInfo, err := model.GetInfoForBytes(filename, bytes)
 		if err != nil {
 			c.Err = err
 			return
@@ -356,7 +359,7 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	userId := params["user_id"]
 	filename := params["filename"]
 
-	if !c.HasPermissionsToChannel(Srv.Store.Channel().CheckPermissionsTo(teamId, channelId, userId), "getFile") {
+	if !c.HasPermissionsToChannel(Srv.Store.Channel().CheckPermissionsToNoTeam(channelId, userId), "getFile") {
 		return
 	}
 
@@ -414,10 +417,6 @@ func getFileData(teamId string, channelId string, userId string, filename string
 		return err, nil
 	}
 
-	if len(teamId) != 26 {
-		return NewInvalidParamError("getFileData", "team_id"), nil
-	}
-
 	if len(channelId) != 26 {
 		return NewInvalidParamError("getFileData", "channel_id"), nil
 	}
@@ -430,17 +429,19 @@ func getFileData(teamId string, channelId string, userId string, filename string
 		return NewInvalidParamError("getFileData", "filename"), nil
 	}
 
-	path := "teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/" + filename
+	path := "channels/" + channelId + "/users/" + userId + "/" + filename
 
-	fileChan := make(chan []byte)
-	go readFile(path, fileChan)
+	// try using the new path and then fall back to the old one if that doesn't work
+	if bytes, readErr := ReadFile(path); readErr == nil {
+		return nil, bytes
+	} else if bytes, readErr := ReadFile("teams/" + teamId + "/" + path); readErr == nil {
+		return nil, bytes
+	} else {
+		l4g.Error(readErr)
 
-	if bytes := <-fileChan; bytes == nil {
 		err := model.NewLocAppError("writeFileResponse", "api.file.get_file.not_found.app_error", nil, "path="+path)
 		err.StatusCode = http.StatusNotFound
 		return err, nil
-	} else {
-		return nil, bytes
 	}
 }
 

--- a/api/file_test.go
+++ b/api/file_test.go
@@ -23,7 +23,6 @@ import (
 func TestUploadFile(t *testing.T) {
 	th := Setup().InitBasic()
 	Client := th.BasicClient
-	team := th.BasicTeam
 	user := th.BasicUser
 	channel := th.BasicChannel
 
@@ -84,17 +83,17 @@ func TestUploadFile(t *testing.T) {
 		// wait a bit for files to ready
 		time.Sleep(5 * time.Second)
 
-		err = bucket.Del("teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + filename)
+		err = bucket.Del("channels/" + channel.Id + "/users/" + user.Id + "/" + filename)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = bucket.Del("teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_thumb.jpg")
+		err = bucket.Del("channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_thumb.jpg")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = bucket.Del("teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_preview.jpg")
+		err = bucket.Del("channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_preview.jpg")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -109,17 +108,17 @@ func TestUploadFile(t *testing.T) {
 		// wait a bit for files to ready
 		time.Sleep(5 * time.Second)
 
-		path := utils.Cfg.FileSettings.Directory + "teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + filename
+		path := utils.Cfg.FileSettings.Directory + "channels/" + channel.Id + "/users/" + user.Id + "/" + filename
 		if err := os.Remove(path); err != nil {
 			t.Fatal("Couldn't remove file at " + path)
 		}
 
-		path = utils.Cfg.FileSettings.Directory + "teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_thumb.jpg"
+		path = utils.Cfg.FileSettings.Directory + "channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_thumb.jpg"
 		if err := os.Remove(path); err != nil {
 			t.Fatal("Couldn't remove file at " + path)
 		}
 
-		path = utils.Cfg.FileSettings.Directory + "teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_preview.jpg"
+		path = utils.Cfg.FileSettings.Directory + "channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_preview.jpg"
 		if err := os.Remove(path); err != nil {
 			t.Fatal("Couldn't remove file at " + path)
 		}
@@ -133,7 +132,6 @@ func TestUploadFile(t *testing.T) {
 func TestGetFile(t *testing.T) {
 	th := Setup().InitBasic()
 	Client := th.BasicClient
-	team := th.BasicTeam
 	user := th.BasicUser
 	channel := th.BasicChannel
 
@@ -207,17 +205,17 @@ func TestGetFile(t *testing.T) {
 			filename := filenames[len(filenames)-2] + "/" + filenames[len(filenames)-1]
 			fileId := strings.Split(filename, ".")[0]
 
-			err = bucket.Del("teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + filename)
+			err = bucket.Del("channels/" + channel.Id + "/users/" + user.Id + "/" + filename)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			err = bucket.Del("teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_thumb.jpg")
+			err = bucket.Del("channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_thumb.jpg")
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			err = bucket.Del("teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_preview.jpg")
+			err = bucket.Del("channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_preview.jpg")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -226,17 +224,17 @@ func TestGetFile(t *testing.T) {
 			filename := filenames[len(filenames)-2] + "/" + filenames[len(filenames)-1]
 			fileId := strings.Split(filename, ".")[0]
 
-			path := utils.Cfg.FileSettings.Directory + "teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + filename
+			path := utils.Cfg.FileSettings.Directory + "channels/" + channel.Id + "/users/" + user.Id + "/" + filename
 			if err := os.Remove(path); err != nil {
 				t.Fatal("Couldn't remove file at " + path)
 			}
 
-			path = utils.Cfg.FileSettings.Directory + "teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_thumb.jpg"
+			path = utils.Cfg.FileSettings.Directory + "channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_thumb.jpg"
 			if err := os.Remove(path); err != nil {
 				t.Fatal("Couldn't remove file at " + path)
 			}
 
-			path = utils.Cfg.FileSettings.Directory + "teams/" + team.Id + "/channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_preview.jpg"
+			path = utils.Cfg.FileSettings.Directory + "channels/" + channel.Id + "/users/" + user.Id + "/" + fileId + "_preview.jpg"
 			if err := os.Remove(path); err != nil {
 				t.Fatal("Couldn't remove file at " + path)
 			}
@@ -347,7 +345,7 @@ func TestGetPublicFile(t *testing.T) {
 		t.Fatal("should've failed to get image with public link while not logged in after salt changed")
 	}
 
-	if err := cleanupTestFile(filenames[0], th.BasicTeam.Id, channel.Id, th.BasicUser.Id); err != nil {
+	if err := cleanupTestFile(filenames[0], channel.Id, th.BasicUser.Id); err != nil {
 		t.Fatal("failed to cleanup test file", err)
 	}
 }
@@ -403,7 +401,7 @@ func TestGetPublicLink(t *testing.T) {
 
 	th.LoginBasic()
 
-	if err := cleanupTestFile(filenames[0], th.BasicTeam.Id, channel.Id, th.BasicUser.Id); err != nil {
+	if err := cleanupTestFile(filenames[0], channel.Id, th.BasicUser.Id); err != nil {
 		t.Fatal("failed to cleanup test file", err)
 	}
 }
@@ -443,7 +441,7 @@ func uploadTestFile(Client *model.Client, channelId string) ([]string, error) {
 	}
 }
 
-func cleanupTestFile(fullFilename, teamId, channelId, userId string) error {
+func cleanupTestFile(fullFilename, channelId, userId string) error {
 	filenames := strings.Split(fullFilename, "/")
 	filename := filenames[len(filenames)-2] + "/" + filenames[len(filenames)-1]
 	fileId := strings.Split(filename, ".")[0]
@@ -457,29 +455,29 @@ func cleanupTestFile(fullFilename, teamId, channelId, userId string) error {
 		s := s3.New(auth, aws.Regions[utils.Cfg.FileSettings.AmazonS3Region])
 		bucket := s.Bucket(utils.Cfg.FileSettings.AmazonS3Bucket)
 
-		if err := bucket.Del("teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/" + filename); err != nil {
+		if err := bucket.Del("channels/" + channelId + "/users/" + userId + "/" + filename); err != nil {
 			return err
 		}
 
-		if err := bucket.Del("teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/" + fileId + "_thumb.jpg"); err != nil {
+		if err := bucket.Del("channels/" + channelId + "/users/" + userId + "/" + fileId + "_thumb.jpg"); err != nil {
 			return err
 		}
 
-		if err := bucket.Del("teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/" + fileId + "_preview.jpg"); err != nil {
+		if err := bucket.Del("channels/" + channelId + "/users/" + userId + "/" + fileId + "_preview.jpg"); err != nil {
 			return err
 		}
 	} else {
-		path := utils.Cfg.FileSettings.Directory + "teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/" + filename
+		path := utils.Cfg.FileSettings.Directory + "channels/" + channelId + "/users/" + userId + "/" + filename
 		if err := os.Remove(path); err != nil {
 			return fmt.Errorf("Couldn't remove file at " + path)
 		}
 
-		path = utils.Cfg.FileSettings.Directory + "teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/" + fileId + "_thumb.jpg"
+		path = utils.Cfg.FileSettings.Directory + "channels/" + channelId + "/users/" + userId + "/" + fileId + "_thumb.jpg"
 		if err := os.Remove(path); err != nil {
 			return fmt.Errorf("Couldn't remove file at " + path)
 		}
 
-		path = utils.Cfg.FileSettings.Directory + "teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/" + fileId + "_preview.jpg"
+		path = utils.Cfg.FileSettings.Directory + "channels/" + channelId + "/users/" + userId + "/" + fileId + "_preview.jpg"
 		if err := os.Remove(path); err != nil {
 			return fmt.Errorf("Couldn't remove file at " + path)
 		}


### PR DESCRIPTION
... instead of data/teams/ID/channels

With the old file path including the team ID, it would make it difficult to load files in cross-team channels (ie direct channels) since you had no way of knowing which team the user was on when they originally made the post. Since you'll never have the same channel ID on multiple teams, that part of the path was redundant so I removed it. If we fail to find a file at the new path, we add the `teams/ID` part back into the path and try again so that we don't break any old file attachments, although I'd prefer to just move the files out of the team-specific folders if anyone has a good way to do that with our current migration code.

Tested when using both the local filesystem and S3