### PR TITLE
PLT-3372 Fixed error when adding incoming webhook to public channel not currently in

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -77,6 +77,7 @@ func createIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.LogAudit("fail - bad channel permissions")
 			return
 		}
+		c.Err = nil
 	}
 
 	if result := <-Srv.Store.Webhook().SaveIncoming(hook); result.Err != nil {

--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -18,6 +18,7 @@ func TestCreateIncomingHook(t *testing.T) {
 	team := th.SystemAdminTeam
 	channel1 := th.CreateChannel(Client, team)
 	channel2 := th.CreatePrivateChannel(Client, team)
+	channel3 := th.CreateChannel(Client, team)
 	user2 := th.CreateUser(Client)
 	LinkUserToTeam(user2, team)
 
@@ -66,6 +67,13 @@ func TestCreateIncomingHook(t *testing.T) {
 		if result.Data.(*model.IncomingWebhook).TeamId != team.Id {
 			t.Fatal("bad team id wasn't overwritten")
 		}
+	}
+
+	Client.Must(Client.LeaveChannel(channel3.Id))
+
+	hook = &model.IncomingWebhook{ChannelId: channel3.Id, UserId: user.Id, TeamId: team.Id}
+	if _, err := Client.CreateIncomingWebhook(hook); err != nil {
+		t.Fatal(err)
 	}
 
 	Client.Logout()


### PR DESCRIPTION
#### Summary
In a special case, the error on the context was not being reset after having the permissions checked. Updated it to reset to nil if the team is correct and the channel is public.

#### Unit Tests
Added a case for this.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3372