### PR TITLE
PLT-4025 "CTRL+ENTER" option isn't honoured on the edit dialog after refresh

### DIFF
--- a/webapp/components/edit_post_modal.jsx
+++ b/webapp/components/edit_post_modal.jsx
@@ -28,7 +28,6 @@ export default class EditPostModal extends React.Component {
         this.handleEdit = this.handleEdit.bind(this);
         this.handleEditKeyPress = this.handleEditKeyPress.bind(this);
         this.handleEditPostEvent = this.handleEditPostEvent.bind(this);
-        this.handleKeyDown = this.handleKeyDown.bind(this);
         this.handleInput = this.handleInput.bind(this);
         this.onPreferenceChange = this.onPreferenceChange.bind(this);
         this.onModalHidden = this.onModalHidden.bind(this);
@@ -37,7 +36,16 @@ export default class EditPostModal extends React.Component {
         this.onModalHide = this.onModalHide.bind(this);
         this.onModalKeyDown = this.onModalKeyDown.bind(this);
 
-        this.state = {editText: '', originalText: '', title: '', post_id: '', channel_id: '', comments: 0, refocusId: ''};
+        this.state = {
+            editText: '',
+            originalText: '',
+            title: '',
+            post_id: '',
+            channel_id: '',
+            comments: 0,
+            refocusId: '',
+            ctrlSend: PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter')
+        };
     }
 
     handleEdit() {
@@ -88,11 +96,11 @@ export default class EditPostModal extends React.Component {
         if (!this.state.ctrlSend && e.which === KeyCodes.ENTER && !e.shiftKey && !e.altKey) {
             e.preventDefault();
             ReactDOM.findDOMNode(this.refs.editbox).blur();
-            this.handleEdit(e);
+            this.handleEdit();
         } else if (this.state.ctrlSend && e.ctrlKey && e.which === KeyCodes.ENTER) {
             e.preventDefault();
             ReactDOM.findDOMNode(this.refs.editbox).blur();
-            this.handleSubmit(e);
+            this.handleEdit();
         }
     }
 
@@ -108,12 +116,6 @@ export default class EditPostModal extends React.Component {
         });
 
         $(ReactDOM.findDOMNode(this.refs.modal)).modal('show');
-    }
-
-    handleKeyDown(e) {
-        if (this.state.ctrlSend && e.keyCode === KeyCodes.ENTER && e.ctrlKey === true) {
-            this.handleEdit(e);
-        }
     }
 
     onPreferenceChange() {
@@ -204,7 +206,6 @@ export default class EditPostModal extends React.Component {
                                 className='close'
                                 data-dismiss='modal'
                                 aria-label='Close'
-                                onClick={this.handleEditClose}
                             >
                                 <span aria-hidden='true'>{'×'}</span>
                             </button>
@@ -222,7 +223,6 @@ export default class EditPostModal extends React.Component {
                             <Textbox
                                 onInput={this.handleInput}
                                 onKeyPress={this.handleEditKeyPress}
-                                onKeyDown={this.handleKeyDown}
                                 messageText={this.state.editText}
                                 createMessage={Utils.localizeMessage('edit_post.editPost', 'Edit the post...')}
                                 supportsCommands={false}


### PR DESCRIPTION
#### Summary
Edit post modal had a bunch of bugs, calls to functions that didn't exist and handling keypress and keydown events for the same functionality, this removes the unnecessary code and fixes the bug by setting the `sendCtrl` state in the constructor.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4025