### PR TITLE
PLT-3408 Add SiteURL to config.json

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -457,7 +457,6 @@ func handleWebhookEvents(c *Context, post *model.Post, team *model.Team, channel
 							Err:          nil,
 							teamURLValid: c.teamURLValid,
 							teamURL:      c.teamURL,
-							siteURL:      c.siteURL,
 							T:            c.T,
 							Locale:       c.Locale,
 							TeamId:       hook.TeamId,

--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,6 @@
 {
     "ServiceSettings": {
+        "SiteURL": "http://localhost:8065",
         "ListenAddress": ":8065",
         "MaximumLoginAttempts": 10,
         "SegmentDeveloperKey": "",

--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,6 @@
 {
     "ServiceSettings": {
-        "SiteURL": "http://localhost:8065",
+        "SiteURL": "",
         "ListenAddress": ":8065",
         "MaximumLoginAttempts": 10,
         "SegmentDeveloperKey": "",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2812,6 +2812,10 @@
     "translation": "Invalid Username attribute. Must be set."
   },
   {
+    "id": "model.config.is_valid.site_url.app_error",
+    "translation": "Site URL must be a valid URL and start with http:// or https://"
+  },
+  {
     "id": "model.config.is_valid.sitename_length.app_error",
     "translation": "Site name must be less than or equal to {{.MaxLength}} characters."
   },

--- a/mattermost.go
+++ b/mattermost.go
@@ -70,7 +70,6 @@ var flagEmail string
 var flagPassword string
 var flagTeamName string
 var flagChannelName string
-var flagSiteURL string
 var flagConfirmBackup string
 var flagRole string
 var flagRunCmds bool
@@ -290,7 +289,6 @@ func parseCmds() {
 	flag.StringVar(&flagPassword, "password", "", "")
 	flag.StringVar(&flagTeamName, "team_name", "", "")
 	flag.StringVar(&flagChannelName, "channel_name", "", "")
-	flag.StringVar(&flagSiteURL, "site_url", "", "")
 	flag.StringVar(&flagConfirmBackup, "confirm_backup", "", "")
 	flag.StringVar(&flagFromAuth, "from_auth", "", "")
 	flag.StringVar(&flagToAuth, "to_auth", "", "")
@@ -863,16 +861,8 @@ func cmdInviteUser() {
 			os.Exit(1)
 		}
 
-		if len(flagSiteURL) == 0 {
-			fmt.Fprintln(os.Stderr, "flag needs an argument: -site_url")
-			flag.Usage()
-			os.Exit(1)
-		}
-
-		// basic validation of the URL format
-		if _, err := url.ParseRequestURI(flagSiteURL); err != nil {
-			fmt.Fprintln(os.Stderr, "-site_url flag is invalid. It should look like http://example.com")
-			flag.Usage()
+		if len(*utils.Cfg.ServiceSettings.SiteURL) == 0 {
+			fmt.Fprintln(os.Stderr, "SiteURL must be specified in config.json")
 			os.Exit(1)
 		}
 
@@ -894,7 +884,6 @@ func cmdInviteUser() {
 
 		invites := []string{flagEmail}
 		c := getMockContext()
-		c.SetSiteURL(strings.TrimSuffix(flagSiteURL, "/"))
 		api.InviteMembers(c, team, user, invites)
 
 		os.Exit(0)
@@ -1590,8 +1579,6 @@ FLAGS:
 
     -team_name="name"                 The team name used in other commands
 
-    -site_url="url"										The site URL used in other commands
-
     -role="system_admin"              The role used in other commands
                                       valid values are
                                         "" - The empty role is basic user
@@ -1611,9 +1598,9 @@ COMMANDS:
             platform -create_user -team_name="name" -email="user@example.com" -password="mypassword" -username="user"
 
     -invite_user                      Invites a user to a team by email. It requires the -team_name
-                                      , -email and -site_url flags.
+                                      and -email flags.
         Example:
-				platform -invite_user -team_name="name" -email="user@example.com" -site_url="https://mattermost.example.com"
+				platform -invite_user -team_name="name" -email="user@example.com"
 
 -leave_team                           Removes a user from a team.  It requires the -team_name
                                       and -email.

--- a/model/config.go
+++ b/model/config.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/url"
 )
 
 const (
@@ -49,6 +50,7 @@ const (
 )
 
 type ServiceSettings struct {
+	SiteURL                           *string
 	ListenAddress                     string
 	MaximumLoginAttempts              int
 	SegmentDeveloperKey               string
@@ -356,6 +358,11 @@ func (o *Config) SetDefaults() {
 
 	if len(o.EmailSettings.PasswordResetSalt) == 0 {
 		o.EmailSettings.PasswordResetSalt = NewRandomString(32)
+	}
+
+	if o.ServiceSettings.SiteURL == nil {
+		o.ServiceSettings.SiteURL = new(string)
+		*o.ServiceSettings.SiteURL = ""
 	}
 
 	if o.ServiceSettings.EnableDeveloper == nil {
@@ -820,6 +827,16 @@ func (o *Config) IsValid() *AppError {
 
 	if o.ServiceSettings.MaximumLoginAttempts <= 0 {
 		return NewLocAppError("Config.IsValid", "model.config.is_valid.login_attempts.app_error", nil, "")
+	}
+
+	if len(*o.ServiceSettings.SiteURL) != 0 {
+		if _, err := url.ParseRequestURI(*o.ServiceSettings.SiteURL); err != nil {
+			return NewLocAppError("Config.IsValid", "model.config.is_valid.site_url.app_error", nil, "")
+		}
+	}
+
+	if len(o.ServiceSettings.ListenAddress) == 0 {
+		return NewLocAppError("Config.IsValid", "model.config.is_valid.listen_address.app_error", nil, "")
 	}
 
 	if len(o.ServiceSettings.ListenAddress) == 0 {

--- a/utils/config.go
+++ b/utils/config.go
@@ -185,7 +185,7 @@ func LoadConfig(fileName string) {
 	}
 
 	Cfg = &config
-	ClientCfg = getClientConfig(Cfg)
+	RegenerateClientConfig()
 
 	// Actions that need to run every time the config is loaded
 	if ldapI := einterfaces.GetLdapInterface(); ldapI != nil {
@@ -198,6 +198,10 @@ func LoadConfig(fileName string) {
 	}
 }
 
+func RegenerateClientConfig() {
+	ClientCfg = getClientConfig(Cfg)
+}
+
 func getClientConfig(c *model.Config) map[string]string {
 	props := make(map[string]string)
 
@@ -208,6 +212,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["BuildHashEnterprise"] = model.BuildHashEnterprise
 	props["BuildEnterpriseReady"] = model.BuildEnterpriseReady
 
+	props["SiteURL"] = *c.ServiceSettings.SiteURL
 	props["SiteName"] = c.TeamSettings.SiteName
 	props["EnableTeamCreation"] = strconv.FormatBool(c.TeamSettings.EnableTeamCreation)
 	props["EnableUserCreation"] = strconv.FormatBool(c.TeamSettings.EnableUserCreation)

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -32,12 +32,26 @@ const MAX_WEBSOCKET_FAILS = 7;
 
 export function initialize() {
     if (window.WebSocket) {
-        let protocol = 'ws://';
-        if (window.location.protocol === 'https:') {
-            protocol = 'wss://';
+        let connUrl = window.mm_config.SiteURL;
+
+        // replace the protocol with a websocket one
+        if (connUrl.startsWith('https:')) {
+            connUrl = connUrl.replace(/^https:/, 'wss:');
+        } else {
+            connUrl = connUrl.replace(/^http:/, 'ws:');
         }
 
-        const connUrl = protocol + location.host + ((/:\d+/).test(location.host) ? '' : Utils.getWebsocketPort(protocol)) + Client.getUsersRoute() + '/websocket';
+        // append a port number if one isn't already specified
+        if (!(/:\d+$/).test(connUrl)) {
+            if (connUrl.startsWith('wss:')) {
+                connUrl += ':' + global.window.mm_config.WebsocketSecurePort;
+            } else {
+                connUrl += ':' + global.window.mm_config.WebsocketPort;
+            }
+        }
+
+        // append the websocket api path
+        connUrl += Client.getUsersRoute() + '/websocket';
 
         WebSocketClient.setEventCallback(handleEvent);
         WebSocketClient.setReconnectCallback(handleReconnect);

--- a/webapp/components/change_url_modal.jsx
+++ b/webapp/components/change_url_modal.jsx
@@ -4,6 +4,7 @@
 import ReactDOM from 'react-dom';
 import Constants from 'utils/constants.jsx';
 import {Modal, Tooltip, OverlayTrigger} from 'react-bootstrap';
+import TeamStore from 'stores/team_store.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import {FormattedMessage} from 'react-intl';
@@ -130,8 +131,8 @@ export default class ChangeUrlModal extends React.Component {
             serverError = <div className='form-group has-error'><p className='input__help error'>{this.props.serverError}</p></div>;
         }
 
-        const fullTeamUrl = Utils.getTeamURLFromAddressBar();
-        const teamURL = Utils.getShortenedTeamURL();
+        const fullTeamUrl = TeamStore.getCurrentTeamUrl();
+        const teamURL = Utils.getShortenedTeamURL(TeamStore.getCurrentTeamUrl());
         const urlTooltip = (
             <Tooltip id='urlTooltip'>{fullTeamUrl}</Tooltip>
         );

--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -123,7 +123,7 @@ export default class ChannelHeader extends React.Component {
                 });
 
                 const townsquare = ChannelStore.getByName('town-square');
-                browserHistory.push(Utils.getTeamURLNoOriginFromAddressBar() + '/channels/' + townsquare.name);
+                browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + townsquare.name);
             },
             (err) => {
                 AsyncClient.dispatchError(err, 'handleLeave');

--- a/webapp/components/channel_info_modal.jsx
+++ b/webapp/components/channel_info_modal.jsx
@@ -5,6 +5,7 @@ import * as Utils from 'utils/utils.jsx';
 
 import {FormattedMessage} from 'react-intl';
 import {Modal} from 'react-bootstrap';
+import TeamStore from 'stores/team_store.jsx';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 
 import React from 'react';
@@ -44,7 +45,7 @@ export default class ChannelInfoModal extends React.Component {
             channelIcon = (<span className='fa fa-lock'/>);
         }
 
-        const channelURL = Utils.getTeamURLFromAddressBar() + '/channels/' + channel.name;
+        const channelURL = TeamStore.getCurrentTeamUrl() + '/channels/' + channel.name;
 
         let channelPurpose = null;
         if (channel.purpose) {

--- a/webapp/components/create_team/components/team_url.jsx
+++ b/webapp/components/create_team/components/team_url.jsx
@@ -105,7 +105,7 @@ export default class TeamUrl extends React.Component {
             nameDivClass += ' has-error';
         }
 
-        const title = `${Utils.getWindowLocationOrigin()}/`;
+        const title = `${window.mm_config.SiteURL}/`;
         const urlTooltip = (
             <Tooltip id='urlTooltip'>{title}</Tooltip>
         );

--- a/webapp/components/file_attachment.jsx
+++ b/webapp/components/file_attachment.jsx
@@ -102,7 +102,7 @@ class FileAttachment extends React.Component {
     getFileInfoFromName(name) {
         var fileInfo = utils.splitFileLocation(name);
 
-        fileInfo.path = utils.getWindowLocationOrigin() + Client.getFilesRoute() + '/get' + fileInfo.path;
+        fileInfo.path = Client.getFilesRoute() + '/get' + fileInfo.path;
 
         return fileInfo;
     }

--- a/webapp/components/integrations/components/installed_incoming_webhook.jsx
+++ b/webapp/components/integrations/components/installed_incoming_webhook.jsx
@@ -97,7 +97,7 @@ export default class InstalledIncomingWebhook extends React.Component {
                                 id='installed_integrations.url'
                                 defaultMessage='URL: {url}'
                                 values={{
-                                    url: Utils.getWindowLocationOrigin() + '/hooks/' + incomingWebhook.id
+                                    url: window.mm_config.SiteURL + '/hooks/' + incomingWebhook.id
                                 }}
                             />
                         </span>

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -277,7 +277,7 @@ export default class LoginController extends React.Component {
     }
 
     createLoginOptions() {
-        const extraParam = Utils.getUrlParameter('extra');
+        const extraParam = this.props.location.query.extra;
         let extraBox = '';
         if (extraParam) {
             if (extraParam === Constants.SIGNIN_CHANGE) {

--- a/webapp/components/more_channels.jsx
+++ b/webapp/components/more_channels.jsx
@@ -74,7 +74,7 @@ export default class MoreChannels extends React.Component {
             channel,
             () => {
                 $(ReactDOM.findDOMNode(this.refs.modal)).modal('hide');
-                browserHistory.push(Utils.getTeamURLNoOriginFromAddressBar() + '/channels/' + channel.name);
+                browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name);
                 this.setState({joiningChannel: ''});
             },
             (err) => {

--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -87,7 +87,7 @@ export default class MoreDirectChannels extends React.Component {
         Utils.openDirectChannelToUser(
             teammate,
             (channel) => {
-                browserHistory.push(Utils.getTeamURLNoOriginFromAddressBar() + '/channels/' + channel.name);
+                browserHistory.push(TeamStore.getCurrentTeamUrl() + '/channels/' + channel.name);
                 this.setState({loadingDMChannel: -1});
                 this.handleHide();
             },

--- a/webapp/components/navbar_dropdown.jsx
+++ b/webapp/components/navbar_dropdown.jsx
@@ -88,7 +88,7 @@ export default class NavbarDropdown extends React.Component {
 
         return (
             <li>
-                <Link to={'/' + Utils.getTeamNameFromUrl() + '/emoji'}>
+                <Link to={'/' + this.props.teamName + '/emoji'}>
                     <FormattedMessage
                         id='navbar_dropdown.emoji'
                         defaultMessage='Custom Emoji'
@@ -207,7 +207,7 @@ export default class NavbarDropdown extends React.Component {
         if (integrationsEnabled && (isAdmin || window.mm_config.EnableOnlyAdminIntegrations !== 'true')) {
             integrationsLink = (
                 <li>
-                    <Link to={'/' + Utils.getTeamNameFromUrl() + '/integrations'}>
+                    <Link to={'/' + this.props.teamName + '/integrations'}>
                         <FormattedMessage
                             id='navbar_dropdown.integrations'
                             defaultMessage='Integrations'

--- a/webapp/components/needs_team.jsx
+++ b/webapp/components/needs_team.jsx
@@ -73,7 +73,7 @@ export default class NeedsTeam extends React.Component {
         // Go to tutorial if we are first arriving
         const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 999);
         if (tutorialStep <= TutorialSteps.INTRO_SCREENS) {
-            browserHistory.push(Utils.getTeamURLNoOriginFromAddressBar() + '/tutorial');
+            browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/tutorial');
         }
     }
 

--- a/webapp/components/new_channel_flow.jsx
+++ b/webapp/components/new_channel_flow.jsx
@@ -3,6 +3,7 @@
 
 import * as Utils from 'utils/utils.jsx';
 import Client from 'client/web_client.jsx';
+import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
 import NewChannelModal from './new_channel_modal.jsx';
@@ -117,7 +118,7 @@ class NewChannelFlow extends React.Component {
                         });
 
                         this.props.onModalDismissed();
-                        browserHistory.push(Utils.getTeamURLNoOriginFromAddressBar() + '/channels/' + data2.channel.name);
+                        browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + data2.channel.name);
                     }
                 );
             },

--- a/webapp/components/popover_list_members.jsx
+++ b/webapp/components/popover_list_members.jsx
@@ -3,6 +3,7 @@
 
 import $ from 'jquery';
 
+import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import {Popover, Overlay} from 'react-bootstrap';
 import * as Utils from 'utils/utils.jsx';
@@ -36,7 +37,7 @@ export default class PopoverListMembers extends React.Component {
         Utils.openDirectChannelToUser(
             teammate,
             (channel, channelAlreadyExisted) => {
-                browserHistory.push(Utils.getTeamURLNoOriginFromAddressBar() + '/channels/' + channel.name);
+                browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name);
                 if (channelAlreadyExisted) {
                     this.closePopover();
                 }

--- a/webapp/components/removed_from_channel_modal.jsx
+++ b/webapp/components/removed_from_channel_modal.jsx
@@ -4,10 +4,10 @@
 import $ from 'jquery';
 import ReactDOM from 'react-dom';
 import ChannelStore from 'stores/channel_store.jsx';
+import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
 
-import * as Utils from 'utils/utils.jsx';
 import {FormattedMessage} from 'react-intl';
 import {browserHistory} from 'react-router/es6';
 
@@ -36,7 +36,7 @@ export default class RemovedFromChannelModal extends React.Component {
         var townSquare = ChannelStore.getByName('town-square');
         setTimeout(
             () => {
-                browserHistory.push(Utils.getTeamURLNoOriginFromAddressBar() + '/channels/' + townSquare.name);
+                browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + townSquare.name);
             },
         1);
 

--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -4,6 +4,7 @@
 import $ from 'jquery';
 import UserProfile from './user_profile.jsx';
 
+import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
@@ -151,7 +152,7 @@ export default class SearchResultsItem extends React.Component {
                                                     this.hideSidebar();
                                                 }
                                                 this.shrinkSidebar();
-                                                browserHistory.push('/' + window.location.pathname.split('/')[1] + '/pl/' + post.id);
+                                                browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/pl/' + post.id);
                                             }
                                         }
                                         className='search-item__jump'

--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -12,7 +12,6 @@ import Constants from 'utils/constants.jsx';
 const ActionTypes = Constants.ActionTypes;
 import * as AsyncClient from 'utils/async_client.jsx';
 import Client from 'client/web_client.jsx';
-import * as Utils from 'utils/utils.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 
 import emojiRoute from 'routes/route_emoji.jsx';
@@ -57,7 +56,7 @@ function doChannelChange(state, replace, callback) {
 function preNeedsTeam(nextState, replace, callback) {
     // First check to make sure you're in the current team
     // for the current url.
-    var teamName = Utils.getTeamNameFromUrl();
+    const teamName = nextState.params.team;
     var team = TeamStore.getByName(teamName);
     const oldTeamId = TeamStore.getCurrentId();
 

--- a/webapp/stores/team_store.jsx
+++ b/webapp/stores/team_store.jsx
@@ -11,12 +11,6 @@ const ActionTypes = Constants.ActionTypes;
 const CHANGE_EVENT = 'change';
 
 var Utils;
-function getWindowLocationOrigin() {
-    if (!Utils) {
-        Utils = require('utils/utils.jsx'); //eslint-disable-line global-require
-    }
-    return Utils.getWindowLocationOrigin();
-}
 
 class TeamStoreClass extends EventEmitter {
     constructor() {
@@ -87,23 +81,23 @@ class TeamStoreClass extends EventEmitter {
 
     getCurrentTeamUrl() {
         if (this.getCurrent()) {
-            return getWindowLocationOrigin() + '/' + this.getCurrent().name;
+            return window.mm_config.SiteURL + '/' + this.getCurrent().name;
         }
-        return null;
+        return '';
     }
 
     getCurrentTeamRelativeUrl() {
         if (this.getCurrent()) {
             return '/' + this.getCurrent().name;
         }
-        return null;
+        return '';
     }
 
     getCurrentInviteLink() {
         const current = this.getCurrent();
 
         if (current) {
-            return getWindowLocationOrigin() + '/signup_user_complete/?id=' + current.invite_id;
+            return window.mm_config.SiteURL + '/signup_user_complete/?id=' + current.invite_id;
         }
 
         return '';
@@ -112,10 +106,10 @@ class TeamStoreClass extends EventEmitter {
     getTeamUrl(id) {
         const team = this.get(id);
         if (team) {
-            return getWindowLocationOrigin() + '/' + team.name;
+            return window.mm_config.SiteURL + '/' + team.name;
         }
 
-        return null;
+        return '';
     }
 
     saveTeam(team) {

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -99,20 +99,6 @@ export function isSystemAdmin(roles) {
     return false;
 }
 
-export function getDomainWithOutSub() {
-    var parts = window.location.host.split('.');
-
-    if (parts.length === 1) {
-        if (parts[0].indexOf('dockerhost') > -1) {
-            return 'dockerhost:8065';
-        }
-
-        return 'localhost:8065';
-    }
-
-    return parts[1] + '.' + parts[2];
-}
-
 export function getCookie(name) {
     var value = '; ' + document.cookie;
     var parts = value.split('; ' + name + '=');
@@ -169,18 +155,6 @@ export function ding() {
             return;
         }, 3000);
     }
-}
-
-export function getUrlParameter(sParam) {
-    var sPageURL = window.location.search.substring(1);
-    var sURLVariables = sPageURL.split('&');
-    for (var i = 0; i < sURLVariables.length; i++) {
-        var sParameterName = sURLVariables[i].split('=');
-        if (sParameterName[0] === sParam) {
-            return sParameterName[1];
-        }
-    }
-    return null;
 }
 
 export function getDateForUnixTicks(ticks) {
@@ -1013,18 +987,6 @@ export function displayUsernameForUser(user) {
     return username;
 }
 
-//IE10 does not set window.location.origin automatically so this must be called instead when using it
-export function getWindowLocationOrigin() {
-    var windowLocationOrigin = window.location.origin;
-    if (!windowLocationOrigin) {
-        windowLocationOrigin = window.location.protocol + '//' + window.location.hostname;
-        if (window.location.port) {
-            windowLocationOrigin += ':' + window.location.port;
-        }
-    }
-    return windowLocationOrigin;
-}
-
 // Converts a file size in bytes into a human-readable string of the form '123MB'.
 export function fileSizeToString(bytes) {
     // it's unlikely that we'll have files bigger than this
@@ -1043,7 +1005,7 @@ export function fileSizeToString(bytes) {
 
 // Converts a filename (like those attached to Post objects) to a url that can be used to retrieve attachments from the server.
 export function getFileUrl(filename) {
-    return getWindowLocationOrigin() + Client.getFilesRoute() + '/get' + filename;
+    return Client.getFilesRoute() + '/get' + filename;
 }
 
 // Gets the name of a file (including extension) from a given url or file path.
@@ -1149,20 +1111,7 @@ export function importSlack(file, success, error) {
     Client.importSlack(formData, success, error);
 }
 
-export function getTeamURLFromAddressBar() {
-    return window.location.origin + '/' + window.location.pathname.split('/')[1];
-}
-
-export function getTeamNameFromUrl() {
-    return window.location.pathname.split('/')[1];
-}
-
-export function getTeamURLNoOriginFromAddressBar() {
-    return '/' + window.location.pathname.split('/')[1];
-}
-
-export function getShortenedTeamURL() {
-    const teamURL = getTeamURLFromAddressBar();
+export function getShortenedTeamURL(teamURL = '') {
     if (teamURL.length > 35) {
         return teamURL.substring(0, 10) + '...' + teamURL.substring(teamURL.length - 12, teamURL.length) + '/';
     }


### PR DESCRIPTION
#### Summary
Surprisingly, it took very little work to do this on the server. Serverside code can access the site URL either from the Context or directly from the config. Clientside code can get it from mm_config or it can use the TeamStore's methods for convenience. I removed most of the references to window.location along with all of the utility functions in utils.jsx that used it.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3408

#### Checklist
- Includes text changes and localization files updated
- Touches critical sections of the codebase (auth, upgrade, etc.)
