### PR TITLE
PLT-3602 Added default to max users per team and password requirements

### DIFF
--- a/webapp/components/admin_console/admin_settings.jsx
+++ b/webapp/components/admin_console/admin_settings.jsx
@@ -85,20 +85,26 @@ export default class AdminSettings extends React.Component {
         );
     }
 
-    parseInt(str) {
+    parseInt(str, defaultValue) {
         const n = parseInt(str, 10);
 
         if (isNaN(n)) {
+            if (defaultValue) {
+                return defaultValue;
+            }
             return 0;
         }
 
         return n;
     }
 
-    parseIntNonZero(str) {
+    parseIntNonZero(str, defaultValue) {
         const n = parseInt(str, 10);
 
         if (isNaN(n) || n < 1) {
+            if (defaultValue) {
+                return defaultValue;
+            }
             return 1;
         }
 

--- a/webapp/components/admin_console/password_settings.jsx
+++ b/webapp/components/admin_console/password_settings.jsx
@@ -64,7 +64,7 @@ export default class PasswordSettings extends AdminSettings {
 
     getConfigFromState(config) {
         if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.PasswordRequirements === 'true') {
-            config.PasswordSettings.MinimumLength = this.parseIntNonZero(this.state.passwordMinimumLength, 10);
+            config.PasswordSettings.MinimumLength = this.parseIntNonZero(this.state.passwordMinimumLength, Constants.MIN_PASSWORD_LENGTH);
             config.PasswordSettings.Lowercase = this.refs.lowercase.checked;
             config.PasswordSettings.Uppercase = this.refs.uppercase.checked;
             config.PasswordSettings.Number = this.refs.number.checked;

--- a/webapp/components/admin_console/users_and_teams_settings.jsx
+++ b/webapp/components/admin_console/users_and_teams_settings.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import * as Utils from 'utils/utils.jsx';
+import Constants from 'utils/constants.jsx';
 
 import AdminSettings from './admin_settings.jsx';
 import BooleanSetting from './boolean_setting.jsx';
@@ -27,7 +28,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
     getConfigFromState(config) {
         config.TeamSettings.EnableUserCreation = this.state.enableUserCreation;
         config.TeamSettings.EnableTeamCreation = this.state.enableTeamCreation;
-        config.TeamSettings.MaxUsersPerTeam = this.parseIntNonZero(this.state.maxUsersPerTeam);
+        config.TeamSettings.MaxUsersPerTeam = this.parseIntNonZero(this.state.maxUsersPerTeam, Constants.DEFAULT_MAX_USERS_PER_TEAM);
         config.TeamSettings.RestrictCreationToDomains = this.state.restrictCreationToDomains;
         config.TeamSettings.RestrictTeamNames = this.state.restrictTeamNames;
         config.TeamSettings.RestrictDirectMessage = this.state.restrictDirectMessage;

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -757,6 +757,7 @@ export const Constants = {
         }
     },
     OVERLAY_TIME_DELAY: 400,
+    DEFAULT_MAX_USERS_PER_TEAM: 50,
     MIN_TEAMNAME_LENGTH: 4,
     MAX_TEAMNAME_LENGTH: 15,
     MIN_USERNAME_LENGTH: 3,


### PR DESCRIPTION
#### Summary
Added default values to Max Users Per Team and Minimum Password Length through adding a `defaultValue` parameter to `parseInt` and `parseIntNonZero`. All other fields are not affected.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3602

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

