### PR TITLE
Fixed TestGetInfoForBytes to work on all platforms

### DIFF
--- a/model/file_info_test.go
+++ b/model/file_info_test.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/base64"
 	"io/ioutil"
+	"strings"
 	"testing"
 )
 
@@ -20,7 +21,7 @@ func TestGetInfoForBytes(t *testing.T) {
 		t.Fatalf("Got incorrect size: %v", info.Size)
 	} else if info.Extension != "txt" {
 		t.Fatalf("Got incorrect file extension: %v", info.Extension)
-	} else if info.MimeType != "text/plain; charset=utf-8" {
+	} else if !strings.HasPrefix(info.MimeType, "text/plain") {
 		t.Fatalf("Got incorrect mime type: %v", info.MimeType)
 	} else if info.HasPreviewImage {
 		t.Fatalf("Got HasPreviewImage = true for non-image file")


### PR DESCRIPTION
TestGetInfoForBytes fails on some platforms because the mime type of a text file may not be utf8 encoded depending on platform. Reported on the forums [here](https://forum.mattermost.org/t/error-then-run-make-test/2050/13).