### PR TITLE
PLT-4007 Fix OAuth: Javascript error when team admin accesses the OAuth 2.0 menu

### DIFF
--- a/webapp/components/backstage/components/backstage_sidebar.jsx
+++ b/webapp/components/backstage/components/backstage_sidebar.jsx
@@ -40,6 +40,7 @@ export default class BackstageSidebar extends React.Component {
 
     renderIntegrations() {
         const config = window.mm_config;
+        const isSystemAdmin = Utils.isSystemAdmin(this.props.user.roles);
         if (config.EnableIncomingWebhooks !== 'true' &&
             config.EnableOutgoingWebhooks !== 'true' &&
             config.EnableCommands !== 'true' &&
@@ -48,7 +49,7 @@ export default class BackstageSidebar extends React.Component {
         }
 
         if (config.EnableOnlyAdminIntegrations !== 'false' &&
-            !Utils.isSystemAdmin(this.props.user.roles) &&
+            !isSystemAdmin &&
             !TeamStore.isTeamAdmin(this.props.user.id, this.props.team.id)) {
             return null;
         }
@@ -99,7 +100,7 @@ export default class BackstageSidebar extends React.Component {
         }
 
         let oauthApps = null;
-        if (config.EnableOAuthServiceProvider === 'true') {
+        if (config.EnableOAuthServiceProvider === 'true' && (isSystemAdmin || config.EnableOnlyAdminIntegrations !== 'true')) {
             oauthApps = (
                 <BackstageSection
                     name='oauth2-apps'

--- a/webapp/components/integrations/components/integrations.jsx
+++ b/webapp/components/integrations/components/integrations.jsx
@@ -11,16 +11,20 @@ import OutgoingWebhookIcon from 'images/outgoing_webhook.jpg';
 import SlashCommandIcon from 'images/slash_command_icon.jpg';
 import OAuthIcon from 'images/oauth_icon.png';
 
+import * as Utils from 'utils/utils.jsx';
+
 export default class Integrations extends React.Component {
     static get propTypes() {
         return {
-            team: React.propTypes.object.isRequired
+            team: React.propTypes.object.isRequired,
+            user: React.PropTypes.object.isRequired
         };
     }
 
     render() {
         const options = [];
         const config = window.mm_config;
+        const isSystemAdmin = Utils.isSystemAdmin(this.props.user.roles);
 
         if (config.EnableIncomingWebhooks === 'true') {
             options.push(
@@ -88,7 +92,7 @@ export default class Integrations extends React.Component {
             );
         }
 
-        if (config.EnableOAuthServiceProvider === 'true') {
+        if (config.EnableOAuthServiceProvider === 'true' && (isSystemAdmin || config.EnableOnlyAdminIntegrations !== 'true')) {
             options.push(
                 <IntegrationOption
                     key='oauth2Apps'

--- a/webapp/components/navbar_dropdown.jsx
+++ b/webapp/components/navbar_dropdown.jsx
@@ -205,7 +205,7 @@ export default class NavbarDropdown extends React.Component {
             config.EnableIncomingWebhooks === 'true' ||
             config.EnableOutgoingWebhooks === 'true' ||
             config.EnableCommands === 'true' ||
-            config.EnableOAuthServiceProvider === 'true';
+            (config.EnableOAuthServiceProvider === 'true' && (isSystemAdmin || config.EnableOnlyAdminIntegrations !== 'true'));
         if (integrationsEnabled && (isAdmin || config.EnableOnlyAdminIntegrations !== 'true')) {
             integrationsLink = (
                 <li>


### PR DESCRIPTION
#### Summary
The ticket says that Accessing OAuth 2.0 apps as a Team Admin was throwing a JS error.

Cause OAuth 2.0 apps are system wide and not team wide I made it so If the setting for "Restrict Integrations to System and Team Admins" is enabled then the OAuth 2.0 apps in backstage are only visible to System Admins, in case the setting is disabled then it will show the option to every user.

There is a discussion queue for UX on How to handle OAuth vs Webhooks/Commands permissions (https://pre-release.mattermost.com/core/pl/x77bq3yg5fb7xjbj8ck9cwzxrr)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4007