### PR TITLE
Removed semi-valid link from list that shouldn't autolink

### DIFF
--- a/tests/test-links.md
+++ b/tests/test-links.md
@@ -52,7 +52,6 @@ readme.md
 @example.com
 ./make-compiled-client.sh
 test.:test
-https://<your-mattermost-url>/signup/gitlab
 `https://example.com`
 
 #### Only the links within these sentences should auto-link:


### PR DESCRIPTION
The newest autolinking regex matches it and it could be argued that the link is valid anyway.