### PR TITLE
PLT-3980 sort custom emoji alphabetically by id.

### DIFF
--- a/webapp/stores/emoji_store.jsx
+++ b/webapp/stores/emoji_store.jsx
@@ -54,6 +54,7 @@ class EmojiStore extends EventEmitter {
             this.addCustomEmoji(emoji);
         }
 
+        this.sortCustomEmojis();
         this.updateEmojiMap();
     }
 
@@ -72,6 +73,10 @@ class EmojiStore extends EventEmitter {
         }
 
         this.updateEmojiMap();
+    }
+
+    sortCustomEmojis() {
+        this.customEmojis = new Map([...this.customEmojis.entries()].sort((a, b) => a[0].localeCompare(b[0])));
     }
 
     updateEmojiMap() {


### PR DESCRIPTION
#### Summary
Sorts custom emoji alphabetically by id in the store, so that they are displayed in order by default wherever they appear. Verified that this works on the "Custom Emoji" page.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3980

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes

I couldn't find any unit tests for the stores, hence no unit test for this change. I'm not sure if they don't exist, or if I just haven't been looking for them in the right place.