### PR TITLE
PLT-3233 Added Error Message for Unchanged Email

### DIFF
--- a/webapp/components/user_settings/user_settings_general.jsx
+++ b/webapp/components/user_settings/user_settings_general.jsx
@@ -160,12 +160,12 @@ class UserSettingsGeneralTab extends React.Component {
         const email = this.state.email.trim().toLowerCase();
         const confirmEmail = this.state.confirmEmail.trim().toLowerCase();
 
+        const {formatMessage} = this.props.intl;
         if (user.email === email) {
-            this.updateSection('');
+            this.setState({emailError: Utils.localizeMessage('user.settings.general.emailUnchanged', 'Your new email address is the same as your old email address.'), clientError: '', serverError: ''});
             return;
         }
 
-        const {formatMessage} = this.props.intl;
         if (email === '' || !Utils.isEmail(email)) {
             this.setState({emailError: formatMessage(holders.validEmail), clientError: '', serverError: ''});
             return;

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1388,6 +1388,7 @@
   "user.settings.general.emailHelp4": "A verification email was sent to {email}.",
   "user.settings.general.emailLdapCantUpdate": "Login occurs through LDAP. Email cannot be updated. Email address used for notifications is {email}.",
   "user.settings.general.emailMatch": "The new emails you entered do not match.",
+  "user.settings.general.emailUnchanged": "Your new email address is the same as your old email address.",
   "user.settings.general.emptyName": "Click 'Edit' to add your full name",
   "user.settings.general.emptyNickname": "Click 'Edit' to add a nickname",
   "user.settings.general.field_handled_externally": "This field is handled through your login provider. If you want to change it, you need to do so through your login provider.",


### PR DESCRIPTION
When attempting to change your email, if the `Primary Email Address` is left unchanged, the section simple exits upon pressing save. Now an error message will display if the email address is left unchanged. This prevents the confusing situation when a user presses save and nothing happens.