### PR TITLE
PLT-3225 Firefox: Channel header disappears after renaming a channel

### DIFF
--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -101,6 +101,10 @@ export default class ChannelHeader extends React.Component {
         document.removeEventListener('keydown', this.openRecentMentions);
     }
 
+    shouldComponentUpdate(nextProps) {
+        return !!nextProps.channelId;
+    }
+
     onListenerChange() {
         const newState = this.getStateFromStores();
         if (!Utils.areObjectsEqual(newState, this.state)) {


### PR DESCRIPTION
#### Summary
Fixes an issue where the channel name in Channel header disappeared

#### Issue/Ticket Link
https://mattermost.atlassian.net/browse/PLT-3225