### PR TITLE
Fix possible race condition in TestUserTyping test case

### DIFF
--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1802,6 +1802,8 @@ func TestUserTyping(t *testing.T) {
 	defer WebSocketClient2.Close()
 	WebSocketClient2.Listen()
 
+	time.Sleep(300 * time.Millisecond)
+
 	WebSocketClient.UserTyping(th.BasicChannel.Id, "")
 
 	time.Sleep(300 * time.Millisecond)


### PR DESCRIPTION
#### Summary
I ran the test 10 times before making any changes and it failed 4 out of 10 times. I was pretty sure it was a race condition between starting up the listener in a go routine and sending the typing event. I added a short delay between the two and re-ran the test locally 10 times without a failure and on the build server 4 times without failure, which I believe is statistically significant :)

#### Checklist
- [x] Added or updated unit tests (required for all new features)

