### PR TITLE
PLT-3875 Update error page to use Markdown and add error for missing OAuth code

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1011,7 +1011,7 @@
   },
   {
     "id": "api.oauth.complete_oauth.missing_code.app_error",
-    "translation": "The service provider {{.service}} did not provide an authorization code in the redirect URL. For [Google Apps](https://docs.mattermost.com/deployment/sso-google.html) make sure your administrator enabled the Google+ API.\nFor [Office 365](https://docs.mattermost.com/deployment/sso-office.html) make sure the administrator of your Microsoft organization has enabled the Mattermost app. For [GitLab](https://docs.mattermost.com/deployment/sso-gitlab.html) please make sure you followed the setup instructions."
+    "translation": "The service provider {{.service}} did not provide an authorization code in the redirect URL.\n\nFor [Google Apps](https://docs.mattermost.com/deployment/sso-google.html) make sure your administrator enabled the Google+ API.\nFor [Office 365](https://docs.mattermost.com/deployment/sso-office.html) make sure the administrator of your Microsoft organization has enabled the Mattermost app.\nFor [GitLab](https://docs.mattermost.com/deployment/sso-gitlab.html) please make sure you followed the setup instructions."
   },
   {
     "id": "api.oauth.allow_oauth.bad_redirect.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1011,7 +1011,7 @@
   },
   {
     "id": "api.oauth.complete_oauth.missing_code.app_error",
-    "translation": "The service provider {{.service}} did not provide an authorization code in the redirect URL.\n\nFor [Google Apps](https://docs.mattermost.com/deployment/sso-google.html) make sure your administrator enabled the Google+ API.\nFor [Office 365](https://docs.mattermost.com/deployment/sso-office.html) make sure the administrator of your Microsoft organization has enabled the Mattermost app.\nFor [GitLab](https://docs.mattermost.com/deployment/sso-gitlab.html) please make sure you followed the setup instructions."
+    "translation": "The service provider {{.service}} did not provide an authorization code in the redirect URL.\n\nFor [Google Apps](https://docs.mattermost.com/deployment/sso-google.html) make sure your administrator enabled the Google+ API.\n\nFor [Office 365](https://docs.mattermost.com/deployment/sso-office.html) make sure the administrator of your Microsoft organization has enabled the Mattermost app.\n\nFor [GitLab](https://docs.mattermost.com/deployment/sso-gitlab.html) please make sure you followed the setup instructions.\n\nIf you reviewed the above and are still having trouble with configuration, you may post in our [Troubleshooting forum](https://forum.mattermost.org/c/general/trouble-shoot) where we'll be happy to help with issues during setup."
   },
   {
     "id": "api.oauth.allow_oauth.bad_redirect.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1010,8 +1010,8 @@
     "translation": "invalid_request: Bad client_id"
   },
   {
-    "id": "api.oauth.receive_redirect.debug",
-    "translation": "OAuth2 redirect: {{.URL}}"
+    "id": "api.oauth.complete_oauth.missing_code.app_error",
+    "translation": "The service provider {{.service}} did not provide an authorization code in the redirect URL. For [Google Apps](https://docs.mattermost.com/deployment/sso-google.html) make sure your administrator enabled the Google+ API.\nFor [Office 365](https://docs.mattermost.com/deployment/sso-office.html) make sure the administrator of your Microsoft organization has enabled the Mattermost app. For [GitLab](https://docs.mattermost.com/deployment/sso-gitlab.html) please make sure you followed the setup instructions."
   },
   {
     "id": "api.oauth.allow_oauth.bad_redirect.app_error",

--- a/webapp/components/error_page.jsx
+++ b/webapp/components/error_page.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {Link} from 'react-router/es6';
 
 import * as Utils from 'utils/utils.jsx';
+import * as TextFormatting from 'utils/text_formatting.jsx';
 
 export default class ErrorPage extends React.Component {
     componentDidMount() {
@@ -43,7 +44,7 @@ export default class ErrorPage extends React.Component {
                         <i className='fa fa-exclamation-triangle'/>
                     </div>
                     <h2>{title}</h2>
-                    <p>{message}</p>
+                    <div dangerouslySetInnerHTML={{__html: TextFormatting.formatText(message)}}/>
                     <Link to={link}>{linkMessage}</Link>
                 </div>
             </div>


### PR DESCRIPTION
#### Summary
Updated error page message to use Markdown and added an error for OAuth redirects that are missing an authorization code.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3875

@jasonblais can you take a look at the error message? Feel free to update on this branch