### PR TITLE
PLT-1424 Added XRegExp library and fix search highlighting

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -31,7 +31,8 @@
     "react-textarea-autosize": "4.0.3",
     "superagent": "2.1.0",
     "twemoji": "2.0.5",
-    "velocity-animate": "1.2.3"
+    "velocity-animate": "1.2.3",
+    "xregexp": "3.1.1"
   },
   "devDependencies": {
     "babel-core": "6.13.2",


### PR DESCRIPTION
#### Summary
This fixes what is considered punctuation when it comes to search highlighting. Previously, this caused non-English characters to be considered punctuation and discarded. This probably could've been done without XRegExp, but we'll want it when we allow hashtags to contain any non-English letter ([PLT-2077](https://mattermost.atlassian.net/browse/PLT-2077)).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-1424

#### Checklist
- Has UI changes