### PR TITLE
PLT-4000 Disable PDFJS worker to fix desktop app

### DIFF
--- a/webapp/root.jsx
+++ b/webapp/root.jsx
@@ -7,6 +7,7 @@ require('perfect-scrollbar/jquery')($);
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Router, browserHistory} from 'react-router/es6';
+import PDFJS from 'pdfjs-dist';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import * as Websockets from 'actions/websocket_actions.jsx';
 import BrowserStore from 'stores/browser_store.jsx';
@@ -20,6 +21,8 @@ import 'katex/dist/katex.min.css';
 
 // Import the root of our routing tree
 import rRoot from 'routes/route_root.jsx';
+
+PDFJS.disableWorker = true;
 
 // This is for anything that needs to be done for ALL react components.
 // This runs before we start to render anything.


### PR DESCRIPTION
#### Summary
PDFJS was looking for a worker but couldn't find one and was creating a fake worker. On the desktop app, trying to find a worker was causing issues so I just disabled it and forced a fake worker to be used.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4000
