### PR TITLE
PLT-3538 Fix Login page doesn't show SAML option if gitlab is enabled

### DIFF
--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -484,7 +484,7 @@ export default class LoginController extends React.Component {
             loginControls.push(
                 <a
                     className='btn btn-custom-login saml'
-                    key='gitlab'
+                    key='saml'
                     href={'/login/sso/saml' + this.props.location.search}
                 >
                     <span>


### PR DESCRIPTION
#### Summary
Now when GitLab and SAML authentication are enabled both shows on the login screen

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3538

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization files updated
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

