### PR TITLE
mail: allow PLAIN auth over non-tls connections

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	CONN_SECURITY_NONE     = ""
+	CONN_SECURITY_PLAIN    = "PLAIN"
 	CONN_SECURITY_TLS      = "TLS"
 	CONN_SECURITY_STARTTLS = "STARTTLS"
 
@@ -964,7 +965,7 @@ func (o *Config) IsValid() *AppError {
 		return NewLocAppError("Config.IsValid", "model.config.is_valid.file_salt.app_error", nil, "")
 	}
 
-	if !(o.EmailSettings.ConnectionSecurity == CONN_SECURITY_NONE || o.EmailSettings.ConnectionSecurity == CONN_SECURITY_TLS || o.EmailSettings.ConnectionSecurity == CONN_SECURITY_STARTTLS) {
+	if !(o.EmailSettings.ConnectionSecurity == CONN_SECURITY_NONE || o.EmailSettings.ConnectionSecurity == CONN_SECURITY_TLS || o.EmailSettings.ConnectionSecurity == CONN_SECURITY_STARTTLS || o.EmailSettings.ConnectionSecurity == CONN_SECURITY_PLAIN) {
 		return NewLocAppError("Config.IsValid", "model.config.is_valid.email_security.app_error", nil, "")
 	}
 

--- a/webapp/components/admin_console/connection_security_dropdown_setting.jsx
+++ b/webapp/components/admin_console/connection_security_dropdown_setting.jsx
@@ -30,6 +30,20 @@ const CONNECTION_SECURITY_HELP_TEXT = (
             <tr>
                 <td>
                     <FormattedMessage
+                        id='admin.connectionSecurityPlain'
+                        defaultMessage='PLAIN'
+                    />
+                </td>
+                <td>
+                    <FormattedMessage
+                        id='admin.connectionSecurityPlainDescription'
+                        defaultMessage='Mattermost will connect and authenticate over an unsecure connection.'
+                    />
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <FormattedMessage
                         id='admin.connectionSecurityTls'
                         defaultMessage='TLS'
                     />
@@ -66,6 +80,7 @@ export default class ConnectionSecurityDropdownSetting extends React.Component {
                 id='connectionSecurity'
                 values={[
                     {value: '', text: Utils.localizeMessage('admin.connectionSecurityNone', 'None')},
+                    {value: 'PLAIN', text: Utils.localizeMessage('admin.connectionSecurityPlain')},
                     {value: 'TLS', text: Utils.localizeMessage('admin.connectionSecurityTls', 'TLS (Recommended)')},
                     {value: 'STARTTLS', text: Utils.localizeMessage('admin.connectionSecurityStart')}
                 ]}

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -198,6 +198,8 @@
   "admin.compliance_table.userId": "Requested By",
   "admin.connectionSecurityNone": "None",
   "admin.connectionSecurityNoneDescription": "Mattermost will connect over an unsecure connection.",
+  "admin.connectionSecurityPlain": "PLAIN",
+  "admin.connectionSecurityPlainDescription": "Mattermost will connect and authenticate over an unsecure connection.",
   "admin.connectionSecurityStart": "STARTTLS",
   "admin.connectionSecurityStartDescription": "Takes an existing insecure connection and attempts to upgrade it to a secure connection using TLS.",
   "admin.connectionSecurityTest": "Test Connection",


### PR DESCRIPTION
#### Summary
This allows mattermost to use a non-tls connection with a SMTP server that
supports PLAIN auth (but not LOGIN). The go library explicitly allows PLAIN
auth over non-tls connections - https://golang.org/src/net/smtp/auth.go#L55

Fixes #2929

#### Ticket Link
https://github.com/mattermost/platform/issues/2929

#### Checklist
- [x] Includes text changes and localization files updated
