### PR TITLE
PLT-3941 Resolve RHS "Recent Mentions" incorrectly including (at)all/(at)channel

### DIFF
--- a/webapp/components/sidebar_right_menu.jsx
+++ b/webapp/components/sidebar_right_menu.jsx
@@ -90,13 +90,14 @@ export default class SidebarRightMenu extends React.Component {
         if (user.notify_props && user.notify_props.mention_keys) {
             const termKeys = UserStore.getMentionKeys(user.id);
 
-            if (user.notify_props.all === 'true' && termKeys.indexOf('@all') !== -1) {
-                termKeys.splice(termKeys.indexOf('@all'), 1);
+            if (termKeys.indexOf('@channel') !== -1) {
+                termKeys[termKeys.indexOf('@channel')] = '';
             }
 
-            if (user.notify_props.channel === 'true' && termKeys.indexOf('@channel') !== -1) {
-                termKeys.splice(termKeys.indexOf('@channel'), 1);
+            if (termKeys.indexOf('@all') !== -1) {
+                termKeys[termKeys.indexOf('@all')] = '';
             }
+
             terms = termKeys.join(' ');
         }
 


### PR DESCRIPTION
#### Summary
Corrects the "Recent Mentions" logic in the RHS to match the "Recent Mentions" logic within the channel header.  Channel Header was modified recently to _remove_ the (at)all and (at)channel terms from the resulting search; while the RHS implemention remained unchanged.  Currently, if you attempt to use the RHS implementation of the Recent Mentions feature AND you have elected to receive notifications for (at)all and (at)channel mentions, then your resulting search will contain these terms, which results in invalid search results (including any message containing the words "all" or "channel" since the (at) is stripped.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/PLT-3941
GitHub: https://github.com/mattermost/platform/issues/3810

#### Checklist
No items in the checklist are applicable.