### PR TITLE
PLT-3985 Send hello event containing server version on WebSocket connect

### DIFF
--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"fmt"
 	l4g "github.com/alecthomas/log4go"
 
 	"github.com/mattermost/platform/einterfaces"
@@ -61,6 +62,10 @@ func InvalidateCacheForChannel(channelId string) {
 
 func (h *Hub) Register(webConn *WebConn) {
 	h.register <- webConn
+
+	msg := model.NewWebSocketEvent("", "", webConn.UserId, model.WEBSOCKET_EVENT_HELLO)
+	msg.Add("server_version", fmt.Sprintf("%v.%v", model.CurrentVersion, utils.CfgHash))
+	go Publish(msg)
 }
 
 func (h *Hub) Unregister(webConn *WebConn) {

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -24,6 +24,7 @@ const (
 	WEBSOCKET_EVENT_PREFERENCE_CHANGED = "preference_changed"
 	WEBSOCKET_EVENT_EPHEMERAL_MESSAGE  = "ephemeral_message"
 	WEBSOCKET_EVENT_STATUS_CHANGE      = "status_change"
+	WEBSOCKET_EVENT_HELLO              = "hello"
 )
 
 type WebSocketMessage interface {

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -156,6 +156,10 @@ function handleEvent(msg) {
         handleStatusChangedEvent(msg);
         break;
 
+    case SocketEvents.HELLO:
+        handleHelloEvent(msg);
+        break;
+
     default:
     }
 }
@@ -283,4 +287,9 @@ function handleUserTypingEvent(msg) {
 
 function handleStatusChangedEvent(msg) {
     UserStore.setStatus(msg.user_id, msg.data.status);
+}
+
+function handleHelloEvent(msg) {
+    Client.serverVersion = msg.data.server_version;
+    AsyncClient.checkVersion();
 }

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -198,7 +198,8 @@ export const Constants = {
         TYPING: 'typing',
         PREFERENCE_CHANGED: 'preference_changed',
         EPHEMERAL_MESSAGE: 'ephemeral_message',
-        STATUS_CHANGED: 'status_change'
+        STATUS_CHANGED: 'status_change',
+        HELLO: 'hello'
     },
 
     UserUpdateEvents: {


### PR DESCRIPTION
#### Summary
Send a `hello` event on WebSocket connect containing the server version (and later possibly other initializing data). If the server version doesn't match the latest client version, force a page reload.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3985

