### PR TITLE
fix for team.display_name instead of team.name

### DIFF
--- a/webapp/components/admin_console/select_team_modal.jsx
+++ b/webapp/components/admin_console/select_team_modal.jsx
@@ -29,20 +29,18 @@ export default class SelectTeamModal extends React.Component {
         }
 
         var options = [];
-
-        for (var key in this.props.teams) {
-            if (this.props.teams.hasOwnProperty(key)) {
-                var team = this.props.teams[key];
-                options.push(
-                    <option
-                        key={'opt_' + team.id}
-                        value={team.id}
-                    >
-                        {team.name}
-                    </option>
-                );
-            }
-        }
+        var teams = this.props.teams;
+        Reflect.ownKeys(teams).forEach((key) => {
+            var team = teams[key];
+            options.push(
+                <option
+                    key={'opt_' + team.id}
+                    value={team.id}
+                >
+                    {team.display_name}
+                </option>
+            );
+        });
 
         return (
             <Modal


### PR DESCRIPTION
#### Summary
Fix team name in `Select Team` of [System Console] -> [TEAMS] -> [+]
It was displayed team.name(url), but displaying team.display_name(real team name) is better.

+ Enhance loop performance.

#### Ticket Link


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

