### PR TITLE
Fix typo in admin.service.siteURLDescription

### DIFF
--- a/webapp/components/admin_console/configuration_settings.jsx
+++ b/webapp/components/admin_console/configuration_settings.jsx
@@ -69,7 +69,7 @@ export default class ConfigurationSettings extends AdminSettings {
                     helpText={
                         <FormattedMessage
                             id='admin.service.siteURLDescription'
-                            defaultMessage='The URL, including post number and protocol, that users will use to access Mattermost. Leave blank to automatically configure based on incoming traffic.'
+                            defaultMessage='The URL, including port number and protocol, that users will use to access Mattermost. Leave blank to automatically configure based on incoming traffic.'
                         />
                     }
                     value={this.state.siteURL}

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -653,7 +653,7 @@
   "admin.service.sessionCacheDesc": "The number of minutes to cache a session in memory.",
   "admin.service.sessionDaysEx": "Ex \"30\"",
   "admin.service.siteURL": "Site URL:",
-  "admin.service.siteURLDescription": "The URL, including post number and protocol, that users will use to access Mattermost. Leave blank to automatically configure based on incoming traffic.",
+  "admin.service.siteURLDescription": "The URL, including port number and protocol, that users will use to access Mattermost. Leave blank to automatically configure based on incoming traffic.",
   "admin.service.siteURLExample": "Ex \"https://mattermost.example.com:1234\"",
   "admin.service.ssoSessionDays": "Session length SSO (days):",
   "admin.service.ssoSessionDaysDesc": "The number of days from the last time a user entered their credentials to the expiry of the user's session. If the authentication method is SAML or GitLab, the user may automatically be logged back in to Mattermost if they are already logged in to SAML or GitLab. After changing this setting, the setting will take effect after the next time the user enters their credentials.",


### PR DESCRIPTION
#### Summary
Fix typo in admin.service.siteURLDescription

#### Ticket Link
N/A  (reported by [community in pre-release.mattermost.com](https://pre-release.mattermost.com/core/pl/m5b8t18ucjritrzqmi5hpgys3h))

#### Checklist
- [X] Includes text changes and localization files updated
