### PR TITLE
PLT-3464 Fixed mobile enter key

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -168,7 +168,7 @@ export default class CreateComment extends React.Component {
     }
 
     commentMsgKeyPress(e) {
-        if ((this.state.ctrlSend && e.ctrlKey) || !this.state.ctrlSend) {
+        if (!Utils.isMobile() && ((this.state.ctrlSend && e.ctrlKey) || !this.state.ctrlSend)) {
             if (e.which === KeyCodes.ENTER && !e.shiftKey && !e.altKey) {
                 e.preventDefault();
                 ReactDOM.findDOMNode(this.refs.textbox).blur();

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -196,7 +196,7 @@ export default class CreatePost extends React.Component {
     }
 
     postMsgKeyPress(e) {
-        if ((this.state.ctrlSend && e.ctrlKey) || !this.state.ctrlSend) {
+        if (!Utils.isMobile() && ((this.state.ctrlSend && e.ctrlKey) || !this.state.ctrlSend)) {
             if (e.which === KeyCodes.ENTER && !e.shiftKey && !e.altKey) {
                 e.preventDefault();
                 ReactDOM.findDOMNode(this.refs.textbox).blur();


### PR DESCRIPTION
#### Summary
Before, the enter key on mobile always submitted a new post/comment, regardless of CTRL+ENTER settings. Now the enter key disregards CTRL+ENTER settings, and will always add a new line. Only the send button can be used to send posts/comments. Desktop behaviour remains unchanged.

Tested working with Android, need iOS tester.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3464

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has driver changes that have been merged and package.json updated
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

