### PR TITLE
PLT-4026 Use client dir constant for OAuth Authorization page

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -429,7 +429,7 @@ func authorizeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
 	w.Header().Set("Cache-Control", "no-cache, max-age=31556926, public")
-	http.ServeFile(w, r, utils.FindDir("webapp/dist")+"root.html")
+	http.ServeFile(w, r, utils.FindDir(model.CLIENT_DIR)+"root.html")
 }
 
 func getAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/model/client.go
+++ b/model/client.go
@@ -35,6 +35,8 @@ const (
 	STATUS_OK                 = "OK"
 	STATUS_FAIL               = "FAIL"
 
+	CLIENT_DIR = "webapp/dist"
+
 	API_URL_SUFFIX_V1 = "/api/v1"
 	API_URL_SUFFIX_V3 = "/api/v3"
 	API_URL_SUFFIX    = API_URL_SUFFIX_V3

--- a/web/web.go
+++ b/web/web.go
@@ -16,17 +16,13 @@ import (
 	"github.com/mssola/user_agent"
 )
 
-const (
-	CLIENT_DIR = "webapp/dist"
-)
-
 func InitWeb() {
 	l4g.Debug(utils.T("web.init.debug"))
 
 	mainrouter := api.Srv.Router
 
 	if *utils.Cfg.ServiceSettings.WebserverMode != "disabled" {
-		staticDir := utils.FindDir(CLIENT_DIR)
+		staticDir := utils.FindDir(model.CLIENT_DIR)
 		l4g.Debug("Using client directory at %v", staticDir)
 		if *utils.Cfg.ServiceSettings.WebserverMode == "gzip" {
 			mainrouter.PathPrefix("/static/").Handler(gziphandler.GzipHandler(staticHandler(http.StripPrefix("/static/", http.FileServer(http.Dir(staticDir))))))
@@ -76,5 +72,5 @@ func root(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Cache-Control", "no-cache, max-age=31556926, public")
-	http.ServeFile(w, r, utils.FindDir(CLIENT_DIR)+"root.html")
+	http.ServeFile(w, r, utils.FindDir(model.CLIENT_DIR)+"root.html")
 }


### PR DESCRIPTION
#### Summary
OAuth Authorization page had the dir for the client hardcoded instead of using a variable like `web.go`

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4026
