### PR TITLE
PLT-3502 Fix Team admins can't give "team admin" privilege to members

### DIFF
--- a/api/user_test.go
+++ b/api/user_test.go
@@ -910,7 +910,7 @@ func TestUserUpdateRolesMoreCases(t *testing.T) {
 	data["user_id"] = th.BasicUser2.Id
 	data["new_roles"] = model.ROLE_TEAM_ADMIN
 	data["team_id"] = th.BasicTeam.Id
-	if _, err := th.BasicClient.UpdateUserRoles(data); err == nil {
+	if _, err := th.BasicClient.UpdateUserRoles(data); err != nil {
 		t.Fatal("Should have succeeded since they are team admin")
 	}
 
@@ -926,7 +926,7 @@ func TestUserUpdateRolesMoreCases(t *testing.T) {
 	data["user_id"] = th.BasicUser2.Id
 	data["new_roles"] = ""
 	data["team_id"] = th.BasicTeam.Id
-	if _, err := th.BasicClient.UpdateUserRoles(data); err == nil {
+	if _, err := th.BasicClient.UpdateUserRoles(data); err != nil {
 		t.Fatal("Should have succeeded since they are team admin")
 	}
 


### PR DESCRIPTION
#### Summary
There was a case where a Team admin couldn't make another user team admin

#### Issue/Ticket Link
https://mattermost.atlassian.net/browse/PLT-3502

