### PR TITLE
Add noscript message to root.html (fixes #3953)

### DIFF
--- a/webapp/root.html
+++ b/webapp/root.html
@@ -52,5 +52,8 @@
     <script>
         window.setup_root();
     </script>
+    <noscript>
+        To use Mattermost, please enable JavaScript.
+    </noscript>
 </body>
 </html>


### PR DESCRIPTION
#### Summary
This PR adds a message for browsers without JavaScript explaining that you need JavaScript to use Mattermost.

#### Ticket Link
https://github.com/mattermost/platform/issues/3953


