### PR TITLE
PLT-3790 Clear search term before displaying flagged posts

### DIFF
--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -135,16 +135,16 @@ export function getFlaggedPosts() {
     Client.getFlaggedPosts(0, Constants.POST_CHUNK_SIZE,
         (data) => {
             AppDispatcher.handleServerAction({
-                type: ActionTypes.RECEIVED_SEARCH,
-                results: data,
-                is_flagged_posts: true
-            });
-
-            AppDispatcher.handleServerAction({
                 type: ActionTypes.RECEIVED_SEARCH_TERM,
                 term: null,
                 do_search: false,
                 is_mention_search: false
+            });
+
+            AppDispatcher.handleServerAction({
+                type: ActionTypes.RECEIVED_SEARCH,
+                results: data,
+                is_flagged_posts: true
             });
         },
         (err) => {


### PR DESCRIPTION
#### Summary
Clear the search term first before displaying the flagged posts so, if the search term is present in a flagged post, it is not highlighted.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3790
