### PR TITLE
PLT-3623 EE: Don't enforce start date on licenses

### DIFF
--- a/utils/license.go
+++ b/utils/license.go
@@ -49,7 +49,7 @@ func LoadLicense(licenseBytes []byte) {
 func SetLicense(license *model.License) bool {
 	license.Features.SetDefaults()
 
-	if !license.IsExpired() && license.IsStarted() {
+	if !license.IsExpired() {
 		License = license
 		IsLicensed = true
 		ClientLicense = getClientLicense(license)

--- a/utils/license_test.go
+++ b/utils/license_test.go
@@ -32,8 +32,8 @@ func TestSetLicense(t *testing.T) {
 	l3.Customer = &model.Customer{}
 	l3.StartsAt = model.GetMillis() + 10000
 	l3.ExpiresAt = model.GetMillis() + 100000
-	if ok := SetLicense(l3); ok {
-		t.Fatal("license should have failed")
+	if ok := SetLicense(l3); !ok {
+		t.Fatal("license should have passed")
 	}
 }
 


### PR DESCRIPTION
#### Summary
Remove enforcement of start dates on licenses.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3623

#### Checklist
- [x] Touches critical sections of the codebase (licensing)

