### PR TITLE
PLT-3504 Sanitize personal information out of license for non system admin users

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -890,7 +890,11 @@ func getInitialLoad(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	il.ClientCfg = utils.ClientCfg
-	il.LicenseCfg = utils.ClientLicense
+	if c.IsSystemAdmin() {
+		il.LicenseCfg = utils.ClientLicense
+	} else {
+		il.LicenseCfg = utils.GetSantizedClientLicense()
+	}
 
 	w.Write([]byte(il.ToJson()))
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -230,7 +230,6 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["EnableSignInWithEmail"] = strconv.FormatBool(*c.EmailSettings.EnableSignInWithEmail)
 	props["EnableSignInWithUsername"] = strconv.FormatBool(*c.EmailSettings.EnableSignInWithUsername)
 	props["RequireEmailVerification"] = strconv.FormatBool(c.EmailSettings.RequireEmailVerification)
-	props["FeedbackEmail"] = c.EmailSettings.FeedbackEmail
 
 	props["EnableSignUpWithGitLab"] = strconv.FormatBool(c.GitLabSettings.Enable)
 	props["EnableSignUpWithGoogle"] = strconv.FormatBool(c.GoogleSettings.Enable)

--- a/utils/license.go
+++ b/utils/license.go
@@ -146,3 +146,23 @@ func GetClientLicenseEtag() string {
 
 	return model.Etag(fmt.Sprintf("%x", md5.Sum([]byte(value))))
 }
+
+func GetSantizedClientLicense() map[string]string {
+	sanitizedLicense := make(map[string]string)
+
+	for k, v := range ClientLicense {
+		sanitizedLicense[k] = v
+	}
+
+	if IsLicensed {
+		delete(sanitizedLicense, "Name")
+		delete(sanitizedLicense, "Email")
+		delete(sanitizedLicense, "Company")
+		delete(sanitizedLicense, "PhoneNumber")
+		delete(sanitizedLicense, "IssuedAt")
+		delete(sanitizedLicense, "StartsAt")
+		delete(sanitizedLicense, "ExpiresAt")
+	}
+
+	return sanitizedLicense
+}


### PR DESCRIPTION
#### Summary
Some personal/unused fields were coming through in the client license, now they are sanitized out for non system admin users.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3504
