### PR TITLE
PLT-3319 Removed URL in Code Preview

### DIFF
--- a/webapp/components/code_preview.jsx
+++ b/webapp/components/code_preview.jsx
@@ -106,10 +106,12 @@ export default class CodePreview extends React.Component {
 
         const highlighted = SyntaxHighlighting.highlight(this.state.lang, this.state.code);
 
+        const fileName = this.props.filename.substring(this.props.filename.lastIndexOf('/') + 1, this.props.filename.length);
+
         return (
             <div className='post-code'>
                 <span className='post-code__language'>
-                    {`${this.props.filename} - ${language}`}
+                    {`${fileName} - ${language}`}
                 </span>
                 <code className='hljs'>
                     <table>


### PR DESCRIPTION
Previously, code preview snippets showed the whole URL (which is a bunch of random characters). Now it simply shows the file name and the file type!

![image](https://cloud.githubusercontent.com/assets/5740966/16423852/c01b748c-3d2b-11e6-9e63-08b5f06a535e.png)
