### PR TITLE
PLT-3994 Fix OAuth2: Properly handle allowing an app fails

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -152,24 +152,27 @@ func allowOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("attempt")
 
-	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	w.Header().Set("Content-Type", "application/json")
 	responseData := map[string]string{}
 
 	responseType := r.URL.Query().Get("response_type")
 	if len(responseType) == 0 {
 		c.Err = model.NewLocAppError("allowOAuth", "api.oauth.allow_oauth.bad_response.app_error", nil, "")
+		c.Err.StatusCode = http.StatusBadRequest
 		return
 	}
 
 	clientId := r.URL.Query().Get("client_id")
 	if len(clientId) != 26 {
 		c.Err = model.NewLocAppError("allowOAuth", "api.oauth.allow_oauth.bad_client.app_error", nil, "")
+		c.Err.StatusCode = http.StatusBadRequest
 		return
 	}
 
 	redirectUri := r.URL.Query().Get("redirect_uri")
 	if len(redirectUri) == 0 {
 		c.Err = model.NewLocAppError("allowOAuth", "api.oauth.allow_oauth.bad_redirect.app_error", nil, "")
+		c.Err.StatusCode = http.StatusBadRequest
 		return
 	}
 
@@ -191,6 +194,7 @@ func allowOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !app.IsValidRedirectURL(redirectUri) {
 		c.LogAudit("fail - redirect_uri did not match registered callback")
 		c.Err = model.NewLocAppError("allowOAuth", "api.oauth.allow_oauth.redirect_callback.app_error", nil, "")
+		c.Err.StatusCode = http.StatusBadRequest
 		return
 	}
 
@@ -226,7 +230,6 @@ func allowOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.LogAudit("success")
 
 	responseData["redirect"] = redirectUri + "?code=" + url.QueryEscape(authData.Code) + "&state=" + url.QueryEscape(authData.State)
-	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(model.MapToJson(responseData)))
 }
 

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -152,7 +152,6 @@ func allowOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("attempt")
 
-	w.Header().Set("Content-Type", "application/json")
 	responseData := map[string]string{}
 
 	responseType := r.URL.Query().Get("response_type")

--- a/webapp/components/authorize.jsx
+++ b/webapp/components/authorize.jsx
@@ -2,9 +2,9 @@
 // See License.txt for license information.
 
 import Client from 'client/web_client.jsx';
+import FormError from 'components/form_error.jsx';
 
 import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
-
 import React from 'react';
 
 import icon50 from 'images/icon50x50.png';
@@ -52,8 +52,8 @@ export default class Authorize extends React.Component {
                     window.location.href = data.redirect;
                 }
             },
-            () => {
-                //Do nothing on error
+            (err) => {
+                this.setState({error: err.message});
             }
         );
     }
@@ -73,6 +73,15 @@ export default class Authorize extends React.Component {
             icon = app.icon_url;
         } else {
             icon = icon50;
+        }
+
+        let error;
+        if (this.state.error) {
+            error = (
+                <div className='prompt__error form-group'>
+                    <FormError error={this.state.error}/>
+                </div>
+            );
         }
 
         return (
@@ -137,6 +146,7 @@ export default class Authorize extends React.Component {
                             />
                         </button>
                     </div>
+                    {error}
                 </div>
             </div>
         );

--- a/webapp/sass/components/_oauth.scss
+++ b/webapp/sass/components/_oauth.scss
@@ -40,4 +40,8 @@
         padding: 1.5em 0;
         text-align: right;
     }
+
+    .prompt__error {
+        display: inline-block;
+    }
 }


### PR DESCRIPTION
#### Summary
When allowing an OAuth 2.0 App fails the failure is handle like this:

If an error occurs during authorization, two situations can occur.

The first is, that the client is not authenticated or recognized. For instance, a wrong redirect URI was sent in the request. In that case the authorization server must not redirect the resource owner to the redirect URI. Instead it should inform the resource owner of the error.

The second situation is that client is authenticated correctly, but that something else failed. In that case the following error response is sent to the client, included in the redirect URI:
```
error	Required. Must be one of a set of predefined error codes. See the specification for the codes and their meaning.
state	Required, if present in authorization request. The same value as sent in the state parameter in the request.
```

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3994

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
