### PR TITLE
PLT-3906 Add Heroku deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,41 @@
 # Mattermost
 
-Mattermost Team Edition is an open source, self-hosted Slack-alternative. 
+Mattermost Team Edition is an open source, self-hosted Slack-alternative.
 
-It's written in Golang and React and runs as a single Linux binary with either MySQL or Postgres. Every month on the 16th a new compiled version is released under an MIT license. 
+It's written in Golang and React and runs as a single Linux binary with either MySQL or Postgres. Every month on the 16th a new compiled version is released under an MIT license.
 
-- See [product documentation](http://docs.mattermost.com/) for full details. 
-- Learn more about the project at [https://mattermost.org](https://mattermost.org). 
+- See [product documentation](http://docs.mattermost.com/) for full details.
+- Learn more about the project at [https://mattermost.org](https://mattermost.org).
 - Download now from [https://mattermost.org/download](https://mattermost.org/download).
 
-Get Started: 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/mattermost/mattermost-heroku)
+
+__Note:__ Mattermost Heroku is meant to be used as a preview instance only. If you're looking to use Mattermost in production, please see our comprehensive [install guides](https://www.mattermost.org/installation/).
+
+Get Started:
 
 - **Preview Mattermost** - If you use Docker, try [a single-line install](http://docs.mattermost.com/install/docker-local-machine.html#one-line-docker-install).
 - **Developer Machine Set Up** - See [http://docs.mattermost.com/developer/developer-setup.html](http://docs.mattermost.com/developer/developer-setup.html)
 - **View All Install Guides** - See [http://www.mattermost.org/installation/](http://www.mattermost.org/installation/)
- 
+
 Get Involved:
 
-- **Contribute Code** - View our [Code Contribution Guidelines](http://docs.mattermost.com/developer/contribution-guide.html) 
+- **Contribute Code** - View our [Code Contribution Guidelines](http://docs.mattermost.com/developer/contribution-guide.html)
 - **Work on "Help Wanted" projects** - See a list of [tickets accepting pull requests](https://mattermost.atlassian.net/issues/?filter=10101)
 - **Discuss Contributions** - Join our [Developer Discussion](https://pre-release.mattermost.com) for contributors on the nightly builds server
-- **File Bugs** - Search for existing bugs and [file a GitHub issue if your bug is new](http://www.mattermost.org/filing-issues/) 
+- **File Bugs** - Search for existing bugs and [file a GitHub issue if your bug is new](http://www.mattermost.org/filing-issues/)
 - **Share Feature Ideas** - Add a [feature idea to be discussed or upvoted](http://www.mattermost.org/feature-requests/)
-- **Get Troubleshooting Help** - Search articles and [add a topic if the issue is new](https://forum.mattermost.org/t/how-to-use-the-troubleshooting-forum/150)  
+- **Get Troubleshooting Help** - Search articles and [add a topic if the issue is new](https://forum.mattermost.org/t/how-to-use-the-troubleshooting-forum/150)
 
-Learn More: 
+Learn More:
 
 - **API Options** - Understand API options via [webhooks, slash commands, drivers and RESTful Web Service](http://docs.mattermost.com/developer/api.html).
-- **Localization Guide** - Learn [how Mattermost supports different languages](http://docs.mattermost.com/developer/localization.html#translation-process). 
+- **Localization Guide** - Learn [how Mattermost supports different languages](http://docs.mattermost.com/developer/localization.html#translation-process).
 
-Get the Latest News: 
+Get the Latest News:
 
 - **Twitter** - Follow [MattermostHQ](https://twitter.com/mattermosthq) on Twitter for the latest updates.   
-- **Email** - Subscribe to our [newsletter for announcements](http://mattermost.us11.list-manage.com/subscribe?u=6cdba22349ae374e188e7ab8e&id=2add1c8034) (1 or 2 per month).  
+- **Email** - Subscribe to our [newsletter for announcements](http://mattermost.us11.list-manage.com/subscribe?u=6cdba22349ae374e188e7ab8e&id=2add1c8034) (1 or 2 per month).
 - **IRC** - Connect with us on IRC Freenode at #matterbridge (thanks to the [matterircd](https://github.com/42wim/matterircd) project).
 
 Any other questions, mail us at info@mattermost.com. We’d love to meet you!


### PR DESCRIPTION
#### Summary
Added a `Deploy to Heroku` button and removed some whitespace from the README.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3906

@it33 feel free to update as needed