### PR TITLE
PLT-2625 Fix the elusive missing posts bug

### DIFF
--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -581,6 +581,7 @@ export function getPostsPage(id, maxPosts) {
                     id: channelId,
                     before: true,
                     numRequested: numPosts,
+                    checkLatest: true,
                     post_list: data
                 });
 
@@ -616,12 +617,7 @@ export function getPosts(id) {
         return;
     }
 
-    const latestPost = PostStore.getLatestPost(channelId);
-    let latestPostTime = 0;
-
-    if (latestPost != null && latestPost.update_at != null) {
-        latestPostTime = latestPost.create_at;
-    }
+    const latestPostTime = PostStore.getLatestPostFromPageTime(id);
 
     callTracker['getPosts_' + channelId] = utils.getTimestamp();
 


### PR DESCRIPTION
#### Summary
Based on @coreyhulen's repro steps I confirmed that receiving some messages while the websocket was disconnected and then receiving more after it reconnects could sometimes cause the user to miss posts in a channel until a refresh.

Fixed by updating the `getPostsSince` request to use the latest time from the last full page request rather than the latest post the client has.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-2625
