### PR TITLE
PLT-3473 Made shortcuts only work for CMD on OSX

### DIFF
--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -143,7 +143,7 @@ export default class ChannelHeader extends React.Component {
         });
     }
     openRecentMentions(e) {
-        if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.keyCode === Constants.KeyCodes.M) {
+        if (Utils.cmdOrCtrlPressed(e) && e.shiftKey && e.keyCode === Constants.KeyCodes.M) {
             e.preventDefault();
             this.searchMentions(e);
         }

--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -279,7 +279,7 @@ class FileUpload extends React.Component {
     }
 
     keyUpload(e) {
-        if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.U) {
+        if (Utils.cmdOrCtrlPressed(e) && e.keyCode === Constants.KeyCodes.U) {
             e.preventDefault();
             if (this.props.postType === 'post' && document.activeElement.id === 'post_textbox' || this.props.postType === 'comment' && document.activeElement.id === 'reply_textbox') {
                 $(this.refs.fileInput).focus().trigger('click');

--- a/webapp/components/navbar.jsx
+++ b/webapp/components/navbar.jsx
@@ -163,7 +163,7 @@ export default class Navbar extends React.Component {
         });
     }
     showChannelSwitchModal(e) {
-        if ((e.ctrlKey || e.metaKey) && e.keyCode === Constants.KeyCodes.K) {
+        if (Utils.cmdOrCtrlPressed(e) && e.keyCode === Constants.KeyCodes.K) {
             e.preventDefault();
             this.setState({
                 showChannelSwitchModal: true

--- a/webapp/components/navbar_dropdown.jsx
+++ b/webapp/components/navbar_dropdown.jsx
@@ -70,7 +70,7 @@ export default class NavbarDropdown extends React.Component {
         document.removeEventListener('keydown', this.openAccountSettings);
     }
     openAccountSettings(e) {
-        if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.keyCode === Constants.KeyCodes.A) {
+        if (Utils.cmdOrCtrlPressed(e) && e.shiftKey && e.keyCode === Constants.KeyCodes.A) {
             e.preventDefault();
             this.setState({showUserSettingsModal: true});
         }

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -33,17 +33,11 @@ export function cleanUpUrlable(input) {
 }
 
 export function isMac() {
-    if (navigator.userAgent.indexOf('Mac') !== -1) {
-        return true;
-    }
-    return false;
+    return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 }
 
 export function cmdOrCtrlPressed(e) {
-    if ((isMac() && e.metaKey) || (!isMac() && e.ctrlKey)) {
-        return true;
-    }
-    return false;
+    return (isMac() && e.metaKey) || (!isMac() && e.ctrlKey);
 }
 
 export function isChrome() {

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -32,6 +32,20 @@ export function cleanUpUrlable(input) {
     return cleaned;
 }
 
+export function isMac() {
+    if (navigator.userAgent.indexOf('Mac') !== -1) {
+        return true;
+    }
+    return false;
+}
+
+export function cmdOrCtrlPressed(e) {
+    if ((isMac() && e.metaKey) || (!isMac() && e.ctrlKey)) {
+        return true;
+    }
+    return false;
+}
+
 export function isChrome() {
     if (navigator.userAgent.indexOf('Chrome') > -1) {
         return true;


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

#### Summary
Previously, the following shortcuts worked with both CTRL and CMD on Mac, now they only work with CMD. Windows behaviour is unchanged, as in only CTRL works.

- Open a quick channel switcher dialog: CMD+K
- Open account settings: CMD+SHIFT+A
- Open recent mentions: CMD+SHIFT+M
- Upload a file: CMD+U

#### Issue/Ticket Link
https://mattermost.atlassian.net/browse/PLT-3473

