### PR TITLE
PLT-3752 Changed email connection test to use the existing password...

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -195,6 +195,19 @@ func testEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// if the user hasn't changed their email settings, fill in the actual SMTP password so that
+	// the user can verify an existing SMTP connection
+	if cfg.EmailSettings.SMTPPassword == model.FAKE_SETTING {
+		if cfg.EmailSettings.SMTPServer == utils.Cfg.EmailSettings.SMTPServer &&
+			cfg.EmailSettings.SMTPPort == utils.Cfg.EmailSettings.SMTPPort &&
+			cfg.EmailSettings.SMTPUsername == utils.Cfg.EmailSettings.SMTPUsername {
+			cfg.EmailSettings.SMTPPassword = utils.Cfg.EmailSettings.SMTPPassword
+		} else {
+			c.Err = model.NewLocAppError("testEmail", "api.admin.test_email.reenter_password", nil, "")
+			return
+		}
+	}
+
 	if result := <-Srv.Store.User().Get(c.Session.UserId); result.Err != nil {
 		c.Err = result.Err
 		return

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -104,6 +104,10 @@
     "translation": "SMTP Server is required"
   },
   {
+    "id": "api.admin.test_email.reenter_password",
+    "translation": "The SMTP server, port, or username has changed. Please re-enter the SMTP password to test connection."
+  },
+  {
     "id": "api.admin.test_email.subject",
     "translation": "Mattermost - Testing Email Settings"
   },

--- a/webapp/components/admin_console/email_connection_test.jsx
+++ b/webapp/components/admin_console/email_connection_test.jsx
@@ -46,9 +46,14 @@ export default class EmailConnectionTestButton extends React.Component {
                 });
             },
             (err) => {
+                let fail = err.message;
+                if (err.detailed_error) {
+                    fail += ' - ' + err.detailed_error;
+                }
+
                 this.setState({
                     testing: false,
-                    fail: err.message + ' - ' + err.detailed_error
+                    fail
                 });
             }
         );


### PR DESCRIPTION
#### Summary
... if unchanged by the client. Makes sure none of the other settings have changed so that malicious admins can't send the user's password to random servers.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3752