### PR TITLE
Updating client dependancies

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,9 +29,9 @@
     "react-intl": "2.1.3",
     "react-router": "2.5.2",
     "react-select": "1.0.0-beta13",
-    "react-textarea-autosize": "4.0.3",
+    "react-textarea-autosize": "4.0.4",
     "superagent": "2.1.0",
-    "twemoji": "2.0.5",
+    "twemoji": "2.1.0",
     "velocity-animate": "1.2.3"
   },
   "devDependencies": {
@@ -45,7 +45,7 @@
     "babel-preset-stage-0": "6.5.0",
     "copy-webpack-plugin": "3.0.1",
     "css-loader": "0.23.1",
-    "eslint": "3.0.1",
+    "eslint": "3.1.0",
     "eslint-plugin-react": "5.2.2",
     "exports-loader": "0.6.3",
     "extract-text-webpack-plugin": "1.0.1",
@@ -67,7 +67,7 @@
     "sass-loader": "4.0.0",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
-    "webpack": "2.1.0-beta.13",
+    "webpack": "2.1.0-beta.18",
     "webpack-node-externals": "1.2.0"
   },
   "scripts": {


### PR DESCRIPTION
#### Summary

###### Patch Update Backwards-compatible bug fixes.
> ◉ react-textarea-autosize missing  4.0.3  ❯  4.0.4  https://github.com/andreypopp/react-textarea-autosize
 ◉ webpack 2.1.0-beta.13  ❯  2.1.0-beta.18

###### Minor Update New backwards-compatible features.
> ◉ twemoji missing        2.0.5  ❯  2.1.0  https://github.com/twitter/twemoji
 ◉ eslint devDep missing  3.0.1  ❯  3.1.0  http://eslint.org

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

