### PR TITLE
Fixed public links being created using percent encoded filename

### DIFF
--- a/webapp/components/get_public_link_modal.jsx
+++ b/webapp/components/get_public_link_modal.jsx
@@ -34,7 +34,7 @@ export default class GetPublicLinkModal extends React.Component {
 
     componentDidUpdate(prevProps, prevState) {
         if (this.state.show && !prevState.show) {
-            AsyncClient.getPublicLink(this.state.filename, this.handlePublicLink);
+            AsyncClient.getPublicLink(decodeURIComponent(this.state.filename), this.handlePublicLink);
         }
     }
 


### PR DESCRIPTION
When we generated public links, the file name sent by the client would be percent encoded (eg "some file.png" would be "some%20file.png") and then when we were checking that the public link hash was valid, we'd use the plain version without percent encoding. This fixes that.