### PR TITLE
Fix web app manifest

### DIFF
--- a/webapp/config/manifest.json
+++ b/webapp/config/manifest.json
@@ -1,40 +1,49 @@
 {
     "name": "Mattermost",
+    "description": "Mattermost is an open source, self-hosted Slack-alternative",
     "icons": [{
-        "src": "/static/images/favicon/android-chrome-36x36.png",
-        "type": "image/png",
-        "sizes": "36x36"
-    }, {
-        "src": "/static/images/favicon/android-chrome-48x48.png",
-        "type": "image/png",
-        "sizes": "48x48"
-    }, {
-        "src": "/static/images/favicon/android-chrome-72x72.png",
-        "type": "image/png",
-        "sizes": "72x72"
-    }, {
-        "src": "/static/images/favicon/android-chrome-96x96.png",
-        "type": "image/png",
-        "sizes": "96x96"
-    }, {
-        "src": "/static/images/favicon/android-chrome-144x144.png",
-        "type": "image/png",
-        "sizes": "144x144"
-    }, {
         "src": "/static/images/favicon/android-chrome-192x192.png",
         "type": "image/png",
         "sizes": "192x192"
     }, {
-        "src": "/static/images/favicon/android-chrome-256x256.png",
+        "src": "/static/images/favicon/apple-touch-icon-120x120.png",
         "type": "image/png",
-        "sizes": "256x256"
+        "sizes": "120x120"
     }, {
-        "src": "/static/images/favicon/android-chrome-384x384.png",
+        "src": "/static/images/favicon/apple-touch-icon-144x144.png",
         "type": "image/png",
-        "sizes": "384x384"
+        "sizes": "144x144"
     }, {
-        "src": "/static/images/favicon/android-chrome-512x512.png",
+        "src": "/static/images/favicon/apple-touch-icon-152x152.png",
         "type": "image/png",
-        "sizes": "512x512"
+        "sizes": "152x152"
+    }, {
+        "src": "/static/images/favicon/apple-touch-icon-57x57.png",
+        "type": "image/png",
+        "sizes": "57x57"
+    }, {
+        "src": "/static/images/favicon/apple-touch-icon-60x60.png",
+        "type": "image/png",
+        "sizes": "60x60"
+    }, {
+        "src": "/static/images/favicon/apple-touch-icon-72x72.png",
+        "type": "image/png",
+        "sizes": "72x72"
+    }, {
+        "src": "/static/images/favicon/apple-touch-icon-76x76.png",
+        "type": "image/png",
+        "sizes": "76x76"
+    }, {
+        "src": "/static/images/favicon/favicon-16x16.png",
+        "type": "image/png",
+        "sizes": "16x16"
+    }, {
+        "src": "/static/images/favicon/favicon-32x32.png",
+        "type": "image/png",
+        "sizes": "32x32"
+    }, {
+        "src": "/static/images/favicon/favicon-96x96.png",
+        "type": "image/png",
+        "sizes": "96x96"
     }]
 }

--- a/webapp/root.html
+++ b/webapp/root.html
@@ -29,7 +29,7 @@
     <link rel='icon' type='image/png' sizes='32x32' href='images/favicon/favicon-32x32.png'>
     <link rel='icon' type='image/png' sizes='96x96' href='images/favicon/favicon-96x96.png'>
     <link rel='icon' type='image/png' sizes='192x192' href='images/favicon/android-chrome-192x192.png'>
-    <link rel='manifest' href='/static/config/manifest.json'>
+    <link rel='manifest' href='config/manifest.json'>
     <!-- Android add to homescreen -->
 
     <!-- CSS Should always go first -->

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -63,7 +63,12 @@ var config = {
             },
             {
                 test: /\.json$/,
+                exclude: /manifest\.json$/,
                 loader: 'json'
+            },
+            {
+                test: /manifest\.json$/,
+                loader: 'file?name=files/[hash].[ext]'
             },
             {
                 test: /(node_modules|non_npm_dependencies)\/.+\.(js|jsx)$/,
@@ -105,7 +110,8 @@ var config = {
         new CopyWebpackPlugin([
             {from: 'images/emoji', to: 'emoji'},
             {from: 'images/logo-email.png', to: 'images'},
-            {from: 'images/circles.png', to: 'images'}
+            {from: 'images/circles.png', to: 'images'},
+            {from: 'images/favicon', to: 'images/favicon'}
         ]),
         new webpack.LoaderOptionsPlugin({
             minimize: !DEV,


### PR DESCRIPTION

#### Summary
This patch includes the manifest.json file that was missing in `dist/`.
It also fixes some issues with the manifest itself:
* Added a `display` setting that forces the app in standalone mode (no browser UI)
* Added a `start_url` setting that makes the app shortcut open the home page (instead of the current page)
* Fixed path to icons

#### Ticket Link
https://github.com/mattermost/platform/issues/3541

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

