### PR TITLE
PLT-4028 System console > Teams are sorted alphabetically regardless of case

### DIFF
--- a/webapp/components/admin_console/select_team_modal.jsx
+++ b/webapp/components/admin_console/select_team_modal.jsx
@@ -25,10 +25,13 @@ export default class SelectTeamModal extends React.Component {
         this.props.onModalDismissed();
     }
     compare(a, b) {
-        if (a.display_name < b.display_name) {
+        const teamA = a.display_name.toLowerCase();
+        const teamB = b.display_name.toLowerCase();
+
+        if (teamA < teamB) {
             return -1;
         }
-        if (a.display_name > b.display_name) {
+        if (teamA > teamB) {
             return 1;
         }
         return 0;


### PR DESCRIPTION
#### Summary
In System Console > Teams, team names are now sorted alphabetically regardless of case. Previously, lowercase team names appeared after capitalised team names.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4028