### PR TITLE
PLT-3575 Fix Cannot upload certificates with .cer file extension on SAML

### DIFF
--- a/webapp/components/admin_console/saml_settings.jsx
+++ b/webapp/components/admin_console/saml_settings.jsx
@@ -166,7 +166,7 @@ export default class SamlSettings extends AdminSettings {
                     }
                     uploadingText={Utils.localizeMessage('admin.saml.uploading.certificate', 'Uploading Certificate...')}
                     disabled={!this.state.enable}
-                    fileType='.crt'
+                    fileType='.crt,.cer'
                     onSubmit={this.uploadCertificate}
                 />
             );
@@ -260,7 +260,7 @@ export default class SamlSettings extends AdminSettings {
                     }
                     uploadingText={Utils.localizeMessage('admin.saml.uploading.certificate', 'Uploading Certificate...')}
                     disabled={!this.state.enable || !this.state.encrypt}
-                    fileType='.crt'
+                    fileType='.crt,.cer'
                     onSubmit={this.uploadCertificate}
                 />
             );


### PR DESCRIPTION
#### Summary
During setup of ADFS by following the instructions to upload the iDP certificate you needed to change the file type to be able to select the exported ADFS certificate, now it allows the file type as default

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3575

