### PR TITLE
PLT-3390 Adding validation for LDAP settings to configuration

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2516,6 +2516,10 @@
     "translation": "Invalid sync interval time. Must be at least one minute."
   },
   {
+    "id": "model.config.is_valid.ldap_required.app_error",
+    "translation": "Required LDAP field missing."
+  },
+  {
     "id": "model.config.is_valid.listen_address.app_error",
     "translation": "Invalid listen address for service settings Must be set."
   },

--- a/mattermost.go
+++ b/mattermost.go
@@ -71,7 +71,7 @@ var flagRunCmds bool
 func doLoadConfig(filename string) (err string) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Sprintf("Error loding config, err=%v", r)
+			err = fmt.Sprintf("%v", r)
 		}
 	}()
 	utils.LoadConfig(filename)
@@ -83,7 +83,7 @@ func main() {
 	parseCmds()
 
 	if errstr := doLoadConfig(flagConfigFile); errstr != "" {
-		l4g.Exit("Unable to load mattermost configuration file:", errstr)
+		l4g.Exit("Unable to load mattermost configuration file: ", errstr)
 		return
 	}
 

--- a/model/config.go
+++ b/model/config.go
@@ -486,6 +486,11 @@ func (o *Config) SetDefaults() {
 		*o.LdapSettings.EmailAttribute = ""
 	}
 
+	if o.LdapSettings.UsernameAttribute == nil {
+		o.LdapSettings.UsernameAttribute = new(string)
+		*o.LdapSettings.UsernameAttribute = ""
+	}
+
 	if o.LdapSettings.NicknameAttribute == nil {
 		o.LdapSettings.NicknameAttribute = new(string)
 		*o.LdapSettings.NicknameAttribute = ""
@@ -707,6 +712,20 @@ func (o *Config) IsValid() *AppError {
 
 	if *o.LdapSettings.SyncIntervalMinutes <= 0 {
 		return NewLocAppError("Config.IsValid", "model.config.is_valid.ldap_sync_interval.app_error", nil, "")
+	}
+
+	if *o.LdapSettings.Enable {
+		if *o.LdapSettings.LdapServer == "" ||
+			*o.LdapSettings.BaseDN == "" ||
+			*o.LdapSettings.BindUsername == "" ||
+			*o.LdapSettings.BindPassword == "" ||
+			*o.LdapSettings.FirstNameAttribute == "" ||
+			*o.LdapSettings.LastNameAttribute == "" ||
+			*o.LdapSettings.EmailAttribute == "" ||
+			*o.LdapSettings.UsernameAttribute == "" ||
+			*o.LdapSettings.IdAttribute == "" {
+			return NewLocAppError("Config.IsValid", "Required LDAP field missing", nil, "")
+		}
 	}
 
 	return nil

--- a/utils/config.go
+++ b/utils/config.go
@@ -168,13 +168,11 @@ func LoadConfig(fileName string) {
 	config.SetDefaults()
 
 	if err := config.IsValid(); err != nil {
-		panic(T("utils.config.load_config.validating.panic",
-			map[string]interface{}{"Filename": fileName, "Error": err.Message}))
+		panic(err.Error())
 	}
 
 	if err := ValidateLdapFilter(&config); err != nil {
-		panic(T("utils.config.load_config.validating.panic",
-			map[string]interface{}{"Filename": fileName, "Error": err.Message}))
+		panic(err.Error())
 	}
 
 	configureLog(&config.LogSettings)


### PR DESCRIPTION
@coreyhulen This doesn't solve the problem, as I could not reproduce it. However it prevents it from happening by making sure you have required LDAP fields filled in. 

How the error message is displayed is a hack. (Message in ID) The translation system does not handle early errors correctly. Ticket created here: https://mattermost.atlassian.net/browse/PLT-3456