### PR TITLE
PLT-3197 Show loading icon until first page of posts is loaded on channel switch

### DIFF
--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -198,11 +198,16 @@ class PostStoreClass extends EventEmitter {
             return;
         }
 
-        if (checkLatest && newPosts.order.length >= 1) {
+        if (checkLatest) {
             const currentLatest = this.latestPageTime[id] || 0;
-            const newLatest = newPosts.posts[newPosts.order[0]].create_at || 0;
-            if (newLatest > currentLatest) {
-                this.latestPageTime[id] = newLatest;
+            if (newPosts.order.length >= 1) {
+                const newLatest = newPosts.posts[newPosts.order[0]].create_at || 0;
+                if (newLatest > currentLatest) {
+                    this.latestPageTime[id] = newLatest;
+                }
+            } else if (currentLatest === 0) {
+                // Mark that an empty page was received
+                this.latestPageTime[id] = 1;
             }
         }
 

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -609,13 +609,12 @@ export function getPosts(id) {
     }
 
     const postList = PostStore.getAllPosts(channelId);
+    const latestPostTime = PostStore.getLatestPostFromPageTime(id);
 
-    if ($.isEmptyObject(postList) || postList.order.length < Constants.POST_CHUNK_SIZE) {
+    if ($.isEmptyObject(postList) || postList.order.length < Constants.POST_CHUNK_SIZE || latestPostTime === 0) {
         getPostsPage(channelId, Constants.POST_CHUNK_SIZE);
         return;
     }
-
-    const latestPostTime = PostStore.getLatestPostFromPageTime(id);
 
     callTracker['getPosts_' + channelId] = utils.getTimestamp();
 


### PR DESCRIPTION
#### Summary
This fixes the issue of not scrolling to the new message indicator if the channel was previously unloaded and you received a new message in that channel before switching to it. What should happen now is the loading icon will be displayed until the first page of posts is loaded, even if we have 1 or 2 posts from the websocket already.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3197

#### Testing
Added `Needs PM Approval` to this bug fix due to the nature of the fix. Can a PM try the following:

1. Confirm the bug is fixed as described in the ticket
2. Test switching to empty channels
3. Test switching to full channels (more than 60 posts)
4. Test switching to semi-full channels (between 1-59 posts)
5. Test receiving 60+ posts to an unloaded channel then switching to the channel (can be done with loadtest command, must have the app active when receiving the posts)
2. Test initially loading empty channels
3. Test initially loading full channels (more than 60 posts)
4. Test initially loading semi-full channels (between 1-59 posts)
9. Any other tests you think might be necessary

I performed all these tests myself and it all seemed to work. I'm not opposed to letting this go to 3.5 so it can soak on master for a bit, although I am 4.5/5 confident that everything works correctly.