### PR TITLE
PLT-3237 Update displayed config values in admin console after saving

### DIFF
--- a/webapp/components/admin_console/admin_settings.jsx
+++ b/webapp/components/admin_console/admin_settings.jsx
@@ -60,13 +60,15 @@ export default class AdminSettings extends React.Component {
             serverError: null
         });
 
-        const config = this.getConfigFromState(this.props.config);
+        // clone config so that we aren't modifying data in the stores
+        let config = JSON.parse(JSON.stringify(this.props.config));
+        config = this.getConfigFromState(config);
 
         Client.saveConfig(
             config,
             () => {
-                AsyncClient.getConfig((newConfig) => {
-                    this.setState(this.getStateFromConfig(newConfig));
+                AsyncClient.getConfig((savedConfig) => {
+                    this.setState(this.getStateFromConfig(savedConfig));
                 });
 
                 this.setState({

--- a/webapp/components/admin_console/admin_settings.jsx
+++ b/webapp/components/admin_console/admin_settings.jsx
@@ -24,11 +24,11 @@ export default class AdminSettings extends React.Component {
         this.handleSubmit = this.handleSubmit.bind(this);
         this.onKeyDown = this.onKeyDown.bind(this);
 
-        this.state = {
+        this.state = Object.assign(this.getStateFromConfig(props.config), {
             saveNeeded: false,
             saving: false,
             serverError: null
-        };
+        });
     }
 
     handleChange(id, value) {
@@ -65,7 +65,10 @@ export default class AdminSettings extends React.Component {
         Client.saveConfig(
             config,
             () => {
-                AsyncClient.getConfig();
+                AsyncClient.getConfig((newConfig) => {
+                    this.setState(this.getStateFromConfig(newConfig));
+                });
+
                 this.setState({
                     saveNeeded: false,
                     saving: false

--- a/webapp/components/admin_console/compliance_settings.jsx
+++ b/webapp/components/admin_console/compliance_settings.jsx
@@ -18,12 +18,6 @@ export default class ComplianceSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enable: props.config.ComplianceSettings.Enable,
-            directory: props.config.ComplianceSettings.Directory,
-            enableDaily: props.config.ComplianceSettings.EnableDaily
-        });
     }
 
     getConfigFromState(config) {
@@ -32,6 +26,14 @@ export default class ComplianceSettings extends AdminSettings {
         config.ComplianceSettings.EnableDaily = this.state.enableDaily;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enable: config.ComplianceSettings.Enable,
+            directory: config.ComplianceSettings.Directory,
+            enableDaily: config.ComplianceSettings.EnableDaily
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/configuration_settings.jsx
+++ b/webapp/components/admin_console/configuration_settings.jsx
@@ -19,17 +19,12 @@ export default class ConfigurationSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            listenAddress: props.config.ServiceSettings.ListenAddress,
-            webserverMode: props.config.ServiceSettings.WebserverMode
-        });
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.config.ServiceSettings.ListenAddress !== this.props.config.ServiceSettings.ListenAddress) {
-            this.setState({listenAddress: nextProps.config.ServiceSettings.ListenAddress});
-        }
+        // special case for this page since we don't update AdminSettings components when the
+        // stored config changes, but we want this page to update when you reload the config
+        this.setState(this.getStateFromConfig(nextProps.config));
     }
 
     getConfigFromState(config) {
@@ -37,6 +32,13 @@ export default class ConfigurationSettings extends AdminSettings {
         config.ServiceSettings.WebserverMode = this.state.webserverMode;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            listenAddress: config.ServiceSettings.ListenAddress,
+            webserverMode: config.ServiceSettings.WebserverMode
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/connection_settings.jsx
+++ b/webapp/components/admin_console/connection_settings.jsx
@@ -18,11 +18,6 @@ export default class ConnectionSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            allowCorsFrom: props.config.ServiceSettings.AllowCorsFrom,
-            enableInsecureOutgoingConnections: props.config.ServiceSettings.EnableInsecureOutgoingConnections
-        });
     }
 
     getConfigFromState(config) {
@@ -30,6 +25,13 @@ export default class ConnectionSettings extends AdminSettings {
         config.ServiceSettings.EnableInsecureOutgoingConnections = this.state.enableInsecureOutgoingConnections;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            allowCorsFrom: config.ServiceSettings.AllowCorsFrom,
+            enableInsecureOutgoingConnections: config.ServiceSettings.EnableInsecureOutgoingConnections
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/custom_brand_settings.jsx
+++ b/webapp/components/admin_console/custom_brand_settings.jsx
@@ -19,12 +19,6 @@ export default class CustomBrandSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            siteName: props.config.TeamSettings.SiteName,
-            enableCustomBrand: props.config.TeamSettings.EnableCustomBrand,
-            customBrandText: props.config.TeamSettings.CustomBrandText
-        });
     }
 
     getConfigFromState(config) {
@@ -35,6 +29,14 @@ export default class CustomBrandSettings extends AdminSettings {
         }
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            siteName: config.TeamSettings.SiteName,
+            enableCustomBrand: config.TeamSettings.EnableCustomBrand,
+            customBrandText: config.TeamSettings.CustomBrandText
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/custom_emoji_settings.jsx
+++ b/webapp/components/admin_console/custom_emoji_settings.jsx
@@ -18,11 +18,6 @@ export default class CustomEmojiSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enableCustomEmoji: props.config.ServiceSettings.EnableCustomEmoji,
-            restrictCustomEmojiCreation: props.config.ServiceSettings.RestrictCustomEmojiCreation
-        });
     }
 
     getConfigFromState(config) {
@@ -33,6 +28,13 @@ export default class CustomEmojiSettings extends AdminSettings {
         }
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enableCustomEmoji: config.ServiceSettings.EnableCustomEmoji,
+            restrictCustomEmojiCreation: config.ServiceSettings.RestrictCustomEmojiCreation
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/database_settings.jsx
+++ b/webapp/components/admin_console/database_settings.jsx
@@ -20,15 +20,6 @@ export default class DatabaseSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            driverName: this.props.config.SqlSettings.DriverName,
-            dataSource: this.props.config.SqlSettings.DataSource,
-            maxIdleConns: props.config.SqlSettings.MaxIdleConns,
-            maxOpenConns: props.config.SqlSettings.MaxOpenConns,
-            atRestEncryptKey: props.config.SqlSettings.AtRestEncryptKey,
-            trace: props.config.SqlSettings.Trace
-        });
     }
 
     getConfigFromState(config) {
@@ -40,6 +31,17 @@ export default class DatabaseSettings extends AdminSettings {
         config.SqlSettings.Trace = this.state.trace;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            driverName: config.SqlSettings.DriverName,
+            dataSource: config.SqlSettings.DataSource,
+            maxIdleConns: config.SqlSettings.MaxIdleConns,
+            maxOpenConns: config.SqlSettings.MaxOpenConns,
+            atRestEncryptKey: config.SqlSettings.AtRestEncryptKey,
+            trace: config.SqlSettings.Trace
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/developer_settings.jsx
+++ b/webapp/components/admin_console/developer_settings.jsx
@@ -15,11 +15,6 @@ export default class DeveloperSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enableTesting: props.config.ServiceSettings.EnableTesting,
-            enableDeveloper: props.config.ServiceSettings.EnableDeveloper
-        });
     }
 
     getConfigFromState(config) {
@@ -27,6 +22,13 @@ export default class DeveloperSettings extends AdminSettings {
         config.ServiceSettings.EnableDeveloper = this.state.enableDeveloper;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enableTesting: config.ServiceSettings.EnableTesting,
+            enableDeveloper: config.ServiceSettings.EnableDeveloper
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/email_authentication_settings.jsx
+++ b/webapp/components/admin_console/email_authentication_settings.jsx
@@ -15,12 +15,6 @@ export default class EmailAuthenticationSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enableSignUpWithEmail: props.config.EmailSettings.EnableSignUpWithEmail,
-            enableSignInWithEmail: props.config.EmailSettings.EnableSignInWithEmail,
-            enableSignInWithUsername: props.config.EmailSettings.EnableSignInWithUsername
-        });
     }
 
     getConfigFromState(config) {
@@ -29,6 +23,14 @@ export default class EmailAuthenticationSettings extends AdminSettings {
         config.EmailSettings.EnableSignInWithUsername = this.state.enableSignInWithUsername;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enableSignUpWithEmail: config.EmailSettings.EnableSignUpWithEmail,
+            enableSignInWithEmail: config.EmailSettings.EnableSignInWithEmail,
+            enableSignInWithUsername: config.EmailSettings.EnableSignInWithUsername
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/email_settings.jsx
+++ b/webapp/components/admin_console/email_settings.jsx
@@ -20,19 +20,6 @@ export default class EmailSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            sendEmailNotifications: props.config.EmailSettings.SendEmailNotifications,
-            feedbackName: props.config.EmailSettings.FeedbackName,
-            feedbackEmail: props.config.EmailSettings.FeedbackEmail,
-            feedbackOrganization: props.config.EmailSettings.FeedbackOrganization,
-            smtpUsername: props.config.EmailSettings.SMTPUsername,
-            smtpPassword: props.config.EmailSettings.SMTPPassword,
-            smtpServer: props.config.EmailSettings.SMTPServer,
-            smtpPort: props.config.EmailSettings.SMTPPort,
-            connectionSecurity: props.config.EmailSettings.ConnectionSecurity,
-            enableSecurityFixAlert: props.config.ServiceSettings.EnableSecurityFixAlert
-        });
     }
 
     getConfigFromState(config) {
@@ -48,6 +35,21 @@ export default class EmailSettings extends AdminSettings {
         config.ServiceSettings.EnableSecurityFixAlert = this.state.enableSecurityFixAlert;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            sendEmailNotifications: config.EmailSettings.SendEmailNotifications,
+            feedbackName: config.EmailSettings.FeedbackName,
+            feedbackEmail: config.EmailSettings.FeedbackEmail,
+            feedbackOrganization: config.EmailSettings.FeedbackOrganization,
+            smtpUsername: config.EmailSettings.SMTPUsername,
+            smtpPassword: config.EmailSettings.SMTPPassword,
+            smtpServer: config.EmailSettings.SMTPServer,
+            smtpPort: config.EmailSettings.SMTPPort,
+            connectionSecurity: config.EmailSettings.ConnectionSecurity,
+            enableSecurityFixAlert: config.ServiceSettings.EnableSecurityFixAlert
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/external_service_settings.jsx
+++ b/webapp/components/admin_console/external_service_settings.jsx
@@ -17,11 +17,6 @@ export default class ExternalServiceSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            segmentDeveloperKey: props.config.ServiceSettings.SegmentDeveloperKey,
-            googleDeveloperKey: props.config.ServiceSettings.GoogleDeveloperKey
-        });
     }
 
     getConfigFromState(config) {
@@ -29,6 +24,13 @@ export default class ExternalServiceSettings extends AdminSettings {
         config.ServiceSettings.GoogleDeveloperKey = this.state.googleDeveloperKey;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            segmentDeveloperKey: config.ServiceSettings.SegmentDeveloperKey,
+            googleDeveloperKey: config.ServiceSettings.GoogleDeveloperKey
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/gitlab_settings.jsx
+++ b/webapp/components/admin_console/gitlab_settings.jsx
@@ -18,15 +18,6 @@ export default class GitLabSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enable: props.config.GitLabSettings.Enable,
-            id: props.config.GitLabSettings.Id,
-            secret: props.config.GitLabSettings.Secret,
-            userApiEndpoint: props.config.GitLabSettings.UserApiEndpoint,
-            authEndpoint: props.config.GitLabSettings.AuthEndpoint,
-            tokenEndpoint: props.config.GitLabSettings.TokenEndpoint
-        });
     }
 
     getConfigFromState(config) {
@@ -38,6 +29,17 @@ export default class GitLabSettings extends AdminSettings {
         config.GitLabSettings.TokenEndpoint = this.state.tokenEndpoint;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enable: config.GitLabSettings.Enable,
+            id: config.GitLabSettings.Id,
+            secret: config.GitLabSettings.Secret,
+            userApiEndpoint: config.GitLabSettings.UserApiEndpoint,
+            authEndpoint: config.GitLabSettings.AuthEndpoint,
+            tokenEndpoint: config.GitLabSettings.TokenEndpoint
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/image_settings.jsx
+++ b/webapp/components/admin_console/image_settings.jsx
@@ -17,15 +17,6 @@ export default class ImageSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            thumbnailWidth: props.config.FileSettings.ThumbnailWidth,
-            thumbnailHeight: props.config.FileSettings.ThumbnailHeight,
-            profileWidth: props.config.FileSettings.ProfileWidth,
-            profileHeight: props.config.FileSettings.ProfileHeight,
-            previewWidth: props.config.FileSettings.PreviewWidth,
-            previewHeight: props.config.FileSettings.PreviewHeight
-        });
     }
 
     getConfigFromState(config) {
@@ -37,6 +28,17 @@ export default class ImageSettings extends AdminSettings {
         config.FileSettings.PreviewHeight = this.parseInt(this.state.previewHeight);
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            thumbnailWidth: config.FileSettings.ThumbnailWidth,
+            thumbnailHeight: config.FileSettings.ThumbnailHeight,
+            profileWidth: config.FileSettings.ProfileWidth,
+            profileHeight: config.FileSettings.ProfileHeight,
+            previewWidth: config.FileSettings.PreviewWidth,
+            previewHeight: config.FileSettings.PreviewHeight
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/ldap_settings.jsx
+++ b/webapp/components/admin_console/ldap_settings.jsx
@@ -19,28 +19,6 @@ export default class LdapSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enable: props.config.LdapSettings.Enable,
-            ldapServer: props.config.LdapSettings.LdapServer,
-            ldapPort: props.config.LdapSettings.LdapPort,
-            connectionSecurity: props.config.LdapSettings.ConnectionSecurity,
-            baseDN: props.config.LdapSettings.BaseDN,
-            bindUsername: props.config.LdapSettings.BindUsername,
-            bindPassword: props.config.LdapSettings.BindPassword,
-            userFilter: props.config.LdapSettings.UserFilter,
-            firstNameAttribute: props.config.LdapSettings.FirstNameAttribute,
-            lastNameAttribute: props.config.LdapSettings.LastNameAttribute,
-            nicknameAttribute: props.config.LdapSettings.NicknameAttribute,
-            emailAttribute: props.config.LdapSettings.EmailAttribute,
-            usernameAttribute: props.config.LdapSettings.UsernameAttribute,
-            idAttribute: props.config.LdapSettings.IdAttribute,
-            syncIntervalMinutes: props.config.LdapSettings.SyncIntervalMinutes,
-            skipCertificateVerification: props.config.LdapSettings.SkipCertificateVerification,
-            queryTimeout: props.config.LdapSettings.QueryTimeout,
-            maxPageSize: props.config.LdapSettings.MaxPageSize,
-            loginFieldName: props.config.LdapSettings.LoginFieldName
-        });
     }
 
     getConfigFromState(config) {
@@ -65,6 +43,30 @@ export default class LdapSettings extends AdminSettings {
         config.LdapSettings.LoginFieldName = this.state.loginFieldName;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enable: config.LdapSettings.Enable,
+            ldapServer: config.LdapSettings.LdapServer,
+            ldapPort: config.LdapSettings.LdapPort,
+            connectionSecurity: config.LdapSettings.ConnectionSecurity,
+            baseDN: config.LdapSettings.BaseDN,
+            bindUsername: config.LdapSettings.BindUsername,
+            bindPassword: config.LdapSettings.BindPassword,
+            userFilter: config.LdapSettings.UserFilter,
+            firstNameAttribute: config.LdapSettings.FirstNameAttribute,
+            lastNameAttribute: config.LdapSettings.LastNameAttribute,
+            nicknameAttribute: config.LdapSettings.NicknameAttribute,
+            emailAttribute: config.LdapSettings.EmailAttribute,
+            usernameAttribute: config.LdapSettings.UsernameAttribute,
+            idAttribute: config.LdapSettings.IdAttribute,
+            syncIntervalMinutes: config.LdapSettings.SyncIntervalMinutes,
+            skipCertificateVerification: config.LdapSettings.SkipCertificateVerification,
+            queryTimeout: config.LdapSettings.QueryTimeout,
+            maxPageSize: config.LdapSettings.MaxPageSize,
+            loginFieldName: config.LdapSettings.LoginFieldName
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/legal_and_support_settings.jsx
+++ b/webapp/components/admin_console/legal_and_support_settings.jsx
@@ -15,15 +15,6 @@ export default class LegalAndSupportSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            termsOfServiceLink: props.config.SupportSettings.TermsOfServiceLink,
-            privacyPolicyLink: props.config.SupportSettings.PrivacyPolicyLink,
-            aboutLink: props.config.SupportSettings.AboutLink,
-            helpLink: props.config.SupportSettings.HelpLink,
-            reportAProblemLink: props.config.SupportSettings.ReportAProblemLink,
-            supportEmail: props.config.SupportSettings.SupportEmail
-        });
     }
 
     getConfigFromState(config) {
@@ -35,6 +26,17 @@ export default class LegalAndSupportSettings extends AdminSettings {
         config.SupportSettings.SupportEmail = this.state.supportEmail;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            termsOfServiceLink: config.SupportSettings.TermsOfServiceLink,
+            privacyPolicyLink: config.SupportSettings.PrivacyPolicyLink,
+            aboutLink: config.SupportSettings.AboutLink,
+            helpLink: config.SupportSettings.HelpLink,
+            reportAProblemLink: config.SupportSettings.ReportAProblemLink,
+            supportEmail: config.SupportSettings.SupportEmail
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/localization_settings.jsx
+++ b/webapp/components/admin_console/localization_settings.jsx
@@ -24,9 +24,6 @@ export default class LocalizationSettings extends AdminSettings {
 
         this.state = Object.assign(this.state, {
             hasErrors: false,
-            defaultServerLocale: props.config.LocalizationSettings.DefaultServerLocale,
-            defaultClientLocale: props.config.LocalizationSettings.DefaultClientLocale,
-            availableLocales: props.config.LocalizationSettings.AvailableLocales ? props.config.LocalizationSettings.AvailableLocales.split(',') : [],
             languages: Object.keys(locales).map((l) => {
                 return {value: locales[l].value, text: locales[l].name};
             })
@@ -43,6 +40,14 @@ export default class LocalizationSettings extends AdminSettings {
         config.LocalizationSettings.AvailableLocales = this.state.availableLocales.join(',');
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            defaultServerLocale: config.LocalizationSettings.DefaultServerLocale,
+            defaultClientLocale: config.LocalizationSettings.DefaultClientLocale,
+            availableLocales: config.LocalizationSettings.AvailableLocales ? config.LocalizationSettings.AvailableLocales.split(',') : []
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/log_settings.jsx
+++ b/webapp/components/admin_console/log_settings.jsx
@@ -19,16 +19,6 @@ export default class LogSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enableConsole: props.config.LogSettings.EnableConsole,
-            consoleLevel: props.config.LogSettings.ConsoleLevel,
-            enableFile: props.config.LogSettings.EnableFile,
-            fileLevel: props.config.LogSettings.FileLevel,
-            fileLocation: props.config.LogSettings.FileLocation,
-            fileFormat: props.config.LogSettings.FileFormat,
-            enableWebhookDebugging: props.config.LogSettings.EnableWebhookDebugging
-        });
     }
 
     getConfigFromState(config) {
@@ -41,6 +31,18 @@ export default class LogSettings extends AdminSettings {
         config.LogSettings.EnableWebhookDebugging = this.state.enableWebhookDebugging;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enableConsole: config.LogSettings.EnableConsole,
+            consoleLevel: config.LogSettings.ConsoleLevel,
+            enableFile: config.LogSettings.EnableFile,
+            fileLevel: config.LogSettings.FileLevel,
+            fileLocation: config.LogSettings.FileLocation,
+            fileFormat: config.LogSettings.FileFormat,
+            enableWebhookDebugging: config.LogSettings.EnableWebhookDebugging
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/login_settings.jsx
+++ b/webapp/components/admin_console/login_settings.jsx
@@ -19,12 +19,6 @@ export default class LoginSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            passwordResetSalt: props.config.EmailSettings.PasswordResetSalt,
-            maximumLoginAttempts: props.config.ServiceSettings.MaximumLoginAttempts,
-            enableMultifactorAuthentication: props.config.ServiceSettings.EnableMultifactorAuthentication
-        });
     }
 
     getConfigFromState(config) {
@@ -35,6 +29,14 @@ export default class LoginSettings extends AdminSettings {
         }
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            passwordResetSalt: config.EmailSettings.PasswordResetSalt,
+            maximumLoginAttempts: config.ServiceSettings.MaximumLoginAttempts,
+            enableMultifactorAuthentication: config.ServiceSettings.EnableMultifactorAuthentication
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/policy_settings.jsx
+++ b/webapp/components/admin_console/policy_settings.jsx
@@ -19,12 +19,6 @@ export default class PolicySettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            restrictTeamInvite: props.config.TeamSettings.RestrictTeamInvite,
-            restrictPublicChannelManagement: props.config.TeamSettings.RestrictPublicChannelManagement,
-            restrictPrivateChannelManagement: props.config.TeamSettings.RestrictPrivateChannelManagement
-        });
     }
 
     getConfigFromState(config) {
@@ -33,6 +27,14 @@ export default class PolicySettings extends AdminSettings {
         config.TeamSettings.RestrictPrivateChannelManagement = this.state.restrictPrivateChannelManagement;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            restrictTeamInvite: config.TeamSettings.RestrictTeamInvite,
+            restrictPublicChannelManagement: config.TeamSettings.RestrictPublicChannelManagement,
+            restrictPrivateChannelManagement: config.TeamSettings.RestrictPrivateChannelManagement
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/privacy_settings.jsx
+++ b/webapp/components/admin_console/privacy_settings.jsx
@@ -15,11 +15,6 @@ export default class PrivacySettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            showEmailAddress: props.config.PrivacySettings.ShowEmailAddress,
-            showFullName: props.config.PrivacySettings.ShowFullName
-        });
     }
 
     getConfigFromState(config) {
@@ -27,6 +22,13 @@ export default class PrivacySettings extends AdminSettings {
         config.PrivacySettings.ShowFullName = this.state.showFullName;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            showEmailAddress: config.PrivacySettings.ShowEmailAddress,
+            showFullName: config.PrivacySettings.ShowFullName
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/public_link_settings.jsx
+++ b/webapp/components/admin_console/public_link_settings.jsx
@@ -16,11 +16,6 @@ export default class PublicLinkSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enablePublicLink: props.config.FileSettings.EnablePublicLink,
-            publicLinkSalt: props.config.FileSettings.PublicLinkSalt
-        });
     }
 
     getConfigFromState(config) {
@@ -28,6 +23,13 @@ export default class PublicLinkSettings extends AdminSettings {
         config.FileSettings.PublicLinkSalt = this.state.publicLinkSalt;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enablePublicLink: config.FileSettings.EnablePublicLink,
+            publicLinkSalt: config.FileSettings.PublicLinkSalt
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/push_settings.jsx
+++ b/webapp/components/admin_console/push_settings.jsx
@@ -28,34 +28,6 @@ export default class PushSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        let pushNotificationServerType = PUSH_NOTIFICATIONS_CUSTOM;
-        let agree = false;
-        if (!props.config.EmailSettings.SendPushNotifications) {
-            pushNotificationServerType = PUSH_NOTIFICATIONS_OFF;
-        } else if (props.config.EmailSettings.PushNotificationServer === Constants.MHPNS &&
-            global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.MHPNS === 'true') {
-            pushNotificationServerType = PUSH_NOTIFICATIONS_MHPNS;
-            agree = true;
-        } else if (props.config.EmailSettings.PushNotificationServer === Constants.MTPNS) {
-            pushNotificationServerType = PUSH_NOTIFICATIONS_MTPNS;
-        } else {
-            pushNotificationServerType = PUSH_NOTIFICATIONS_CUSTOM;
-        }
-
-        let pushNotificationServer = this.props.config.EmailSettings.PushNotificationServer;
-        if (pushNotificationServerType === PUSH_NOTIFICATIONS_MTPNS) {
-            pushNotificationServer = Constants.MTPNS;
-        } else if (pushNotificationServerType === PUSH_NOTIFICATIONS_MHPNS) {
-            pushNotificationServer = Constants.MHPNS;
-        }
-
-        this.state = Object.assign(this.state, {
-            pushNotificationServerType,
-            pushNotificationServer,
-            pushNotificationContents: props.config.EmailSettings.PushNotificationContents,
-            agree
-        });
     }
 
     canSave() {
@@ -94,6 +66,36 @@ export default class PushSettings extends AdminSettings {
         config.EmailSettings.PushNotificationContents = this.state.pushNotificationContents;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        let pushNotificationServerType = PUSH_NOTIFICATIONS_CUSTOM;
+        let agree = false;
+        if (!config.EmailSettings.SendPushNotifications) {
+            pushNotificationServerType = PUSH_NOTIFICATIONS_OFF;
+        } else if (config.EmailSettings.PushNotificationServer === Constants.MHPNS &&
+            global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.MHPNS === 'true') {
+            pushNotificationServerType = PUSH_NOTIFICATIONS_MHPNS;
+            agree = true;
+        } else if (config.EmailSettings.PushNotificationServer === Constants.MTPNS) {
+            pushNotificationServerType = PUSH_NOTIFICATIONS_MTPNS;
+        } else {
+            pushNotificationServerType = PUSH_NOTIFICATIONS_CUSTOM;
+        }
+
+        let pushNotificationServer = config.EmailSettings.PushNotificationServer;
+        if (pushNotificationServerType === PUSH_NOTIFICATIONS_MTPNS) {
+            pushNotificationServer = Constants.MTPNS;
+        } else if (pushNotificationServerType === PUSH_NOTIFICATIONS_MHPNS) {
+            pushNotificationServer = Constants.MHPNS;
+        }
+
+        return {
+            pushNotificationServerType,
+            pushNotificationServer,
+            pushNotificationContents: config.EmailSettings.PushNotificationContents,
+            agree
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/rate_settings.jsx
+++ b/webapp/components/admin_console/rate_settings.jsx
@@ -18,14 +18,6 @@ export default class RateSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enableRateLimiter: props.config.RateLimitSettings.EnableRateLimiter,
-            perSec: props.config.RateLimitSettings.PerSec,
-            memoryStoreSize: props.config.RateLimitSettings.MemoryStoreSize,
-            varyByRemoteAddr: props.config.RateLimitSettings.VaryByRemoteAddr,
-            varyByHeader: props.config.RateLimitSettings.VaryByHeader
-        });
     }
 
     getConfigFromState(config) {
@@ -36,6 +28,16 @@ export default class RateSettings extends AdminSettings {
         config.RateLimitSettings.VaryByHeader = this.state.varyByHeader;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enableRateLimiter: config.RateLimitSettings.EnableRateLimiter,
+            perSec: config.RateLimitSettings.PerSec,
+            memoryStoreSize: config.RateLimitSettings.MemoryStoreSize,
+            varyByRemoteAddr: config.RateLimitSettings.VaryByRemoteAddr,
+            varyByHeader: config.RateLimitSettings.VaryByHeader
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/saml_settings.jsx
+++ b/webapp/components/admin_console/saml_settings.jsx
@@ -24,27 +24,6 @@ export default class SamlSettings extends AdminSettings {
         this.renderSettings = this.renderSettings.bind(this);
         this.uploadCertificate = this.uploadCertificate.bind(this);
         this.removeCertificate = this.removeCertificate.bind(this);
-
-        const settings = props.config.SamlSettings;
-
-        this.state = Object.assign(this.state, {
-            enable: settings.Enable,
-            verify: settings.Verify,
-            encrypt: settings.Encrypt,
-            idpUrl: settings.IdpUrl,
-            idpDescriptorUrl: settings.IdpDescriptorUrl,
-            assertionConsumerServiceURL: settings.AssertionConsumerServiceURL,
-            idpCertificateFile: settings.IdpCertificateFile,
-            publicCertificateFile: settings.PublicCertificateFile,
-            privateKeyFile: settings.PrivateKeyFile,
-            firstNameAttribute: settings.FirstNameAttribute,
-            lastNameAttribute: settings.LastNameAttribute,
-            emailAttribute: settings.EmailAttribute,
-            usernameAttribute: settings.UsernameAttribute,
-            nicknameAttribute: settings.NicknameAttribute,
-            localeAttribute: settings.LocaleAttribute,
-            loginButtonText: settings.LoginButtonText
-        });
     }
 
     getConfigFromState(config) {
@@ -66,6 +45,29 @@ export default class SamlSettings extends AdminSettings {
         config.SamlSettings.LoginButtonText = this.state.loginButtonText;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        const settings = config.SamlSettings;
+
+        return {
+            enable: settings.Enable,
+            verify: settings.Verify,
+            encrypt: settings.Encrypt,
+            idpUrl: settings.IdpUrl,
+            idpDescriptorUrl: settings.IdpDescriptorUrl,
+            assertionConsumerServiceURL: settings.AssertionConsumerServiceURL,
+            idpCertificateFile: settings.IdpCertificateFile,
+            publicCertificateFile: settings.PublicCertificateFile,
+            privateKeyFile: settings.PrivateKeyFile,
+            firstNameAttribute: settings.FirstNameAttribute,
+            lastNameAttribute: settings.LastNameAttribute,
+            emailAttribute: settings.EmailAttribute,
+            usernameAttribute: settings.UsernameAttribute,
+            nicknameAttribute: settings.NicknameAttribute,
+            localeAttribute: settings.LocaleAttribute,
+            loginButtonText: settings.LoginButtonText
+        };
     }
 
     uploadCertificate(id, file, callback) {

--- a/webapp/components/admin_console/session_settings.jsx
+++ b/webapp/components/admin_console/session_settings.jsx
@@ -17,13 +17,6 @@ export default class SessionSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            sessionLengthWebInDays: props.config.ServiceSettings.SessionLengthWebInDays,
-            sessionLengthMobileInDays: props.config.ServiceSettings.SessionLengthMobileInDays,
-            sessionLengthSSOInDays: props.config.ServiceSettings.SessionLengthSSOInDays,
-            sessionCacheInMinutes: props.config.ServiceSettings.SessionCacheInMinutes
-        });
     }
 
     getConfigFromState(config) {
@@ -33,6 +26,15 @@ export default class SessionSettings extends AdminSettings {
         config.ServiceSettings.SessionCacheInMinutes = this.parseIntNonZero(this.state.sessionCacheInMinutes);
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            sessionLengthWebInDays: config.ServiceSettings.SessionLengthWebInDays,
+            sessionLengthMobileInDays: config.ServiceSettings.SessionLengthMobileInDays,
+            sessionLengthSSOInDays: config.ServiceSettings.SessionLengthSSOInDays,
+            sessionCacheInMinutes: config.ServiceSettings.SessionCacheInMinutes
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/signup_settings.jsx
+++ b/webapp/components/admin_console/signup_settings.jsx
@@ -16,12 +16,6 @@ export default class SignupSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            requireEmailVerification: props.config.EmailSettings.RequireEmailVerification,
-            inviteSalt: props.config.EmailSettings.InviteSalt,
-            enableOpenServer: props.config.TeamSettings.EnableOpenServer
-        });
     }
 
     getConfigFromState(config) {
@@ -30,6 +24,14 @@ export default class SignupSettings extends AdminSettings {
         config.TeamSettings.EnableOpenServer = this.state.enableOpenServer;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            requireEmailVerification: config.EmailSettings.RequireEmailVerification,
+            inviteSalt: config.EmailSettings.InviteSalt,
+            enableOpenServer: config.TeamSettings.EnableOpenServer
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/storage_settings.jsx
+++ b/webapp/components/admin_console/storage_settings.jsx
@@ -21,16 +21,6 @@ export default class StorageSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            maxFileSize: props.config.FileSettings.MaxFileSize / 1024 / 1024,
-            driverName: props.config.FileSettings.DriverName,
-            directory: props.config.FileSettings.Directory,
-            amazonS3AccessKeyId: props.config.FileSettings.AmazonS3AccessKeyId,
-            amazonS3SecretAccessKey: props.config.FileSettings.AmazonS3SecretAccessKey,
-            amazonS3Bucket: props.config.FileSettings.AmazonS3Bucket,
-            amazonS3Region: props.config.FileSettings.AmazonS3Region
-        });
     }
 
     getConfigFromState(config) {
@@ -43,6 +33,18 @@ export default class StorageSettings extends AdminSettings {
         config.FileSettings.AmazonS3Region = this.state.amazonS3Region;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            maxFileSize: config.FileSettings.MaxFileSize / 1024 / 1024,
+            driverName: config.FileSettings.DriverName,
+            directory: config.FileSettings.Directory,
+            amazonS3AccessKeyId: config.FileSettings.AmazonS3AccessKeyId,
+            amazonS3SecretAccessKey: config.FileSettings.AmazonS3SecretAccessKey,
+            amazonS3Bucket: config.FileSettings.AmazonS3Bucket,
+            amazonS3Region: config.FileSettings.AmazonS3Region
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/users_and_teams_settings.jsx
+++ b/webapp/components/admin_console/users_and_teams_settings.jsx
@@ -22,15 +22,6 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enableUserCreation: props.config.TeamSettings.EnableUserCreation,
-            enableTeamCreation: props.config.TeamSettings.EnableTeamCreation,
-            maxUsersPerTeam: props.config.TeamSettings.MaxUsersPerTeam,
-            restrictCreationToDomains: props.config.TeamSettings.RestrictCreationToDomains,
-            restrictTeamNames: props.config.TeamSettings.RestrictTeamNames,
-            restrictDirectMessage: props.config.TeamSettings.RestrictDirectMessage
-        });
     }
 
     getConfigFromState(config) {
@@ -42,6 +33,17 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         config.TeamSettings.RestrictDirectMessage = this.state.restrictDirectMessage;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enableUserCreation: config.TeamSettings.EnableUserCreation,
+            enableTeamCreation: config.TeamSettings.EnableTeamCreation,
+            maxUsersPerTeam: config.TeamSettings.MaxUsersPerTeam,
+            restrictCreationToDomains: config.TeamSettings.RestrictCreationToDomains,
+            restrictTeamNames: config.TeamSettings.RestrictTeamNames,
+            restrictDirectMessage: config.TeamSettings.RestrictDirectMessage
+        };
     }
 
     renderTitle() {

--- a/webapp/components/admin_console/webhook_settings.jsx
+++ b/webapp/components/admin_console/webhook_settings.jsx
@@ -15,15 +15,6 @@ export default class WebhookSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
-
-        this.state = Object.assign(this.state, {
-            enableIncomingWebhooks: props.config.ServiceSettings.EnableIncomingWebhooks,
-            enableOutgoingWebhooks: props.config.ServiceSettings.EnableOutgoingWebhooks,
-            enableCommands: props.config.ServiceSettings.EnableCommands,
-            enableOnlyAdminIntegrations: props.config.ServiceSettings.EnableOnlyAdminIntegrations,
-            enablePostUsernameOverride: props.config.ServiceSettings.EnablePostUsernameOverride,
-            enablePostIconOverride: props.config.ServiceSettings.EnablePostIconOverride
-        });
     }
 
     getConfigFromState(config) {
@@ -35,6 +26,17 @@ export default class WebhookSettings extends AdminSettings {
         config.ServiceSettings.EnablePostIconOverride = this.state.enablePostIconOverride;
 
         return config;
+    }
+
+    getStateFromConfig(config) {
+        return {
+            enableIncomingWebhooks: config.ServiceSettings.EnableIncomingWebhooks,
+            enableOutgoingWebhooks: config.ServiceSettings.EnableOutgoingWebhooks,
+            enableCommands: config.ServiceSettings.EnableCommands,
+            enableOnlyAdminIntegrations: config.ServiceSettings.EnableOnlyAdminIntegrations,
+            enablePostUsernameOverride: config.ServiceSettings.EnablePostUsernameOverride,
+            enablePostIconOverride: config.ServiceSettings.EnablePostIconOverride
+        };
     }
 
     renderTitle() {

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -405,7 +405,7 @@ export function getComplianceReports() {
     );
 }
 
-export function getConfig() {
+export function getConfig(success, error) {
     if (isCallInProgress('getConfig')) {
         return;
     }
@@ -419,10 +419,17 @@ export function getConfig() {
                 type: ActionTypes.RECEIVED_CONFIG,
                 config: data
             });
+
+            if (success) {
+                success(data);
+            }
         },
         (err) => {
             callTracker.getConfig = 0;
-            dispatchError(err, 'getConfig');
+
+            if (!error) {
+                dispatchError(err, 'getConfig');
+            }
         }
     );
 }


### PR DESCRIPTION
#### Summary
Some fields reset their values to defaults when invalid data is entered (like when the max number of login attempts is set to "asdf", it resets to 1). Now, those defaults are shown when you save the page.

Also, I fixed an issue where attempting to save config changes would overwrite the data stored in the stores

#### Issue/Ticket Link
https://mattermost.atlassian.net/browse/PLT-3237