### PR TITLE
PLT-1890 Added @username and full name to user profile popover

### DIFF
--- a/webapp/components/user_profile.jsx
+++ b/webapp/components/user_profile.jsx
@@ -79,6 +79,24 @@ export default class UserProfile extends React.Component {
             />
         );
 
+        let fullname = Utils.getFullName(this.props.user);
+        if (fullname) {
+            dataContent.push(
+                <div
+                    data-toggle='tooltip'
+                    title={fullname}
+                    key='user-popover-fullname'
+                >
+
+                    <p
+                        className='text-nowrap'
+                    >
+                        {fullname}
+                    </p>
+                </div>
+            );
+        }
+
         if (global.window.mm_config.ShowEmailAddress === 'true' || UserStore.isSystemAdminForCurrentUser() || this.props.user === UserStore.getCurrentUser()) {
             dataContent.push(
                 <div
@@ -103,7 +121,7 @@ export default class UserProfile extends React.Component {
                 rootClose={true}
                 overlay={
                     <Popover
-                        title={name}
+                        title={'@' + this.props.user.username}
                         id='user-profile-popover'
                     >
                         {dataContent}


### PR DESCRIPTION
#### Summary
Always show `@username` in user popover. Also show full name above email if the user has set a full name.

This PR handles text changes only, making it more efficient with a custom component is another ticket.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-1890

#### Checklist
- [x] Has UI changes

