### PR TITLE
PLT-3238 Added error message when there is no sign-in methods

### DIFF
--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -527,6 +527,20 @@ export default class LoginController extends React.Component {
             );
         }
 
+        if (loginControls.length === 0) {
+            loginControls.push(
+                <FormError
+                    error={
+                        <FormattedMessage
+                            id='login.noMethods'
+                            defaultMessage='No sign in methods are enabled. Please contact your System Administrator.'
+                        />
+                    }
+                    margin={true}
+                />
+            );
+        }
+
         return (
             <div>
                 {extraBox}

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1339,6 +1339,7 @@
   "login_mfa.submit": "Submit",
   "login_mfa.token": "MFA Token",
   "login_mfa.tokenReq": "Please enter an MFA token",
+  "login.noMethods": "No sign in methods are enabled. Please contact your System Administrator.",
   "member_item.makeAdmin": "Make Admin",
   "member_item.member": "Member",
   "member_list.noUsersAdd": "No users to add.",


### PR DESCRIPTION
#### Summary
When no sign-in methods are enabled, add an error message.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3238

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization files updated

![image](https://cloud.githubusercontent.com/assets/5740966/17748633/54214ad4-6488-11e6-8d32-a8e744ad1b11.png)
