### PR TITLE
PLT-3702 Fixed outgoing webhook creation API to properly clear error flag

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -209,6 +209,8 @@ func createOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 				c.LogAudit("fail - bad channel permissions")
 				c.Err = model.NewLocAppError("createOutgoingHook", "api.webhook.create_outgoing.permissions.app_error", nil, "")
 				return
+			} else {
+				c.Err = nil
 			}
 		}
 	} else if len(hook.TriggerWords) == 0 {


### PR DESCRIPTION
#### Summary
When creating an outgoing webhook for a public channel that you weren't a member of, the c.Err field wasn't being cleared properly so the client was seeing an error even though the webhook was created properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3702