### PR TITLE
PLT-3462 Add the ability to clear push notifications after channel is viewed

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -888,12 +888,10 @@ func getMessageForNotification(post *model.Post, translateFunc i18n.TranslateFun
 }
 
 func sendPushNotification(post *model.Post, user *model.User, channel *model.Channel, senderName string, wasMentioned bool) {
-	var sessions []*model.Session
-	if result := <-Srv.Store.Session().GetSessions(user.Id); result.Err != nil {
-		l4g.Error(utils.T("api.post.send_notifications_and_forget.sessions.error"), user.Id, result.Err)
+	session := getMobileAppSession(user.Id)
+
+	if session == nil {
 		return
-	} else {
-		sessions = result.Data.([]*model.Session)
 	}
 
 	var channelName string
@@ -906,65 +904,98 @@ func sendPushNotification(post *model.Post, user *model.User, channel *model.Cha
 
 	userLocale := utils.GetUserTranslations(user.Locale)
 
-	for _, session := range sessions {
-		if len(session.DeviceId) > 0 &&
-			(strings.HasPrefix(session.DeviceId, model.PUSH_NOTIFY_APPLE+":") || strings.HasPrefix(session.DeviceId, model.PUSH_NOTIFY_ANDROID+":")) {
+	msg := model.PushNotification{}
+	if badge := <-Srv.Store.User().GetUnreadCount(user.Id); badge.Err != nil {
+		msg.Badge = 1
+		l4g.Error(utils.T("store.sql_user.get_unread_count.app_error"), user.Id, badge.Err)
+	} else {
+		msg.Badge = int(badge.Data.(int64))
+	}
+	msg.Type = model.PUSH_TYPE_MESSAGE
+	msg.ChannelId = channel.Id
+	msg.ChannelName = channel.Name
 
-			msg := model.PushNotification{}
-			if badge := <-Srv.Store.User().GetUnreadCount(user.Id); badge.Err != nil {
-				msg.Badge = 1
-				l4g.Error(utils.T("store.sql_user.get_unread_count.app_error"), user.Id, badge.Err)
-			} else {
-				msg.Badge = int(badge.Data.(int64))
-			}
-			msg.ServerId = utils.CfgDiagnosticId
-			msg.ChannelId = channel.Id
-			msg.ChannelName = channel.Name
+	msg.SetDeviceIdAndPlatform(session.DeviceId)
 
-			if strings.HasPrefix(session.DeviceId, model.PUSH_NOTIFY_APPLE+":") {
-				msg.Platform = model.PUSH_NOTIFY_APPLE
-				msg.DeviceId = strings.TrimPrefix(session.DeviceId, model.PUSH_NOTIFY_APPLE+":")
-			} else if strings.HasPrefix(session.DeviceId, model.PUSH_NOTIFY_ANDROID+":") {
-				msg.Platform = model.PUSH_NOTIFY_ANDROID
-				msg.DeviceId = strings.TrimPrefix(session.DeviceId, model.PUSH_NOTIFY_ANDROID+":")
-			}
-
-			if *utils.Cfg.EmailSettings.PushNotificationContents == model.FULL_NOTIFICATION {
-				if channel.Type == model.CHANNEL_DIRECT {
-					msg.Category = model.CATEGORY_DM
-					msg.Message = "@" + senderName + ": " + model.ClearMentionTags(post.Message)
-				} else {
-					msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_in") + channelName + ": " + model.ClearMentionTags(post.Message)
-				}
-			} else {
-				if channel.Type == model.CHANNEL_DIRECT {
-					msg.Category = model.CATEGORY_DM
-					msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_message")
-				} else if wasMentioned {
-					msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_mention") + channelName
-				} else {
-					msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_non_mention") + channelName
-				}
-			}
-
-			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: *utils.Cfg.ServiceSettings.EnableInsecureOutgoingConnections},
-			}
-			httpClient := &http.Client{Transport: tr}
-			request, _ := http.NewRequest("POST", *utils.Cfg.EmailSettings.PushNotificationServer+model.API_URL_SUFFIX_V1+"/send_push", strings.NewReader(msg.ToJson()))
-
-			l4g.Debug(utils.T("api.post.send_notifications_and_forget.push_notification.debug"), msg.DeviceId, msg.Message)
-			if resp, err := httpClient.Do(request); err != nil {
-				l4g.Error(utils.T("api.post.send_notifications_and_forget.push_notification.error"), user.Id, err)
-			} else {
-				ioutil.ReadAll(resp.Body)
-				resp.Body.Close()
-			}
-
-			// notification sent, don't need to check other sessions
-			break
+	if *utils.Cfg.EmailSettings.PushNotificationContents == model.FULL_NOTIFICATION {
+		if channel.Type == model.CHANNEL_DIRECT {
+			msg.Category = model.CATEGORY_DM
+			msg.Message = "@" + senderName + ": " + model.ClearMentionTags(post.Message)
+		} else {
+			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_in") + channelName + ": " + model.ClearMentionTags(post.Message)
+		}
+	} else {
+		if channel.Type == model.CHANNEL_DIRECT {
+			msg.Category = model.CATEGORY_DM
+			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_message")
+		} else if wasMentioned {
+			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_mention") + channelName
+		} else {
+			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_non_mention") + channelName
 		}
 	}
+
+	l4g.Debug(utils.T("api.post.send_notifications_and_forget.push_notification.debug"), msg.DeviceId, msg.Message)
+	sendToPushProxy(msg)
+}
+
+func clearPushNotification(userId string, channelId string) {
+	session := getMobileAppSession(userId)
+
+	if session == nil {
+		return
+	}
+
+	msg := model.PushNotification{}
+	msg.Type = model.PUSH_TYPE_CLEAR
+	msg.ChannelId = channelId
+	msg.ContentAvailable = 0
+	if badge := <-Srv.Store.User().GetUnreadCount(userId); badge.Err != nil {
+		msg.Badge = 0
+		l4g.Error(utils.T("store.sql_user.get_unread_count.app_error"), userId, badge.Err)
+	} else {
+		msg.Badge = int(badge.Data.(int64))
+	}
+
+	msg.SetDeviceIdAndPlatform(session.DeviceId)
+
+	l4g.Debug(utils.T("api.post.send_notifications_and_forget.clear_push_notification.debug"), msg.DeviceId, msg.ChannelId)
+	sendToPushProxy(msg)
+}
+
+func sendToPushProxy(msg model.PushNotification) {
+	msg.ServerId = utils.CfgDiagnosticId
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: *utils.Cfg.ServiceSettings.EnableInsecureOutgoingConnections},
+	}
+	httpClient := &http.Client{Transport: tr}
+	request, _ := http.NewRequest("POST", *utils.Cfg.EmailSettings.PushNotificationServer+model.API_URL_SUFFIX_V1+"/send_push", strings.NewReader(msg.ToJson()))
+
+	if resp, err := httpClient.Do(request); err != nil {
+		l4g.Error(utils.T("api.post.send_notifications_and_forget.push_notification.error"), msg.DeviceId, err)
+	} else {
+		ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+}
+
+func getMobileAppSession(userId string) *model.Session {
+	var sessions []*model.Session
+	if result := <-Srv.Store.Session().GetSessions(userId); result.Err != nil {
+		l4g.Error(utils.T("api.post.send_notifications_and_forget.sessions.error"), userId, result.Err)
+		return nil
+	} else {
+		sessions = result.Data.([]*model.Session)
+	}
+
+	for _, session := range sessions {
+		if session.IsMobileApp() {
+			return session
+		}
+	}
+
+	return nil
 }
 
 func sendOutOfChannelMentions(c *Context, post *model.Post, profiles map[string]*model.User, outOfChannelMentions map[string]bool) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -152,6 +152,10 @@
     "translation": "%v added to the channel by %v"
   },
   {
+    "id": "api.channel.update_last_viewed_at.get_unread_count_for_channel.errord",
+    "translation": "Unable to get the unread count for user_id=%v and channel_id=%v, err=%v"
+  },
+  {
     "id": "api.channel.add_member.find_channel.app_error",
     "translation": "Failed to find channel"
   },
