### PR TITLE
PLT-3982 Add statuses to profile pictures in the RHS and popover member list

### DIFF
--- a/webapp/components/popover_list_members.jsx
+++ b/webapp/components/popover_list_members.jsx
@@ -1,19 +1,21 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import $ from 'jquery';
+import ProfilePicture from 'components/profile_picture.jsx';
 
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
-import {Popover, Overlay} from 'react-bootstrap';
+
+import Client from 'client/web_client.jsx';
 import * as Utils from 'utils/utils.jsx';
 import Constants from 'utils/constants.jsx';
-import Client from 'client/web_client.jsx';
 
+import $ from 'jquery';
+import React from 'react';
+import {Popover, Overlay} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import {browserHistory} from 'react-router/es6';
 
-import React from 'react';
 
 export default class PopoverListMembers extends React.Component {
     constructor(props) {
@@ -89,24 +91,23 @@ export default class PopoverListMembers extends React.Component {
                 }
 
                 if (name) {
-                    if (!m.status) {
-                        var status = UserStore.getStatus(m.id);
-                        m.status = status ? 'status-' + status : '';
+                    let status;
+                    if (m.status) {
+                        status = m.status;
+                    } else {
+                        status = UserStore.getStatus(m.id);
                     }
                     popoverHtml.push(
                         <div
                             className='more-modal__row'
                             key={'popover-member-' + i}
                         >
-
-                            <span className={`more-modal__image-wrapper ${m.status}`}>
-                                <img
-                                    className='more-modal__image'
-                                    width='26px'
-                                    height='26px'
-                                    src={`${Client.getUsersRoute()}/${m.id}/image?time=${m.update_at}`}
-                                />
-                            </span>
+                            <ProfilePicture
+                                src={`${Client.getUsersRoute()}/${m.id}/image?time=${m.update_at}`}
+                                status={status}
+                                width='26'
+                                height='26'
+                            />
                             <div className='more-modal__details'>
                                 <div
                                     className='more-modal__name'

--- a/webapp/components/popover_list_members.jsx
+++ b/webapp/components/popover_list_members.jsx
@@ -16,7 +16,6 @@ import {Popover, Overlay} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import {browserHistory} from 'react-router/es6';
 
-
 export default class PopoverListMembers extends React.Component {
     constructor(props) {
         super(props);

--- a/webapp/components/rhs_comment.jsx
+++ b/webapp/components/rhs_comment.jsx
@@ -4,6 +4,7 @@
 import UserProfile from './user_profile.jsx';
 import FileAttachmentList from './file_attachment_list.jsx';
 import PendingPostOptions from 'components/post_view/components/pending_post_options.jsx';
+import ProfilePicture from 'components/profile_picture.jsx';
 
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
@@ -13,7 +14,7 @@ import {flagPost, unflagPost} from 'actions/post_actions.jsx';
 
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';
-import Client from 'client/web_client.jsx';
+import * as PostUtils from 'utils/post_utils.jsx';
 
 import Constants from 'utils/constants.jsx';
 import {Tooltip, OverlayTrigger} from 'react-bootstrap';
@@ -41,6 +42,10 @@ export default class RhsComment extends React.Component {
     }
 
     shouldComponentUpdate(nextProps) {
+        if (nextProps.status !== this.props.status) {
+            return true;
+        }
+
         if (nextProps.compactDisplay !== this.props.compactDisplay) {
             return true;
         }
@@ -75,7 +80,7 @@ export default class RhsComment extends React.Component {
     }
 
     createDropdown() {
-        var post = this.props.post;
+        const post = this.props.post;
 
         if (post.state === Constants.POST_FAILED || post.state === Constants.POST_LOADING || post.state === Constants.POST_DELETED) {
             return '';
@@ -212,7 +217,7 @@ export default class RhsComment extends React.Component {
     }
 
     render() {
-        var post = this.props.post;
+        const post = this.props.post;
         const flagIcon = Constants.FLAG_ICON_SVG;
 
         var currentUserCss = '';
@@ -258,10 +263,11 @@ export default class RhsComment extends React.Component {
         }
 
         let profilePic = (
-            <img
-                src={Client.getUsersRoute() + '/' + post.user_id + '/image?time=' + timestamp}
-                height='36'
+            <ProfilePicture
+                src={PostUtils.getProfilePicSrcForPost(post, timestamp)}
+                status={this.props.status}
                 width='36'
+                height='36'
             />
         );
 
@@ -385,5 +391,6 @@ RhsComment.propTypes = {
     currentUser: React.PropTypes.object.isRequired,
     compactDisplay: React.PropTypes.bool,
     useMilitaryTime: React.PropTypes.bool.isRequired,
-    isFlagged: React.PropTypes.bool
+    isFlagged: React.PropTypes.bool,
+    status: React.PropTypes.string
 };

--- a/webapp/components/rhs_root_post.jsx
+++ b/webapp/components/rhs_root_post.jsx
@@ -4,6 +4,7 @@
 import UserProfile from './user_profile.jsx';
 import PostBodyAdditionalContent from 'components/post_view/components/post_body_additional_content.jsx';
 import FileAttachmentList from './file_attachment_list.jsx';
+import ProfilePicture from 'components/profile_picture.jsx';
 
 import ChannelStore from 'stores/channel_store.jsx';
 import UserStore from 'stores/user_store.jsx';
@@ -40,6 +41,10 @@ export default class RhsRootPost extends React.Component {
     }
 
     shouldComponentUpdate(nextProps) {
+        if (nextProps.status !== this.props.status) {
+            return true;
+        }
+
         if (nextProps.compactDisplay !== this.props.compactDisplay) {
             return true;
         }
@@ -276,11 +281,11 @@ export default class RhsRootPost extends React.Component {
         }
 
         let profilePic = (
-            <img
-                className='post-profile-img'
+            <ProfilePicture
                 src={PostUtils.getProfilePicSrcForPost(post, timestamp)}
-                height='36'
+                status={this.props.status}
                 width='36'
+                height='36'
             />
         );
 
@@ -410,5 +415,6 @@ RhsRootPost.propTypes = {
     commentCount: React.PropTypes.number,
     compactDisplay: React.PropTypes.bool,
     useMilitaryTime: React.PropTypes.bool.isRequired,
-    isFlagged: React.PropTypes.bool
+    isFlagged: React.PropTypes.bool,
+    status: React.PropTypes.string
 };

--- a/webapp/sass/components/_modal.scss
+++ b/webapp/sass/components/_modal.scss
@@ -485,13 +485,11 @@
 
 
 .status-wrapper {
-    display: inline-block;
-    margin-right: 9%;
     position: relative;
 
     &:after {
         border-radius: 100%;
-        bottom: 7%;
+        bottom: 4px;
         content: '';
         display: block;
         height: 8px;
@@ -517,6 +515,12 @@
 
         .more-modal__row {
             padding: 5px 10px;
+
+            .status-wrapper {
+                &:after {
+                    bottom: 0;
+                }
+            }
         }
 
         .more-modal__name {

--- a/webapp/sass/components/_modal.scss
+++ b/webapp/sass/components/_modal.scss
@@ -486,12 +486,12 @@
 
 .status-wrapper {
     display: inline-block;
-    margin-right: 3px;
+    margin-right: 9%;
     position: relative;
 
     &:after {
         border-radius: 100%;
-        bottom: 4px;
+        bottom: 7%;
         content: '';
         display: block;
         height: 8px;

--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -865,6 +865,7 @@ body.ios {
             height: 32px;
             vertical-align: inherit;
             width: 32px;
+            max-width:none;
         }
     }
 

--- a/webapp/stores/user_store.jsx
+++ b/webapp/stores/user_store.jsx
@@ -330,7 +330,7 @@ class UserStoreClass extends EventEmitter {
 }
 
 var UserStore = new UserStoreClass();
-UserStore.setMaxListeners(15);
+UserStore.setMaxListeners(16);
 
 UserStore.dispatchToken = AppDispatcher.register((payload) => {
     var action = payload.action;


### PR DESCRIPTION
#### Summary
Add the little circle status icon back to the popover member list and newly to RHS threads. Also fixes squishy profile pictures in the centre channel. Thanks to @asaadmahmood again for some CSS help.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3982

#### Checklist
- [x] Has UI changes
