### PR TITLE
PLT-387 Convert @mentions on Slack import.

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1384,6 +1384,10 @@
     "translation": "Bad timestamp detected"
   },
   {
+    "id": "api.slackimport.slack_convert_user_mentions.compile_regexp_failed.warn",
+    "translation": "Failed to compile the @mention matching regular expression for Slack user {{.UserID}} {{.Username}}"
+  },
+  {
     "id": "api.slackimport.slack_import.log",
     "translation": "Mattermost Slack Import Log\r\n"
   },

--- a/webapp/components/team_import_tab.jsx
+++ b/webapp/components/team_import_tab.jsx
@@ -48,7 +48,7 @@ class TeamImportTab extends React.Component {
             <div>
                 <FormattedHTMLMessage
                     id='team_import_tab.importHelp'
-                    defaultMessage="<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export files, images, private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of text messages in your Slack team's public channels.</p><p>The Slack import to Mattermost is in 'Beta'. Slack bot posts do not yet import and Slack @mentions are not currently supported.</p>"
+                    defaultMessage="<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export files, images, private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of text messages in your Slack team's public channels.</p><p>The Slack import to Mattermost is in 'Beta'. Slack bot posts do not yet import.</p>"
                 />
             </div>
         );

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1570,7 +1570,7 @@
   "team_export_tab.unable": " Unable to export: {error}",
   "team_import_tab.failure": " Import failure: ",
   "team_import_tab.import": "Import",
-  "team_import_tab.importHelp": "<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export files, images, private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of text messages in your Slack team's public channels.</p><p>The Slack import to Mattermost is in 'Beta'. Slack bot posts do not yet import and Slack @mentions are not currently supported.</p>",
+  "team_import_tab.importHelp": "<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export files, images, private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of text messages in your Slack team's public channels.</p><p>The Slack import to Mattermost is in 'Beta'. Slack bot posts do not yet import.</p>",
   "team_import_tab.importSlack": "Import from Slack (Beta)",
   "team_import_tab.importing": " Importing...",
   "team_import_tab.successful": " Import successful: ",


### PR DESCRIPTION
#### Summary
This fixes the Slack importer to import "@mentions" correctly in messages, comments and the "Slack attachment" messages.

As far as I can see, there are no unit tests for the Slack importer, but the changes work successfully using test Slack import data. I'm new to the Mattermost codebase, so please let me know if I've missed something about how the Slack importer is tested and I'll be happy to add any extra tests to this PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-387

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [X] Includes text changes and localization files updated



Converts @mentions in Slack imports for regular messages, comments and
Slack upload messages.

Updates the description on the Team Settings Import tab to remove
mention of @mentions not importing.