### PR TITLE
PLT-3219 	Fixed file upload overlay not showing up on Edge

### DIFF
--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -1297,7 +1297,7 @@ export function fillArray(value, length) {
 // Checks if a data transfer contains files not text, folders, etc..
 // Slightly modified from http://stackoverflow.com/questions/6848043/how-do-i-detect-a-file-is-being-dragged-rather-than-a-draggable-element-on-my-pa
 export function isFileTransfer(files) {
-    if (isBrowserIE()) {
+    if (isBrowserIE() || isBrowserEdge()) {
         return files.types != null && files.types.contains('Files');
     }
 


### PR DESCRIPTION
#### Summary
Despite various standardization claims, Edge uses the same file handling code as IE11.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3219
