### PR TITLE
PLT-3584 Fix no team found when creating account

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -2527,7 +2527,9 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 		switch action {
 		case model.OAUTH_ACTION_SIGNUP:
 			teamId := relayProps["team_id"]
-			go addDirectChannels(teamId, user)
+			if len(teamId) > 0 {
+				go addDirectChannels(teamId, user)
+			}
 			break
 		case model.OAUTH_ACTION_EMAIL_TO_SSO:
 			RevokeAllSession(c, user.Id)


### PR DESCRIPTION
#### Summary
Creating an account with SAML from the home page "Don't have an account? Create one now" gave an error

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3584

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields.]
- [x] Has enterprise changes (https://github.com/mattermost/enterprise/pull/44)
- [x] Touches critical sections of the codebase (authentication and account creation)

