### PR TITLE
PLT-3482/PLT-3551/PLT-3552 Fixed some markdown list parsing

### DIFF
--- a/tests/test-markdown-lists.md
+++ b/tests/test-markdown-lists.md
@@ -227,3 +227,18 @@ This text should be on a new line.
 1. [ ] One
 2. [ ] Two
 3. [x] Completed item
+
+### Multiple Lists
+
+**Expected:**
+```
+List A:
+1. One
+List B:
+2. Two
+```
+
+List A:
+1. One
+List B:
+2. Two

--- a/tests/test-markdown-lists.md
+++ b/tests/test-markdown-lists.md
@@ -194,25 +194,6 @@ This text should be on a new line.
 2. Two
 This text should be on a new line.
 
-**Expected:**
-```
-List:
-
-- One
-- Two
-
-This line should have a line break above it.
-```
-
-**Actual:**
-
-List:
-
-- One
-- Two
-
-This line should have a line break above it.
-
 ### Task Lists
 
 **Expected:**

--- a/tests/test-markdown-lists.md
+++ b/tests/test-markdown-lists.md
@@ -1,7 +1,7 @@
 # Markdown List Testing
 Verify that all list types render as expected.
 
-### Single-item Ordered List
+### Single-Item Ordered List
 
 **Expected:**
 ```
@@ -11,7 +11,7 @@ Verify that all list types render as expected.
 **Actual:**
 7. Single Item
 
-### Multi-item Ordered List
+### Multi-Item Ordered List
 
 **Expected:**
 ```
@@ -47,7 +47,7 @@ Verify that all list types render as expected.
   1. Echo
   1. Foxtrot
 
-### Single-item Unordered List
+### Single-Item Unordered List
 
 **Expected:**
 ```
@@ -57,7 +57,7 @@ Verify that all list types render as expected.
 **Actual:**
 * Single Item
 
-### Multi-item Unordered List
+### Multi-Item Unordered List
 
 **Expected:**
 ```
@@ -179,20 +179,20 @@ Verify that all list types render as expected.
 1. One
 2. Two
 
-### Carriage Return and New Line After a List
+### New Line After a List
 
 **Expected:**
 ```
 1. One
-- Two
+2. Two
 This text should be on a new line.
 ```
 
 **Actual:**
 
 1. One
-- Two
- This text should be on a new line.
+2. Two
+This text should be on a new line.
 
 **Expected:**
 ```

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -16,7 +16,7 @@
     "jasny-bootstrap": "3.1.3",
     "jquery": "3.1.0",
     "keymirror": "0.1.1",
-    "marked": "mattermost/marked#bbba29c38ea5b498561202abc376998d84e746db",
+    "marked": "mattermost/marked#69736482dbad685c398a5eec33a59b5ab06057ac",
     "match-at": "0.1.0",
     "object-assign": "4.1.0",
     "perfect-scrollbar": "0.6.12",


### PR DESCRIPTION
#### Summary

1. Fixes the rendering of two lists separated by text
2. Removes an invalid test case testing behaviour that we won't fix
3. Fixes an incorrectly written test case containing text directly after a list

#### Ticket Link
1. https://mattermost.atlassian.net/browse/PLT-3482
2. https://mattermost.atlassian.net/browse/PLT-3551 (won't fix)
3. https://mattermost.atlassian.net/browse/PLT-3552

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
