### PR TITLE
PLT-3581 Trimmed beginning slash from command trigger word 

### DIFF
--- a/webapp/components/integrations/components/add_command.jsx
+++ b/webapp/components/integrations/components/add_command.jsx
@@ -69,10 +69,15 @@ export default class AddCommand extends React.Component {
             clientError: ''
         });
 
+        let triggerWord = this.state.trigger.trim().toLowerCase();
+        if (triggerWord.indexOf('/') === 0) {
+            triggerWord = triggerWord.substr(1);
+        }
+
         const command = {
             display_name: this.state.displayName,
             description: this.state.description,
-            trigger: this.state.trigger.trim().toLowerCase(),
+            trigger: triggerWord,
             url: this.state.url.trim(),
             method: this.state.method,
             username: this.state.username,


### PR DESCRIPTION
#### Summary
Automatically trimmed the beginning '/' from the command trigger word. If there is more than one '/' in the trigger word, the error gets thrown, saying the trigger word cannot have a '/'.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3581

