### PR TITLE
Revert PLT-3233

### DIFF
--- a/webapp/components/user_settings/user_settings_general.jsx
+++ b/webapp/components/user_settings/user_settings_general.jsx
@@ -161,8 +161,9 @@ class UserSettingsGeneralTab extends React.Component {
         const confirmEmail = this.state.confirmEmail.trim().toLowerCase();
 
         const {formatMessage} = this.props.intl;
-        if (user.email === email) {
-            this.setState({emailError: Utils.localizeMessage('user.settings.general.emailUnchanged', 'Your new email address is the same as your old email address.'), clientError: '', serverError: ''});
+
+        if (user.email === email && confirmEmail === '') {
+            this.updateSection('');
             return;
         }
 


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

#### Summary
Reverted PLT-3233 to not give an error when the user attempts to change their email but does not actually change it. Now the user will only see an error if the two fields do not match and the email was actually changed. Ticket was unclear in intended behaviour.

#### Issue/Ticket Link
https://mattermost.atlassian.net/browse/PLT-3233

