### PR TITLE
PLT-3741 Slash command in uppercase shows autocomplete

### DIFF
--- a/webapp/components/suggestion/command_provider.jsx
+++ b/webapp/components/suggestion/command_provider.jsx
@@ -35,7 +35,7 @@ class CommandSuggestion extends Suggestion {
 export default class CommandProvider {
     handlePretextChanged(suggestionId, pretext) {
         if (pretext.startsWith('/')) {
-            AsyncClient.getSuggestedCommands(pretext, suggestionId, CommandSuggestion, pretext);
+            AsyncClient.getSuggestedCommands(pretext.toLowerCase(), suggestionId, CommandSuggestion, pretext.toLowerCase());
         }
     }
 }


### PR DESCRIPTION
#### Summary
Typing slash commands in uppercase will show autocomplete for both built-in and custom commands. Behaviour for typing slash commands in lowercase remains the same.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3741

