### PR TITLE
PLT-3698 Improved handling of colons around a custom emoji's name

### DIFF
--- a/webapp/components/emoji/components/add_emoji.jsx
+++ b/webapp/components/emoji/components/add_emoji.jsx
@@ -56,6 +56,11 @@ export default class AddEmoji extends React.Component {
             name: this.state.name.trim().toLowerCase()
         };
 
+        // trim surrounding colons if the user accidentally included them in the name
+        if (emoji.name.startsWith(':') && emoji.name.endsWith(':')) {
+            emoji.name = emoji.name.substring(1, emoji.name.length - 1);
+        }
+
         if (!emoji.name) {
             this.setState({
                 saving: false,


### PR DESCRIPTION
#### Summary
If the user accidentally surrounds the name of their custom emoji with colons, just ignore them.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3698

#### Checklist
- Has UI changes
