### PR TITLE
PLT-3358 Focus textbox after switching channels using Channel Switcher

### DIFF
--- a/webapp/components/channel_switch_modal.jsx
+++ b/webapp/components/channel_switch_modal.jsx
@@ -82,8 +82,8 @@ export default class SwitchChannelModal extends React.Component {
         }
 
         if (channel !== null) {
-            ChannelActions.goToChannel(channel);
             this.onHide();
+            ChannelActions.goToChannel(channel);
         } else if (this.state.text !== '') {
             this.setState({
                 error: Utils.localizeMessage('channel_switch_modal.not_found', 'No matches found.')

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -322,10 +322,8 @@ export default class CreatePost extends React.Component {
         document.addEventListener('keydown', this.showShortcuts);
     }
 
-    componentDidUpdate(prevProps, prevState) {
-        if (prevState.channelId !== this.state.channelId) {
-            this.focusTextbox();
-        }
+    componentDidUpdate() {
+        this.focusTextbox();
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
#### Summary
If the textbox was already focused, keep it focused when you switch channels.

Test server please, cannot confirm 100% working on all platforms.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3358

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

