### PR TITLE
Include build number in server version given to the client

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -150,7 +150,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.RequestId)
-	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v", model.CurrentVersion, utils.CfgHash))
+	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash))
 	if einterfaces.GetClusterInterface() != nil {
 		w.Header().Set(model.HEADER_CLUSTER_ID, einterfaces.GetClusterInterface().GetClusterId())
 	}

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -64,7 +64,7 @@ func (h *Hub) Register(webConn *WebConn) {
 	h.register <- webConn
 
 	msg := model.NewWebSocketEvent("", "", webConn.UserId, model.WEBSOCKET_EVENT_HELLO)
-	msg.Add("server_version", fmt.Sprintf("%v.%v", model.CurrentVersion, utils.CfgHash))
+	msg.Add("server_version", fmt.Sprintf("%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash))
 	go Publish(msg)
 }
 


### PR DESCRIPTION
#### Summary
The client was only refreshing when the actual version number changed but not when the build number changed. This fixes that.