### PR TITLE
Fix javascript error when getting a notification about a reply in a channel not loaded

### DIFF
--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -92,7 +92,12 @@ class PostStoreClass extends EventEmitter {
     }
 
     getPost(channelId, postId) {
-        const posts = this.postsInfo[channelId].postList;
+        const postInfo = this.postsInfo[channelId];
+        if (postInfo == null) {
+            return null;
+        }
+
+        const posts = postInfo.postList;
         let post = null;
 
         if (posts.posts.hasOwnProperty(postId)) {


### PR DESCRIPTION
#### Summary
Fix javascript error when getting a notification about a reply in a channel not loaded