### PR TITLE
Increased wait time for TestUserTyping event test case

### DIFF
--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1822,7 +1822,7 @@ func TestUserTyping(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 
 	stop <- true
 


### PR DESCRIPTION
#### Summary
Test was failing sometimes likely because the wait time was too short.

#### Checklist
- [x] Added or updated unit tests (required for all new features)