@@ -1253,11 +1257,15 @@
   },
   {
     "id": "api.post.send_notifications_and_forget.push_notification.debug",
-    "translation": "Sending push notification to %v wi msg of '%v'"
+    "translation": "Sending push notification to %v with msg of '%v'"
+  },
+  {
+    "id": "api.post.send_notifications_and_forget.clear_push_notification.debug",
+    "translation": "Clearing push notification to %v with channel_id %v"
   },
   {
     "id": "api.post.send_notifications_and_forget.push_notification.error",
-    "translation": "Failed to send push notificationid=%v, err=%v"
+    "translation": "Failed to send push device_id=%v, err=%v"
   },
   {
     "id": "api.post.send_notifications_and_forget.send.error",
@@ -4410,6 +4418,10 @@
   {
     "id": "store.sql_user.get_unread_count.app_error",
     "translation": "We could not get the unread message count for the user"
+  },
+  {
+    "id": "store.sql_user.get_unread_count_for_channel.app_error",
+    "translation": "We could not get the unread message count for the user and channel"
   },
   {
     "id": "store.sql_user.migrate_theme.critical",

--- a/model/push_notification.go
+++ b/model/push_notification.go
@@ -6,11 +6,15 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 const (
 	PUSH_NOTIFY_APPLE   = "apple"
 	PUSH_NOTIFY_ANDROID = "android"
+
+	PUSH_TYPE_MESSAGE = "message"
+	PUSH_TYPE_CLEAR   = "clear"
 
 	CATEGORY_DM = "DIRECT_MESSAGE"
 
@@ -28,6 +32,7 @@ type PushNotification struct {
 	ContentAvailable int    `json:"cont_ava"`
 	ChannelId        string `json:"channel_id"`
 	ChannelName      string `json:"channel_name"`
+	Type             string `json:"type"`
 }
 
 func (me *PushNotification) ToJson() string {
@@ -36,6 +41,16 @@ func (me *PushNotification) ToJson() string {
 		return ""
 	} else {
 		return string(b)
+	}
+}
+
+func (me *PushNotification) SetDeviceIdAndPlatform(deviceId string) {
+	if strings.HasPrefix(deviceId, PUSH_NOTIFY_APPLE+":") {
+		me.Platform = PUSH_NOTIFY_APPLE
+		me.DeviceId = strings.TrimPrefix(deviceId, PUSH_NOTIFY_APPLE+":")
+	} else if strings.HasPrefix(deviceId, PUSH_NOTIFY_ANDROID+":") {
+		me.Platform = PUSH_NOTIFY_ANDROID
+		me.DeviceId = strings.TrimPrefix(deviceId, PUSH_NOTIFY_ANDROID+":")
 	}
 }
 

--- a/model/session.go
+++ b/model/session.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 const (
@@ -107,6 +108,11 @@ func (me *Session) GetTeamByTeamId(teamId string) *TeamMember {
 	}
 
 	return nil
+}
+
+func (me *Session) IsMobileApp() bool {
+	return len(me.DeviceId) > 0 &&
+		(strings.HasPrefix(me.DeviceId, PUSH_NOTIFY_APPLE+":") || strings.HasPrefix(me.DeviceId, PUSH_NOTIFY_ANDROID+":"))
 }
 
 func SessionsToJson(o []*Session) string {

--- a/store/sql_user_store_test.go
+++ b/store/sql_user_store_test.go
@@ -660,6 +660,16 @@ func TestUserUnreadCount(t *testing.T) {
 	if badge != 3 {
 		t.Fatal("should have 3 unread messages")
 	}
+
+	badge = (<-store.User().GetUnreadCountForChannel(u2.Id, c1.Id)).Data.(int64)
+	if badge != 1 {
+		t.Fatal("should have 1 unread messages for that channel")
+	}
+
+	badge = (<-store.User().GetUnreadCountForChannel(u2.Id, c2.Id)).Data.(int64)
+	if badge != 2 {
+		t.Fatal("should have 2 unread messages for that channel")
+	}
 }
 
 func TestUserStoreUpdateMfaSecret(t *testing.T) {

--- a/store/store.go
+++ b/store/store.go
@@ -153,6 +153,7 @@ type UserStore interface {
 	PermanentDelete(userId string) StoreChannel
 	AnalyticsUniqueUserCount(teamId string) StoreChannel
 	GetUnreadCount(userId string) StoreChannel
+	GetUnreadCountForChannel(userId string, channelId string) StoreChannel
 }
 
 type SessionStore interface {


### PR DESCRIPTION
#### Summary
Main change was adding a SQL query for getting the unread count for a single channel and then updating `update_last_viewed_at` to send a push notification to clear existing notifications. I also organized and cleaned-up how push notifications were sent in general.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3462

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization files updated

Marked as WIP, and cannot be tested, until the following related PRs are merged:
mattermost/push-proxy#5
mattermost/android#29