### PR TITLE
PLT-3512 adding join/leave channel to the CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,12 @@ run-server: prepare-enterprise start-docker
 	mkdir -p $(BUILD_WEBAPP_DIR)/dist/files
 	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) *.go &
 
+run-cli: prepare-enterprise start-docker
+	@echo Running mattermost for development
+	@echo Example should be like >'make ARGS="-version" run-cli'
+
+	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) *.go ${ARGS}
+
 run-client:
 	@echo Running mattermost client for development
 

--- a/api/cli_test.go
+++ b/api/cli_test.go
@@ -269,6 +269,41 @@ func TestCliListChannels(t *testing.T) {
 	}
 }
 
+func TestCliRestoreChannel(t *testing.T) {
+	if disableCliTests {
+		return
+	}
+
+	th := Setup().InitBasic()
+	channel := th.CreateChannel(th.BasicClient, th.BasicTeam)
+	th.BasicClient.Must(th.BasicClient.DeleteChannel(channel.Id))
+
+	// These test cannot run since this feature requires an enteprise license
+
+	// cmd := exec.Command("bash", "-c", `go run ../mattermost.go -restore_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`"`)
+	// output, err := cmd.CombinedOutput()
+	// if err != nil {
+	// 	t.Log(string(output))
+	// 	t.Fatal(err)
+	// }
+
+	// // restoring twice should succeed
+	// cmd1 := exec.Command("bash", "-c", `go run ../mattermost.go -restore_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`"`)
+	// output1, err1 := cmd1.CombinedOutput()
+	// if err1 != nil {
+	// 	t.Log(string(output1))
+	// 	t.Fatal(err1)
+	// }
+
+	// should fail because channel does not have license
+	cmd3 := exec.Command("bash", "-c", `go run ../mattermost.go -restore_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`"`)
+	output3, err3 := cmd3.CombinedOutput()
+	if err3 == nil {
+		t.Log(string(output3))
+		t.Fatal()
+	}
+}
+
 func TestCliJoinTeam(t *testing.T) {
 	if disableCliTests {
 		return

--- a/api/cli_test.go
+++ b/api/cli_test.go
@@ -135,6 +135,105 @@ func TestCliAssignRole(t *testing.T) {
 	}
 }
 
+func TestCliJoinChannel(t *testing.T) {
+	if disableCliTests {
+		return
+	}
+
+	th := Setup().InitBasic()
+	channel := th.CreateChannel(th.BasicClient, th.BasicTeam)
+
+	// These test cannot run since this feature requires an enteprise license
+
+	// cmd := exec.Command("bash", "-c", `go run ../mattermost.go -join_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`" -email="`+th.BasicUser2.Email+`"`)
+	// output, err := cmd.CombinedOutput()
+	// if err != nil {
+	// 	t.Log(string(output))
+	// 	t.Fatal(err)
+	// }
+
+	// // Joining twice should succeed
+	// cmd1 := exec.Command("bash", "-c", `go run ../mattermost.go -join_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`" -email="`+th.BasicUser2.Email+`"`)
+	// output1, err1 := cmd1.CombinedOutput()
+	// if err1 != nil {
+	// 	t.Log(string(output1))
+	// 	t.Fatal(err1)
+	// }
+
+	// should fail because channel does not exist
+	cmd2 := exec.Command("bash", "-c", `go run ../mattermost.go -join_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`asdf" -email="`+th.BasicUser2.Email+`"`)
+	output2, err2 := cmd2.CombinedOutput()
+	if err2 == nil {
+		t.Log(string(output2))
+		t.Fatal()
+	}
+
+	// should fail because channel does not have license
+	cmd3 := exec.Command("bash", "-c", `go run ../mattermost.go -join_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`" -email="`+th.BasicUser2.Email+`"`)
+	output3, err3 := cmd3.CombinedOutput()
+	if err3 == nil {
+		t.Log(string(output3))
+		t.Fatal()
+	}
+}
+
+func TestCliRemoveChannel(t *testing.T) {
+	if disableCliTests {
+		return
+	}
+
+	th := Setup().InitBasic()
+	channel := th.CreateChannel(th.BasicClient, th.BasicTeam)
+
+	// These test cannot run since this feature requires an enteprise license
+
+	// cmd := exec.Command("bash", "-c", `go run ../mattermost.go -join_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`" -email="`+th.BasicUser2.Email+`"`)
+	// output, err := cmd.CombinedOutput()
+	// if err != nil {
+	// 	t.Log(string(output))
+	// 	t.Fatal(err)
+	// }
+
+	// cmd0 := exec.Command("bash", "-c", `go run ../mattermost.go -leave_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`" -email="`+th.BasicUser2.Email+`"`)
+	// output0, err0 := cmd0.CombinedOutput()
+	// if err0 != nil {
+	// 	t.Log(string(output0))
+	// 	t.Fatal(err0)
+	// }
+
+	// // Leaving twice should succeed
+	// cmd1 := exec.Command("bash", "-c", `go run ../mattermost.go -leave_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`" -email="`+th.BasicUser2.Email+`"`)
+	// output1, err1 := cmd1.CombinedOutput()
+	// if err1 != nil {
+	// 	t.Log(string(output1))
+	// 	t.Fatal(err1)
+	// }
+
+	// cannot leave town-square
+	cmd1a := exec.Command("bash", "-c", `go run ../mattermost.go -leave_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="town-square" -email="`+th.BasicUser2.Email+`"`)
+	output1a, err1a := cmd1a.CombinedOutput()
+	if err1a == nil {
+		t.Log(string(output1a))
+		t.Fatal()
+	}
+
+	// should fail because channel does not exist
+	cmd2 := exec.Command("bash", "-c", `go run ../mattermost.go -leave_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`asdf" -email="`+th.BasicUser2.Email+`"`)
+	output2, err2 := cmd2.CombinedOutput()
+	if err2 == nil {
+		t.Log(string(output2))
+		t.Fatal()
+	}
+
+	// should fail because channel does not have license
+	cmd3 := exec.Command("bash", "-c", `go run ../mattermost.go -leave_channel -team_name="`+th.BasicTeam.Name+`" -channel_name="`+channel.Name+`" -email="`+th.BasicUser2.Email+`"`)
+	output3, err3 := cmd3.CombinedOutput()
+	if err3 == nil {
+		t.Log(string(output3))
+		t.Fatal()
+	}
+}
+
 func TestCliJoinTeam(t *testing.T) {
 	if disableCliTests {
 		return

--- a/api/cli_test.go
+++ b/api/cli_test.go
@@ -234,6 +234,41 @@ func TestCliRemoveChannel(t *testing.T) {
 	}
 }
 
+func TestCliListChannels(t *testing.T) {
+	if disableCliTests {
+		return
+	}
+
+	th := Setup().InitBasic()
+	channel := th.CreateChannel(th.BasicClient, th.BasicTeam)
+	th.BasicClient.Must(th.BasicClient.DeleteChannel(channel.Id))
+
+	// These test cannot run since this feature requires an enteprise license
+
+	// cmd := exec.Command("bash", "-c", `go run ../mattermost.go -list_channels -team_name="`+th.BasicTeam.Name+`"`)
+	// output, err := cmd.CombinedOutput()
+	// if err != nil {
+	// 	t.Log(string(output))
+	// 	t.Fatal(err)
+	// }
+
+	// if !strings.Contains(string(output), "town-square") {
+	// 	t.Fatal("should have channels")
+	// }
+
+	// if !strings.Contains(string(output), channel.Name+" (archived)") {
+	// 	t.Fatal("should have archived channel")
+	// }
+
+	// should fail because channel does not have license
+	cmd3 := exec.Command("bash", "-c", `go run ../mattermost.go -list_channels -team_name="`+th.BasicTeam.Name+``)
+	output3, err3 := cmd3.CombinedOutput()
+	if err3 == nil {
+		t.Log(string(output3))
+		t.Fatal()
+	}
+}
+
 func TestCliJoinTeam(t *testing.T) {
 	if disableCliTests {
 		return

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3016,6 +3016,10 @@
     "translation": "More than 1 read replica functionality disabled by current license. Please contact your system administrator about upgrading your enterprise license."
   },
   {
+    "id": "cli.license.critical",
+    "translation": "Feature requires an enterprise license. Please contact your system administrator about upgrading your enterprise license."
+  },
+  {
     "id": "store.sql.remove_index.critical",
     "translation": "Failed to remove index %v"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3140,6 +3140,10 @@
     "translation": "We couldn't get all the channels"
   },
   {
+    "id": "store.sql_channel.get_all.app_error",
+    "translation": "We couldn't get all the channels"
+  },
+  {
     "id": "store.sql_channel.get_member.app_error",
     "translation": "We couldn't get the channel member"
   },

--- a/mattermost.go
+++ b/mattermost.go
@@ -1550,7 +1550,7 @@ COMMANDS:
                                        It requires the -channel_name flag and
                                        -team_name flag.  Requires an enterprise license.
         Example:
-            platform -list_channels -team_name="name"
+            platform -restore_channel -team_name="name" -channel_name="channel_name"
 
     -reset_password                   Resets the password for a user.  It requires the
                                       -email and -password flag.

--- a/mattermost.go
+++ b/mattermost.go
@@ -1529,26 +1529,26 @@ COMMANDS:
             platform -assign_role -email="user@example.com" -role="system_admin"
 
     -join_channel                      Joins a user to the channel.  It requires the -email, channel_name and
-                                       -team_name.  You may need to logout of your current session
+                                       -team_name flags.  You may need to logout of your current session
                                        for the new channel to be applied.  Requires an enterprise license.
         Example:
             platform -join_channel -email="user@example.com" -team_name="name" -channel_name="channel_name"
 
     -leave_channel                     Removes a user from the channel.  It requires the -email, channel_name and
-                                       -team_name.  You may need to logout of your current session
+                                       -team_name flags.  You may need to logout of your current session
                                        for the channel to be removed.  Requires an enterprise license.
         Example:
             platform -leave_channel -email="user@example.com" -team_name="name" -channel_name="channel_name"
 
-    -list_channels                     Lists all private/public channels for a given team.
+    -list_channels                     Lists all public channels and private groups for a given team.
                                        It will append ' (archived)' to the channel name if archived.  It requires the 
                                        -team_name flag.  Requires an enterprise license.
         Example:
             platform -list_channels -team_name="name"
 
     -restore_channel                   Restores a previously deleted channel.
-                                       It requires the -channel_name flag and
-                                       -team_name flag.  Requires an enterprise license.
+                                       It requires the -channel_name and
+                                       -team_name flags.  Requires an enterprise license.
         Example:
             platform -restore_channel -team_name="name" -channel_name="channel_name"
 

--- a/mattermost.go
+++ b/mattermost.go
@@ -280,6 +280,7 @@ func parseCmds() {
 	flag.BoolVar(&flagCmdInviteUser, "invite_user", false, "")
 	flag.BoolVar(&flagCmdAssignRole, "assign_role", false, "")
 	flag.BoolVar(&flagCmdJoinChannel, "join_channel", false, "")
+	flag.BoolVar(&flagCmdLeaveChannel, "leave_channel", false, "")
 	flag.BoolVar(&flagCmdListChannels, "list_channels", false, "")
 	flag.BoolVar(&flagCmdRestoreChannel, "restore_channel", false, "")
 	flag.BoolVar(&flagCmdJoinTeam, "join_team", false, "")

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -948,6 +948,28 @@ func (s SqlChannelStore) GetForExport(teamId string) StoreChannel {
 	return storeChannel
 }
 
+func (s SqlChannelStore) GetAll(teamId string) StoreChannel {
+	storeChannel := make(StoreChannel)
+
+	go func() {
+		result := StoreResult{}
+
+		var data []*model.Channel
+		_, err := s.GetReplica().Select(&data, "SELECT * FROM Channels WHERE TeamId = :TeamId AND Type != 'D' ORDER BY Name", map[string]interface{}{"TeamId": teamId})
+
+		if err != nil {
+			result.Err = model.NewLocAppError("SqlChannelStore.GetAll", "store.sql_channel.get_all.app_error", nil, "teamId="+teamId+", err="+err.Error())
+		} else {
+			result.Data = data
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
 func (s SqlChannelStore) AnalyticsTypeCount(teamId string, channelType string) StoreChannel {
 	storeChannel := make(StoreChannel)
 

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -289,12 +289,16 @@ func (s SqlChannelStore) get(id string, master bool) StoreChannel {
 }
 
 func (s SqlChannelStore) Delete(channelId string, time int64) StoreChannel {
+	return s.SetDeleteAt(channelId, time, time)
+}
+
+func (s SqlChannelStore) SetDeleteAt(channelId string, deleteAt int64, updateAt int64) StoreChannel {
 	storeChannel := make(StoreChannel)
 
 	go func() {
 		result := StoreResult{}
 
-		_, err := s.GetMaster().Exec("Update Channels SET DeleteAt = :Time, UpdateAt = :Time WHERE Id = :ChannelId", map[string]interface{}{"Time": time, "ChannelId": channelId})
+		_, err := s.GetMaster().Exec("Update Channels SET DeleteAt = :DeleteAt, UpdateAt = :UpdateAt WHERE Id = :ChannelId", map[string]interface{}{"DeleteAt": deleteAt, "UpdateAt": updateAt, "ChannelId": channelId})
 		if err != nil {
 			result.Err = model.NewLocAppError("SqlChannelStore.Delete", "store.sql_channel.delete.channel.app_error", nil, "id="+channelId+", err="+err.Error())
 		}

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -200,6 +200,15 @@ func TestChannelStoreGet(t *testing.T) {
 			t.Fatal("invalid returned channel")
 		}
 	}
+
+	if r3 := <-store.Channel().GetAll(o1.TeamId); r3.Err != nil {
+		t.Fatal(r3.Err)
+	} else {
+		channels := r3.Data.([]*model.Channel)
+		if len(channels) == 0 {
+			t.Fatal("too little")
+		}
+	}
 }
 
 func TestChannelStoreDelete(t *testing.T) {

--- a/store/store.go
+++ b/store/store.go
@@ -83,6 +83,7 @@ type ChannelStore interface {
 	GetMoreChannels(teamId string, userId string) StoreChannel
 	GetChannelCounts(teamId string, userId string) StoreChannel
 	GetForExport(teamId string) StoreChannel
+	GetAll(teamId string) StoreChannel
 
 	SaveMember(member *model.ChannelMember) StoreChannel
 	UpdateMember(member *model.ChannelMember) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -77,6 +77,7 @@ type ChannelStore interface {
 	Get(id string) StoreChannel
 	GetFromMaster(id string) StoreChannel
 	Delete(channelId string, time int64) StoreChannel
+	SetDeleteAt(channelId string, deleteAt int64, updateAt int64) StoreChannel
 	PermanentDeleteByTeam(teamId string) StoreChannel
 	GetByName(team_id string, domain string) StoreChannel
 	GetChannels(teamId string, userId string) StoreChannel

--- a/utils/diagnostic.go
+++ b/utils/diagnostic.go
@@ -19,6 +19,7 @@ const (
 	PROP_DIAGNOSTIC_DATABASE          = "db"
 	PROP_DIAGNOSTIC_OS                = "os"
 	PROP_DIAGNOSTIC_USER_COUNT        = "uc"
+	PROP_DIAGNOSTIC_TEAM_COUNT        = "tc"
 	PROP_DIAGNOSTIC_ACTIVE_USER_COUNT = "auc"
 	PROP_DIAGNOSTIC_UNIT_TESTS        = "ut"
 )


### PR DESCRIPTION
#### Summary
Added CLI commands
```
    -join_channel                      Joins a user to the channel.  It requires the -email, channel_name and
                                       -team_name.  You may need to logout of your current session
                                       for the new channel to be applied.  Requires an enterprise license.
        Example:
            platform -join_channel -email="user@example.com" -team_name="name" -channel_name="channel_name"

    -leave_channel                     Removes a user from the channel.  It requires the -email, channel_name and
                                       -team_name.  You may need to logout of your current session
                                       for the channel to be removed.  Requires an enterprise license.
        Example:
            platform -leave_channel -email="user@example.com" -team_name="name" -channel_name="channel_name"

    -list_channels                     Lists all private/public channels for a given team.
                                       It will append ' (archived)' to the channel name if archived.  It requires the 
                                       -team_name flag.  Requires an enterprise license.
        Example:
            platform -list_channels -team_name="name"

    -restore_channel                   Restores a previously deleted channel.
                                       It requires the -channel_name flag and
                                       -team_name flag.  Requires an enterprise license.
        Example:
            platform -restore_channel -team_name="name" -channel_name="channel_name"

```

#### Unit Tests
Have you updated the unit tests or added new ones to cover your changes? If not, you probably should

YES

#### Issue/Ticket Link
https://mattermost.atlassian.net/browse/PLT-3512

#### Has Critical Changes
YES, for the command line