### PR TITLE
PLT-3786 Correctly reset tracker for updateLastViewedAt and other asynchronous calls

### DIFF
--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -133,11 +133,11 @@ export function updateLastViewedAt(id) {
     Client.updateLastViewedAt(
         channelId,
         () => {
-            callTracker.updateLastViewed = 0;
+            callTracker[`updateLastViewed${channelId}`] = 0;
             ErrorStore.clearLastError();
         },
         (err) => {
-            callTracker.updateLastViewed = 0;
+            callTracker[`updateLastViewed${channelId}`] = 0;
             var count = ErrorStore.getConnectionErrorCount();
             ErrorStore.setConnectionErrorCount(count + 1);
             dispatchError(err, 'updateLastViewedAt');
@@ -170,11 +170,11 @@ export function setLastViewedAt(lastViewedAt, id) {
         channelId,
         lastViewedAt,
         () => {
-            callTracker.setLastViewedAt = 0;
+            callTracker[`setLastViewedAt${channelId}${lastViewedAt}`] = 0;
             ErrorStore.clearLastError();
         },
         (err) => {
-            callTracker.setLastViewedAt = 0;
+            callTracker[`setLastViewedAt${channelId}${lastViewedAt}`] = 0;
             var count = ErrorStore.getConnectionErrorCount();
             ErrorStore.setConnectionErrorCount(count + 1);
             dispatchError(err, 'setLastViewedAt');
@@ -1190,6 +1190,7 @@ export function getRecentAndNewUsersAnalytics(teamId) {
                 teamId,
                 stats
             });
+            callTracker[callName] = 0;
         },
         (err) => {
             callTracker[callName] = 0;


### PR DESCRIPTION
#### Summary
This should fix the issue with some channels still being marked unread when switching out of them after receiving a message recently.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3786