### PR TITLE
PLT-3942 Add real-time updates for center channel profile picture popover

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -898,17 +898,7 @@ func getInitialLoad(c *Context, w http.ResponseWriter, r *http.Request) {
 			profiles := dp.Data.(map[string]*model.User)
 
 			for k, p := range profiles {
-				options := utils.Cfg.GetSanitizeOptions()
-				options["passwordupdate"] = false
-
-				if c.IsSystemAdmin() {
-					options["fullname"] = true
-					options["email"] = true
-				} else {
-					p.ClearNonProfileFields()
-				}
-
-				p.Sanitize(options)
+				p.SanitizeProfile(c.IsSystemAdmin(), false, true, true)
 				profiles[k] = p
 			}
 
@@ -984,17 +974,7 @@ func getProfilesForDirectMessageList(c *Context, w http.ResponseWriter, r *http.
 		profiles := result.Data.(map[string]*model.User)
 
 		for k, p := range profiles {
-			options := utils.Cfg.GetSanitizeOptions()
-			options["passwordupdate"] = false
-
-			if c.IsSystemAdmin() {
-				options["fullname"] = true
-				options["email"] = true
-			} else {
-				p.ClearNonProfileFields()
-			}
-
-			p.Sanitize(options)
+			p.SanitizeProfile(c.IsSystemAdmin(), false, false, false)
 			profiles[k] = p
 		}
 
@@ -1024,17 +1004,7 @@ func getProfiles(c *Context, w http.ResponseWriter, r *http.Request) {
 		profiles := result.Data.(map[string]*model.User)
 
 		for k, p := range profiles {
-			options := utils.Cfg.GetSanitizeOptions()
-			options["passwordupdate"] = false
-
-			if c.IsSystemAdmin() {
-				options["fullname"] = true
-				options["email"] = true
-			} else {
-				p.ClearNonProfileFields()
-			}
-
-			p.Sanitize(options)
+			p.SanitizeProfile(c.IsSystemAdmin(), false, true, true)
 			profiles[k] = p
 		}
 
@@ -1056,17 +1026,7 @@ func getDirectProfiles(c *Context, w http.ResponseWriter, r *http.Request) {
 		profiles := result.Data.(map[string]*model.User)
 
 		for k, p := range profiles {
-			options := utils.Cfg.GetSanitizeOptions()
-			options["passwordupdate"] = false
-
-			if c.IsSystemAdmin() {
-				options["fullname"] = true
-				options["email"] = true
-			} else {
-				p.ClearNonProfileFields()
-			}
-
-			p.Sanitize(options)
+			p.SanitizeProfile(c.IsSystemAdmin(), false, true, true)
 			profiles[k] = p
 		}
 
@@ -1316,7 +1276,7 @@ func uploadProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		l4g.Error(utils.T("api.user.get_me.getting.error"), c.Session.UserId)
 	} else {
 		user := result.Data.(*model.User)
-		user.Sanitize(map[string]bool{})
+		user.SanitizeProfile(c.IsSystemAdmin(), false, true, true)
 		message := model.NewWebSocketEvent("", "", c.Session.UserId, model.WEBSOCKET_EVENT_USER_UPDATED)
 		message.Add("user", user)
 		go Publish(message)
@@ -1366,7 +1326,7 @@ func updateUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		updatedUser := rusers[0]
-		updatedUser.Sanitize(map[string]bool{})
+		updatedUser.SanitizeProfile(c.IsSystemAdmin(), false, true, true)
 
 		message := model.NewWebSocketEvent("", "", user.Id, model.WEBSOCKET_EVENT_USER_UPDATED)
 		message.Add("user", updatedUser)

--- a/api/user.go
+++ b/api/user.go
@@ -1312,6 +1312,9 @@ func uploadProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	Srv.Store.User().UpdateLastPictureUpdate(c.Session.UserId)
 
+	message := model.NewWebSocketEvent("", "", c.Session.UserId, model.WEBSOCKET_EVENT_USER_UPDATED)
+	go Publish(message)
+
 	c.LogAudit("")
 
 	// write something as the response since jQuery expects a json response
@@ -1354,6 +1357,9 @@ func updateUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		if rusers[0].Username != rusers[1].Username {
 			go sendEmailChangeUsername(c, rusers[1].Username, rusers[0].Username, rusers[0].Email, c.GetSiteURL())
 		}
+
+		message := model.NewWebSocketEvent("", "", user.Id, model.WEBSOCKET_EVENT_USER_UPDATED)
+		go Publish(message)
 
 		rusers[0].Password = ""
 		rusers[0].AuthData = new(string)

--- a/model/user.go
+++ b/model/user.go
@@ -251,6 +251,22 @@ func (u *User) ClearNonProfileFields() {
 	u.FailedAttempts = 0
 }
 
+func (u *User) SanitizeProfile(isSystemAdmin, pwdupdate, fullname, email bool) {
+	options := map[string]bool{}
+	options["passwordupdate"] = pwdupdate
+
+	if isSystemAdmin {
+		options["fullname"] = true
+		options["email"] = true
+	} else {
+		options["fullname"] = fullname
+		options["email"] = email
+		u.ClearNonProfileFields()
+	}
+
+	u.Sanitize(options)
+}
+
 func (u *User) MakeNonNil() {
 	if u.Props == nil {
 		u.Props = make(map[string]string)

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -19,6 +19,7 @@ const (
 	WEBSOCKET_EVENT_NEW_USER           = "new_user"
 	WEBSOCKET_EVENT_LEAVE_TEAM         = "leave_team"
 	WEBSOCKET_EVENT_USER_ADDED         = "user_added"
+	WEBSOCKET_EVENT_USER_UPDATED       = "user_updated"
 	WEBSOCKET_EVENT_USER_REMOVED       = "user_removed"
 	WEBSOCKET_EVENT_PREFERENCE_CHANGED = "preference_changed"
 	WEBSOCKET_EVENT_EPHEMERAL_MESSAGE  = "ephemeral_message"

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -128,6 +128,10 @@ function handleEvent(msg) {
         handleUserRemovedEvent(msg);
         break;
 
+    case SocketEvents.USER_UPDATED:
+        handleUserUpdatedEvent(msg);
+        break;
+
     case SocketEvents.CHANNEL_VIEWED:
         handleChannelViewedEvent(msg);
         break;
@@ -238,6 +242,12 @@ function handleUserRemovedEvent(msg) {
         }
     } else if (ChannelStore.getCurrentId() === msg.channel_id) {
         AsyncClient.getChannelExtraInfo();
+    }
+}
+
+function handleUserUpdatedEvent(msg) {
+    if (UserStore.getCurrentId() !== msg.user_id) {
+        AsyncClient.getProfiles();
     }
 }
 

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -247,7 +247,8 @@ function handleUserRemovedEvent(msg) {
 
 function handleUserUpdatedEvent(msg) {
     if (UserStore.getCurrentId() !== msg.user_id) {
-        AsyncClient.getProfiles();
+        UserStore.saveProfile(msg.data.user);
+        UserStore.emitChange(msg.user_id);
     }
 }
 

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -194,6 +194,7 @@ export const Constants = {
         LEAVE_TEAM: 'leave_team',
         USER_ADDED: 'user_added',
         USER_REMOVED: 'user_removed',
+        USER_UPDATED: 'user_updated',
         TYPING: 'typing',
         PREFERENCE_CHANGED: 'preference_changed',
         EPHEMERAL_MESSAGE: 'ephemeral_message',


### PR DESCRIPTION
#### Summary
Added a Websocket event that notifies when a user has updated their profile as in:
* First name
* Lastname
* Nickname
* Username
* Email
* Profile picture

once this event fires then every other user will fetch the profiles to update the center channel and every other component that listens for User change.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3942