### PR TITLE
PLT-3037 Removed Legal & Support settings from UI if empty

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -476,7 +476,7 @@ func (o *Config) SetDefaults() {
 
 	if o.SupportSettings.TermsOfServiceLink == nil {
 		o.SupportSettings.TermsOfServiceLink = new(string)
-		*o.SupportSettings.TermsOfServiceLink = "/static/help/terms.html"
+		*o.SupportSettings.TermsOfServiceLink = ""
 	}
 
 	if !IsSafeLink(o.SupportSettings.PrivacyPolicyLink) {
@@ -485,7 +485,7 @@ func (o *Config) SetDefaults() {
 
 	if o.SupportSettings.PrivacyPolicyLink == nil {
 		o.SupportSettings.PrivacyPolicyLink = new(string)
-		*o.SupportSettings.PrivacyPolicyLink = "/static/help/privacy.html"
+		*o.SupportSettings.PrivacyPolicyLink = ""
 	}
 
 	if !IsSafeLink(o.SupportSettings.AboutLink) {
@@ -494,7 +494,7 @@ func (o *Config) SetDefaults() {
 
 	if o.SupportSettings.AboutLink == nil {
 		o.SupportSettings.AboutLink = new(string)
-		*o.SupportSettings.AboutLink = "/static/help/about.html"
+		*o.SupportSettings.AboutLink = ""
 	}
 
 	if !IsSafeLink(o.SupportSettings.HelpLink) {
@@ -503,7 +503,7 @@ func (o *Config) SetDefaults() {
 
 	if o.SupportSettings.HelpLink == nil {
 		o.SupportSettings.HelpLink = new(string)
-		*o.SupportSettings.HelpLink = "/static/help/help.html"
+		*o.SupportSettings.HelpLink = ""
 	}
 
 	if !IsSafeLink(o.SupportSettings.ReportAProblemLink) {
@@ -512,7 +512,7 @@ func (o *Config) SetDefaults() {
 
 	if o.SupportSettings.ReportAProblemLink == nil {
 		o.SupportSettings.ReportAProblemLink = new(string)
-		*o.SupportSettings.ReportAProblemLink = "/static/help/report_problem.html"
+		*o.SupportSettings.ReportAProblemLink = ""
 	}
 
 	if o.SupportSettings.SupportEmail == nil {

--- a/webapp/components/header_footer_template.jsx
+++ b/webapp/components/header_footer_template.jsx
@@ -16,6 +16,64 @@ export default class NotLoggedIn extends React.Component {
         $('#root').removeClass('container-fluid');
     }
     render() {
+        let content = [];
+
+        if (global.window.mm_config.HelpLink) {
+            content.push(
+                <a
+                    id='help_link'
+                    className='pull-right footer-link'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    href={global.window.mm_config.HelpLink}
+                >
+                    <FormattedMessage id='web.footer.help'/>
+                </a>
+            );
+        }
+
+        if (global.window.mm_config.TermsOfServiceLink) {
+            content.push(
+                <a
+                    id='terms_link'
+                    className='pull-right footer-link'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    href={global.window.mm_config.TermsOfServiceLink}
+                >
+                    <FormattedMessage id='web.footer.terms'/>
+                </a>
+            );
+        }
+
+        if (global.window.mm_config.PrivacyPolicyLink) {
+            content.push(
+                <a
+                    id='privacy_link'
+                    className='pull-right footer-link'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    href={global.window.mm_config.PrivacyPolicyLink}
+                >
+                    <FormattedMessage id='web.footer.privacy'/>
+                </a>
+            );
+        }
+
+        if (global.window.mm_config.AboutLink) {
+            content.push(
+                <a
+                    id='about_link'
+                    className='pull-right footer-link'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    href={global.window.mm_config.AboutLink}
+                >
+                    <FormattedMessage id='web.footer.about'/>
+                </a>
+            );
+        }
+
         return (
             <div className='inner-wrap'>
                 <div className='row content'>
@@ -29,42 +87,7 @@ export default class NotLoggedIn extends React.Component {
                         </div>
                         <div className='col-xs-12'>
                             <span className='pull-right footer-link copyright'>{'© 2015-2016 Mattermost, Inc.'}</span>
-                            <a
-                                id='help_link'
-                                className='pull-right footer-link'
-                                target='_blank'
-                                rel='noopener noreferrer'
-                                href={global.window.mm_config.HelpLink}
-                            >
-                                <FormattedMessage id='web.footer.help'/>
-                            </a>
-                            <a
-                                id='terms_link'
-                                className='pull-right footer-link'
-                                target='_blank'
-                                rel='noopener noreferrer'
-                                href={global.window.mm_config.TermsOfServiceLink}
-                            >
-                                <FormattedMessage id='web.footer.terms'/>
-                            </a>
-                            <a
-                                id='privacy_link'
-                                className='pull-right footer-link'
-                                target='_blank'
-                                rel='noopener noreferrer'
-                                href={global.window.mm_config.PrivacyPolicyLink}
-                            >
-                                <FormattedMessage id='web.footer.privacy'/>
-                            </a>
-                            <a
-                                id='about_link'
-                                className='pull-right footer-link'
-                                target='_blank'
-                                rel='noopener noreferrer'
-                                href={global.window.mm_config.AboutLink}
-                            >
-                                <FormattedMessage id='web.footer.about'/>
-                            </a>
+                            {content}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
#### Summary
If any link in Legal & Support settings are empty, remove them from the UI.
Also removed `/static/help/terms.html` and others, because they 404

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3037

#### Checklist
- [x] Has UI changes

