### PR TITLE
Fix load config panic errors to display message instead of id

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -168,11 +168,11 @@ func LoadConfig(fileName string) {
 	config.SetDefaults()
 
 	if err := config.IsValid(); err != nil {
-		panic(err.Error())
+		panic(T(err.Id))
 	}
 
 	if err := ValidateLdapFilter(&config); err != nil {
-		panic(err.Error())
+		panic(T(err.Id))
 	}
 
 	configureLog(&config.LogSettings)


### PR DESCRIPTION
#### Summary
When an error on the validation of the config file occurred then a AppError was returned and the message had the reference id of the string instead of the localized string.

Now we make use of that id to search for the localized string and return that to the console.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3888

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

