### PR TITLE
Made em(..) return an actual number

### DIFF
--- a/webapp/sass/utils/_functions.scss
+++ b/webapp/sass/utils/_functions.scss
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 
 @function em($pixels, $context: 14px) {
-	@return #{$pixels/$context}em
+	@return ($pixels / $context * 1em)
 }
 
 @function alpha-color($color, $amount) {


### PR DESCRIPTION
#### Summary

Right now, the `em(..)` function is returning a string, which is not ideal at all because it prevents any further operation of the returned value. By treating the unit as part of the number rather than like a string appended at its end, we can have proper number to number transformation.

Related links:

- http://hugogiraudel.com/2013/09/03/use-lengths-not-strings/
- https://www.sitepoint.com/understanding-sass-units/

