### PR TITLE
PLT-4015/PLT-4016 Update LastViewAt in create post API if not from a webhook

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -76,8 +76,11 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		return
 	} else {
-		if result := <-Srv.Store.Channel().UpdateLastViewedAt(post.ChannelId, c.Session.UserId); result.Err != nil {
-			l4g.Error(utils.T("api.post.create_post.last_viewed.error"), post.ChannelId, c.Session.UserId, result.Err)
+		// Update the LastViewAt only if the post does not have from_webhook prop set (eg. Zapier app)
+		if _, ok := post.Props["from_webhook"]; !ok {
+			if result := <-Srv.Store.Channel().UpdateLastViewedAt(post.ChannelId, c.Session.UserId); result.Err != nil {
+				l4g.Error(utils.T("api.post.create_post.last_viewed.error"), post.ChannelId, c.Session.UserId, result.Err)
+			}
 		}
 
 		w.Write([]byte(rp.ToJson()))


### PR DESCRIPTION
#### Summary
By creating a post using the Zapier app the channel wasn't marked as unread and the jewel wasn't cleared cause the LastViewAt of the member for that channel was updated and then the request to update the UI were handled by the etag returning the same result always causing both bugs

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4015
https://mattermost.atlassian.net/browse/PLT-4016

