### PR TITLE
Fixed calculation of mention count for direct channels

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -982,7 +982,7 @@ func (us SqlUserStore) GetUnreadCount(userId string) StoreChannel {
 	go func() {
 		result := StoreResult{}
 
-		if count, err := us.GetReplica().SelectInt("SELECT SUM(CASE WHEN c.Type = 'D' THEN (c.TotalMsgCount - cm.MsgCount) ELSE 0 END + cm.MentionCount) FROM Channels c INNER JOIN ChannelMembers cm ON cm.ChannelId = c.Id AND cm.UserId = :UserId", map[string]interface{}{"UserId": userId}); err != nil {
+		if count, err := us.GetReplica().SelectInt("SELECT SUM(CASE WHEN c.Type = 'D' THEN (c.TotalMsgCount - cm.MsgCount) ELSE cm.MentionCount END) FROM Channels c INNER JOIN ChannelMembers cm ON cm.ChannelId = c.Id AND cm.UserId = :UserId", map[string]interface{}{"UserId": userId}); err != nil {
 			result.Err = model.NewLocAppError("SqlUserStore.GetMentionCount", "store.sql_user.get_unread_count.app_error", nil, err.Error())
 		} else {
 			result.Data = count

--- a/store/sql_user_store_test.go
+++ b/store/sql_user_store_test.go
@@ -647,12 +647,14 @@ func TestUserUnreadCount(t *testing.T) {
 	p2.UserId = u1.Id
 	p2.Message = "first message"
 	Must(store.Post().Save(&p2))
+	Must(store.Channel().IncrementMentionCount(c2.Id, u2.Id))
 
 	p3 := model.Post{}
 	p3.ChannelId = c2.Id
 	p3.UserId = u1.Id
 	p3.Message = "second message"
 	Must(store.Post().Save(&p3))
+	Must(store.Channel().IncrementMentionCount(c2.Id, u2.Id))
 
 	badge := (<-store.User().GetUnreadCount(u2.Id)).Data.(int64)
 	if badge != 3 {

--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -325,7 +325,7 @@ class ChannelStoreClass extends EventEmitter {
         const chMember = this.getMember(id);
 
         let chMentionCount = chMember.mention_count;
-        let chUnreadCount = ch.total_msg_count - chMember.msg_count - chMentionCount;
+        let chUnreadCount = ch.total_msg_count - chMember.msg_count;
 
         if (ch.type === 'D') {
             chMentionCount = chUnreadCount;


### PR DESCRIPTION
My changes to the mention code started incrementing the ChannelMember.MentionCount field for direct channels (which was previously always 0), but this caused some issues with the code that special cased the mention count of those channels.