### PR TITLE
PLT-3578 Fixed permissions when getting a file attachment to use the correct user id

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -356,7 +356,7 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	userId := params["user_id"]
 	filename := params["filename"]
 
-	if !c.HasPermissionsToChannel(Srv.Store.Channel().CheckPermissionsTo(teamId, channelId, userId), "getFile") {
+	if !c.HasPermissionsToChannel(Srv.Store.Channel().CheckPermissionsTo(teamId, channelId, c.Session.UserId), "getFile") {
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Changes the get file API to use the ID of the calling user as opposed to the user who made a post when getting a file

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3578