### PR TITLE
PLT-3712 Send verification email if user has never logged in, send email changed email otherwise

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -2321,9 +2321,9 @@ func resendVerification(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		if _, err := GetStatus(user.Id); err != nil {
-			go SendEmailChangeVerifyEmail(c, user.Id, user.Email, c.GetSiteURL())
-		} else {
 			go SendVerifyEmail(c, user.Id, user.Email, c.GetSiteURL())
+		} else {
+			go SendEmailChangeVerifyEmail(c, user.Id, user.Email, c.GetSiteURL())
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
Logic was reversed, fixed here. If the status does not exist the user has never signed in so we want to send the verification email. If they have a status, then they signed in previously and must be changing their email address.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3712