### PR TITLE
PLT-3648 Restricting visibility of detailed_error message

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -204,11 +204,17 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleFunc(c, w, r)
 	}
 
+	// Handle errors that have occoured
 	if c.Err != nil {
 		c.Err.Translate(c.T)
 		c.Err.RequestId = c.RequestId
 		c.LogError(c.Err)
 		c.Err.Where = r.URL.Path
+
+		// Block out detailed error whenn not in developer mode
+		if !*utils.Cfg.ServiceSettings.EnableDeveloper {
+			c.Err.DetailedError = ""
+		}
 
 		if h.isApi {
 			w.WriteHeader(c.Err.StatusCode)

--- a/mattermost.go
+++ b/mattermost.go
@@ -105,6 +105,11 @@ func main() {
 	l4g.Info(utils.T("mattermost.working_dir"), pwd)
 	l4g.Info(utils.T("mattermost.config_file"), utils.FindConfigFile(flagConfigFile))
 
+	// Enable developer settings if this is a "dev" build
+	if model.BuildNumber == "dev" {
+		*utils.Cfg.ServiceSettings.EnableDeveloper = true
+	}
+
 	// Special case for upgrading the db to 3.0
 	// ADDED for 3.0 REMOVE for 3.4
 	cmdUpdateDb30()


### PR DESCRIPTION
#### Summary
- Filters the detailed_error message from AppErrors when developer mode is diabled.
- Enables developer mode when running a 'dev' build automatically. 

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

