### PR TITLE
PLT-3838 Remove close button shadow in modals

### DIFF
--- a/webapp/sass/components/_modal.scss
+++ b/webapp/sass/components/_modal.scss
@@ -169,6 +169,7 @@
                 right: 10px;
                 width: 30px;
                 z-index: 5;
+                text-shadow: none;
 
                 &:hover {
                     @include alpha-property(background, $black, .1);


### PR DESCRIPTION
#### Summary
Removed the close icons (text) shadow in modals.

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/PLT-3838)

#### Checklist
- [x] Has UI changes

