### PR TITLE
PLT-3222/PLT-1441 Refactored mention parsing and added unit tests

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1096,6 +1096,10 @@
     "translation": "Unable to send notification to online users with @here, err=%v"
   },
   {
+    "id": "api.post.notification.member_profile.warn",
+    "translation": "Unable to get profile for channel member, user_id=%v"
+  },
+  {
     "id": "api.post.send_notifications_and_forget.comment_thread.error",
     "translation": "Failed to retrieve comment thread posts in notifications root_post_id=%v, err=%v"
   },


### PR DESCRIPTION
#### Summary
This is a refactor to consolidate the handling of regular mentions and the out-of-channel mention warnings. I also made separate functions that 1) list all the mention keywords for a group of users and 2) finds the mentioned users in a post so that they could have tests added for them

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3222
https://mattermost.atlassian.net/browse/PLT-1441

#### Checklist
- Added or updated unit tests (required for all new features)
- Includes text changes and localization files updated
- Touches critical sections of the codebase (auth, upgrade, etc.)

