### PR TITLE
PLT-3624 quick fix remove SAML certificates without saving

### DIFF
--- a/webapp/components/admin_console/file_upload_setting.jsx
+++ b/webapp/components/admin_console/file_upload_setting.jsx
@@ -18,7 +18,8 @@ export default class FileUploadSetting extends Setting {
             uploadingText: React.PropTypes.node,
             onSubmit: React.PropTypes.func.isRequired,
             disabled: React.PropTypes.bool,
-            fileType: React.PropTypes.string.isRequired
+            fileType: React.PropTypes.string.isRequired,
+            error: React.PropTypes.string
         };
     }
 
@@ -29,7 +30,8 @@ export default class FileUploadSetting extends Setting {
         this.handleSubmit = this.handleSubmit.bind(this);
 
         this.state = {
-            fileName: null
+            fileName: null,
+            serverError: props.error
         };
     }
 

--- a/webapp/components/admin_console/remove_file_setting.jsx
+++ b/webapp/components/admin_console/remove_file_setting.jsx
@@ -23,28 +23,18 @@ export default class RemoveFileSetting extends Setting {
     constructor(props) {
         super(props);
         this.handleRemove = this.handleRemove.bind(this);
-
-        this.state = {
-            serverError: null
-        };
     }
 
     handleRemove(e) {
         e.preventDefault();
 
         $(this.refs.remove_button).button('loading');
-        this.props.onSubmit(this.props.id, (error) => {
+        this.props.onSubmit(this.props.id, () => {
             $(this.refs.remove_button).button('reset');
-            this.setState({serverError: error});
         });
     }
 
     render() {
-        let serverError;
-        if (this.state.serverError) {
-            serverError = <div className='form-group has-error'><label className='control-label'>{this.state.serverError}</label></div>;
-        }
-
         return (
             <Setting
                 label={this.props.label}
@@ -64,7 +54,6 @@ export default class RemoveFileSetting extends Setting {
                     >
                         {this.props.removeButtonText}
                     </button>
-                    {serverError}
                 </div>
             </Setting>
         );

--- a/webapp/components/admin_console/saml_settings.jsx
+++ b/webapp/components/admin_console/saml_settings.jsx
@@ -76,7 +76,7 @@ export default class SamlSettings extends AdminSettings {
             () => {
                 const fileName = file.name;
                 this.handleChange(id, fileName);
-                this.setState({[id]: fileName});
+                this.setState({[id]: fileName, [`${id}Error`]: null});
                 if (callback && typeof callback === 'function') {
                     callback();
                 }
@@ -94,12 +94,13 @@ export default class SamlSettings extends AdminSettings {
             this.state[id],
             () => {
                 this.handleChange(id, '');
-                this.setState({[id]: null});
+                this.setState({[id]: null, [`${id}Error`]: null});
             },
             (error) => {
                 if (callback && typeof callback === 'function') {
-                    callback(error.message);
+                    callback();
                 }
+                this.setState({[id]: null, [`${id}Error`]: error.message});
             }
         );
     }
@@ -168,6 +169,7 @@ export default class SamlSettings extends AdminSettings {
                     disabled={!this.state.enable}
                     fileType='.crt,.cer'
                     onSubmit={this.uploadCertificate}
+                    error={this.state.idpCertificateFileError}
                 />
             );
         }
@@ -215,6 +217,7 @@ export default class SamlSettings extends AdminSettings {
                     disabled={!this.state.enable || !this.state.encrypt}
                     fileType='.key'
                     onSubmit={this.uploadCertificate}
+                    error={this.state.privateKeyFileError}
                 />
             );
         }
@@ -262,6 +265,7 @@ export default class SamlSettings extends AdminSettings {
                     disabled={!this.state.enable || !this.state.encrypt}
                     fileType='.crt,.cer'
                     onSubmit={this.uploadCertificate}
+                    error={this.state.publicCertificateFileError}
                 />
             );
         }


### PR DESCRIPTION
#### Summary
In System Console > SAML, after removing IDP certificate without saving SAML settings, the user has no option to upload another file

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3624

Then this quick fix will be revisited on this ticket https://mattermost.atlassian.net/browse/PLT-3629 for 3.3
