### PR TITLE
PLT-3869 Fix set default language when user logs out

### DIFF
--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -457,6 +457,7 @@ export function emitUserLoggedOutEvent(redirectTo) {
             PreferenceStore.clear();
             UserStore.clear();
             TeamStore.clear();
+            newLocalizationSelected(global.window.mm_config.DefaultClientLocale);
             browserHistory.push(rURL);
         },
         () => {


### PR DESCRIPTION
#### Summary
If a user is using a different languages than the default, then when logs out the UI resets to the default language set on the server

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3869