### PR TITLE
PLT-3399 Do not send push notifications for channels being actively viewed

### DIFF
--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -647,7 +647,7 @@ func TestGetChannel(t *testing.T) {
 		t.Fatal("cache should be empty")
 	}
 
-	if _, err := Client.UpdateLastViewedAt(channel2.Id); err != nil {
+	if _, err := Client.UpdateLastViewedAt(channel2.Id, true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/post.go
+++ b/api/post.go
@@ -679,7 +679,7 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 			var status *model.Status
 			var err *model.AppError
 			if status, err = GetStatus(id); err != nil {
-				status = &model.Status{id, model.STATUS_OFFLINE, false, 0}
+				status = &model.Status{id, model.STATUS_OFFLINE, false, 0, ""}
 			}
 
 			if userAllowsEmails && status.Status != model.STATUS_ONLINE {
@@ -736,10 +736,10 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 			var status *model.Status
 			var err *model.AppError
 			if status, err = GetStatus(id); err != nil {
-				status = &model.Status{id, model.STATUS_OFFLINE, false, 0}
+				status = &model.Status{id, model.STATUS_OFFLINE, false, 0, ""}
 			}
 
-			if profileMap[id].StatusAllowsPushNotification(status) {
+			if DoesStatusAllowPushNotification(profileMap[id], status, post.ChannelId) {
 				sendPushNotification(post, profileMap[id], channel, senderName, true)
 			}
 		}
@@ -749,10 +749,10 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 				var status *model.Status
 				var err *model.AppError
 				if status, err = GetStatus(id); err != nil {
-					status = &model.Status{id, model.STATUS_OFFLINE, false, 0}
+					status = &model.Status{id, model.STATUS_OFFLINE, false, 0, ""}
 				}
 
-				if profileMap[id].StatusAllowsPushNotification(status) {
+				if DoesStatusAllowPushNotification(profileMap[id], status, post.ChannelId) {
 					sendPushNotification(post, profileMap[id], channel, senderName, false)
 				}
 			}
@@ -942,7 +942,6 @@ func sendPushNotification(post *model.Post, user *model.User, channel *model.Cha
 
 func clearPushNotification(userId string, channelId string) {
 	session := getMobileAppSession(userId)
-
 	if session == nil {
 		return
 	}

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -151,3 +151,39 @@ func TestStatuses(t *testing.T) {
 		t.Fatal("didn't get offline event")
 	}
 }
+
+func TestSetActiveChannel(t *testing.T) {
+	th := Setup().InitBasic()
+	Client := th.BasicClient
+
+	if _, err := Client.SetActiveChannel(th.BasicChannel.Id); err != nil {
+		t.Fatal(err)
+	}
+
+	status, _ := GetStatus(th.BasicUser.Id)
+	if status.ActiveChannel != th.BasicChannel.Id {
+		t.Fatal("active channel should be set")
+	}
+
+	if _, err := Client.SetActiveChannel(""); err != nil {
+		t.Fatal(err)
+	}
+
+	status, _ = GetStatus(th.BasicUser.Id)
+	if status.ActiveChannel != "" {
+		t.Fatal("active channel should be blank")
+	}
+
+	if _, err := Client.SetActiveChannel("123456789012345678901234567890"); err == nil {
+		t.Fatal("should have failed, id too long")
+	}
+
+	if _, err := Client.UpdateLastViewedAt(th.BasicChannel.Id, true); err != nil {
+		t.Fatal(err)
+	}
+
+	status, _ = GetStatus(th.BasicUser.Id)
+	if status.ActiveChannel != th.BasicChannel.Id {
+		t.Fatal("active channel should be set")
+	}
+}

--- a/model/client.go
+++ b/model/client.go
@@ -1127,8 +1127,13 @@ func (c *Client) RemoveChannelMember(id, user_id string) (*Result, *AppError) {
 	}
 }
 
-func (c *Client) UpdateLastViewedAt(channelId string) (*Result, *AppError) {
-	if r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/update_last_viewed_at", ""); err != nil {
+// UpdateLastViewedAt will mark a channel as read.
+// The channelId indicates the channel to mark as read. If active is true, push notifications
+// will be cleared if there are unread messages. The default for active is true.
+func (c *Client) UpdateLastViewedAt(channelId string, active bool) (*Result, *AppError) {
+	data := make(map[string]interface{})
+	data["active"] = active
+	if r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/update_last_viewed_at", StringInterfaceToJson(data)); err != nil {
 		return nil, err
 	} else {
 		defer closeBody(r)
@@ -1442,6 +1447,21 @@ func (c *Client) AdminResetPassword(userId, newPassword string) (*Result, *AppEr
 // GetStatuses returns a map of string statuses using user id as the key
 func (c *Client) GetStatuses() (*Result, *AppError) {
 	if r, err := c.DoApiGet("/users/status", "", ""); err != nil {
+		return nil, err
+	} else {
+		defer closeBody(r)
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), MapFromJson(r.Body)}, nil
+	}
+}
+
+// SetActiveChannel sets the the channel id the user is currently viewing.
+// The channelId key is required but the value can be blank. Returns standard
+// response.
+func (c *Client) SetActiveChannel(channelId string) (*Result, *AppError) {
+	data := map[string]string{}
+	data["channel_id"] = channelId
+	if r, err := c.DoApiPost("/users/status/set_active_channel", MapToJson(data)); err != nil {
 		return nil, err
 	} else {
 		defer closeBody(r)

--- a/model/status.go
+++ b/model/status.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	STATUS_OFFLINE    = "offline"
-	STATUS_AWAY       = "away"
-	STATUS_ONLINE     = "online"
-	STATUS_CACHE_SIZE = 10000
+	STATUS_OFFLINE         = "offline"
+	STATUS_AWAY            = "away"
+	STATUS_ONLINE          = "online"
+	STATUS_CACHE_SIZE      = 10000
+	STATUS_CHANNEL_TIMEOUT = 20000 // 20 seconds
 )
 
 type Status struct {
@@ -20,6 +21,7 @@ type Status struct {
 	Status         string `json:"status"`
 	Manual         bool   `json:"manual"`
 	LastActivityAt int64  `json:"last_activity_at"`
+	ActiveChannel  string `json:"active_channel"`
 }
 
 func (o *Status) ToJson() string {

--- a/model/status_test.go
+++ b/model/status_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestStatus(t *testing.T) {
-	status := Status{NewId(), STATUS_ONLINE, true, 0}
+	status := Status{NewId(), STATUS_ONLINE, true, 0, ""}
 	json := status.ToJson()
 	status2 := StatusFromJson(strings.NewReader(json))
 

--- a/model/user.go
+++ b/model/user.go
@@ -388,24 +388,6 @@ func (u *User) IsLDAPUser() bool {
 	return false
 }
 
-func (u *User) StatusAllowsPushNotification(status *Status) bool {
-	props := u.NotifyProps
-
-	if props["push"] == "none" {
-		return false
-	}
-
-	if pushStatus, ok := props["push_status"]; pushStatus == STATUS_ONLINE || !ok {
-		return true
-	} else if pushStatus == STATUS_AWAY && (status.Status == STATUS_AWAY || status.Status == STATUS_OFFLINE) {
-		return true
-	} else if pushStatus == STATUS_OFFLINE && status.Status == STATUS_OFFLINE {
-		return true
-	}
-
-	return false
-}
-
 // UserFromJson will decode the input and return a User
 func UserFromJson(data io.Reader) *User {
 	decoder := json.NewDecoder(data)

--- a/store/sql_status_store.go
+++ b/store/sql_status_store.go
@@ -24,6 +24,7 @@ func NewSqlStatusStore(sqlStore *SqlStore) StatusStore {
 		table := db.AddTableWithName(model.Status{}, "Status").SetKeys(false, "UserId")
 		table.ColMap("UserId").SetMaxSize(26)
 		table.ColMap("Status").SetMaxSize(32)
+		table.ColMap("ActiveChannel").SetMaxSize(26)
 	}
 
 	return s

--- a/store/sql_status_store_test.go
+++ b/store/sql_status_store_test.go
@@ -12,7 +12,7 @@ import (
 func TestSqlStatusStore(t *testing.T) {
 	Setup()
 
-	status := &model.Status{model.NewId(), model.STATUS_ONLINE, false, 0}
+	status := &model.Status{model.NewId(), model.STATUS_ONLINE, false, 0, ""}
 
 	if err := (<-store.Status().SaveOrUpdate(status)).Err; err != nil {
 		t.Fatal(err)
@@ -28,12 +28,12 @@ func TestSqlStatusStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	status2 := &model.Status{model.NewId(), model.STATUS_AWAY, false, 0}
+	status2 := &model.Status{model.NewId(), model.STATUS_AWAY, false, 0, ""}
 	if err := (<-store.Status().SaveOrUpdate(status2)).Err; err != nil {
 		t.Fatal(err)
 	}
 
-	status3 := &model.Status{model.NewId(), model.STATUS_OFFLINE, false, 0}
+	status3 := &model.Status{model.NewId(), model.STATUS_OFFLINE, false, 0, ""}
 	if err := (<-store.Status().SaveOrUpdate(status3)).Err; err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestSqlStatusStore(t *testing.T) {
 func TestActiveUserCount(t *testing.T) {
 	Setup()
 
-	status := &model.Status{model.NewId(), model.STATUS_ONLINE, false, model.GetMillis()}
+	status := &model.Status{model.NewId(), model.STATUS_ONLINE, false, model.GetMillis(), ""}
 	Must(store.Status().SaveOrUpdate(status))
 
 	if result := <-store.Status().GetTotalActiveUsersCount(); result.Err != nil {

--- a/store/sql_upgrade.go
+++ b/store/sql_upgrade.go
@@ -180,7 +180,9 @@ func UpgradeDatabaseToVersion33(sqlStore *SqlStore) {
 
 func UpgradeDatabaseToVersion34(sqlStore *SqlStore) {
 	if shouldPerformUpgrade(sqlStore, VERSION_3_3_0, VERSION_3_4_0) {
+
 		sqlStore.CreateColumnIfNotExists("Status", "Manual", "BOOLEAN", "BOOLEAN", "0")
+		sqlStore.CreateColumnIfNotExists("Status", "ActiveChannel", "varchar(26)", "varchar(26)", "")
 
 		// TODO XXX FIXME should be removed before release
 		//saveSchemaVersion(sqlStore, VERSION_3_4_0)

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -19,7 +19,7 @@ const Preferences = Constants.Preferences;
 export function handleNewPost(post, msg) {
     if (ChannelStore.getCurrentId() === post.channel_id) {
         if (window.isActive) {
-            AsyncClient.updateLastViewedAt();
+            AsyncClient.updateLastViewedAt(null, false);
         } else {
             AsyncClient.getChannel(post.channel_id);
         }

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -174,7 +174,7 @@ function handlePostEditEvent(msg) {
     // Update channel state
     if (ChannelStore.getCurrentId() === msg.channel_id) {
         if (window.isActive) {
-            AsyncClient.updateLastViewedAt();
+            AsyncClient.updateLastViewedAt(null, false);
         }
     }
 }

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -994,6 +994,16 @@ export default class Client {
             end(this.handleResponse.bind(this, 'getStatuses', success, error));
     }
 
+    setActiveChannel(id, success, error) {
+        request.
+            post(`${this.getUsersRoute()}/status/set_active_channel`).
+            set(this.defaultHeaders).
+            type('application/json').
+            accept('application/json').
+            send({channel_id: id}).
+            end(this.handleResponse.bind(this, 'setActiveChannel', success, error));
+    }
+
     verifyEmail(uid, hid, success, error) {
         request.
             post(`${this.getUsersRoute()}/verify_email`).
@@ -1163,12 +1173,13 @@ export default class Client {
         this.track('api', 'api_channels_delete');
     }
 
-    updateLastViewedAt(channelId, success, error) {
+    updateLastViewedAt(channelId, active, success, error) {
         request.
             post(`${this.getChannelNeededRoute(channelId)}/update_last_viewed_at`).
             set(this.defaultHeaders).
             type('application/json').
             accept('application/json').
+            send({active}).
             end(this.handleResponse.bind(this, 'updateLastViewedAt', success, error));
     }
 

--- a/webapp/components/needs_team.jsx
+++ b/webapp/components/needs_team.jsx
@@ -94,6 +94,7 @@ export default class NeedsTeam extends React.Component {
 
         $(window).on('blur', () => {
             window.isActive = false;
+            AsyncClient.setActiveChannel('');
         });
 
         Utils.applyTheme(this.state.theme);

--- a/webapp/components/post_view/post_view_cache.jsx
+++ b/webapp/components/post_view/post_view_cache.jsx
@@ -4,6 +4,7 @@
 import PostViewController from './post_view_controller.jsx';
 
 import ChannelStore from 'stores/channel_store.jsx';
+import * as AsyncClient from 'utils/async_client.jsx';
 
 import React from 'react';
 
@@ -28,6 +29,7 @@ export default class PostViewCache extends React.Component {
     }
 
     componentWillUnmount() {
+        AsyncClient.setActiveChannel('');
         ChannelStore.removeChangeListener(this.onChannelChange);
     }
 

--- a/webapp/tests/client_channel.test.jsx
+++ b/webapp/tests/client_channel.test.jsx
@@ -216,6 +216,7 @@ describe('Client.Channels', function() {
             var channel = TestHelper.basicChannel();
             TestHelper.basicClient().updateLastViewedAt(
                 channel.id,
+                true,
                 function(data) {
                     assert.equal(data.id, channel.id);
                     done();

--- a/webapp/tests/client_user.test.jsx
+++ b/webapp/tests/client_user.test.jsx
@@ -509,6 +509,23 @@ describe('Client.User', function() {
     });
     */
 
+    it('setActiveChannel', function(done) {
+        TestHelper.initBasic(() => {
+            var ids = [];
+            ids.push(TestHelper.basicUser().id);
+
+            TestHelper.basicClient().setActiveChannel(
+                TestHelper.basicChannel().id,
+                function() {
+                    done();
+                },
+                function(err) {
+                    done(new Error(err.message));
+                }
+            );
+        });
+    });
+
     it('verifyEmail', function(done) {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().enableLogErrorsToConsole(false); // Disabling since this unit test causes an error

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -113,7 +113,7 @@ export function getChannel(id) {
     );
 }
 
-export function updateLastViewedAt(id) {
+export function updateLastViewedAt(id, active) {
     let channelId;
     if (id) {
         channelId = id;
@@ -129,9 +129,17 @@ export function updateLastViewedAt(id) {
         return;
     }
 
+    let isActive;
+    if (active == null) {
+        isActive = true;
+    } else {
+        isActive = active;
+    }
+
     callTracker[`updateLastViewed${channelId}`] = utils.getTimestamp();
     Client.updateLastViewedAt(
         channelId,
+        isActive,
         () => {
             callTracker[`updateLastViewed${channelId}`] = 0;
             ErrorStore.clearLastError();
@@ -750,6 +758,24 @@ export function getStatuses() {
         (err) => {
             callTracker.getStatuses = 0;
             dispatchError(err, 'getStatuses');
+        }
+    );
+}
+
+export function setActiveChannel(channelId) {
+    if (isCallInProgress(`setActiveChannel${channelId}`)) {
+        return;
+    }
+
+    callTracker[`setActiveChannel${channelId}`] = utils.getTimestamp();
+    Client.setActiveChannel(
+        channelId,
+        () => {
+            callTracker[`setActiveChannel${channelId}`] = 0;
+        },
+        (err) => {
+            callTracker[`setActiveChannel${channelId}`] = 0;
+            dispatchError(err, 'setActiveChannel');
         }
     );
 }


### PR DESCRIPTION
#### Summary
This PR will prevent push notifications being sent for a channel the user is actively viewing. "Actively viewing" is defined as clicked onto the app and in that channel. The implementation is as follows:
* When the user clicks into a channel an `updateLastViewedAt` request goes out. This is old news but now this updates a new field on the `Status` object called `ActiveChannel` which tracks which channel is active
* When the user clicks into a new channel a new `updateLastViewedAt` request will update the `ActiveChannel`
* When the user clicks off the app, or switches to a non-channel page, a new API `setActiveChannel` request will update the `ActiveChannel` to blank
* When sending push notifications, check if the user is online and if the notification is for the `ActiveChannel`. If it is, then don't send the notification unless 20 seconds has gone by since the last user activity.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3399

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
