### PR TITLE
PLT-3897 Fixed ALT+UP/DOWN crashing browser

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -281,11 +281,12 @@ export default class Sidebar extends React.Component {
 
     navigateChannelShortcut(e) {
         if (e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
+            e.preventDefault();
+
             if (this.isSwitchingChannel) {
                 return;
             }
 
-            e.preventDefault();
             this.isSwitchingChannel = true;
             const allChannels = this.getDisplayedChannels();
             const curChannelId = this.state.activeId;
@@ -311,11 +312,12 @@ export default class Sidebar extends React.Component {
 
     navigateUnreadChannelShortcut(e) {
         if (e.altKey && e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
+            e.preventDefault();
+
             if (this.isSwitchingChannel) {
                 return;
             }
 
-            e.preventDefault();
             this.isSwitchingChannel = true;
             const allChannels = this.getDisplayedChannels();
             const curChannelId = this.state.activeId;

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -65,6 +65,7 @@ export default class Sidebar extends React.Component {
         this.updateScrollbarOnChannelChange = this.updateScrollbarOnChannelChange.bind(this);
 
         this.isLeaving = new Map();
+        this.isSwitchingChannel = false;
 
         const state = this.getStateFromStores();
         state.newChannelModalType = '';
@@ -280,7 +281,12 @@ export default class Sidebar extends React.Component {
 
     navigateChannelShortcut(e) {
         if (e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
+            if (this.isSwitchingChannel) {
+                return;
+            }
+
             e.preventDefault();
+            this.isSwitchingChannel = true;
             const allChannels = this.getDisplayedChannels();
             const curChannelId = this.state.activeId;
             let curIndex = -1;
@@ -299,12 +305,18 @@ export default class Sidebar extends React.Component {
             nextChannel = allChannels[Utils.mod(nextIndex, allChannels.length)];
             ChannelActions.goToChannel(nextChannel);
             this.updateScrollbarOnChannelChange(nextChannel);
+            this.isSwitchingChannel = false;
         }
     }
 
     navigateUnreadChannelShortcut(e) {
         if (e.altKey && e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
+            if (this.isSwitchingChannel) {
+                return;
+            }
+
             e.preventDefault();
+            this.isSwitchingChannel = true;
             const allChannels = this.getDisplayedChannels();
             const curChannelId = this.state.activeId;
             let curIndex = -1;
@@ -333,6 +345,7 @@ export default class Sidebar extends React.Component {
                 nextChannel = allChannels[nextIndex];
                 ChannelActions.goToChannel(nextChannel);
                 this.updateScrollbarOnChannelChange(nextChannel);
+                this.isSwitchingChannel = false;
             }
         }
     }


### PR DESCRIPTION
#### Summary
Previously, pressing ALT+UP/DOWN and holding it caused the browser to crash. Now it does not crash your browser...

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3897

