### PR TITLE
PLT-3865 Fix OAuth provider routes

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -33,11 +33,11 @@ func InitOAuth() {
 	BaseRoutes.OAuth.Handle("/{service:[A-Za-z0-9]+}/complete", AppHandlerIndependent(completeOAuth)).Methods("GET")
 	BaseRoutes.OAuth.Handle("/{service:[A-Za-z0-9]+}/login", AppHandlerIndependent(loginWithOAuth)).Methods("GET")
 	BaseRoutes.OAuth.Handle("/{service:[A-Za-z0-9]+}/signup", AppHandlerIndependent(signupWithOAuth)).Methods("GET")
-	BaseRoutes.OAuth.Handle("/authorize", ApiUserRequired(authorizeOAuth)).Methods("GET")
-	BaseRoutes.OAuth.Handle("/access_token", ApiAppHandler(getAccessToken)).Methods("POST")
+	BaseRoutes.OAuth.Handle("/authorize", AppHandlerTrustRequester(authorizeOAuth)).Methods("GET")
+	BaseRoutes.OAuth.Handle("/access_token", ApiAppHandlerTrustRequester(getAccessToken)).Methods("POST")
 
 	BaseRoutes.Root.Handle("/authorize", AppHandlerTrustRequester(authorizeOAuth)).Methods("GET")
-	BaseRoutes.Root.Handle("/access_token", ApiAppHandler(getAccessToken)).Methods("POST")
+	BaseRoutes.Root.Handle("/access_token", ApiAppHandlerTrustRequester(getAccessToken)).Methods("POST")
 
 	// Handle all the old routes, to be later removed
 	BaseRoutes.Root.Handle("/{service:[A-Za-z0-9]+}/complete", AppHandlerIndependent(completeOAuth)).Methods("GET")


### PR DESCRIPTION
#### Summary
In order to prevent `Appears to bea CSRF attempt` the routes for OAuth provider must be with **Trust Requester**

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3865

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

