### PR TITLE
PLT-3525	Allow system admins to see the Integrations sidebar

### DIFF
--- a/webapp/components/backstage/components/backstage_sidebar.jsx
+++ b/webapp/components/backstage/components/backstage_sidebar.jsx
@@ -45,7 +45,9 @@ export default class BackstageSidebar extends React.Component {
             return null;
         }
 
-        if (window.mm_config.EnableOnlyAdminIntegrations !== 'false' && !TeamStore.isTeamAdmin(this.props.user.id, this.props.team.id)) {
+        if (window.mm_config.EnableOnlyAdminIntegrations !== 'false' &&
+            !Utils.isSystemAdmin(this.props.user.roles) &&
+            !TeamStore.isTeamAdmin(this.props.user.id, this.props.team.id)) {
             return null;
         }
 


### PR DESCRIPTION
#### Summary
Currently, they can access the integrations pages, but the sidebar options don't show up for them

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3525

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)