### PR TITLE
PLT-2992 Fix porting theme to preferences so that it works for users who never set their theme

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -83,7 +83,9 @@ func (us SqlUserStore) UpgradeSchemaIfNeeded() {
 			SELECT
 				Id, '`+model.PREFERENCE_CATEGORY_THEME+`', '', ThemeProps
 			FROM
-				Users`, params); err != nil {
+				Users
+			WHERE
+				Users.ThemeProps != 'null'`, params); err != nil {
 			themeMigrationFailed(err)
 		}
 


### PR DESCRIPTION
#### Summary
The old code was inserting a row into the preferences table which just contained `null` so when the theme code tried to apply it, it was erroring out. Now it just won't create that row so the default theme will be properly applied.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)