### PR TITLE
PLT-3805 Fixed emojis not being stored by EmojiStore on first page load

### DIFF
--- a/webapp/components/logged_in.jsx
+++ b/webapp/components/logged_in.jsx
@@ -18,6 +18,9 @@ const BACKSPACE_CHAR = 8;
 
 import React from 'react';
 
+// import the EmojiStore so that it'll register to receive the results of the listEmojis call further down
+import 'stores/emoji_store.jsx';
+
 export default class LoggedIn extends React.Component {
     constructor(params) {
         super(params);


### PR DESCRIPTION
As it turns out, the EmojiStore isn't always initialized when AsyncClient.listEmojis was called so it wasn't receiving the results of that call.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3805
