### PR TITLE
Fix SAML config validation

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -907,7 +907,7 @@ func (o *Config) IsValid() *AppError {
 	}
 
 	if *o.SamlSettings.Enable {
-		if len(*o.SamlSettings.IdpUrl) == 0 {
+		if len(*o.SamlSettings.IdpUrl) == 0 || !IsValidHttpUrl(*o.SamlSettings.IdpDescriptorUrl) {
 			return NewLocAppError("Config.IsValid", "model.config.is_valid.saml_idp_url.app_error", nil, "")
 		}
 


### PR DESCRIPTION
#### Summary
This is a fix for SAML config validation. IDP URL wasn't verified as a valid url