### PR TITLE
Remove getPosts request after deleting a post

### DIFF
--- a/webapp/components/delete_post_modal.jsx
+++ b/webapp/components/delete_post_modal.jsx
@@ -55,7 +55,6 @@ export default class DeletePostModal extends React.Component {
             this.state.post.id,
             () => {
                 PostStore.deletePost(this.state.post);
-                AsyncClient.getPosts(this.state.post.channel_id);
 
                 if (this.state.post.id === PostStore.getSelectedPostId()) {
                     AppDispatcher.handleServerAction({

--- a/webapp/components/post_view/components/post_info.jsx
+++ b/webapp/components/post_view/components/post_info.jsx
@@ -147,7 +147,10 @@ export default class PostInfo extends React.Component {
                     <a
                         href='#'
                         role='menuitem'
-                        onClick={() => GlobalActions.showDeletePostModal(post, dataComments)}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            GlobalActions.showDeletePostModal(post, dataComments);
+                        }}
                     >
                         <FormattedMessage
                             id='post_info.del'

--- a/webapp/components/rhs_comment.jsx
+++ b/webapp/components/rhs_comment.jsx
@@ -200,7 +200,10 @@ export default class RhsComment extends React.Component {
                     <a
                         href='#'
                         role='menuitem'
-                        onClick={() => GlobalActions.showDeletePostModal(post, 0)}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            GlobalActions.showDeletePostModal(post, 0);
+                        }}
                     >
                         <FormattedMessage
                             id='rhs_comment.del'

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -216,6 +216,11 @@ class PostStoreClass extends EventEmitter {
                     if (combinedPosts.order.indexOf(pid) === -1 && newPosts.order.indexOf(pid) !== -1) {
                         combinedPosts.order.push(pid);
                     }
+                } else if (combinedPosts.posts.hasOwnProperty(pid)) {
+                    combinedPosts.posts[pid] = Object.assign({}, np, {
+                        state: Constants.POST_DELETED,
+                        filenames: []
+                    });
                 }
             }
         }


### PR DESCRIPTION
#### Summary
* Remove getPosts request after deleting a post since it's not needed and was causing issues
* Remove appending of `#`to the URL when opening the delete post modal
* When receiving posts that have been deleted, check if we have those posts then set the state to deleted if so

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4014