### PR TITLE
fix OAuth provider when running test multiple times

### DIFF
--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -193,8 +193,8 @@ func TestGetOAuthAppsByUser(t *testing.T) {
 	} else {
 		apps := result.Data.([]*model.OAuthApp)
 
-		if len(apps) != 4 {
-			t.Fatal("incorrect number of apps should have been 4")
+		if len(apps) < 4 {
+			t.Fatal("incorrect number of apps should have been 4 or more")
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
After this you can run `make test` multiple times without hitting an error with test for OAuth provider

#### Ticket Link
No ticket assigned

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
