### PR TITLE
PLT-3176 On receive of a comment that we don't have the thread for, acquire the thread

### DIFF
--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
+import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
+
 import ChannelStore from 'stores/channel_store.jsx';
 import PostStore from 'stores/post_store.jsx';
 import UserStore from 'stores/user_store.jsx';
@@ -10,19 +11,21 @@ import ErrorStore from 'stores/error_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 import SearchStore from 'stores/search_store.jsx';
+
+import * as Websockets from 'actions/websocket_actions.jsx';
+import {handleNewPost} from 'actions/post_actions.jsx';
+
 import Constants from 'utils/constants.jsx';
 const ActionTypes = Constants.ActionTypes;
-import * as AsyncClient from 'utils/async_client.jsx';
+
 import Client from 'utils/web_client.jsx';
+import * as AsyncClient from 'utils/async_client.jsx';
 import * as Utils from 'utils/utils.jsx';
-import * as Websockets from './websocket_actions.jsx';
-import * as I18n from 'i18n/i18n.jsx';
-
-import {trackPage} from 'actions/analytics_actions.jsx';
-
-import {browserHistory} from 'react-router/es6';
 
 import en from 'i18n/en.json';
+import * as I18n from 'i18n/i18n.jsx';
+import {trackPage} from 'actions/analytics_actions.jsx';
+import {browserHistory} from 'react-router/es6';
 
 export function emitChannelClickEvent(channel) {
     function userVisitedFakeChannel(chan, success, fail) {
@@ -230,29 +233,6 @@ export function emitLoadMorePostsFocusedBottomEvent() {
     AsyncClient.getPostsAfter(latestPostId, 0, Constants.POST_CHUNK_SIZE, !!id);
 }
 
-export function emitPostRecievedEvent(post, msg) {
-    if (ChannelStore.getCurrentId() === post.channel_id) {
-        if (window.isActive) {
-            AsyncClient.updateLastViewedAt();
-        } else {
-            AsyncClient.getChannel(post.channel_id);
-        }
-    } else if (msg && (TeamStore.getCurrentId() === msg.team_id || msg.props.channel_type === Constants.DM_CHANNEL)) {
-        AsyncClient.getChannel(post.channel_id);
-    }
-
-    var websocketMessageProps = null;
-    if (msg) {
-        websocketMessageProps = msg.props;
-    }
-
-    AppDispatcher.handleServerAction({
-        type: ActionTypes.RECEIVED_POST,
-        post,
-        websocketMessageProps
-    });
-}
-
 export function emitUserPostedEvent(post) {
     AppDispatcher.handleServerAction({
         type: ActionTypes.CREATE_POST,
@@ -389,7 +369,7 @@ export function sendEphemeralPost(message, channelId) {
         props: {}
     };
 
-    emitPostRecievedEvent(post);
+    handleNewPost(post);
 }
 
 export function newLocalizationSelected(locale) {

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
+
+import ChannelStore from 'stores/channel_store.jsx';
+import PostStore from 'stores/post_store.jsx';
+import TeamStore from 'stores/team_store.jsx';
+
+import Constants from 'utils/constants.jsx';
+const ActionTypes = Constants.ActionTypes;
+
+import Client from 'utils/web_client.jsx';
+import * as AsyncClient from 'utils/async_client.jsx';
+
+export function handleNewPost(post, msg) {
+    if (ChannelStore.getCurrentId() === post.channel_id) {
+        if (window.isActive) {
+            AsyncClient.updateLastViewedAt();
+        } else {
+            AsyncClient.getChannel(post.channel_id);
+        }
+    } else if (msg && (TeamStore.getCurrentId() === msg.team_id || msg.props.channel_type === Constants.DM_CHANNEL)) {
+        AsyncClient.getChannel(post.channel_id);
+    }
+
+    var websocketMessageProps = null;
+    if (msg) {
+        websocketMessageProps = msg.props;
+    }
+
+    if (post.root_id && PostStore.getPost(post.channel_id, post.root_id) == null) {
+        Client.getPost(
+            post.channel_id,
+            post.root_id,
+            (data) => {
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_POSTS,
+                    id: post.channel_id,
+                    numRequested: 0,
+                    post_list: data
+                });
+
+                // Required to update order
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_POST,
+                    post,
+                    websocketMessageProps
+                });
+            },
+            (err) => {
+                AsyncClient.dispatchError(err, 'getPost');
+            }
+        );
+
+        return;
+    }
+
+    AppDispatcher.handleServerAction({
+        type: ActionTypes.RECEIVED_POST,
+        post,
+        websocketMessageProps
+    });
+}

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -14,6 +14,7 @@ import Client from 'utils/web_client.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
+import {handleNewPost} from 'actions/post_actions.jsx';
 
 import Constants from 'utils/constants.jsx';
 const SocketEvents = Constants.SocketEvents;
@@ -190,7 +191,7 @@ export function close() {
 
 function handleNewPostEvent(msg) {
     const post = JSON.parse(msg.props.post);
-    GlobalActions.emitPostRecievedEvent(post, msg);
+    handleNewPost(post, msg);
 }
 
 function handlePostEditEvent(msg) {

--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -136,7 +136,9 @@ export default class PostList extends React.Component {
         }
     }
 
-    loadMorePostsTop() {
+    loadMorePostsTop(e) {
+        e.preventDefault();
+
         if (this.props.isFocusPost) {
             return GlobalActions.emitLoadMorePostsFocusedTopEvent();
         }


### PR DESCRIPTION
#### Summary
When another user commented on an unloaded thread, undefined behaviour occurred. This PR updates the client to acquire missing threads for new comments from the server to fix the issue.

Also fixed a `#` getting added to the URL from clicking "Load more messages"

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3176