### PR TITLE
PLT-3328 Added Title for Direct Message Desktop Notifications

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1083,6 +1083,7 @@
   "navbar_dropdown.switchTo": "Switch to ",
   "navbar_dropdown.teamLink": "Get Team Invite Link",
   "navbar_dropdown.teamSettings": "Team Settings",
+  "notification.dm": "Direct Message",
   "password_form.change": "Change my password",
   "password_form.click": "Click <a href={url}>here</a> to log in.",
   "password_form.enter": "Enter a new password for your {siteName} account.",

--- a/webapp/stores/notification_store.jsx
+++ b/webapp/stores/notification_store.jsx
@@ -63,12 +63,12 @@ class NotificationStoreClass extends EventEmitter {
             }
 
             let title = Utils.localizeMessage('channel_loader.posted', 'Posted');
-            if (channel.type === Constants.DM_CHANNEL) {
-                title = Utils.localizeMessage('notification.dm', 'Direct Message');
-            } else if (channel) {
-                title = channel.display_name;
-            } else if (msgProps.channel_display_name) {
+            if (!channel) {
                 title = msgProps.channel_display_name;
+            } else if (channel.type === Constants.DM_CHANNEL) {
+                title = Utils.localizeMessage('notification.dm', 'Direct Message');
+            } else {
+                title = channel.display_name;
             }
 
             let notifyText = post.message.replace(/\n+/g, ' ');

--- a/webapp/stores/notification_store.jsx
+++ b/webapp/stores/notification_store.jsx
@@ -63,7 +63,9 @@ class NotificationStoreClass extends EventEmitter {
             }
 
             let title = Utils.localizeMessage('channel_loader.posted', 'Posted');
-            if (channel) {
+            if (channel.type === Constants.DM_CHANNEL) {
+                title = Utils.localizeMessage('notification.dm', 'Direct Message');
+            } else if (channel) {
                 title = channel.display_name;
             } else if (msgProps.channel_display_name) {
                 title = msgProps.channel_display_name;


### PR DESCRIPTION
Previously, direct message notifications did not have a title on desktop. Now the title is `Direct Message`.