### PR TITLE
Unescape HTML entities in e-mail titles (fixes #3906)

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -6,6 +6,7 @@ package api
 import (
 	"crypto/tls"
 	"fmt"
+	"html"
 	"html/template"
 	"io"
 	"io/ioutil"
@@ -858,7 +859,7 @@ func sendNotificationEmail(c *Context, post *model.Post, user *model.User, chann
 			"Hour": fmt.Sprintf("%02d", tm.Hour()), "Minute": fmt.Sprintf("%02d", tm.Minute()),
 			"TimeZone": zone, "Month": month, "Day": day}))
 
-	if err := utils.SendMail(user.Email, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(user.Email, html.UnescapeString(subjectPage.Render()), bodyPage.Render()); err != nil {
 		l4g.Error(utils.T("api.post.send_notifications_and_forget.send.error"), user.Email, err)
 	}
 }


### PR DESCRIPTION

#### Summary
This PR unescapes HTML entities in e-mail notification titles.

#### Ticket Link
https://github.com/mattermost/platform/issues/3906

