### PR TITLE
PLT-3697 Fixed mentions not updating when team is switched

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -79,8 +79,13 @@ export default class Sidebar extends React.Component {
         const unreadCounts = this.state.unreadCounts;
 
         Object.keys(unreadCounts).forEach((chId) => {
-            msgs += unreadCounts[chId].msgs;
-            mentions += unreadCounts[chId].mentions;
+            const channel = ChannelStore.get(chId);
+            if (channel) {
+                if (channel.team_id === this.state.currentTeam.id) {
+                    msgs += unreadCounts[chId].msgs;
+                    mentions += unreadCounts[chId].mentions;
+                }
+            }
         });
 
         return {msgs, mentions};


### PR DESCRIPTION
#### Summary
Previously, unread mention counts did not update when the user switched teams. Now only channels that can be found will count towards the unread mention/message count.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3697

