### PR TITLE
PLT-3456 Fix Errors while starting the server

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -29,6 +29,7 @@ type TestHelper struct {
 
 func SetupEnterprise() *TestHelper {
 	if Srv == nil {
+		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
 		utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
@@ -49,6 +50,7 @@ func SetupEnterprise() *TestHelper {
 
 func Setup() *TestHelper {
 	if Srv == nil {
+		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
 		utils.Cfg.TeamSettings.MaxUsersPerTeam = 50

--- a/mattermost.go
+++ b/mattermost.go
@@ -74,12 +74,12 @@ func doLoadConfig(filename string) (err string) {
 			err = fmt.Sprintf("%v", r)
 		}
 	}()
+	utils.TranslationsPreInit()
 	utils.LoadConfig(filename)
 	return ""
 }
 
 func main() {
-
 	parseCmds()
 
 	if errstr := doLoadConfig(flagConfigFile); errstr != "" {

--- a/store/sql_store_test.go
+++ b/store/sql_store_test.go
@@ -15,6 +15,7 @@ var store Store
 
 func Setup() {
 	if store == nil {
+		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
 		store = NewSqlStore()

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
+	TranslationsPreInit()
 	LoadConfig("config.json")
 	InitTranslations(Cfg.LocalizationSettings)
 }

--- a/utils/i18n.go
+++ b/utils/i18n.go
@@ -15,9 +15,16 @@ var T i18n.TranslateFunc
 var locales map[string]string = make(map[string]string)
 var settings model.LocalizationSettings
 
+// this functions loads translations from filesystem
+// and assign english while loading server config
+func TranslationsPreInit() {
+	InitTranslationsWithDir("i18n")
+	T = TfuncWithFallback("en")
+}
+
 func InitTranslations(localizationSettings model.LocalizationSettings) {
 	settings = localizationSettings
-	InitTranslationsWithDir("i18n")
+	T = GetTranslationsBySystemLocale()
 }
 
 func InitTranslationsWithDir(dir string) {
@@ -30,8 +37,6 @@ func InitTranslationsWithDir(dir string) {
 			i18n.MustLoadTranslationFile(i18nDirectory + filename)
 		}
 	}
-
-	T = GetTranslationsBySystemLocale()
 }
 
 func GetTranslationsBySystemLocale() i18n.TranslateFunc {

--- a/utils/mail.go
+++ b/utils/mail.go
@@ -79,14 +79,14 @@ func TestConnection(config *model.Config) {
 
 	conn, err1 := connectToSMTPServer(config)
 	if err1 != nil {
-		l4g.Error(T("utils.mail.test.configured.error"), err1.Message, err1.DetailedError)
+		l4g.Error(T("utils.mail.test.configured.error"), T(err1.Message), err1.DetailedError)
 		return
 	}
 	defer conn.Close()
 
 	c, err2 := newSMTPClient(conn, config)
 	if err2 != nil {
-		l4g.Error(T("utils.mail.test.configured.error"), err2.Message, err2.DetailedError)
+		l4g.Error(T("utils.mail.test.configured.error"), T(err2.Message), err2.DetailedError)
 		return
 	}
 	defer c.Quit()

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -20,6 +20,7 @@ var URL string
 
 func Setup() {
 	if api.Srv == nil {
+		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
 		api.NewServer()


### PR DESCRIPTION
#### Summary
Fixes AppErrors that are triggered before translations are loaded crash server or produce bad error messages by loading english translations as default before loading the configuration file.

#### Unit Tests
No unit tests

#### Issue/Ticket Link
https://mattermost.atlassian.net/browse/PLT-3456

#### Has Critical Changes
PR modifies server startup