### PR TITLE
PLT-2986 EE: Added custom branding to login description

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -37,6 +37,7 @@
         "RestrictTeamNames": true,
         "EnableCustomBrand": false,
         "CustomBrandText": "",
+        "CustomDescriptionText": "",
         "RestrictDirectMessage": "any",
         "RestrictTeamInvite": "all",
         "RestrictPublicChannelManagement": "all",

--- a/model/config.go
+++ b/model/config.go
@@ -192,6 +192,7 @@ type TeamSettings struct {
 	RestrictTeamNames                *bool
 	EnableCustomBrand                *bool
 	CustomBrandText                  *string
+	CustomDescriptionText            *string
 	RestrictDirectMessage            *string
 	RestrictTeamInvite               *string
 	RestrictPublicChannelManagement  *string
@@ -420,6 +421,11 @@ func (o *Config) SetDefaults() {
 	if o.TeamSettings.CustomBrandText == nil {
 		o.TeamSettings.CustomBrandText = new(string)
 		*o.TeamSettings.CustomBrandText = ""
+	}
+
+	if o.TeamSettings.CustomDescriptionText == nil {
+		o.TeamSettings.CustomDescriptionText = new(string)
+		*o.TeamSettings.CustomDescriptionText = ""
 	}
 
 	if o.TeamSettings.EnableOpenServer == nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -271,6 +271,7 @@ func getClientConfig(c *model.Config) map[string]string {
 		if *License.Features.CustomBrand {
 			props["EnableCustomBrand"] = strconv.FormatBool(*c.TeamSettings.EnableCustomBrand)
 			props["CustomBrandText"] = *c.TeamSettings.CustomBrandText
+			props["CustomDescriptionText"] = *c.TeamSettings.CustomDescriptionText
 		}
 
 		if *License.Features.LDAP {

--- a/webapp/components/admin_console/custom_brand_settings.jsx
+++ b/webapp/components/admin_console/custom_brand_settings.jsx
@@ -27,6 +27,7 @@ export default class CustomBrandSettings extends AdminSettings {
         if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true') {
             config.TeamSettings.EnableCustomBrand = this.state.enableCustomBrand;
             config.TeamSettings.CustomBrandText = this.state.customBrandText;
+            config.TeamSettings.customDescriptionText = this.state.customDescriptionText;
         }
 
         return config;
@@ -36,7 +37,8 @@ export default class CustomBrandSettings extends AdminSettings {
         return {
             siteName: config.TeamSettings.SiteName,
             enableCustomBrand: config.TeamSettings.EnableCustomBrand,
-            customBrandText: config.TeamSettings.CustomBrandText
+            customBrandText: config.TeamSettings.CustomBrandText,
+            customDescriptionText: config.TeamSettings.CustomDescriptionText
         };
     }
 
@@ -100,6 +102,30 @@ export default class CustomBrandSettings extends AdminSettings {
                         />
                     }
                     value={this.state.customBrandText}
+                    onChange={this.handleChange}
+                    disabled={!this.state.enableCustomBrand}
+                />
+            );
+
+            enterpriseSettings.push(
+                <TextSetting
+                    key='customDescriptionText'
+                    id='customDescriptionText'
+                    type='textarea'
+                    label={
+                        <FormattedMessage
+                            id='admin.team.brandDescriptionTitle'
+                            defaultMessage='Site Description'
+                        />
+                    }
+                    helpText={
+                        <FormattedMessage
+                            id='admin.team.brandDescriptionHelp'
+                            defaultMessage='Description of service shown in login screens and UI.'
+                        />
+                    }
+                    value={this.state.customDescriptionText}
+                    placeholder={Utils.localizeMessage('web.root.signup_info', 'All team communication in one place, searchable and accessible anywhere')}
                     onChange={this.handleChange}
                     disabled={!this.state.enableCustomBrand}
                 />

--- a/webapp/components/create_team/create_team_controller.jsx
+++ b/webapp/components/create_team/create_team_controller.jsx
@@ -35,6 +35,18 @@ export default class CreateTeamController extends React.Component {
     }
 
     render() {
+        let description = null;
+        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && global.window.mm_config.EnableCustomBrand === 'true') {
+            description = global.window.mm_config.CustomDescriptionText;
+        } else {
+            description = (
+                <FormattedMessage
+                    id='web.root.signup_info'
+                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
+                />
+            );
+        }
+
         return (
             <div>
                 <ErrorBar/>
@@ -50,9 +62,7 @@ export default class CreateTeamController extends React.Component {
                     <div className='signup-team__container'>
                         <h1>{global.window.mm_config.SiteName}</h1>
                         <h4 className='color--light'>
-                            <FormattedMessage
-                                id='web.root.singup_info'
-                            />
+                            {description}
                         </h4>
                         <div className='signup__content'>
                             {React.cloneElement(this.props.children, {

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -549,6 +549,18 @@ export default class LoginController extends React.Component {
             }
         }
 
+        let description = null;
+        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && global.window.mm_config.EnableCustomBrand === 'true') {
+            description = global.window.mm_config.CustomDescriptionText;
+        } else {
+            description = (
+                <FormattedMessage
+                    id='web.root.signup_info'
+                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
+                />
+            );
+        }
+
         return (
             <div>
                 <ErrorBar/>
@@ -564,9 +576,7 @@ export default class LoginController extends React.Component {
                         <div className='signup__content'>
                             <h1>{global.window.mm_config.SiteName}</h1>
                             <h4 className='color--light'>
-                                <FormattedMessage
-                                    id='web.root.singup_info'
-                                />
+                                {description}
                             </h4>
                             {content}
                         </div>

--- a/webapp/components/select_team/select_team.jsx
+++ b/webapp/components/select_team/select_team.jsx
@@ -212,6 +212,18 @@ export default class SelectTeam extends React.Component {
             );
         }
 
+        let description = null;
+        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && global.window.mm_config.EnableCustomBrand === 'true') {
+            description = global.window.mm_config.CustomDescriptionText;
+        } else {
+            description = (
+                <FormattedMessage
+                    id='web.root.signup_info'
+                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
+                />
+            );
+        }
+
         return (
             <div>
                 <ErrorBar/>
@@ -234,9 +246,7 @@ export default class SelectTeam extends React.Component {
                         />
                         <h1>{global.window.mm_config.SiteName}</h1>
                         <h4 className='color--light'>
-                            <FormattedMessage
-                                id='web.root.singup_info'
-                            />
+                            {description}
                         </h4>
                         {content}
                         {openContent}

--- a/webapp/components/signup_user_complete.jsx
+++ b/webapp/components/signup_user_complete.jsx
@@ -765,6 +765,18 @@ export default class SignupUserComplete extends React.Component {
             ldapSignup = null;
         }
 
+        let description = null;
+        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && global.window.mm_config.EnableCustomBrand === 'true') {
+            description = global.window.mm_config.CustomDescriptionText;
+        } else {
+            description = (
+                <FormattedMessage
+                    id='web.root.signup_info'
+                    defaultMessage='All team communication in one place, searchable and accessible anywhere'
+                />
+            );
+        }
+
         return (
             <div>
                 <div className='signup-header'>
@@ -783,9 +795,7 @@ export default class SignupUserComplete extends React.Component {
                         />
                         <h1>{global.window.mm_config.SiteName}</h1>
                         <h4 className='color--light'>
-                            <FormattedMessage
-                                id='web.root.singup_info'
-                            />
+                            {description}
                         </h4>
                         <h4 className='color--light'>
                             <FormattedMessage

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -691,6 +691,9 @@
   "admin.team.brandTextDescription": "The custom branding Markdown-formatted text you would like to appear below your custom brand image on your login screen.",
   "admin.team.brandTextTitle": "Custom Brand Text:",
   "admin.team.brandTitle": "Enable Custom Branding: ",
+  "admin.team.brandDescriptionTitle": "Site Description",
+  "admin.team.brandDescriptionHelp": "Description of service shown in login screens and UI.",
+  "admin.team.brandDescriptionExample": "All team communication in one place, searchable and accessible anywhere",
   "admin.team.chooseImage": "Choose New Image",
   "admin.team.dirDesc": "When true, teams that are configured to show in team directory will show on main page inplace of creating a new team.",
   "admin.team.dirTitle": "Enable Team Directory: ",
@@ -1748,6 +1751,6 @@
   "web.footer.privacy": "Privacy",
   "web.footer.terms": "Terms",
   "web.header.back": "Back",
-  "web.root.singup_info": "All team communication in one place, searchable and accessible anywhere",
+  "web.root.signup_info": "All team communication in one place, searchable and accessible anywhere",
   "youtube_video.notFound": "Video not found"
 }


### PR DESCRIPTION
#### Summary
- Added custom branding to login description
- Changed `singup` to `signup` everywhere

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-2986

#### Checklist
- [x] Has enterprise changes (please link)
- [x] Has UI changes
- [x] Includes text changes and localization files updated

