### PR TITLE
PLT-3892 Added custom logging package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,16 +161,18 @@ test-server: start-docker prepare-enterprise
 
 	$(GO) test $(GOFLAGS) -run=$(TESTS) -test.v -test.timeout=440s -covermode=count -coverprofile=capi.out ./api || exit 1
 	$(GO) test $(GOFLAGS) -run=$(TESTS) -test.v -test.timeout=60s -covermode=count -coverprofile=cmodel.out ./model || exit 1
+	$(GO) test $(GOFLAGS) -run=$(TESTS) -test.v -test.timeout=30s -covermode=count -coverprofile=clog.out ./log || exit 1
 	$(GO) test $(GOFLAGS) -run=$(TESTS) -test.v -test.timeout=180s -covermode=count -coverprofile=cstore.out ./store || exit 1
 	$(GO) test $(GOFLAGS) -run=$(TESTS) -test.v -test.timeout=120s -covermode=count -coverprofile=cutils.out ./utils || exit 1
 	$(GO) test $(GOFLAGS) -run=$(TESTS) -test.v -test.timeout=120s -covermode=count -coverprofile=cweb.out ./web || exit 1
 
 	tail -n +2 capi.out >> cover.out
 	tail -n +2 cmodel.out >> cover.out
+	tail -n +2 clog.out >> cover.out
 	tail -n +2 cstore.out >> cover.out
 	tail -n +2 cutils.out >> cover.out
 	tail -n +2 cweb.out >> cover.out
