### PR TITLE
PLT-3437 Show Email in User Profile for Sysadmins even when turned off

### DIFF
--- a/webapp/components/user_profile.jsx
+++ b/webapp/components/user_profile.jsx
@@ -3,6 +3,7 @@
 
 import * as Utils from 'utils/utils.jsx';
 import Client from 'utils/web_client.jsx';
+import UserStore from 'stores/user_store.jsx';
 
 import {Popover, OverlayTrigger} from 'react-bootstrap';
 
@@ -78,7 +79,7 @@ export default class UserProfile extends React.Component {
             />
         );
 
-        if (global.window.mm_config.ShowEmailAddress === 'true') {
+        if (global.window.mm_config.ShowEmailAddress === 'true' || UserStore.isSystemAdminForCurrentUser() || this.props.user === UserStore.getCurrentUser()) {
             dataContent.push(
                 <div
                     data-toggle='tooltip'


### PR DESCRIPTION
Previously, when `Show Email Address` was set to false, user profile popovers did not show the user's email for anyone. It is now changed to show the email if the current user is a system admin, or the popover is for the current user. 