### PR TITLE
PLT-3492 Fix connection leaks in push notifications, diagnostics and oauth

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -8,6 +8,7 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -195,6 +196,11 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	} else {
+		defer func() {
+			ioutil.ReadAll(body)
+			body.Close()
+		}()
+
 		action := props["action"]
 		switch action {
 		case model.OAUTH_ACTION_SIGNUP:
@@ -578,6 +584,10 @@ func AuthorizeOAuthUser(service, code, state, redirectUri string) (io.ReadCloser
 		return nil, "", nil, model.NewLocAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.token_failed.app_error", nil, err.Error())
 	} else {
 		ar = model.AccessResponseFromJson(resp.Body)
+		defer func() {
+			ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+		}()
 		if ar == nil {
 			return nil, "", nil, model.NewLocAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.bad_response.app_error", nil, "")
 		}

--- a/api/post.go
+++ b/api/post.go
@@ -803,8 +803,11 @@ func sendPushNotification(post *model.Post, user *model.User, channel *model.Cha
 			request, _ := http.NewRequest("POST", *utils.Cfg.EmailSettings.PushNotificationServer+model.API_URL_SUFFIX_V1+"/send_push", strings.NewReader(msg.ToJson()))
 
 			l4g.Debug(utils.T("api.post.send_notifications_and_forget.push_notification.debug"), msg.DeviceId, msg.Message)
-			if _, err := httpClient.Do(request); err != nil {
+			if resp, err := httpClient.Do(request); err != nil {
 				l4g.Error(utils.T("api.post.send_notifications_and_forget.push_notification.error"), user.Id, err)
+			} else {
+				ioutil.ReadAll(resp.Body)
+				resp.Body.Close()
 			}
 
 			// notification sent, don't need to check other sessions

--- a/mattermost.go
+++ b/mattermost.go
@@ -205,6 +205,8 @@ func doSecurityAndDiagnostics() {
 				}
 
 				bulletins := model.SecurityBulletinsFromJson(res.Body)
+				ioutil.ReadAll(res.Body)
+				res.Body.Close()
 
 				for _, bulletin := range bulletins {
 					if bulletin.AppliesToVersion == model.CurrentVersion {


### PR DESCRIPTION
#### Summary
Fix the last file descriptor leaks, these ones caused by HTTP requests made in push notifications, diagnostics and OAuth.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3492
