### PR TITLE
PLT-3690 Updated marked to not break URLs on exclamation marks

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -16,7 +16,7 @@
     "jasny-bootstrap": "3.1.3",
     "jquery": "3.1.0",
     "keymirror": "0.1.1",
-    "marked": "mattermost/marked#12d2be4cdf54d4ec95fead934e18840b6a2c1a7b",
+    "marked": "mattermost/marked#bbba29c38ea5b498561202abc376998d84e746db",
     "match-at": "0.1.0",
     "mattermost": "mattermost/mattermost-javascript#84b6f1ebf33aa4b5d8e7ddd7be97d3f5bff5ed17",
     "object-assign": "4.1.0",


### PR DESCRIPTION
#### Summary
Changed the regex to once again treat exclamation marks like other characters that could be part of the URL, but can't be at the end of it. https://github.com/mattermost/marked/commit/f05df8b0f25aeb6dda5945fc70ac240727556f77

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3690

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields.]
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [x] Has ~~driver~~ *marked* changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

