### PR TITLE
PLT-3643 Rendered invalid URLs as plain text when parsing markdown

### DIFF
--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -139,10 +139,10 @@ class MattermostMarkdownRenderer extends marked.Renderer {
             const unescaped = decodeURIComponent(unescape(href)).replace(/[^\w:]/g, '').toLowerCase();
 
             if (unescaped.indexOf('javascript:') === 0 || unescaped.indexOf('vbscript:') === 0 || unescaped.indexOf('data:') === 0) { // eslint-disable-line no-script-url
-                return '';
+                return text;
             }
         } catch (e) {
-            return '';
+            return text;
         }
 
         if (!(/[a-z+.-]+:/i).test(outHref)) {


### PR DESCRIPTION
#### Summary
This just makes invalid links that fail to decode properly (like http://example.com/%% which contains an invalid percent encoding) still display their text so that they can be copied and pasted if they still happen to be valid.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3643