### PR TITLE
Updating markdown links test

### DIFF
--- a/tests/test-markdown-lists.md
+++ b/tests/test-markdown-lists.md
@@ -167,8 +167,8 @@ Verify that all list types render as expected.
 1. One
   • Two
 
-1. One
 2. Two
+3. Three
 ```
 
 **Actual:**
@@ -176,8 +176,8 @@ Verify that all list types render as expected.
 1. One
   - Two
 
-1. One
 2. Two
+3. Three
 
 ### New Line After a List
 


### PR DESCRIPTION
#### Summary

Updating markdown links test

#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-3829 and https://mattermost.atlassian.net/browse/PLT-3551 are marked as `Won't Fix`, so the markdown links test needs to be updated too.