### PR TITLE
PLT-3840 Fix Typos in cluster localization strings

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4708,12 +4708,12 @@
     "translation": "Cluster ping successful with hostname=%v on=%v with id=%v self=%v"
   },
   {
-    "id": "ent.cluster.incompatibile.warn",
-    "translation": "Potential incompatibile version detected for clustering with %v"
+    "id": "ent.cluster.incompatible.warn",
+    "translation": "Potential incompatible version detected for clustering with %v"
   },
   {
-    "id": "ent.cluster.incompatibile_config.warn",
-    "translation": "Potential incompatibile config detected for clustering with %v"
+    "id": "ent.cluster.incompatible_config.warn",
+    "translation": "Potential incompatible config detected for clustering with %v"
   },
   {
     "id": "ent.cluster.debug_fail.debug",


### PR DESCRIPTION
#### Summary
Fixes a typo en cluster localization

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3840

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [x] Has enterprise changes (https://github.com/mattermost/enterprise/pull/50)
- [ ] Has UI changes
- [x] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

