### PR TITLE
PLT-3629 fix uploading certificates if the files in the config do not exists

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -45,6 +45,7 @@ func InitAdmin() {
 	BaseRoutes.Admin.Handle("/saml_metadata", ApiAppHandler(samlMetadata)).Methods("GET")
 	BaseRoutes.Admin.Handle("/add_certificate", ApiAdminSystemRequired(addCertificate)).Methods("POST")
 	BaseRoutes.Admin.Handle("/remove_certificate", ApiAdminSystemRequired(removeCertificate)).Methods("POST")
+	BaseRoutes.Admin.Handle("/saml_cert_status", ApiAdminSystemRequired(samlCertificateStatus)).Methods("GET")
 }
 
 func getLogs(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -658,4 +659,14 @@ func removeCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ReturnStatusOK(w)
+}
+
+func samlCertificateStatus(c *Context, w http.ResponseWriter, r *http.Request) {
+	status := make(map[string]interface{})
+
+	status["IdpCertificateFile"] = utils.FileExistsInConfigFolder(*utils.Cfg.SamlSettings.IdpCertificateFile)
+	status["PrivateKeyFile"] = utils.FileExistsInConfigFolder(*utils.Cfg.SamlSettings.PrivateKeyFile)
+	status["PublicCertificateFile"] = utils.FileExistsInConfigFolder(*utils.Cfg.SamlSettings.PublicCertificateFile)
+
+	w.Write([]byte(model.StringInterfaceToJson(status)))
 }

--- a/model/client.go
+++ b/model/client.go
@@ -1730,12 +1730,23 @@ func (c *Client) UploadCertificateFile(data []byte, contentType string) *AppErro
 }
 
 // Removes a x509 base64 Certificate or Private Key file used with SAML.
-// filename is required. Returns nil if succesful, otherwise returns an AppError
+// filename is required. Returns nil if successful, otherwise returns an AppError
 func (c *Client) RemoveCertificateFile(filename string) *AppError {
 	if r, err := c.DoApiPost("/admin/remove_certificate", MapToJson(map[string]string{"filename": filename})); err != nil {
 		return err
 	} else {
 		defer closeBody(r)
 		return nil
+	}
+}
+
+// Checks if the x509 base64 Certificates and Private Key files used with SAML exists on the file system.
+// Returns a map[string]interface{} if successful, otherwise returns an AppError. Must be System Admin authenticated.
+func (c *Client) SamlCertificateStatus(filename string) (map[string]interface{}, *AppError) {
+	if r, err := c.DoApiGet("/admin/remove_certificate", "", ""); err != nil {
+		return nil, err
+	} else {
+		defer closeBody(r)
+		return StringInterfaceFromJson(r.Body), nil
 	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,10 @@
 
 package utils
 
+import (
+	"os"
+)
+
 func StringArrayIntersection(arr1, arr2 []string) []string {
 	arrMap := map[string]bool{}
 	result := []string{}
@@ -18,4 +22,15 @@ func StringArrayIntersection(arr1, arr2 []string) []string {
 	}
 
 	return result
+}
+
+func FileExistsInConfigFolder(filename string) bool {
+	if len(filename) == 0 {
+		return false
+	}
+
+	if _, err := os.Stat(FindConfigFile(filename)); err == nil {
+		return true
+	}
+	return false
 }

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -1667,4 +1667,17 @@ export default class Client {
         send({filename}).
         end(this.handleResponse.bind(this, 'removeCertificateFile', success, error));
     }
+
+    samlCertificateStatus(success, error) {
+        request.get(`${this.getAdminRoute()}/saml_cert_status`).
+        set(this.defaultHeaders).
+        type('application/json').
+        accept('application/json').
+        end((err, res) => {
+            if (err) {
+                return error(err);
+            }
+            return success(res.body);
+        });
+    }
 }

--- a/webapp/components/admin_console/saml_settings.jsx
+++ b/webapp/components/admin_console/saml_settings.jsx
@@ -70,6 +70,26 @@ export default class SamlSettings extends AdminSettings {
         };
     }
 
+    componentWillMount() {
+        Client.samlCertificateStatus(
+            (data) => {
+                const files = {};
+                if (!data.IdpCertificateFile) {
+                    files.idpCertificateFile = '';
+                }
+
+                if (!data.PublicCertificateFile) {
+                    files.publicCertificateFile = '';
+                }
+
+                if (!data.PrivateKeyFile) {
+                    files.privateKeyFile = '';
+                }
+                this.setState(files);
+            }
+        );
+    }
+
     uploadCertificate(id, file, callback) {
         Client.uploadCertificateFile(
             file,


### PR DESCRIPTION
#### Summary
When a certificate was removed from the file system but the config file had it present, there was no way to re-upload the certificate, Now it detect if the file is not present and shows the upload buttons.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3629

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
