### PR TITLE
PLT-3841/PLT-3883 Fixed detection of local storage, persist system console team list after logout

### DIFF
--- a/webapp/stores/admin_store.jsx
+++ b/webapp/stores/admin_store.jsx
@@ -140,7 +140,7 @@ class AdminStoreClass extends EventEmitter {
     }
 
     getSelectedTeams() {
-        const result = BrowserStore.getItem('seleted_teams');
+        const result = BrowserStore.getItem('selected_teams');
         if (!result) {
             return {};
         }
@@ -148,7 +148,7 @@ class AdminStoreClass extends EventEmitter {
     }
 
     saveSelectedTeams(teams) {
-        BrowserStore.setItem('seleted_teams', teams);
+        BrowserStore.setItem('selected_teams', teams);
     }
 }
 

--- a/webapp/stores/browser_store.jsx
+++ b/webapp/stores/browser_store.jsx
@@ -163,7 +163,7 @@ class BrowserStoreClass {
     }
 
     isLocalStorageSupported() {
-        if (this.checkedLocalStorageSupported !== '') {
+        if (this.checkedLocalStorageSupported !== undefined) { // eslint-disable-line no-undefined
             return this.checkedLocalStorageSupported;
         }
 

--- a/webapp/stores/browser_store.jsx
+++ b/webapp/stores/browser_store.jsx
@@ -145,6 +145,7 @@ class BrowserStoreClass {
         const logoutId = sessionStorage.getItem('__logout__');
         const serverVersion = this.getLastServerVersion();
         const landingPageSeen = this.hasSeenLandingPage();
+        const selectedTeams = this.getItem('selected_teams');
 
         sessionStorage.clear();
         localStorage.clear();
@@ -159,6 +160,10 @@ class BrowserStoreClass {
 
         if (landingPageSeen) {
             this.setLandingPageSeen(landingPageSeen);
+        }
+
+        if (selectedTeams) {
+            this.setItem('selected_teams', selectedTeams);
         }
     }
 

--- a/webapp/stores/browser_store.jsx
+++ b/webapp/stores/browser_store.jsx
@@ -20,6 +20,11 @@ function getPrefix() {
 }
 
 class BrowserStoreClass {
+    constructor() {
+        this.hasCheckedLocalStorage = false;
+        this.localStorageSupported = false;
+    }
+
     setItem(name, value) {
         this.setGlobalItem(getPrefix() + name, value);
     }
@@ -168,20 +173,20 @@ class BrowserStoreClass {
     }
 
     isLocalStorageSupported() {
-        if (this.checkedLocalStorageSupported !== undefined) { // eslint-disable-line no-undefined
-            return this.checkedLocalStorageSupported;
+        if (this.hasCheckedLocalStorage) {
+            return this.localStorageSupported;
         }
+
+        this.localStorageSupported = false;
 
         try {
             localStorage.setItem('__testLocal__', '1');
-            if (localStorage.getItem('__testLocal__') !== '1') {
-                this.checkedLocalStorageSupported = false;
+            if (localStorage.getItem('__testLocal__') === '1') {
+                this.localStorageSupported = true;
             }
             localStorage.removeItem('__testLocal__', '1');
-
-            this.checkedLocalStorageSupported = true;
         } catch (e) {
-            this.checkedLocalStorageSupported = false;
+            this.localStorageSupported = false;
         }
 
         try {
@@ -192,7 +197,9 @@ class BrowserStoreClass {
             browserHistory.push(window.location.origin + '/error?title=' + notSupportedParams.title + '&message=' + notSupportedParams.message);
         }
 
-        return this.checkedLocalStorageSupported;
+        this.hasCheckedLocalStorage = true;
+
+        return this.localStorageSupported;
     }
 
     hasSeenLandingPage() {


### PR DESCRIPTION
#### Summary
Fixed the code that checks if local and session storage are usable since I accidentally broke it in 3.3. This caused the error page that shows when using private browsing in Safari to not work.

Also, save the team list in the system console across after the user logs out.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3841
https://mattermost.atlassian.net/browse/PLT-3883