### PR TITLE
PLT-1752/PLT-3567/PLT-3998 Highlighting links in search, unit tests for autolinking

### DIFF
--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -581,9 +581,9 @@ export default class ChannelHeader extends React.Component {
                                         ref='headerOverlay'
                                     >
                                         <div
-                                            onClick={TextFormatting.handleClick}
+                                            onClick={Utils.handleFormattedTextClick}
                                             className='description'
-                                            dangerouslySetInnerHTML={{__html: TextFormatting.formatText(channel.header, {singleline: true, mentionHighlight: false})}}
+                                            dangerouslySetInnerHTML={{__html: TextFormatting.formatText(channel.header, {singleline: true, mentionHighlight: false, siteURL: Utils.getSiteURL()})}}
                                         />
                                     </OverlayTrigger>
                                 </div>

--- a/webapp/components/message_wrapper.jsx
+++ b/webapp/components/message_wrapper.jsx
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import * as TextFormatting from 'utils/text_formatting.jsx';
+import * as Utils from 'utils/utils.jsx';
 
 import React from 'react';
 
@@ -10,9 +11,19 @@ export default class MessageWrapper extends React.Component {
         super(props);
         this.state = {};
     }
+
     render() {
         if (this.props.message) {
-            return <div dangerouslySetInnerHTML={{__html: TextFormatting.formatText(this.props.message, this.props.options)}}/>;
+            const options = Object.assign({}, this.props.options, {
+                siteURL: Utils.getSiteURL()
+            });
+
+            return (
+                <div
+                    onClick={Utils.handleFormattedTextClick}
+                    dangerouslySetInnerHTML={{__html: TextFormatting.formatText(this.props.message, options)}}
+                />
+            );
         }
 
         return <div/>;

--- a/webapp/components/post_view/components/post.jsx
+++ b/webapp/components/post_view/components/post.jsx
@@ -114,10 +114,6 @@ export default class Post extends React.Component {
             return true;
         }
 
-        if (nextProps.emojis !== this.props.emojis) {
-            return true;
-        }
-
         if (nextState.dropdownOpened !== this.state.dropdownOpened) {
             return true;
         }
@@ -259,7 +255,6 @@ export default class Post extends React.Component {
                                 handleCommentClick={this.handleCommentClick}
                                 compactDisplay={this.props.compactDisplay}
                                 previewCollapsed={this.props.previewCollapsed}
-                                emojis={this.props.emojis}
                             />
                         </div>
                     </div>
@@ -279,7 +274,6 @@ Post.propTypes = {
     isLastComment: React.PropTypes.bool,
     shouldHighlight: React.PropTypes.bool,
     displayNameType: React.PropTypes.string,
-    hasProfiles: React.PropTypes.bool,
     currentUser: React.PropTypes.object.isRequired,
     center: React.PropTypes.bool,
     compactDisplay: React.PropTypes.bool,
@@ -287,7 +281,6 @@ Post.propTypes = {
     commentCount: React.PropTypes.number,
     isCommentMention: React.PropTypes.bool,
     useMilitaryTime: React.PropTypes.bool.isRequired,
-    emojis: React.PropTypes.object.isRequired,
     isFlagged: React.PropTypes.bool,
     status: React.PropTypes.string
 };

--- a/webapp/components/post_view/components/post_body.jsx
+++ b/webapp/components/post_view/components/post_body.jsx
@@ -6,8 +6,8 @@ import UserStore from 'stores/user_store.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import Constants from 'utils/constants.jsx';
-import * as TextFormatting from 'utils/text_formatting.jsx';
 import PostBodyAdditionalContent from './post_body_additional_content.jsx';
+import PostMessageContainer from './post_message_container.jsx';
 import PendingPostOptions from './pending_post_options.jsx';
 
 import {FormattedMessage} from 'react-intl';
@@ -40,10 +40,6 @@ export default class PostBody extends React.Component {
         }
 
         if (nextProps.handleCommentClick.toString() !== this.props.handleCommentClick.toString()) {
-            return true;
-        }
-
-        if (nextProps.emojis !== this.props.emojis) {
             return true;
         }
 
@@ -165,10 +161,7 @@ export default class PostBody extends React.Component {
             );
         } else {
             message = (
-                <span
-                    onClick={TextFormatting.handleClick}
-                    dangerouslySetInnerHTML={{__html: TextFormatting.formatText(this.props.post.message, {emojis: this.props.emojis})}}
-                />
+                <PostMessageContainer post={this.props.post}/>
             );
         }
 
@@ -215,6 +208,5 @@ PostBody.propTypes = {
     retryPost: React.PropTypes.func.isRequired,
     handleCommentClick: React.PropTypes.func.isRequired,
     compactDisplay: React.PropTypes.bool,
-    previewCollapsed: React.PropTypes.string,
-    emojis: React.PropTypes.object.isRequired
+    previewCollapsed: React.PropTypes.string
 };

--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -314,7 +314,6 @@ export default class PostList extends React.Component {
                     compactDisplay={this.props.compactDisplay}
                     previewCollapsed={this.props.previewsCollapsed}
                     useMilitaryTime={this.props.useMilitaryTime}
-                    emojis={this.props.emojis}
                     isFlagged={isFlagged}
                     status={status}
                 />
@@ -584,7 +583,6 @@ PostList.propTypes = {
     previewsCollapsed: React.PropTypes.string,
     useMilitaryTime: React.PropTypes.bool.isRequired,
     isFocusPost: React.PropTypes.bool,
-    emojis: React.PropTypes.object.isRequired,
     flaggedPosts: React.PropTypes.object,
     statuses: React.PropTypes.object
 };

--- a/webapp/components/post_view/components/post_message_container.jsx
+++ b/webapp/components/post_view/components/post_message_container.jsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+
+import EmojiStore from 'stores/emoji_store.jsx';
+import PreferenceStore from 'stores/preference_store.jsx';
+import {Preferences} from 'utils/constants.jsx';
+
+import PostMessageView from './post_message_view.jsx';
+
+export default class PostMessageContainer extends React.Component {
+    static propTypes = {
+        post: React.PropTypes.object.isRequired
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.onEmojiChange = this.onEmojiChange.bind(this);
+        this.onPreferenceChange = this.onPreferenceChange.bind(this);
+
+        this.state = {
+            emojis: EmojiStore.getEmojis(),
+            enableFormatting: PreferenceStore.getBool(Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true)
+        };
+    }
+
+    componentDidMount() {
+        EmojiStore.addChangeListener(this.onEmojiChange);
+        PreferenceStore.addChangeListener(this.onPreferenceChange);
+    }
+
+    componentWillUnmount() {
+        EmojiStore.removeChangeListener(this.onEmojiChange);
+        PreferenceStore.removeChangeListener(this.onPreferenceChange);
+    }
+
+    onEmojiChange() {
+        this.setState({
+            emojis: EmojiStore.getEmojis()
+        });
+    }
+
+    onPreferenceChange() {
+        this.setState({
+            enableFormatting: PreferenceStore.getBool(Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true)
+        });
+    }
+
+    render() {
+        return (
+            <PostMessageView
+                message={this.props.post.message}
+                emojis={this.state.emojis}
+                enableFormatting={this.state.enableFormatting}
+                profiles={this.state.profiles}
+            />
+        );
+    }
+}

--- a/webapp/components/post_view/components/post_message_container.jsx
+++ b/webapp/components/post_view/components/post_message_container.jsx
@@ -12,7 +12,12 @@ import PostMessageView from './post_message_view.jsx';
 
 export default class PostMessageContainer extends React.Component {
     static propTypes = {
-        post: React.PropTypes.object.isRequired
+        post: React.PropTypes.object.isRequired,
+        options: React.PropTypes.object
+    };
+
+    static defaultProps = {
+        options: {}
     };
 
     constructor(props) {
@@ -68,6 +73,7 @@ export default class PostMessageContainer extends React.Component {
     render() {
         return (
             <PostMessageView
+                options={this.props.options}
                 message={this.props.post.message}
                 emojis={this.state.emojis}
                 enableFormatting={this.state.enableFormatting}

--- a/webapp/components/post_view/components/post_message_container.jsx
+++ b/webapp/components/post_view/components/post_message_container.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import EmojiStore from 'stores/emoji_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 import {Preferences} from 'utils/constants.jsx';
+import UserStore from 'stores/user_store.jsx';
 
 import PostMessageView from './post_message_view.jsx';
 
@@ -19,21 +20,28 @@ export default class PostMessageContainer extends React.Component {
 
         this.onEmojiChange = this.onEmojiChange.bind(this);
         this.onPreferenceChange = this.onPreferenceChange.bind(this);
+        this.onUserChange = this.onUserChange.bind(this);
+
+        const mentionKeys = UserStore.getCurrentMentionKeys();
+        mentionKeys.push('@here');
 
         this.state = {
             emojis: EmojiStore.getEmojis(),
-            enableFormatting: PreferenceStore.getBool(Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true)
+            enableFormatting: PreferenceStore.getBool(Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
+            mentionKeys
         };
     }
 
     componentDidMount() {
         EmojiStore.addChangeListener(this.onEmojiChange);
         PreferenceStore.addChangeListener(this.onPreferenceChange);
+        UserStore.addChangeListener(this.onUserChange);
     }
 
     componentWillUnmount() {
         EmojiStore.removeChangeListener(this.onEmojiChange);
         PreferenceStore.removeChangeListener(this.onPreferenceChange);
+        UserStore.removeChangeListener(this.onUserChange);
     }
 
     onEmojiChange() {
@@ -48,13 +56,22 @@ export default class PostMessageContainer extends React.Component {
         });
     }
 
+    onUserChange() {
+        const mentionKeys = UserStore.getCurrentMentionKeys();
+        mentionKeys.push('@here');
+
+        this.setState({
+            mentionKeys
+        });
+    }
+
     render() {
         return (
             <PostMessageView
                 message={this.props.post.message}
                 emojis={this.state.emojis}
                 enableFormatting={this.state.enableFormatting}
-                profiles={this.state.profiles}
+                mentionKeys={this.state.mentionKeys}
             />
         );
     }

--- a/webapp/components/post_view/components/post_message_container.jsx
+++ b/webapp/components/post_view/components/post_message_container.jsx
@@ -33,7 +33,8 @@ export default class PostMessageContainer extends React.Component {
         this.state = {
             emojis: EmojiStore.getEmojis(),
             enableFormatting: PreferenceStore.getBool(Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
-            mentionKeys
+            mentionKeys,
+            usernameMap: UserStore.getProfilesUsernameMap()
         };
     }
 
@@ -66,7 +67,8 @@ export default class PostMessageContainer extends React.Component {
         mentionKeys.push('@here');
 
         this.setState({
-            mentionKeys
+            mentionKeys,
+            usernameMap: UserStore.getProfilesUsernameMap()
         });
     }
 
@@ -78,6 +80,7 @@ export default class PostMessageContainer extends React.Component {
                 emojis={this.state.emojis}
                 enableFormatting={this.state.enableFormatting}
                 mentionKeys={this.state.mentionKeys}
+                usernameMap={this.state.usernameMap}
             />
         );
     }

--- a/webapp/components/post_view/components/post_message_view.jsx
+++ b/webapp/components/post_view/components/post_message_view.jsx
@@ -8,6 +8,7 @@ import * as Utils from 'utils/utils.jsx';
 
 export default class PostMessageView extends React.Component {
     static propTypes = {
+        options: React.PropTypes.object.isRequired,
         message: React.PropTypes.string.isRequired,
         emojis: React.PropTypes.object.isRequired,
         enableFormatting: React.PropTypes.bool.isRequired,
@@ -15,6 +16,10 @@ export default class PostMessageView extends React.Component {
     };
 
     shouldComponentUpdate(nextProps) {
+        if (!Utils.areObjectsEqual(nextProps.options, this.props.options)) {
+            return true;
+        }
+
         if (nextProps.message !== this.props.message) {
             return true;
         }
@@ -40,11 +45,11 @@ export default class PostMessageView extends React.Component {
             return <span>{this.props.message}</span>;
         }
 
-        const options = {
+        const options = Object.assign({}, this.props.options, {
             emojis: this.props.emojis,
             siteURL: Utils.getSiteURL(),
             mentionKeys: this.props.mentionKeys
-        };
+        });
 
         return (
             <span

--- a/webapp/components/post_view/components/post_message_view.jsx
+++ b/webapp/components/post_view/components/post_message_view.jsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+
+import {browserHistory} from 'react-router/es6';
+import * as TextFormatting from 'utils/text_formatting.jsx';
+import * as Utils from 'utils/utils.jsx';
+
+export default class PostMessageView extends React.Component {
+    static propTypes = {
+        message: React.PropTypes.string.isRequired,
+        emojis: React.PropTypes.object.isRequired,
+        enableFormatting: React.PropTypes.bool.isRequired
+    };
+
+    shouldComponentUpdate(nextProps) {
+        if (nextProps.message !== this.props.message) {
+            return true;
+        }
+
+        // emojis are immutable
+        if (nextProps.emojis !== this.props.emojis) {
+            return true;
+        }
+
+        if (nextProps.enableFormatting !== this.props.enableFormatting) {
+            return true;
+        }
+
+        return false;
+    }
+
+    handleClick(e) {
+        // TODO should this be here or somewhere else? it's already copied from TextFormatting
+        const mentionAttribute = e.target.getAttributeNode('data-mention');
+        const hashtagAttribute = e.target.getAttributeNode('data-hashtag');
+        const linkAttribute = e.target.getAttributeNode('data-link');
+
+        if (mentionAttribute) {
+            e.preventDefault();
+
+            Utils.searchForTerm(mentionAttribute.value);
+        } else if (hashtagAttribute) {
+            e.preventDefault();
+
+            Utils.searchForTerm(hashtagAttribute.value);
+        } else if (linkAttribute) {
+            const MIDDLE_MOUSE_BUTTON = 1;
+
+            if (!(e.button === MIDDLE_MOUSE_BUTTON || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) {
+                e.preventDefault();
+
+                browserHistory.push(linkAttribute.value);
+            }
+        }
+    }
+
+    render() {
+        if (!this.props.enableFormatting) {
+            return <span>{this.props.message}</span>;
+        }
+
+        const options = {
+            emojis: this.props.emojis,
+            siteURL: global.mm_config.SiteURL || window.location.origin
+        };
+
+        return (
+            <span
+                onClick={this.handleClick}
+                dangerouslySetInnerHTML={{__html: TextFormatting.formatText(this.props.message, options)}}
+            />
+        );
+    }
+}

--- a/webapp/components/post_view/components/post_message_view.jsx
+++ b/webapp/components/post_view/components/post_message_view.jsx
@@ -3,7 +3,6 @@
 
 import React from 'react';
 
-import {browserHistory} from 'react-router/es6';
 import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -31,31 +30,6 @@ export default class PostMessageView extends React.Component {
         return false;
     }
 
-    handleClick(e) {
-        // TODO should this be here or somewhere else? it's already copied from TextFormatting
-        const mentionAttribute = e.target.getAttributeNode('data-mention');
-        const hashtagAttribute = e.target.getAttributeNode('data-hashtag');
-        const linkAttribute = e.target.getAttributeNode('data-link');
-
-        if (mentionAttribute) {
-            e.preventDefault();
-
-            Utils.searchForTerm(mentionAttribute.value);
-        } else if (hashtagAttribute) {
-            e.preventDefault();
-
-            Utils.searchForTerm(hashtagAttribute.value);
-        } else if (linkAttribute) {
-            const MIDDLE_MOUSE_BUTTON = 1;
-
-            if (!(e.button === MIDDLE_MOUSE_BUTTON || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) {
-                e.preventDefault();
-
-                browserHistory.push(linkAttribute.value);
-            }
-        }
-    }
-
     render() {
         if (!this.props.enableFormatting) {
             return <span>{this.props.message}</span>;
@@ -63,12 +37,12 @@ export default class PostMessageView extends React.Component {
 
         const options = {
             emojis: this.props.emojis,
-            siteURL: global.mm_config.SiteURL || window.location.origin
+            siteURL: Utils.getSiteURL()
         };
 
         return (
             <span
-                onClick={this.handleClick}
+                onClick={Utils.handleFormattedTextClick}
                 dangerouslySetInnerHTML={{__html: TextFormatting.formatText(this.props.message, options)}}
             />
         );

--- a/webapp/components/post_view/components/post_message_view.jsx
+++ b/webapp/components/post_view/components/post_message_view.jsx
@@ -10,7 +10,8 @@ export default class PostMessageView extends React.Component {
     static propTypes = {
         message: React.PropTypes.string.isRequired,
         emojis: React.PropTypes.object.isRequired,
-        enableFormatting: React.PropTypes.bool.isRequired
+        enableFormatting: React.PropTypes.bool.isRequired,
+        mentionKeys: React.PropTypes.arrayOf(React.PropTypes.string).isRequired
     };
 
     shouldComponentUpdate(nextProps) {
@@ -27,6 +28,10 @@ export default class PostMessageView extends React.Component {
             return true;
         }
 
+        if (!Utils.areObjectsEqual(nextProps.mentionKeys, this.props.mentionKeys)) {
+            return true;
+        }
+
         return false;
     }
 
@@ -37,7 +42,8 @@ export default class PostMessageView extends React.Component {
 
         const options = {
             emojis: this.props.emojis,
-            siteURL: Utils.getSiteURL()
+            siteURL: Utils.getSiteURL(),
+            mentionKeys: this.props.mentionKeys
         };
 
         return (

--- a/webapp/components/post_view/components/post_message_view.jsx
+++ b/webapp/components/post_view/components/post_message_view.jsx
@@ -12,7 +12,8 @@ export default class PostMessageView extends React.Component {
         message: React.PropTypes.string.isRequired,
         emojis: React.PropTypes.object.isRequired,
         enableFormatting: React.PropTypes.bool.isRequired,
-        mentionKeys: React.PropTypes.arrayOf(React.PropTypes.string).isRequired
+        mentionKeys: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
+        usernameMap: React.PropTypes.object.isRequired
     };
 
     shouldComponentUpdate(nextProps) {
@@ -37,6 +38,9 @@ export default class PostMessageView extends React.Component {
             return true;
         }
 
+        // Don't check if props.usernameMap changes since it is very large and inefficient to do so.
+        // This mimics previous behaviour, but could be changed if we decide it's worth it.
+
         return false;
     }
 
@@ -48,7 +52,8 @@ export default class PostMessageView extends React.Component {
         const options = Object.assign({}, this.props.options, {
             emojis: this.props.emojis,
             siteURL: Utils.getSiteURL(),
-            mentionKeys: this.props.mentionKeys
+            mentionKeys: this.props.mentionKeys,
+            usernameMap: this.props.usernameMap
         });
 
         return (

--- a/webapp/components/post_view/post_view_controller.jsx
+++ b/webapp/components/post_view/post_view_controller.jsx
@@ -4,7 +4,6 @@
 import PostList from './components/post_list.jsx';
 import LoadingScreen from 'components/loading_screen.jsx';
 
-import EmojiStore from 'stores/emoji_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import PostStore from 'stores/post_store.jsx';
@@ -25,7 +24,6 @@ export default class PostViewController extends React.Component {
         this.onPreferenceChange = this.onPreferenceChange.bind(this);
         this.onUserChange = this.onUserChange.bind(this);
         this.onPostsChange = this.onPostsChange.bind(this);
-        this.onEmojisChange = this.onEmojisChange.bind(this);
         this.onStatusChange = this.onStatusChange.bind(this);
         this.onPostsViewJumpRequest = this.onPostsViewJumpRequest.bind(this);
         this.onSetNewMessageIndicator = this.onSetNewMessageIndicator.bind(this);
@@ -67,7 +65,6 @@ export default class PostViewController extends React.Component {
             compactDisplay: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.MESSAGE_DISPLAY, Preferences.MESSAGE_DISPLAY_DEFAULT) === Preferences.MESSAGE_DISPLAY_COMPACT,
             previewsCollapsed: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.COLLAPSE_DISPLAY, 'false'),
             useMilitaryTime: PreferenceStore.getBool(Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false),
-            emojis: EmojiStore.getEmojis(),
             flaggedPosts: PreferenceStore.getCategory(Constants.Preferences.CATEGORY_FLAGGED_POST)
         };
     }
@@ -123,12 +120,6 @@ export default class PostViewController extends React.Component {
         });
     }
 
-    onEmojisChange() {
-        this.setState({
-            emojis: EmojiStore.getEmojis()
-        });
-    }
-
     onStatusChange() {
         const channel = this.state.channel;
         let statuses;
@@ -145,7 +136,6 @@ export default class PostViewController extends React.Component {
         UserStore.addStatusesChangeListener(this.onStatusChange);
         PostStore.addChangeListener(this.onPostsChange);
         PostStore.addPostsViewJumpListener(this.onPostsViewJumpRequest);
-        EmojiStore.addChangeListener(this.onEmojisChange);
         ChannelStore.addLastViewedListener(this.onSetNewMessageIndicator);
     }
 
@@ -155,7 +145,6 @@ export default class PostViewController extends React.Component {
         UserStore.removeStatusesChangeListener(this.onStatusChange);
         PostStore.removeChangeListener(this.onPostsChange);
         PostStore.removePostsViewJumpListener(this.onPostsViewJumpRequest);
-        EmojiStore.removeChangeListener(this.onEmojisChange);
         ChannelStore.removeLastViewedListener(this.onSetNewMessageIndicator);
     }
 
@@ -298,10 +287,6 @@ export default class PostViewController extends React.Component {
             return true;
         }
 
-        if (nextState.emojis !== this.state.emojis) {
-            return true;
-        }
-
         return false;
     }
 
@@ -332,7 +317,6 @@ export default class PostViewController extends React.Component {
                     useMilitaryTime={this.state.useMilitaryTime}
                     flaggedPosts={this.state.flaggedPosts}
                     lastViewed={this.state.lastViewed}
-                    emojis={this.state.emojis}
                     ownNewMessage={this.state.ownNewMessage}
                     statuses={this.state.statuses}
                 />

--- a/webapp/components/rhs_comment.jsx
+++ b/webapp/components/rhs_comment.jsx
@@ -4,6 +4,7 @@
 import UserProfile from './user_profile.jsx';
 import FileAttachmentList from './file_attachment_list.jsx';
 import PendingPostOptions from 'components/post_view/components/pending_post_options.jsx';
+import PostMessageContainer from 'components/post_view/components/post_message_container.jsx';
 import ProfilePicture from 'components/profile_picture.jsx';
 
 import TeamStore from 'stores/team_store.jsx';
@@ -12,7 +13,6 @@ import UserStore from 'stores/user_store.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {flagPost, unflagPost} from 'actions/post_actions.jsx';
 
-import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 
@@ -234,13 +234,7 @@ export default class RhsComment extends React.Component {
         }
         let loading;
         let postClass = '';
-        let message = (
-            <div
-                ref='message_holder'
-                onClick={TextFormatting.handleClick}
-                dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message)}}
-            />
-        );
+        let message = <PostMessageContainer post={post}/>;
 
         if (post.state === Constants.POST_FAILED) {
             postClass += ' post-fail';

--- a/webapp/components/rhs_root_post.jsx
+++ b/webapp/components/rhs_root_post.jsx
@@ -3,6 +3,7 @@
 
 import UserProfile from './user_profile.jsx';
 import PostBodyAdditionalContent from 'components/post_view/components/post_body_additional_content.jsx';
+import PostMessageContainer from 'components/post_view/components/post_message_container.jsx';
 import FileAttachmentList from './file_attachment_list.jsx';
 import ProfilePicture from 'components/profile_picture.jsx';
 
@@ -15,7 +16,6 @@ import {flagPost, unflagPost} from 'actions/post_actions.jsx';
 
 import * as Utils from 'utils/utils.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
-import * as TextFormatting from 'utils/text_formatting.jsx';
 
 import Constants from 'utils/constants.jsx';
 import {Tooltip, OverlayTrigger} from 'react-bootstrap';
@@ -305,13 +305,7 @@ export default class RhsRootPost extends React.Component {
             profilePicContainer = '';
         }
 
-        const messageWrapper = (
-            <div
-                ref='message_holder'
-                onClick={TextFormatting.handleClick}
-                dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message)}}
-            />
-        );
+        const messageWrapper = <PostMessageContainer post={post}/>;
 
         let flag;
         let flagFunc;

--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import $ from 'jquery';
+import PostMessageContainer from 'components/post_view/components/post_message_container.jsx';
 import UserProfile from './user_profile.jsx';
 
 import TeamStore from 'stores/team_store.jsx';
@@ -11,7 +12,6 @@ import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {flagPost, unflagPost} from 'actions/post_actions.jsx';
 
-import * as TextFormatting from 'utils/text_formatting.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 
@@ -77,11 +77,6 @@ export default class SearchResultsItem extends React.Component {
                 );
             }
         }
-
-        const formattingOptions = {
-            searchTerm: this.props.term,
-            mentionHighlight: this.props.isMentionSearch
-        };
 
         let overrideUsername;
         let disableProfilePopover = false;
@@ -251,9 +246,12 @@ export default class SearchResultsItem extends React.Component {
                                 </li>
                             </ul>
                             <div className='search-item-snippet'>
-                                <span
-                                    onClick={TextFormatting.handleClick}
-                                    dangerouslySetInnerHTML={{__html: TextFormatting.formatText(post.message, formattingOptions)}}
+                                <PostMessageContainer
+                                    post={post}
+                                    options={{
+                                        searchTerm: this.props.term,
+                                        mentionHighlight: this.props.isMentionSearch
+                                    }}
                                 />
                             </div>
                         </div>

--- a/webapp/root.jsx
+++ b/webapp/root.jsx
@@ -16,6 +16,7 @@ import * as I18n from 'i18n/i18n.jsx';
 import 'bootstrap-colorpicker/dist/css/bootstrap-colorpicker.css';
 import 'google-fonts/google-fonts.css';
 import 'sass/styles.scss';
+import 'katex/dist/katex.min.css';
 
 // Import the root of our routing tree
 import rRoot from 'routes/route_root.jsx';

--- a/webapp/stores/emoji_store.jsx
+++ b/webapp/stores/emoji_store.jsx
@@ -17,6 +17,8 @@ class EmojiStore extends EventEmitter {
 
         this.dispatchToken = AppDispatcher.register(this.handleEventPayload.bind(this));
 
+        this.setMaxListeners(600);
+
         this.emojis = new Map(EmojiJson);
         this.systemEmojis = new Map(EmojiJson);
 

--- a/webapp/stores/preference_store.jsx
+++ b/webapp/stores/preference_store.jsx
@@ -8,7 +8,7 @@ import EventEmitter from 'events';
 
 const CHANGE_EVENT = 'change';
 
-class PreferenceStoreClass extends EventEmitter {
+class PreferenceStore extends EventEmitter {
     constructor() {
         super();
 
@@ -17,7 +17,7 @@ class PreferenceStoreClass extends EventEmitter {
 
         this.preferences = new Map();
 
-        this.setMaxListeners(20);
+        this.setMaxListeners(600);
     }
 
     getKey(category, name) {
@@ -144,7 +144,5 @@ class PreferenceStoreClass extends EventEmitter {
     }
 }
 
-const PreferenceStore = new PreferenceStoreClass();
-PreferenceStore.setMaxListeners(25);
-export default PreferenceStore;
-global.window.PreferenceStore = PreferenceStore;
+global.PreferenceStore = new PreferenceStore();
+export default global.PreferenceStore;

--- a/webapp/stores/user_store.jsx
+++ b/webapp/stores/user_store.jsx
@@ -4,7 +4,6 @@
 import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import EventEmitter from 'events';
 
-import * as GlobalActions from 'actions/global_actions.jsx';
 import LocalizationStore from './localization_store.jsx';
 
 import Constants from 'utils/constants.jsx';
@@ -18,6 +17,7 @@ const CHANGE_EVENT_AUDITS = 'change_audits';
 const CHANGE_EVENT_STATUSES = 'change_statuses';
 
 var Utils;
+var GlobalActions;
 
 class UserStoreClass extends EventEmitter {
     constructor() {
@@ -105,6 +105,10 @@ class UserStoreClass extends EventEmitter {
         this.currentUserId = user.id;
         global.window.mm_current_user_id = this.currentUserId;
         if (LocalizationStore.getLocale() !== user.locale) {
+            if (!GlobalActions) {
+                GlobalActions = require('actions/global_actions.jsx'); //eslint-disable-line global-require
+            }
+
             setTimeout(() => GlobalActions.newLocalizationSelected(user.locale), 0);
         }
     }

--- a/webapp/stores/user_store.jsx
+++ b/webapp/stores/user_store.jsx
@@ -4,6 +4,7 @@
 import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import EventEmitter from 'events';
 
+import * as GlobalActions from 'actions/global_actions.jsx';
 import LocalizationStore from './localization_store.jsx';
 
 import Constants from 'utils/constants.jsx';
@@ -17,7 +18,6 @@ const CHANGE_EVENT_AUDITS = 'change_audits';
 const CHANGE_EVENT_STATUSES = 'change_statuses';
 
 var Utils;
-var GlobalActions;
 
 class UserStoreClass extends EventEmitter {
     constructor() {
@@ -105,10 +105,6 @@ class UserStoreClass extends EventEmitter {
         this.currentUserId = user.id;
         global.window.mm_current_user_id = this.currentUserId;
         if (LocalizationStore.getLocale() !== user.locale) {
-            if (!GlobalActions) {
-                GlobalActions = require('actions/global_actions.jsx'); //eslint-disable-line global-require
-            }
-
             setTimeout(() => GlobalActions.newLocalizationSelected(user.locale), 0);
         }
     }

--- a/webapp/stores/user_store.jsx
+++ b/webapp/stores/user_store.jsx
@@ -338,7 +338,7 @@ class UserStoreClass extends EventEmitter {
 }
 
 var UserStore = new UserStoreClass();
-UserStore.setMaxListeners(16);
+UserStore.setMaxListeners(600);
 
 UserStore.dispatchToken = AppDispatcher.register((payload) => {
     var action = payload.action;

--- a/webapp/tests/formatting_links.test.jsx
+++ b/webapp/tests/formatting_links.test.jsx
@@ -1,0 +1,504 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import * as Markdown from 'utils/markdown.jsx';
+import * as TextFormatting from 'utils/text_formatting.jsx';
+
+describe('Markdown.Links', function() {
+    this.timeout(10000);
+
+    it('Not links', function(done) {
+        assert.equal(
+            Markdown.format('example.com').trim(),
+            '<p>example.com</p>'
+        );
+
+        assert.equal(
+            Markdown.format('readme.md').trim(),
+            '<p>readme.md</p>'
+        );
+
+        assert.equal(
+            Markdown.format('@example.com').trim(),
+            '<p>@example.com</p>'
+        );
+
+        assert.equal(
+            Markdown.format('./make-compiled-client.sh').trim(),
+            '<p>./make-compiled-client.sh</p>'
+        );
+
+        assert.equal(
+            Markdown.format('test.:test').trim(),
+            '<p>test.:test</p>'
+        );
+
+        assert.equal(
+            Markdown.format('`https://example.com`').trim(),
+            '<p>' +
+                '<span class="codespan__pre-wrap">' +
+                    '<code>' +
+                        'https://example.com' +
+                    '</code>' +
+                '</span>' +
+            '</p>'
+        );
+
+        assert.equal(
+            Markdown.format('[link](example.com').trim(),
+            '<p>[link](example.com</p>'
+        );
+
+        done();
+    });
+
+    it('External links', function(done) {
+        assert.equal(
+            Markdown.format('http://example.com').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">http://example.com</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('https://example.com').trim(),
+            '<p><a class="theme markdown__link" href="https://example.com" rel="noreferrer" target="_blank">https://example.com</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('www.example.com').trim(),
+            '<p><a class="theme markdown__link" href="http://www.example.com" rel="noreferrer" target="_blank">www.example.com</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('www.example.com/index').trim(),
+            '<p><a class="theme markdown__link" href="http://www.example.com/index" rel="noreferrer" target="_blank">www.example.com/index</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('www.example.com/index.html').trim(),
+            '<p><a class="theme markdown__link" href="http://www.example.com/index.html" rel="noreferrer" target="_blank">www.example.com/index.html</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('www.example.com/index/sub').trim(),
+            '<p><a class="theme markdown__link" href="http://www.example.com/index/sub" rel="noreferrer" target="_blank">www.example.com/index/sub</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('www1.example.com').trim(),
+            '<p><a class="theme markdown__link" href="http://www1.example.com" rel="noreferrer" target="_blank">www1.example.com</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('example.com/index').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com/index" rel="noreferrer" target="_blank">example.com/index</a></p>'
+        );
+
+        done();
+    });
+
+    it('IP addresses', function(done) {
+        assert.equal(
+            Markdown.format('http://127.0.0.1').trim(),
+            '<p><a class="theme markdown__link" href="http://127.0.0.1" rel="noreferrer" target="_blank">http://127.0.0.1</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://192.168.1.1:4040').trim(),
+            '<p><a class="theme markdown__link" href="http://192.168.1.1:4040" rel="noreferrer" target="_blank">http://192.168.1.1:4040</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://[::1]:80').trim(),
+            '<p><a class="theme markdown__link" href="http://[::1]:80" rel="noreferrer" target="_blank">http://[::1]:80</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://[::1]:8065').trim(),
+            '<p><a class="theme markdown__link" href="http://[::1]:8065" rel="noreferrer" target="_blank">http://[::1]:8065</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('https://[::1]:80').trim(),
+            '<p><a class="theme markdown__link" href="https://[::1]:80" rel="noreferrer" target="_blank">https://[::1]:80</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80').trim(),
+            '<p><a class="theme markdown__link" href="http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80" rel="noreferrer" target="_blank">http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:8065').trim(),
+            '<p><a class="theme markdown__link" href="http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:8065" rel="noreferrer" target="_blank">http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:8065</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('https://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:443').trim(),
+            '<p><a class="theme markdown__link" href="https://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:443" rel="noreferrer" target="_blank">https://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:443</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://username:password@127.0.0.1').trim(),
+            '<p><a class="theme markdown__link" href="http://username:password@127.0.0.1" rel="noreferrer" target="_blank">http://username:password@127.0.0.1</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://username:password@[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80').trim(),
+            '<p><a class="theme markdown__link" href="http://username:password@[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80" rel="noreferrer" target="_blank">http://username:password@[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80</a></p>'
+        );
+
+        done();
+    });
+
+    it('Links with anchors', function(done) {
+        assert.equal(
+            Markdown.format('https://en.wikipedia.org/wiki/URLs#Syntax').trim(),
+            '<p><a class="theme markdown__link" href="https://en.wikipedia.org/wiki/URLs#Syntax" rel="noreferrer" target="_blank">https://en.wikipedia.org/wiki/URLs#Syntax</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('https://groups.google.com/forum/#!msg').trim(),
+            '<p><a class="theme markdown__link" href="https://groups.google.com/forum/#!msg" rel="noreferrer" target="_blank">https://groups.google.com/forum/#!msg</a></p>'
+        );
+
+        done();
+    });
+
+    it('Links with parameters', function(done) {
+        assert.equal(
+            Markdown.format('www.example.com/index?params=1').trim(),
+            '<p><a class="theme markdown__link" href="http://www.example.com/index?params=1" rel="noreferrer" target="_blank">www.example.com/index?params=1</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('www.example.com/index?params=1&other=2').trim(),
+            '<p><a class="theme markdown__link" href="http://www.example.com/index?params=1&amp;other=2" rel="noreferrer" target="_blank">www.example.com/index?params=1&amp;other=2</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('www.example.com/index?params=1;other=2').trim(),
+            '<p><a class="theme markdown__link" href="http://www.example.com/index?params=1;other=2" rel="noreferrer" target="_blank">www.example.com/index?params=1;other=2</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://example.com:8065').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com:8065" rel="noreferrer" target="_blank">http://example.com:8065</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://username:password@example.com').trim(),
+            '<p><a class="theme markdown__link" href="http://username:password@example.com" rel="noreferrer" target="_blank">http://username:password@example.com</a></p>'
+        );
+
+        done();
+    });
+
+    it('Special characters', function(done) {
+        assert.equal(
+            Markdown.format('http://www.example.com/_/page').trim(),
+            '<p><a class="theme markdown__link" href="http://www.example.com/_/page" rel="noreferrer" target="_blank">http://www.example.com/_/page</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('www.example.com/_/page').trim(),
+            '<p><a class="theme markdown__link" href="http://www.example.com/_/page" rel="noreferrer" target="_blank">www.example.com/_/page</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('https://en.wikipedia.org/wiki/🐬').trim(),
+            '<p><a class="theme markdown__link" href="https://en.wikipedia.org/wiki/🐬" rel="noreferrer" target="_blank">https://en.wikipedia.org/wiki/🐬</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://✪df.ws/1234').trim(),
+            '<p><a class="theme markdown__link" href="http://✪df.ws/1234" rel="noreferrer" target="_blank">http://✪df.ws/1234</a></p>'
+        );
+
+        done();
+    });
+
+    it('Brackets', function(done) {
+        assert.equal(
+            Markdown.format('https://en.wikipedia.org/wiki/Rendering_(computer_graphics)').trim(),
+            '<p><a class="theme markdown__link" href="https://en.wikipedia.org/wiki/Rendering_(computer_graphics)" rel="noreferrer" target="_blank">https://en.wikipedia.org/wiki/Rendering_(computer_graphics)</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://example.com/more_(than)_one_(parens)').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com/more_(than)_one_(parens)" rel="noreferrer" target="_blank">http://example.com/more_(than)_one_(parens)</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://example.com/(something)?after=parens').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com/(something)?after=parens" rel="noreferrer" target="_blank">http://example.com/(something)?after=parens</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('http://foo.com/unicode_(✪)_in_parens').trim(),
+            '<p><a class="theme markdown__link" href="http://foo.com/unicode_(✪)_in_parens" rel="noreferrer" target="_blank">http://foo.com/unicode_(✪)_in_parens</a></p>'
+        );
+
+        done();
+    });
+
+    it('Email addresses', function(done) {
+        assert.equal(
+            Markdown.format('test@example.com').trim(),
+            '<p><a class="theme" href="mailto:test@example.com">test@example.com</a></p>'
+        );
+        assert.equal(
+            Markdown.format('test_underscore@example.com').trim(),
+            '<p><a class="theme" href="mailto:test_underscore@example.com">test_underscore@example.com</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('mailto:test@example.com').trim(),
+            '<p><a class="theme markdown__link" href="mailto:test@example.com" rel="noreferrer" target="_blank">mailto:test@example.com</a></p>'
+        );
+
+        done();
+    });
+
+    it('Formatted links', function(done) {
+        assert.equal(
+            Markdown.format('*https://example.com*').trim(),
+            '<p><em><a class="theme markdown__link" href="https://example.com" rel="noreferrer" target="_blank">https://example.com</a></em></p>'
+        );
+
+        assert.equal(
+            Markdown.format('_https://example.com_').trim(),
+            '<p><em><a class="theme markdown__link" href="https://example.com" rel="noreferrer" target="_blank">https://example.com</a></em></p>'
+        );
+
+        assert.equal(
+            Markdown.format('**https://example.com**').trim(),
+            '<p><strong><a class="theme markdown__link" href="https://example.com" rel="noreferrer" target="_blank">https://example.com</a></strong></p>'
+        );
+
+        assert.equal(
+            Markdown.format('__https://example.com__').trim(),
+            '<p><strong><a class="theme markdown__link" href="https://example.com" rel="noreferrer" target="_blank">https://example.com</a></strong></p>'
+        );
+
+        assert.equal(
+            Markdown.format('***https://example.com***').trim(),
+            '<p><strong><em><a class="theme markdown__link" href="https://example.com" rel="noreferrer" target="_blank">https://example.com</a></em></strong></p>'
+        );
+
+        assert.equal(
+            Markdown.format('___https://example.com___').trim(),
+            '<p><strong><em><a class="theme markdown__link" href="https://example.com" rel="noreferrer" target="_blank">https://example.com</a></em></strong></p>'
+        );
+
+        assert.equal(
+            Markdown.format('<https://example.com>').trim(),
+            '<p><a class="theme markdown__link" href="https://example.com" rel="noreferrer" target="_blank">https://example.com</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('<https://en.wikipedia.org/wiki/Rendering_(computer_graphics)>').trim(),
+            '<p><a class="theme markdown__link" href="https://en.wikipedia.org/wiki/Rendering_(computer_graphics)" rel="noreferrer" target="_blank">https://en.wikipedia.org/wiki/Rendering_(computer_graphics)</a></p>'
+        );
+
+        done();
+    });
+
+    it('Links with text', function(done) {
+        assert.equal(
+            Markdown.format('[example link](example.com)').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">example link</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('[example.com](example.com)').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">example.com</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('[example.com/other](example.com)').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">example.com/other</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('[example.com/other_link](example.com/example)').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com/example" rel="noreferrer" target="_blank">example.com/other_link</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('[link with spaces](example.com/ spaces in the url)').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com/ spaces in the url" rel="noreferrer" target="_blank">link with spaces</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('[This whole #sentence should be a link](https://example.com)').trim(),
+            '<p><a class="theme markdown__link" href="https://example.com" rel="noreferrer" target="_blank">This whole #sentence should be a link</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('[email link](mailto:test@example.com)').trim(),
+            '<p><a class="theme markdown__link" href="mailto:test@example.com" rel="noreferrer" target="_blank">email link</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('[other link](ts3server://example.com)').trim(),
+            '<p><a class="theme markdown__link" href="ts3server://example.com" rel="noreferrer" target="_blank">other link</a></p>'
+        );
+
+        done();
+    });
+
+    it('Links with tooltips', function(done) {
+        assert.equal(
+            Markdown.format('[link](example.com "catch phrase!")').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank" title="catch phrase!">link</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('[link](example.com "title with "quotes"")').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank" title="title with &quot;quotes&quot;">link</a></p>'
+        );
+        assert.equal(
+            Markdown.format('[link with spaces](example.com/ spaces in the url "and a title")').trim(),
+            '<p><a class="theme markdown__link" href="http://example.com/ spaces in the url" rel="noreferrer" target="_blank" title="and a title">link with spaces</a></p>'
+        );
+
+        done();
+    });
+
+    it('Links with surrounding text', function(done) {
+        assert.equal(
+            Markdown.format('This is a sentence with a http://example.com in it.').trim(),
+            '<p>This is a sentence with a <a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">http://example.com</a> in it.</p>'
+        );
+
+        assert.equal(
+            Markdown.format('This is a sentence with a http://example.com/_/underscore in it.').trim(),
+            '<p>This is a sentence with a <a class="theme markdown__link" href="http://example.com/_/underscore" rel="noreferrer" target="_blank">http://example.com/_/underscore</a> in it.</p>'
+        );
+
+        assert.equal(
+            Markdown.format('This is a sentence with a http://192.168.1.1:4040 in it.').trim(),
+            '<p>This is a sentence with a <a class="theme markdown__link" href="http://192.168.1.1:4040" rel="noreferrer" target="_blank">http://192.168.1.1:4040</a> in it.</p>'
+        );
+
+        assert.equal(
+            Markdown.format('This is a sentence with a https://[::1]:80 in it.').trim(),
+            '<p>This is a sentence with a <a class="theme markdown__link" href="https://[::1]:80" rel="noreferrer" target="_blank">https://[::1]:80</a> in it.</p>'
+        );
+
+        done();
+    });
+
+    it('Links with trailing punctuation', function(done) {
+        assert.equal(
+            Markdown.format('This is a link to http://example.com.').trim(),
+            '<p>This is a link to <a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">http://example.com</a>.</p>'
+        );
+
+        assert.equal(
+            Markdown.format('This is a link containing http://example.com/something?with,commas,in,url, but not at the end').trim(),
+            '<p>This is a link containing <a class="theme markdown__link" href="http://example.com/something?with,commas,in,url" rel="noreferrer" target="_blank">http://example.com/something?with,commas,in,url</a>, but not at the end</p>'
+        );
+
+        assert.equal(
+            Markdown.format('This is a question about a link http://example.com?').trim(),
+            '<p>This is a question about a link <a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">http://example.com</a>?</p>'
+        );
+
+        done();
+    });
+
+    it('Links with surrounding brackets', function(done) {
+        assert.equal(
+            Markdown.format('(http://example.com)').trim(),
+            '<p>(<a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">http://example.com</a>)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('(see http://example.com)').trim(),
+            '<p>(see <a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">http://example.com</a>)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('(http://example.com watch this)').trim(),
+            '<p>(<a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">http://example.com</a> watch this)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('(www.example.com)').trim(),
+            '<p>(<a class="theme markdown__link" href="http://www.example.com" rel="noreferrer" target="_blank">www.example.com</a>)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('(see www.example.com)').trim(),
+            '<p>(see <a class="theme markdown__link" href="http://www.example.com" rel="noreferrer" target="_blank">www.example.com</a>)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('(www.example.com watch this)').trim(),
+            '<p>(<a class="theme markdown__link" href="http://www.example.com" rel="noreferrer" target="_blank">www.example.com</a> watch this)</p>'
+        );
+        assert.equal(
+            Markdown.format('([link](http://example.com))').trim(),
+            '<p>(<a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">link</a>)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('(see [link](http://example.com))').trim(),
+            '<p>(see <a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">link</a>)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('([link](http://example.com) watch this)').trim(),
+            '<p>(<a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">link</a> watch this)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('(test@example.com)').trim(),
+            '<p>(<a class="theme" href="mailto:test@example.com">test@example.com</a>)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('(email test@example.com)').trim(),
+            '<p>(email <a class="theme" href="mailto:test@example.com">test@example.com</a>)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('(test@example.com email)').trim(),
+            '<p>(<a class="theme" href="mailto:test@example.com">test@example.com</a> email)</p>'
+        );
+
+        assert.equal(
+            Markdown.format('This is a sentence with a [link](http://example.com) in it.').trim(),
+            '<p>This is a sentence with a <a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">link</a> in it.</p>'
+        );
+
+        assert.equal(
+            Markdown.format('This is a sentence with a link (http://example.com) in it.').trim(),
+            '<p>This is a sentence with a link (<a class="theme markdown__link" href="http://example.com" rel="noreferrer" target="_blank">http://example.com</a>) in it.</p>'
+        );
+
+        assert.equal(
+            Markdown.format('This is a sentence with a (https://en.wikipedia.org/wiki/Rendering_(computer_graphics)) in it.').trim(),
+            '<p>This is a sentence with a (<a class="theme markdown__link" href="https://en.wikipedia.org/wiki/Rendering_(computer_graphics)" rel="noreferrer" target="_blank">https://en.wikipedia.org/wiki/Rendering_(computer_graphics)</a>) in it.</p>'
+        );
+
+        done();
+    });
+
+    it('Searching for links', function(done) {
+        assert.equal(
+            TextFormatting.formatText('https://en.wikipedia.org/wiki/Unix', {searchTerm: 'wikipedia'}).trim(),
+            '<p><a class="theme markdown__link search-highlight" href="https://en.wikipedia.org/wiki/Unix" rel="noreferrer" target="_blank">https:/<wbr />/<wbr />en.wikipedia.org/<wbr />wiki/<wbr />Unix</a></p>'
+        );
+
+        assert.equal(
+            TextFormatting.formatText('[Link](https://en.wikipedia.org/wiki/Unix)', {searchTerm: 'unix'}).trim(),
+            '<p><a class="theme markdown__link search-highlight" href="https://en.wikipedia.org/wiki/Unix" rel="noreferrer" target="_blank">Link</a></p>'
+        );
+
+        done();
+    });
+});

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -6,12 +6,11 @@ import * as SyntaxHighlighting from './syntax_hightlighting.jsx';
 
 import marked from 'marked';
 import katex from 'katex';
-import 'katex/dist/katex.min.css';
 
 function markdownImageLoaded(image) {
     image.style.height = 'auto';
 }
-window.markdownImageLoaded = markdownImageLoaded;
+global.markdownImageLoaded = markdownImageLoaded;
 
 class MattermostMarkdownRenderer extends marked.Renderer {
     constructor(options, formattingOptions = {}) {

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -163,8 +163,8 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         output += '" href="' + outHref + '" rel="noreferrer"';
 
         // special case for channel links and permalinks that are inside the app
-        if (new RegExp('^' + TextFormatting.escapeRegex(global.mm_config.SiteURL) + '\\/[^\\/]+\\/(pl|channels)\\/').test(outHref)) {
-            output += ' data-link="' + outHref.substring(global.mm_config.SiteURL.length) + '"';
+        if (this.formattingOptions.siteURL && new RegExp('^' + TextFormatting.escapeRegex(this.formattingOptions.siteURL) + '\\/[^\\/]+\\/(pl|channels)\\/').test(outHref)) {
+            output += ' data-link="' + outHref.substring(this.formattingOptions.siteURL) + '"';
         } else {
             output += ' target="_blank"';
         }

--- a/webapp/utils/syntax_hightlighting.jsx
+++ b/webapp/utils/syntax_hightlighting.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import * as Utils from './utils.jsx';
 import * as TextFormatting from './text_formatting.jsx';
 import Constants from './constants.jsx';
 
@@ -138,18 +137,17 @@ export function highlight(lang, code) {
 }
 
 export function getLanguageFromFilename(filename) {
-    const fileInfo = Utils.splitFileLocation(filename);
-    var ext = fileInfo.ext;
-    if (!ext) {
-        return null;
-    }
+    const fileSplit = filename.split('.');
 
+    let ext = fileSplit.length > 1 ? fileSplit[fileSplit.length - 1] : '';
     ext = ext.toLowerCase();
+
     for (var key in HighlightedLanguages) {
         if (HighlightedLanguages[key].extensions.find((x) => x === ext)) {
             return key;
         }
     }
+
     return null;
 }
 

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -2,14 +2,12 @@
 // See License.txt for license information.
 
 import Autolinker from 'autolinker';
-import {browserHistory} from 'react-router/es6';
 import Constants from './constants.jsx';
 import EmojiStore from 'stores/emoji_store.jsx';
 import * as Emoticons from './emoticons.jsx';
 import * as Markdown from './markdown.jsx';
 import UserStore from 'stores/user_store.jsx';
 import twemoji from 'twemoji';
-import * as Utils from './utils.jsx';
 import XRegExp from 'xregexp';
 
 // pattern to detect the existance of a Chinese, Japanese, or Korean character in a string
@@ -238,7 +236,7 @@ function highlightCurrentMentions(text, tokens) {
         return prefix + alias;
     }
 
-    for (const mention of UserStore.getCurrentMentionKeys()) {
+    for (const mention of mentionKeys) {
         if (!mention) {
             continue;
         }
@@ -431,32 +429,6 @@ export function replaceTokens(text, tokens) {
 
 function replaceNewlines(text) {
     return text.replace(/\n/g, ' ');
-}
-
-// A click handler that can be used with the results of TextFormatting.formatText to add default functionality
-// to clicked hashtags and @mentions.
-export function handleClick(e) {
-    const mentionAttribute = e.target.getAttributeNode('data-mention');
-    const hashtagAttribute = e.target.getAttributeNode('data-hashtag');
-    const linkAttribute = e.target.getAttributeNode('data-link');
-
-    if (mentionAttribute) {
-        e.preventDefault();
-
-        Utils.searchForTerm(mentionAttribute.value);
-    } else if (hashtagAttribute) {
-        e.preventDefault();
-
-        Utils.searchForTerm(hashtagAttribute.value);
-    } else if (linkAttribute) {
-        const MIDDLE_MOUSE_BUTTON = 1;
-
-        if (!(e.button === MIDDLE_MOUSE_BUTTON || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) {
-            e.preventDefault();
-
-            browserHistory.push(linkAttribute.value);
-        }
-    }
 }
 
 //replace all "/" inside <a> tags to "/<wbr />"

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -7,7 +7,6 @@ import Constants from './constants.jsx';
 import EmojiStore from 'stores/emoji_store.jsx';
 import * as Emoticons from './emoticons.jsx';
 import * as Markdown from './markdown.jsx';
-import PreferenceStore from 'stores/preference_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import twemoji from 'twemoji';
 import * as Utils from './utils.jsx';
@@ -29,11 +28,6 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 //     that can be handled by a special click handler.
 export function formatText(text, inputOptions) {
     let output = text;
-
-    // would probably make more sense if it was on the calling components, but this option is intended primarily for debugging
-    if (window.mm_config.EnableDeveloper === 'true' && PreferenceStore.get(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', 'true') === 'false') {
-        return output;
-    }
 
     const options = Object.assign({}, inputOptions);
     options.searchPatterns = parseSearchTerms(options.searchTerm).map(convertSearchTermToRegex);

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -18,7 +18,7 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 // @mentions to links by taking a user's message and returning a string of formatted html. Also takes a number of options
 // as part of the second parameter:
 // - searchTerm - If specified, this word is highlighted in the resulting html. Defaults to nothing.
-// - mentionHighlight - Specifies whether or not to highlight mentions of the current user. Defaults to true.
+// - mentionKeys - A list of mention keys for the current user to highlight.
 // - singleline - Specifies whether or not to remove newlines. Defaults to false.
 // - emoticons - Enables emoticon parsing. Defaults to true.
 // - markdown - Enables markdown parsing. Defaults to true.
@@ -67,9 +67,7 @@ export function doFormatText(text, options) {
         output = highlightSearchTerms(output, tokens, options.searchPatterns);
     }
 
-    if (!('mentionHighlight' in options) || options.mentionHighlight) {
-        output = highlightCurrentMentions(output, tokens);
-    }
+    output = highlightCurrentMentions(output, tokens, options.mentionKeys);
 
     if (!('emoticons' in options) || options.emoticon) {
         output = twemoji.parse(output, {
@@ -197,11 +195,8 @@ export function escapeRegex(text) {
     return text.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-function highlightCurrentMentions(text, tokens) {
+function highlightCurrentMentions(text, tokens, mentionKeys = []) {
     let output = text;
-
-    const mentionKeys = UserStore.getCurrentMentionKeys();
-    mentionKeys.push('@here');
 
     // look for any existing tokens which are self mentions and should be highlighted
     var newTokens = new Map();

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -18,6 +18,7 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 // @mentions to links by taking a user's message and returning a string of formatted html. Also takes a number of options
 // as part of the second parameter:
 // - searchTerm - If specified, this word is highlighted in the resulting html. Defaults to nothing.
+// - mentionHighlight - Specifies whether or not to highlight mentions of the current user. Defaults to true.
 // - mentionKeys - A list of mention keys for the current user to highlight.
 // - singleline - Specifies whether or not to remove newlines. Defaults to false.
 // - emoticons - Enables emoticon parsing. Defaults to true.
@@ -67,7 +68,9 @@ export function doFormatText(text, options) {
         output = highlightSearchTerms(output, tokens, options.searchPatterns);
     }
 
-    output = highlightCurrentMentions(output, tokens, options.mentionKeys);
+    if (!('mentionHighlight' in options) || options.mentionHighlight) {
+        output = highlightCurrentMentions(output, tokens, options.mentionKeys);
+    }
 
     if (!('emoticons' in options) || options.emoticon) {
         output = twemoji.parse(output, {

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -25,6 +25,8 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 // - singleline - Specifies whether or not to remove newlines. Defaults to false.
 // - emoticons - Enables emoticon parsing. Defaults to true.
 // - markdown - Enables markdown parsing. Defaults to true.
+// - siteURL - The origin of this Mattermost instance. If provided, links to channels and posts will be replaced with internal links
+//     that can be handled by a special click handler.
 export function formatText(text, inputOptions) {
     let output = text;
 

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -1344,3 +1344,27 @@ export function isValidPassword(password) {
 export function getSiteURL() {
     return global.mm_config.SiteURL || window.location.origin;
 }
+
+export function handleFormattedTextClick(e) {
+    const mentionAttribute = e.target.getAttributeNode('data-mention');
+    const hashtagAttribute = e.target.getAttributeNode('data-hashtag');
+    const linkAttribute = e.target.getAttributeNode('data-link');
+
+    if (mentionAttribute) {
+        e.preventDefault();
+
+        searchForTerm(mentionAttribute.value);
+    } else if (hashtagAttribute) {
+        e.preventDefault();
+
+        searchForTerm(hashtagAttribute.value);
+    } else if (linkAttribute) {
+        const MIDDLE_MOUSE_BUTTON = 1;
+
+        if (!(e.button === MIDDLE_MOUSE_BUTTON || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) {
+            e.preventDefault();
+
+            browserHistory.push(linkAttribute.value);
+        }
+    }
+}


### PR DESCRIPTION
This should've been broken down into a couple PRs, but the rest of it came naturally after I decided to add unit tests for the updated link highlighting which lead to me refactoring TextFormatting.

#### Summary

- PostMessageContainer listens to the stores for the list of emojis, mention keys for the current user, and any preferences directly used in formatting text instead of having them passed through the component tree
- PostMessageContainer passes those to PostMessageView which passes them to TextFormatting so TextFormatting doesn't rely as much on other stores and can be more easily tested.
- TextFormatting and its dependencies have changed to not rely on any code that uses window/mm_config or imports react-router since that breaks mocha-webpack. Either stuff was moved out of TextFormatting or a small bit of it was inlined.
- [Links containing the search term will be highlighted when searching](https://mattermost.atlassian.net/browse/PLT-1752)
- [Changing mention keywords will update their highlighting without a refresh](https://mattermost.atlassian.net/browse/PLT-3567)
- [Fixed an issue with links to channels/posts when SiteURL isn't set](https://mattermost.atlassian.net/browse/PLT-3998)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-1752
https://mattermost.atlassian.net/browse/PLT-3567
https://mattermost.atlassian.net/browse/PLT-3998

#### Checklist
- Added or updated unit tests (required for all new features)
