### PR TITLE
PLT-3880 Dynamic Password Min Length help text

### DIFF
--- a/webapp/components/admin_console/password_settings.jsx
+++ b/webapp/components/admin_console/password_settings.jsx
@@ -187,7 +187,7 @@ export default class PasswordSettings extends AdminSettings {
                                 id='admin.password.minimumLengthDescription'
                                 defaultMessage='Minimum number of characters required for a valid password. Must be a whole number greater than or equal to {min} and less than or equal to {max}.'
                                 values={{
-                                    min: Constants.MIN_PASSWORD_LENGTH,
+                                    min: (this.state.passwordMinimumLength || Constants.MIN_PASSWORD_LENGTH),
                                     max: Constants.MAX_PASSWORD_LENGTH
                                 }}
                             />


### PR DESCRIPTION
#### Summary
Fixes a ux-defect when updating the min length password requirement the help text was fixed with the default value, now it dynamically updates and in case is empty it uses the default value in the help text

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3880