-	rm -f capi.out cmodel.out cstore.out cutils.out cweb.out
+	rm -f capi.out cmodel.out clog.out cstore.out cutils.out cweb.out
 
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo Running Enterprise tests

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2588,6 +2588,38 @@
     "translation": "Yes"
   },
   {
+    "id": "log_test.debug",
+    "translation": "Testing debug logging"
+  },
+  {
+    "id": "log_test.debug_param",
+    "translation": "Testing debug logging, param=%v"
+  },
+  {
+    "id": "log_test.info",
+    "translation": "Testing info logging"
+  },
+  {
+    "id": "log_test.info_param",
+    "translation": "Testing info logging, param=%v"
+  },
+  {
+    "id": "log_test.warn",
+    "translation": "Testing warning logging"
+  },
+  {
+    "id": "log_test.warn_param",
+    "translation": "Testing warning logging, param=%v"
+  },
+  {
+    "id": "log_test.error",
+    "translation": "Testing error logging"
+  },
+  {
+    "id": "log_test.error_param",
+    "translation": "Testing error logging, param=%v"
+  },
+  {
     "id": "manaultesting.get_channel_id.no_found.debug",
     "translation": "Could not find channel: %v, %v possibilites searched"
   },

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package log
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mattermost/platform/model"
+	"github.com/nicksnyder/go-i18n/i18n"
+)
+
+const (
+	DEBUG   = "[debug]"
+	INFO    = "[info]"
+	WARNING = "[warn]"
+	ERROR   = "[error]"
+)
+
+var Level = DEBUG
+var EnableConsole = true
+var LogFile *os.File
+var T i18n.TranslateFunc
+
+func Open(fileLocation string) {
+	file, err := os.Create(fileLocation)
+
+	if err != nil {
+		fmt.Println("Log file failed to initialize")
+		panic(err)
+	}
+
+	if LogFile != nil {
+		fmt.Println("Log file not nil")
+		return
+	}
+
+	LogFile = file
+}
+
+func Close() {
+	err := LogFile.Close()
+
+	if err != nil {
+		fmt.Println("Log file failed to close")
+		panic(err)
+	}
+
+	LogFile = nil
+}
+
+func SetLocale(locale string) {
+	t, _ := i18n.Tfunc(locale)
+	T = func(translationID string, args ...interface{}) string {
+		if translated := t(translationID, args...); translated != translationID {
+			return translated
+		}
+
+		t, _ := i18n.Tfunc(model.DEFAULT_LOCALE)
+		return t(translationID, args...)
+	}
+}
+
+func Debug(debugId string, args ...interface{}) {
+	message := fmt.Sprintf(T(debugId), args)
+
+	log(DEBUG, message)
+}
+
+func Info(infoId string, args ...interface{}) {
+	message := fmt.Sprintf(T(infoId), args)
+
+	log(INFO, message)
+}
+
+func Warn(warnId string, args ...interface{}) {
+	message := fmt.Sprintf(T(warnId), args)
+
+	log(WARNING, message)
+}
+
+func Error(err *model.AppError) {
+	err.Translate(T)
+
+	log(ERROR, err.Error())
+}
+
+func Errorf(errString string, args ...interface{}) {
+	message := fmt.Sprintf(errString, args)
+
+	log(ERROR, message)
+}
+
+func log(logType string, message string) {
+	if message == "" {
+		return
+	}
+
+	fullMessage := fmt.Sprintf("%s %s \"%s\"", getTimeStamp(), logType, message)
+
+	if shouldPrint(logType) {
+		if EnableConsole {
+			fmt.Println(fullMessage)
+		}
+
+		if LogFile != nil {
+			LogFile.WriteString(fullMessage + "\n")
+		}
+	}
+}
+
+func getTimeStamp() string {
+	time := time.Now()
+	month, day, year := time.Month(), time.Day(), time.Year()
+	hour, minute, second := time.Hour(), time.Minute(), time.Second()
+	_, offset := time.Zone() // offset given in seconds
+
+	offsetSign := '+'
+	if offset < 0 {
+		offsetSign = '-'
+	}
+	offsetHour := offset / 3600
+	offsetMinute := offset % 3600
+
+	return fmt.Sprintf("[%02d/%02d/%04d:%02d:%02d:%02d %c%02d%02d]", day, month, year, hour, minute, second, offsetSign, offsetHour, offsetMinute)
+}
+
+func shouldPrint(logType string) bool {
+	if Level == INFO && logType == DEBUG {
+		return false
+	}
+
+	if Level == WARNING && (logType == DEBUG || logType == INFO) {
+		return false
+	}
+
+	if Level == ERROR && (logType == DEBUG || logType == INFO || logType == WARNING) {
+		return false
+	}
+
+	return true
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package log
+
+import (
+	"testing"
+
+	"github.com/mattermost/platform/model"
+)
+
+const (
+	DEFAULT_LOCATION = "./mattermost.log"
+)
+
+func TestLogDebug(t *testing.T) {
+	Open(DEFAULT_LOCATION)
+	SetLocale("en")
+	Debug("log_test.debug")
+	Debug("log_test.debug_param", "test")
+	Close()
+}
+
+func TestLogInfo(t *testing.T) {
+	Open(DEFAULT_LOCATION)
+	SetLocale("en")
+	Info("log_test.info")
+	Info("log_test.info_param", "test")
+	Close()
+}
+
+func TestLogWarn(t *testing.T) {
+	Open(DEFAULT_LOCATION)
+	SetLocale("en")
+	Warn("log_test.warn")
+	Warn("log_test.warn_param", "test")
+	Close()
+}
+
+func TestLogError(t *testing.T) {
+	Open(DEFAULT_LOCATION)
+	SetLocale("en")
+	err1 := model.NewLocAppError("log.test", "log_test.error", nil, "")
+	Error(err1)
+
+	err2 := model.NewLocAppError("log.test", "log_test.error_param", map[string]interface{}{
+		"test": "abc",
+	}, "this should print")
+	Error(err2)
+	Close()
+}
+
+func TestLogErrorf(t *testing.T) {
+	Open(DEFAULT_LOCATION)
+	SetLocale("en")
+	Errorf("This is a raw string")
+	Errorf("This is a string with %s and %s", "hello", "happy")
+	Close()
+}


### PR DESCRIPTION
#### Summary
A custom logging package in NGINX format, yay!
Currently not used anywhere, passes unit tests.

Logs are as such
`[DD/MM/YYYY:HH:MM:SS +HHMM] [error] "message here"`

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3892

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization files updated
