### PR TITLE
Remove legacy code adding useless team name to oauth URLs

### DIFF
--- a/webapp/components/signup_user_complete.jsx
+++ b/webapp/components/signup_user_complete.jsx
@@ -591,7 +591,7 @@ export default class SignupUserComplete extends React.Component {
                 <a
                     className='btn btn-custom-login google'
                     key='google'
-                    href={Client.getOAuthRoute() + '/google/signup' + window.location.search + '&team=' + encodeURIComponent(this.state.teamName)}
+                    href={Client.getOAuthRoute() + '/google/signup' + window.location.search}
                 >
                     <span className='icon'/>
                     <span>
@@ -609,7 +609,7 @@ export default class SignupUserComplete extends React.Component {
                 <a
                     className='btn btn-custom-login office365'
                     key='office365'
-                    href={Client.getOAuthRoute() + '/office365/signup' + window.location.search + '&team=' + encodeURIComponent(this.state.teamName)}
+                    href={Client.getOAuthRoute() + '/office365/signup' + window.location.search}
                 >
                     <span className='icon'/>
                     <span>


### PR DESCRIPTION
#### Summary
Team name was (uselessly) being appended by some legacy code and it was causing an issue if there wasn't already a query string.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3862

#### Checklist
- [x] Touches critical sections of the codebase (sign-up)