### PR TITLE
PLT-3602 Added default to max users per team

### DIFF
--- a/webapp/components/admin_console/users_and_teams_settings.jsx
+++ b/webapp/components/admin_console/users_and_teams_settings.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import * as Utils from 'utils/utils.jsx';
+import Constants from 'utils/constants.jsx';
 
 import AdminSettings from './admin_settings.jsx';
 import BooleanSetting from './boolean_setting.jsx';
@@ -25,9 +26,14 @@ export default class UsersAndTeamsSettings extends AdminSettings {
     }
 
     getConfigFromState(config) {
+        let maxUsersPerTeam = this.parseIntNonZero(this.state.maxUsersPerTeam);
+        if (maxUsersPerTeam === 1) {
+            maxUsersPerTeam = Constants.DEFAULT_MAX_USERS_PER_TEAM;
+        }
+
         config.TeamSettings.EnableUserCreation = this.state.enableUserCreation;
         config.TeamSettings.EnableTeamCreation = this.state.enableTeamCreation;
-        config.TeamSettings.MaxUsersPerTeam = this.parseIntNonZero(this.state.maxUsersPerTeam);
+        config.TeamSettings.MaxUsersPerTeam = maxUsersPerTeam;
         config.TeamSettings.RestrictCreationToDomains = this.state.restrictCreationToDomains;
         config.TeamSettings.RestrictTeamNames = this.state.restrictTeamNames;
         config.TeamSettings.RestrictDirectMessage = this.state.restrictDirectMessage;

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -757,6 +757,7 @@ export const Constants = {
         }
     },
     OVERLAY_TIME_DELAY: 400,
+    DEFAULT_MAX_USERS_PER_TEAM: 50,
     MIN_TEAMNAME_LENGTH: 4,
     MAX_TEAMNAME_LENGTH: 15,
     MIN_USERNAME_LENGTH: 3,


### PR DESCRIPTION
#### Summary
Added a default value of 50 to max users per team when the input entered is invalid (e.g. `ten`)

As a side effect, 1 or 0 is no longer accepted for max users per team. This is probably a feature and not a bug. We do not want teams of 1 or 0 people.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3602

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

