### PR TITLE
PLT-3740 Terms of Service link updates

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -493,7 +493,7 @@ func (o *Config) SetDefaults() {
 
 	if o.SupportSettings.TermsOfServiceLink == nil {
 		o.SupportSettings.TermsOfServiceLink = new(string)
-		*o.SupportSettings.TermsOfServiceLink = ""
+		*o.SupportSettings.TermsOfServiceLink = "https://about.mattermost.com/default-terms/"
 	}
 
 	if !IsSafeLink(o.SupportSettings.PrivacyPolicyLink) {

--- a/webapp/components/admin_console/legal_and_support_settings.jsx
+++ b/webapp/components/admin_console/legal_and_support_settings.jsx
@@ -64,7 +64,7 @@ export default class LegalAndSupportSettings extends AdminSettings {
                     helpText={
                         <FormattedMessage
                             id='admin.support.termsDesc'
-                            defaultMessage='Link to Terms of Service available to users on desktop and on mobile. Leaving this blank will hide the option to display a notice.'
+                            defaultMessage='Link to the terms under which users may use your online service. By default, this includes the "Mattermost Conditions of Use (End Users)" explaining the terms under which Mattermost software is provided to end users. If you change the default link to add your own terms for using the service you provide, your new terms must include a link to the default terms so end users are aware of the Mattermost Conditions of Use (End User) for Mattermost software.'
                         />
                     }
                     value={this.state.termsOfServiceLink}

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -681,7 +681,7 @@
   "admin.support.privacyTitle": "Privacy Policy link:",
   "admin.support.problemDesc": "Link to help documentation from team site main menu. By default this points to the peer-to-peer troubleshooting forum where users can search for, find and request help with technical issues.",
   "admin.support.problemTitle": "Report a Problem link:",
-  "admin.support.termsDesc": "Link to Terms of Service available to users on desktop and on mobile. Leaving this blank will hide the option to display a notice.",
+  "admin.support.termsDesc": "Link to the terms under which users may use your online service. By default, this includes the \"Mattermost Conditions of Use (End Users)\" explaining the terms under which Mattermost software is provided to end users. If you change the default link to add your own terms for using the service you provide, your new terms must include a link to the default terms so end users are aware of the Mattermost Conditions of Use (End User) for Mattermost software.",
   "admin.support.termsTitle": "Terms of Service link:",
   "admin.system_analytics.activeUsers": "Active Users With Posts",
   "admin.system_analytics.title": "the System",


### PR DESCRIPTION
#### Summary
Set Mattermost terms of service default to https://about.mattermost.com/default-terms/ and asks to be included in case the link is changed

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3740

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

