### PR TITLE
PLT-3527 Added getStateFromConfig to Password Settings

### DIFF
--- a/webapp/components/admin_console/password_settings.jsx
+++ b/webapp/components/admin_console/password_settings.jsx
@@ -80,6 +80,19 @@ export default class PasswordSettings extends AdminSettings {
         return config;
     }
 
+    getStateFromConfig(config) {
+        return {
+            passwordMinimumLength: config.PasswordSettings.MinimumLength,
+            passwordLowercase: config.PasswordSettings.Lowercase,
+            passwordNumber: config.PasswordSettings.Number,
+            passwordUppercase: config.PasswordSettings.Uppercase,
+            passwordSymbol: config.PasswordSettings.Symbol,
+            maximumLoginAttempts: config.ServiceSettings.MaximumLoginAttempts,
+            enableMultifactorAuthentication: config.ServiceSettings.EnableMultifactorAuthentication,
+            passwordResetSalt: config.EmailSettings.PasswordResetSalt
+        };
+    }
+
     getSampleErrorMsg() {
         if (this.props.config.PasswordSettings.MinimumLength > Constants.MAX_PASSWORD_LENGTH || this.props.config.PasswordSettings.MinimumLength < Constants.MIN_PASSWORD_LENGTH) {
             return (
@@ -161,6 +174,7 @@ export default class PasswordSettings extends AdminSettings {
                                 defaultMessage='Minimum Password Length:'
                             />
                         }
+                        placeholder={Utils.localizeMessage('admin.password.minimumLengthExample', 'Ex "5"')}
                         helpText={
                             <FormattedMessage
                                 id='admin.password.minimumLengthDescription'

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -410,6 +410,7 @@
   "admin.password.lowercase": "At least one lowercase letter",
   "admin.password.minimumLength": "Minimum Password Length:",
   "admin.password.minimumLengthDescription": "Minimum number of characters required for a valid password. Must be a whole number greater than or equal to {min} and less than or equal to {max}.",
+  "admin.password.minimumLengthExample": "Ex \"5\"",
   "admin.password.number": "At least one number",
   "admin.password.preview": "Error message preview",
   "admin.password.requirements": "Password Requirements:",


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Added `getStateFromConfig` to Password Settings. Password settings now do not break the system console, and work as intended.

Also added placeholder text for Minimum Password Length in the same style as Maximum Login Attempts

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3527

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [x] Has enterprise changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

