### PR TITLE
PLT-3668 Fix Dropdown for System Admins in Manage Members is empty

### DIFF
--- a/webapp/components/team_members_dropdown.jsx
+++ b/webapp/components/team_members_dropdown.jsx
@@ -338,6 +338,10 @@ export default class TeamMembersDropdown extends React.Component {
             );
         }
 
+        if (!removeFromTeam && !makeAdmin && !makeMember && !makeActive && !makeNotActive) {
+            return <div>{currentRoles}</div>;
+        }
+
         return (
             <div className='dropdown member-drop'>
                 <a


### PR DESCRIPTION
#### Summary
Currently the Manage members modal shows an empty dropdown when no options apply for a user in the list, now theres no dropdown if it doesn't have options to show but the current role is displayed.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3688

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

