### PR TITLE
PLT-4036 Fix disable button on LDAP sign up page

### DIFF
--- a/webapp/components/signup/components/signup_ldap.jsx
+++ b/webapp/components/signup/components/signup_ldap.jsx
@@ -28,8 +28,29 @@ export default class SignupLdap extends React.Component {
         this.handleLdapSignup = this.handleLdapSignup.bind(this);
         this.handleLdapSignupSuccess = this.handleLdapSignupSuccess.bind(this);
 
+        this.handleLdapIdChange = this.handleLdapIdChange.bind(this);
+        this.handleLdapPasswordChange = this.handleLdapPasswordChange.bind(this);
+
         this.state = ({
-            ldapError: ''
+            ldapError: '',
+            ldapId: '',
+            ldapPassword: ''
+        });
+    }
+
+    handleLdapIdChange(e) {
+        e.preventDefault();
+
+        this.setState({
+            ldapId: e.target.value
+        });
+    }
+
+    handleLdapPasswordChange(e) {
+        e.preventDefault();
+
+        this.setState({
+            ldapPassword: e.target.value
         });
     }
 
@@ -39,8 +60,8 @@ export default class SignupLdap extends React.Component {
         this.setState({ldapError: ''});
 
         Client.webLoginByLdap(
-            this.refs.id.value.trim(),
-            this.refs.password.value,
+            this.state.ldapId,
+            this.state.ldapPassword,
             null,
             this.handleLdapSignupSuccess,
             (err) => {
@@ -118,8 +139,9 @@ export default class SignupLdap extends React.Component {
                                 <input
                                     className='form-control'
                                     name='ldapId'
-                                    ref='id'
+                                    value={this.state.ldapId}
                                     placeholder={ldapIdPlaceholder}
+                                    onChange={this.handleLdapIdChange}
                                     spellCheck='false'
                                     autoCapitalize='off'
                                 />
@@ -129,8 +151,9 @@ export default class SignupLdap extends React.Component {
                                     type='password'
                                     className='form-control'
                                     name='password'
-                                    ref='password'
+                                    value={this.state.ldapPassword}
                                     placeholder={Utils.localizeMessage('login.password', 'Password')}
+                                    onChange={this.handleLdapPasswordChange}
                                     spellCheck='false'
                                 />
                             </div>


### PR DESCRIPTION
#### Summary
On the sign up page for LDAP the Sign up button was always disabled

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4036

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

