### PR TITLE
PLT-3775/PLT-4067 Fixes for email notifications for 3.4

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1272,6 +1272,10 @@
     "translation": "Failed to retrieve comment thread posts in notifications root_post_id=%v, err=%v"
   },
   {
+    "id": "api.post.send_notifications_and_forget.get_teams.error",
+    "translation": "Failed to get teams when sending cross-team DM user_id=%v, err=%v"
+  },
+  {
     "id": "api.post.send_notifications_and_forget.mention_body",
     "translation": "You have one new mention."
   },

--- a/webapp/components/user_settings/email_notification_setting.jsx
+++ b/webapp/components/user_settings/email_notification_setting.jsx
@@ -159,6 +159,12 @@ export default class EmailNotificationSetting extends React.Component {
                 title={localizeMessage('user.settings.notifications.emailNotifications', 'Email notifications')}
                 inputs={[
                     <div key='userNotificationEmailOptions'>
+                        <label>
+                            <FormattedMessage
+                                id='user.settings.notifications.email.send'
+                                defaultMessage='Send email notifications'
+                            />
+                        </label>
                         <div className='radio'>
                             <label>
                                 <input

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1899,6 +1899,7 @@
   "user.settings.notifications.email.everyXMinutes": "Every {count, plural, one {minute} other {{count, number} minutes}}",
   "user.settings.notifications.email.immediately": "Immediately",
   "user.settings.notifications.email.never": "Never",
+  "user.settings.notifications.email.send": "Send email notifications",
   "user.settings.notifications.emailBatchingInfo": "Notifications received over the time period selected are combined and sent in a single email.",
   "user.settings.notifications.emailInfo": "Email notifications are sent for mentions and direct messages when you are offline or away from {siteName} for more than 5 minutes.",
   "user.settings.notifications.emailNotifications": "Email notifications",


### PR DESCRIPTION
#### Summary
- The post link in email notifications for cross-team DMs will now work as expected
- Setting Send Email Notifications to Immediately when batching is enabled will now send them immediately instead of with a 30 second delay

#### Ticket Link
- https://mattermost.atlassian.net/browse/PLT-3775
- https://mattermost.atlassian.net/browse/PLT-4067

#### Checklist
- Has UI changes
- Includes text changes and localization files updated
