### PR TITLE
PLT-3427 Added channel header to view channel info modal

### DIFF
--- a/webapp/components/channel_info_modal.jsx
+++ b/webapp/components/channel_info_modal.jsx
@@ -5,6 +5,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import {FormattedMessage} from 'react-intl';
 import {Modal} from 'react-bootstrap';
+import * as TextFormatting from 'utils/text_formatting.jsx';
 
 import React from 'react';
 
@@ -32,6 +33,7 @@ export default class ChannelInfoModal extends React.Component {
                 display_name: notFound,
                 name: notFound,
                 purpose: notFound,
+                header: notFound,
                 id: notFound
             };
         }
@@ -43,6 +45,39 @@ export default class ChannelInfoModal extends React.Component {
         }
 
         const channelURL = Utils.getTeamURLFromAddressBar() + '/channels/' + channel.name;
+
+        let channelPurpose = null;
+        if (channel.purpose) {
+            channelPurpose = (
+                <div className='form-group'>
+                    <div className='info__label'>
+                        <FormattedMessage
+                            id='channel_info.purpose'
+                            defaultMessage='Purpose:'
+                        />
+                    </div>
+                    <div className='info__value'>{channel.purpose}</div>
+                </div>
+            );
+        }
+
+        let channelHeader = null;
+        if (channel.header) {
+            channelHeader = (
+                <div className='form-group'>
+                    <div className='info__label'>
+                        <FormattedMessage
+                            id='channel_info.header'
+                            defaultMessage='Header:'
+                        />
+                    </div>
+                    <div
+                        className='info__value'
+                        dangerouslySetInnerHTML={{__html: TextFormatting.formatText(channel.header, {singleline: false, mentionHighlight: false})}}
+                    />
+                </div>
+            );
+        }
 
         return (
             <Modal
@@ -60,15 +95,8 @@ export default class ChannelInfoModal extends React.Component {
                     </Modal.Title>
                 </Modal.Header>
                 <Modal.Body ref='modalBody'>
-                    <div className='form-group'>
-                        <div className='info__label'>
-                            <FormattedMessage
-                                id='channel_info.purpose'
-                                defaultMessage='Purpose:'
-                            />
-                        </div>
-                        <div className='info__value'>{channel.purpose}</div>
-                    </div>
+                    {channelPurpose}
+                    {channelHeader}
                     <div className='form-group'>
                         <div className='info__label'>
                             <FormattedMessage

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -847,6 +847,7 @@
   "channel_header.viewInfo": "View Info",
   "channel_info.about": "About",
   "channel_info.close": "Close",
+  "channel_info.header": "Header:",
   "channel_info.id": "ID: ",
   "channel_info.name": "Name:",
   "channel_info.notFound": "No Channel Found",


### PR DESCRIPTION
#### Summary
Added channel header (with markdown formatting) to the view channel info modal.
Also removed Purpose and Header displays if they do not exist.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3427
https://github.com/mattermost/platform/pull/3563 (discussion)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [x] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

