### PR TITLE
PLT-3872 Reset context error for incoming webhooks after checking permission

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -480,6 +480,7 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = model.NewLocAppError("incomingWebhook", "web.incoming_webhook.permissions.app_error", nil, "")
 		return
 	}
+	c.Err = nil
 
 	if _, err := CreateWebhookPost(hook.UserId, channel.Id, hook.TeamId, text, overrideUsername, overrideIconUrl, parsedRequest.Props, webhookType); err != nil {
 		c.Err = err


### PR DESCRIPTION
#### Summary
The context wasn't getting reset after checking permissions for open channels on incoming webhooks.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3872