### PR TITLE
PLT-3988 Add statuses to profiles pictures and remove from header in DMs

### DIFF
--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -15,7 +15,6 @@ import ChannelNotificationsModal from './channel_notifications_modal.jsx';
 import DeleteChannelModal from './delete_channel_modal.jsx';
 import RenameChannelModal from './rename_channel_modal.jsx';
 import ToggleModalButton from './toggle_modal_button.jsx';
-import StatusIcon from './status_icon.jsx';
 
 import ChannelStore from 'stores/channel_store.jsx';
 import UserStore from 'stores/user_store.jsx';
@@ -31,7 +30,6 @@ import * as AsyncClient from 'utils/async_client.jsx';
 import {getFlaggedPosts} from 'actions/post_actions.jsx';
 
 import Constants from 'utils/constants.jsx';
-const UserStatuses = Constants.UserStatuses;
 const ActionTypes = Constants.ActionTypes;
 
 import React from 'react';
@@ -87,7 +85,6 @@ export default class ChannelHeader extends React.Component {
         SearchStore.addSearchChangeListener(this.onListenerChange);
         PreferenceStore.addChangeListener(this.onListenerChange);
         UserStore.addChangeListener(this.onListenerChange);
-        UserStore.addStatusesChangeListener(this.onListenerChange);
         $('.sidebar--left .dropdown-menu').perfectScrollbar();
         document.addEventListener('keydown', this.openRecentMentions);
     }
@@ -98,7 +95,6 @@ export default class ChannelHeader extends React.Component {
         SearchStore.removeSearchChangeListener(this.onListenerChange);
         PreferenceStore.removeChangeListener(this.onListenerChange);
         UserStore.removeChangeListener(this.onListenerChange);
-        UserStore.removeStatusesChangeListener(this.onListenerChange);
         document.removeEventListener('keydown', this.openRecentMentions);
     }
 
@@ -182,21 +178,6 @@ export default class ChannelHeader extends React.Component {
         this.setState({
             showRenameChannelModal: false
         });
-    }
-
-    getTeammateStatus() {
-        const channel = this.state.channel;
-
-        // get status for direct message channels
-        if (channel.type === 'D') {
-            const currentUserId = this.state.currentUser.id;
-            const teammate = this.state.users.find((user) => user.id !== currentUserId);
-            if (teammate) {
-                return UserStore.getStatus(teammate.id);
-            }
-            return UserStatuses.OFFLINE;
-        }
-        return null;
     }
 
     showManagementOptions(channel, isAdmin, isSystemAdmin) {
@@ -562,7 +543,7 @@ export default class ChannelHeader extends React.Component {
                                             data-toggle='dropdown'
                                             aria-expanded='true'
                                         >
-                                            <strong className='heading'><StatusIcon status={this.getTeammateStatus()}/>{channelTitle} </strong>
+                                            <strong className='heading'>{channelTitle} </strong>
                                             <span className='fa fa-chevron-down header-dropdown__icon'/>
                                         </a>
                                         <ul

--- a/webapp/components/post_view/post_view_controller.jsx
+++ b/webapp/components/post_view/post_view_controller.jsx
@@ -45,10 +45,7 @@ export default class PostViewController extends React.Component {
 
         const joinLeaveEnabled = PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave', true);
 
-        let statuses;
-        if (channel && channel.type !== Constants.DM_CHANNEL) {
-            statuses = Object.assign({}, UserStore.getStatuses());
-        }
+        const statuses = Object.assign({}, UserStore.getStatuses());
 
         // If we haven't received a page time then we aren't done loading the posts yet
         const loading = PostStore.getLatestPostFromPageTime(channel.id) === 0;
@@ -133,13 +130,7 @@ export default class PostViewController extends React.Component {
     }
 
     onStatusChange() {
-        const channel = this.state.channel;
-        let statuses;
-        if (channel && channel.type !== Constants.DM_CHANNEL) {
-            statuses = Object.assign({}, UserStore.getStatuses());
-        }
-
-        this.setState({statuses});
+        this.setState({statuses: Object.assign({}, UserStore.getStatuses())});
     }
 
     onActivate() {


### PR DESCRIPTION
#### Summary
Adds statuses to the profile pictures in DMs to match every other channel and removes it from the channel header in DMs.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3988

#### Checklist
- [x] Has UI changes
