### PR TITLE
PLT-4005 Generates default Salts if empty in the config file

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -52,7 +52,7 @@
         "MaxIdleConns": 10,
         "MaxOpenConns": 10,
         "Trace": false,
-        "AtRestEncryptKey": "7rAh6iwQCkV4cA1Gsg3fgGOXJAQ43QVg"
+        "AtRestEncryptKey": ""
     },
     "LogSettings": {
         "EnableConsole": true,
@@ -75,7 +75,7 @@
         "DriverName": "local",
         "Directory": "./data/",
         "EnablePublicLink": false,
-        "PublicLinkSalt": "A705AklYF8MFDOfcwh3I488G8vtLlVip",
+        "PublicLinkSalt": "",
         "ThumbnailWidth": 120,
         "ThumbnailHeight": 100,
         "PreviewWidth": 1024,
@@ -106,8 +106,8 @@
         "SMTPServer": "",
         "SMTPPort": "",
         "ConnectionSecurity": "",
-        "InviteSalt": "bjlSR4QqkXFBr7TP4oDzlfZmcNuH9YoS",
-        "PasswordResetSalt": "vZ4DcKyVVRlKHHJpexcuXzojkE5PZ5eL",
+        "InviteSalt": "",
+        "PasswordResetSalt": "",
         "SendPushNotifications": false,
         "PushNotificationServer": "",
         "PushNotificationContents": "generic",

--- a/utils/config.go
+++ b/utils/config.go
@@ -165,10 +165,19 @@ func LoadConfig(fileName string) {
 		CfgFileName = fileName
 	}
 
+	needSave := len(config.SqlSettings.AtRestEncryptKey) == 0 || len(*config.FileSettings.PublicLinkSalt) == 0 ||
+		len(config.EmailSettings.InviteSalt) == 0 || len(config.EmailSettings.PasswordResetSalt) == 0
+
 	config.SetDefaults()
 
 	if err := config.IsValid(); err != nil {
 		panic(T(err.Id))
+	}
+
+	if needSave {
+		if err := SaveConfig(fileName, &config); err != nil {
+			l4g.Warn(T(err.Id))
+		}
 	}
 
 	if err := ValidateLdapFilter(&config); err != nil {


### PR DESCRIPTION
#### Summary
To avoid every installation to have the same Salts we detect if they are blank and auto generate and save them to the config file with a silent fail if thats the case.

And then ship the release with those Salts empty.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4005

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

