### PR TITLE
PLT-3610 Adding migration support to LDAP from other account types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,16 +182,19 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 	$(GO) test $(GOFLAGS) -run=$(TESTS) -covermode=count -c ./enterprise/compliance && ./compliance.test -test.v -test.timeout=120s -test.coverprofile=ccompliance.out || exit 1
 	$(GO) test $(GOFLAGS) -run=$(TESTS) -covermode=count -c ./enterprise/emoji && ./emoji.test -test.v -test.timeout=120s -test.coverprofile=cemoji.out || exit 1
 	$(GO) test $(GOFLAGS) -run=$(TESTS) -covermode=count -c ./enterprise/saml && ./saml.test -test.v -test.timeout=60s -test.coverprofile=csaml.out || exit 1
+	$(GO) test $(GOFLAGS) -run=$(TESTS) -covermode=count -c ./enterprise/account_migration && ./account_migration.test -test.v -test.timeout=60s -test.coverprofile=caccount_migration.out || exit 1
 
 	tail -n +2 cldap.out >> ecover.out
 	tail -n +2 ccompliance.out >> ecover.out
 	tail -n +2 cemoji.out >> ecover.out
 	tail -n +2 csaml.out >> ecover.out
-	rm -f cldap.out ccompliance.out cemoji.out csaml.out
+	tail -n +2 caccount_migration.out >> ecover.out
+	rm -f cldap.out ccompliance.out cemoji.out csaml.out caccount_migration.out
 	rm -r ldap.test
 	rm -r compliance.test
 	rm -r emoji.test
 	rm -r saml.test
+	rm -r account_migration.test
 	rm -f config/*.crt
 	rm -f config/*.key
 endif

--- a/api/admin.go
+++ b/api/admin.go
@@ -571,11 +571,7 @@ func ldapSyncNow(c *Context, w http.ResponseWriter, r *http.Request) {
 	go func() {
 		if utils.IsLicensed && *utils.License.Features.LDAP && *utils.Cfg.LdapSettings.Enable {
 			if ldapI := einterfaces.GetLdapInterface(); ldapI != nil {
-				if err := ldapI.Syncronize(); err != nil {
-					l4g.Error("%v", err.Error())
-				} else {
-					l4g.Info(utils.T("ent.ldap.syncdone.info"))
-				}
+				ldapI.SyncNow()
 			} else {
 				l4g.Error("%v", model.NewLocAppError("saveComplianceReport", "ent.compliance.licence_disable.app_error", nil, "").Error())
 			}

--- a/einterfaces/account_migration.go
+++ b/einterfaces/account_migration.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package einterfaces
+
+import "github.com/mattermost/platform/model"
+
+type AccountMigrationInterface interface {
+	MigrateToLdap(fromAuthService string, forignUserFieldNameToMatch string) *model.AppError
+}
+
+var theAccountMigrationInterface AccountMigrationInterface
+
+func RegisterAccountMigrationInterface(newInterface AccountMigrationInterface) {
+	theAccountMigrationInterface = newInterface
+}
+
+func GetAccountMigrationInterface() AccountMigrationInterface {
+	return theAccountMigrationInterface
+}

--- a/einterfaces/ldap.go
+++ b/einterfaces/ldap.go
@@ -15,6 +15,8 @@ type LdapInterface interface {
 	ValidateFilter(filter string) *model.AppError
 	Syncronize() *model.AppError
 	StartLdapSyncJob()
+	SyncNow()
+	GetAllLdapUsers() ([]*model.User, *model.AppError)
 }
 
 var theLdapInterface LdapInterface

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2084,6 +2084,14 @@
     "translation": "Feature requires an enterprise license. Please contact your system administrator about upgrading your enterprise license."
   },
   {
+    "id": "ent.migration.migratetoldap.duplicate_field",
+    "translation": "Unable to migrate LDAP users with specified field. Duplicate entry detected. Please remove all duplcates and try again."
+  },
+  {
+    "id": "ent.migration.migratetoldap.user_not_found",
+    "translation": "Unable to find user on LDAP server: "
+  },
+  {
     "id": "ent.brand.save_brand_image.decode.app_error",
     "translation": "Unable to decode image."
   },

--- a/model/job.go
+++ b/model/job.go
@@ -84,6 +84,12 @@ func (task *ScheduledTask) Cancel() {
 	removeTaskByName(task.Name)
 }
 
+// Executes the task immediatly. A recurring task will be run regularally after interval.
+func (task *ScheduledTask) Execute() {
+	task.function()
+	task.timer.Reset(task.Interval)
+}
+
 func (task *ScheduledTask) String() string {
 	return fmt.Sprintf(
 		"%s\nInterval: %s\nRecurring: %t\n",

--- a/model/job_test.go
+++ b/model/job_test.go
@@ -126,3 +126,63 @@ func TestGetAllTasks(t *testing.T) {
 		}
 	}
 }
+
+func TestExecuteTask(t *testing.T) {
+	TASK_NAME := "Test Task"
+	TASK_TIME := time.Second * 5
+
+	testValue := 0
+	testFunc := func() {
+		testValue += 1
+	}
+
+	task := CreateTask(TASK_NAME, testFunc, TASK_TIME)
+	if testValue != 0 {
+		t.Fatal("Unexpected execuition of task")
+	}
+
+	task.Execute()
+
+	if testValue != 1 {
+		t.Fatal("Task did not execute")
+	}
+
+	time.Sleep(TASK_TIME + time.Second)
+
+	if testValue != 2 {
+		t.Fatal("Task re-executed")
+	}
+}
+
+func TestExecuteTaskRecurring(t *testing.T) {
+	TASK_NAME := "Test Recurring Task"
+	TASK_TIME := time.Second * 5
+
+	testValue := 0
+	testFunc := func() {
+		testValue += 1
+	}
+
+	task := CreateRecurringTask(TASK_NAME, testFunc, TASK_TIME)
+	if testValue != 0 {
+		t.Fatal("Unexpected execuition of task")
+	}
+
+	time.Sleep(time.Second * 3)
+
+	task.Execute()
+	if testValue != 1 {
+		t.Fatal("Task did not execute")
+	}
+
+	time.Sleep(time.Second * 3)
+	if testValue != 1 {
+		t.Fatal("Task should not have executed before 5 seconds")
+	}
+
+	time.Sleep(time.Second * 3)
+
+	if testValue != 2 {
+		t.Fatal("Task did not re-execute after forced execution")
+	}
+}


### PR DESCRIPTION
#### Summary
Adds command to migrate users to LDAP accounts. 

Related Enterprise PR: https://github.com/mattermost/enterprise/pull/45

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes (please link)
- [x] Includes text changes and localization files updated

