### PR TITLE
Fix garbled mail subject

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -737,11 +737,6 @@ func sendNotificationEmail(c *Context, post *model.Post, user *model.User, chann
 	}
 
 	month := userLocale(tm.Month().String())
-	monthRune := []rune(month)
-	monthShort := string(monthRune)
-	if len(monthRune) > 3 {
-		monthShort = string(monthRune[:3])
-	}
 	day := fmt.Sprintf("%d", tm.Day())
 	year := fmt.Sprintf("%d", tm.Year())
 	zone, _ := tm.Zone()
@@ -749,7 +744,7 @@ func sendNotificationEmail(c *Context, post *model.Post, user *model.User, chann
 	subjectPage := utils.NewHTMLTemplate("post_subject", user.Locale)
 	subjectPage.Props["Subject"] = userLocale("api.templates.post_subject",
 		map[string]interface{}{"SubjectText": subjectText, "TeamDisplayName": team.DisplayName,
-			"Month": monthShort, "Day": day, "Year": year})
+			"Month": month, "Day": day, "Year": year})
 	subjectPage.Props["SiteName"] = utils.Cfg.TeamSettings.SiteName
 
 	bodyPage := utils.NewHTMLTemplate("post_body", user.Locale)

--- a/api/post.go
+++ b/api/post.go
@@ -737,6 +737,11 @@ func sendNotificationEmail(c *Context, post *model.Post, user *model.User, chann
 	}
 
 	month := userLocale(tm.Month().String())
+	monthRune := []rune(month)
+	monthShort := string(monthRune)
+	if len(monthRune) > 3 {
+		monthShort = string(monthRune[:3])
+	}
 	day := fmt.Sprintf("%d", tm.Day())
 	year := fmt.Sprintf("%d", tm.Year())
 	zone, _ := tm.Zone()
@@ -744,7 +749,7 @@ func sendNotificationEmail(c *Context, post *model.Post, user *model.User, chann
 	subjectPage := utils.NewHTMLTemplate("post_subject", user.Locale)
 	subjectPage.Props["Subject"] = userLocale("api.templates.post_subject",
 		map[string]interface{}{"SubjectText": subjectText, "TeamDisplayName": team.DisplayName,
-			"Month": month[:3], "Day": day, "Year": year})
+			"Month": monthShort, "Day": day, "Year": year})
 	subjectPage.Props["SiteName"] = utils.Cfg.TeamSettings.SiteName
 
 	bodyPage := utils.NewHTMLTemplate("post_body", user.Locale)


### PR DESCRIPTION
#### Summary
Notification email subject is garbled in Japanese.
![mm-garbled-subject](https://cloud.githubusercontent.com/assets/1310661/17212043/a63c7306-5507-11e6-9f1a-f1366c35129f.png)
For example, 20th July should be `7月 20, 2016` in Japanese. 

#### Ticket Link
There was no tickets for this PR but I thought this is obvious bug.