### PR TITLE
PLT-3453 Reloading the configuration in the system console

### DIFF
--- a/webapp/components/admin_console/configuration_settings.jsx
+++ b/webapp/components/admin_console/configuration_settings.jsx
@@ -24,6 +24,12 @@ export default class ConfigurationSettings extends AdminSettings {
         });
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.config.ServiceSettings.ListenAddress !== this.props.config.ServiceSettings.ListenAddress) {
+            this.setState({listenAddress: nextProps.config.ServiceSettings.ListenAddress});
+        }
+    }
+
     getConfigFromState(config) {
         config.ServiceSettings.ListenAddress = this.state.listenAddress;
 


### PR DESCRIPTION
#### Summary
Before System console config where updated when clicking on `Reload config from disk` but the actual view wasn't updated if the listen address changed. now it does

#### Issue/Ticket Link
https://mattermost.atlassian.net/browse/PLT-3453