### PR TITLE
PLT-3605 Fixed invalid password error when admin resets password

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -552,7 +552,6 @@ func adminResetPassword(c *Context, w http.ResponseWriter, r *http.Request) {
 	newPassword := props["new_password"]
 	if err := utils.IsPasswordValid(newPassword); err != nil {
 		c.Err = err
-		c.SetInvalidParam("adminResetPassword", "new_password")
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Previously, when the admin attempted to reset a user's password to an invalid one, they received the message "Invalid new_password parameter". Now they receive the correct error message.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3605

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

