### PR TITLE
PLT-4053 Fix @channel, @here and @everyone Slack import.

### DIFF
--- a/api/slackimport.go
+++ b/api/slackimport.go
@@ -242,6 +242,11 @@ func SlackConvertUserMentions(users []SlackUser, posts map[string][]SlackPost) m
 		regexes["@"+user.Username] = r
 	}
 
+	// Special cases.
+	regexes["@here"], _ = regexp.Compile(`<!here\|@here>`)
+	regexes["@channel"], _ = regexp.Compile("<!channel>")
+	regexes["@all"], _ = regexp.Compile("<!everyone>")
+
 	for channelName, channelPosts := range posts {
 		for postIdx, post := range channelPosts {
 			for mention, r := range regexes {


### PR DESCRIPTION
#### Summary
Fix @channel, @here and @everyone Slack import.

Does this by adding special case regexes to the @mention importing code
in the Slack importer for these three special mention types.

This probably should have been in the original @mention slack import patch, but it didn't occur to me at the time.

Fixes PLT-4053

#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-4053