### PR TITLE
Revert/Fix PLT-2805

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -354,7 +354,7 @@ func PostUpdateChannelHeaderMessage(c *Context, channelId string, oldChannelHead
 			Type:      model.POST_HEADER_CHANGE,
 			UserId:    c.Session.UserId,
 		}
-		if _, err := CreatePost(c.TeamId, post, false); err != nil {
+		if _, err := CreatePost(c, post, false); err != nil {
 			l4g.Error(utils.T("api.channel.post_update_channel_header_message_and_forget.join_leave.error"), err)
 		}
 	}
@@ -546,7 +546,7 @@ func PostUserAddRemoveMessage(c *Context, channelId string, message, postType st
 		Type:      postType,
 		UserId:    c.Session.UserId,
 	}
-	if _, err := CreatePost(c.TeamId, post, false); err != nil {
+	if _, err := CreatePost(c, post, false); err != nil {
 		l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 	}
 }
@@ -618,7 +618,16 @@ func JoinDefaultChannels(teamId string, user *model.User, channelRole string) *m
 			Type:      model.POST_JOIN_LEAVE,
 			UserId:    user.Id,
 		}
-		if _, err := CreatePost(teamId, post, false); err != nil {
+
+		fakeContext := &Context{
+			Session: model.Session{
+				UserId: user.Id,
+			},
+			TeamId: teamId,
+			T:      utils.TfuncWithFallback(user.Locale),
+		}
+
+		if _, err := CreatePost(fakeContext, post, false); err != nil {
 			l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 		}
 	}
@@ -794,7 +803,7 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 				Type:      model.POST_CHANNEL_DELETED,
 				UserId:    c.Session.UserId,
 			}
-			if _, err := CreatePost(c.TeamId, post, false); err != nil {
+			if _, err := CreatePost(c, post, false); err != nil {
 				l4g.Error(utils.T("api.channel.delete_channel.failed_post.error"), err)
 			}
 		}()

--- a/api/command.go
+++ b/api/command.go
@@ -248,7 +248,7 @@ func handleResponse(c *Context, w http.ResponseWriter, response *model.CommandRe
 	if response.ResponseType == model.COMMAND_RESPONSE_TYPE_IN_CHANNEL {
 		post.Message = response.Text
 		post.UserId = c.Session.UserId
-		if _, err := CreatePost(c.TeamId, post, true); err != nil {
+		if _, err := CreatePost(c, post, true); err != nil {
 			c.Err = model.NewLocAppError("command", "api.command.execute_command.save.app_error", nil, "")
 		}
 	} else if response.ResponseType == model.COMMAND_RESPONSE_TYPE_EPHEMERAL && response.Text != "" {

--- a/api/command_echo.go
+++ b/api/command_echo.go
@@ -81,7 +81,7 @@ func (me *EchoProvider) DoCommand(c *Context, channelId string, message string) 
 
 		time.Sleep(time.Duration(delay) * time.Second)
 
-		if _, err := CreatePost(c.TeamId, post, true); err != nil {
+		if _, err := CreatePost(c, post, true); err != nil {
 			l4g.Error(c.T("api.command_echo.create.app_error"), err)
 		}
 	}()

--- a/api/command_loadtest.go
+++ b/api/command_loadtest.go
@@ -357,7 +357,7 @@ func (me *LoadTestProvider) UrlCommand(c *Context, channelId string, message str
 		post.ChannelId = channelId
 		post.UserId = c.Session.UserId
 
-		if _, err := CreatePost(c.TeamId, post, false); err != nil {
+		if _, err := CreatePost(c, post, false); err != nil {
 			return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 	}
@@ -396,7 +396,7 @@ func (me *LoadTestProvider) JsonCommand(c *Context, channelId string, message st
 		post.Message = message
 	}
 
-	if _, err := CreatePost(c.TeamId, post, false); err != nil {
+	if _, err := CreatePost(c, post, false); err != nil {
 		return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 	return &model.CommandResponse{Text: "Loaded data", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}

--- a/api/command_msg.go
+++ b/api/command_msg.go
@@ -85,7 +85,7 @@ func (me *msgProvider) DoCommand(c *Context, channelId string, message string) *
 					post.Message = parsedMessage
 					post.ChannelId = targetChannelId
 					post.UserId = c.Session.UserId
-					if _, err := CreatePost(c.TeamId, post, true); err != nil {
+					if _, err := CreatePost(c, post, true); err != nil {
 						return &model.CommandResponse{Text: c.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 					}
 				}

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -482,7 +482,7 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	c.Err = nil
 
-	if _, err := CreateWebhookPost(hook.UserId, channel.Id, hook.TeamId, text, overrideUsername, overrideIconUrl, parsedRequest.Props, webhookType); err != nil {
+	if _, err := CreateWebhookPost(c, channel.Id, text, overrideUsername, overrideIconUrl, parsedRequest.Props, webhookType); err != nil {
 		c.Err = err
 		return
 	}


### PR DESCRIPTION
#### Summary
- Reverted PLT-2805 by not ripping out `c *Context` from a bunch of functions
- Kept functionality of PLT-2805 by making a fake `Context`

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-2805
https://mattermost.atlassian.net/browse/PLT-3991

