### PR TITLE
PLT-3879 Fix OAuth provider routes

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -33,11 +33,9 @@ func InitOAuth() {
 	BaseRoutes.OAuth.Handle("/{service:[A-Za-z0-9]+}/complete", AppHandlerIndependent(completeOAuth)).Methods("GET")
 	BaseRoutes.OAuth.Handle("/{service:[A-Za-z0-9]+}/login", AppHandlerIndependent(loginWithOAuth)).Methods("GET")
 	BaseRoutes.OAuth.Handle("/{service:[A-Za-z0-9]+}/signup", AppHandlerIndependent(signupWithOAuth)).Methods("GET")
-	BaseRoutes.OAuth.Handle("/authorize", AppHandlerTrustRequester(authorizeOAuth)).Methods("GET")
-	BaseRoutes.OAuth.Handle("/access_token", ApiAppHandlerTrustRequester(getAccessToken)).Methods("POST")
 
-	BaseRoutes.Root.Handle("/authorize", AppHandlerTrustRequester(authorizeOAuth)).Methods("GET")
-	BaseRoutes.Root.Handle("/access_token", ApiAppHandlerTrustRequester(getAccessToken)).Methods("POST")
+	BaseRoutes.Root.Handle("/oauth/authorize", AppHandlerTrustRequester(authorizeOAuth)).Methods("GET")
+	BaseRoutes.Root.Handle("/oauth/access_token", ApiAppHandlerTrustRequester(getAccessToken)).Methods("POST")
 
 	// Handle all the old routes, to be later removed
 	BaseRoutes.Root.Handle("/{service:[A-Za-z0-9]+}/complete", AppHandlerIndependent(completeOAuth)).Methods("GET")

--- a/model/client.go
+++ b/model/client.go
@@ -1533,7 +1533,7 @@ func (c *Client) DeleteOAuthApp(id string) (*Result, *AppError) {
 }
 
 func (c *Client) GetAccessToken(data url.Values) (*Result, *AppError) {
-	if r, err := c.DoPost(API_URL_SUFFIX+"/oauth/access_token", data.Encode(), "application/x-www-form-urlencoded"); err != nil {
+	if r, err := c.DoPost("/oauth/access_token", data.Encode(), "application/x-www-form-urlencoded"); err != nil {
 		return nil, err
 	} else {
 		defer closeBody(r)


### PR DESCRIPTION
#### Summary
Removed some legacy routes for the OAuth Provider since they were never used

Change the current routes to be `/oauth/xxxx` instead of having the API prefix to be more consistent with other OAuth Providers

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3879

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

