### PR TITLE
update osixia/openldap 1.1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ start-docker:
 			-e LDAP_ORGANISATION="Mattermost Test" \
 			-e LDAP_DOMAIN="mm.test.com" \
 			-e LDAP_ADMIN_PASSWORD="mostest" \
-			-d osixia/openldap:1.1.2 > /dev/null;\
+			-d osixia/openldap:1.1.4 > /dev/null;\
 		sleep 10; \
 		docker exec -ti mattermost-openldap bash -c 'echo -e "dn: ou=testusers,dc=mm,dc=test,dc=com\nobjectclass: organizationalunit" | ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest';\
 		docker exec -ti mattermost-openldap bash -c 'echo -e "dn: uid=test.one,ou=testusers,dc=mm,dc=test,dc=com\nobjectclass: iNetOrgPerson\nsn: User\ncn: Test1\nmail: success+testone@simulator.amazonses.com" | ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest';\


### PR DESCRIPTION
This fixes crash I had with 

```
$ make test
Starting docker containers
Ldap test user test.one
starting mattermost-openldap
Unable to find image 'osixia/openldap:1.1.2' locally
Pulling repository docker.io/osixia/openldap
docker: Tag 1.1.2 not found in repository docker.io/osixia/openldap.
See 'docker run --help'.
Error response from daemon: No such container: mattermost-openldap
Error response from daemon: No such container: mattermost-openldap
Error response from daemon: No such container: mattermost-openldap
Error response from daemon: No such container: mattermost-openldap
Error response from daemon: No such container: mattermost-openldap
Error response from daemon: No such container: mattermost-openldap
make: *** [start-docker] Error 1
```