### PR TITLE
PLT-4087 Displayed proper token on integration creation confirmation

### DIFF
--- a/webapp/components/integrations/components/add_command.jsx
+++ b/webapp/components/integrations/components/add_command.jsx
@@ -166,7 +166,7 @@ export default class AddCommand extends React.Component {
         AsyncClient.addCommand(
             command,
             (data) => {
-                browserHistory.push('/' + this.props.team.name + '/integrations/confirm?type=commands&id=' + data.token);
+                browserHistory.push('/' + this.props.team.name + '/integrations/confirm?type=commands&id=' + data.id);
             },
             (err) => {
                 this.setState({

--- a/webapp/components/integrations/components/add_outgoing_webhook.jsx
+++ b/webapp/components/integrations/components/add_outgoing_webhook.jsx
@@ -120,7 +120,7 @@ export default class AddOutgoingWebhook extends React.Component {
         AsyncClient.addOutgoingHook(
             hook,
             (data) => {
-                browserHistory.push('/' + this.props.team.name + '/integrations/confirm?type=outgoing_webhooks&id=' + data.token);
+                browserHistory.push('/' + this.props.team.name + '/integrations/confirm?type=outgoing_webhooks&id=' + data.id);
             },
             (err) => {
                 this.setState({

--- a/webapp/components/integrations/components/confirm_integration.jsx
+++ b/webapp/components/integrations/components/confirm_integration.jsx
@@ -5,8 +5,7 @@ import React from 'react';
 
 import BackstageHeader from 'components/backstage/components/backstage_header.jsx';
 import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
-import {browserHistory, Link} from 'react-router/es6';
-import SpinnerButton from 'components/spinner_button.jsx';
+import {Link} from 'react-router/es6';
 
 import UserStore from 'stores/user_store.jsx';
 import IntegrationStore from 'stores/integration_store.jsx';
@@ -23,8 +22,6 @@ export default class ConfirmIntegration extends React.Component {
 
     constructor(props) {
         super(props);
-
-        this.handleDone = this.handleDone.bind(this);
 
         this.handleIntegrationChange = this.handleIntegrationChange.bind(this);
 
@@ -55,13 +52,6 @@ export default class ConfirmIntegration extends React.Component {
         });
     }
 
-    handleDone() {
-        browserHistory.push('/' + this.props.team.name + '/integrations/' + this.state.type);
-        this.setState({
-            id: ''
-        });
-    }
-
     render() {
         let headerText = null;
         let helpText = null;
@@ -87,7 +77,7 @@ export default class ConfirmIntegration extends React.Component {
                         id='add_command.token'
                         defaultMessage='<b>Token</b>: {token}'
                         values={{
-                            token: this.state.id
+                            token: IntegrationStore.getCommand(this.props.team.id, this.state.id).token
                         }}
                     />
                 </p>
@@ -139,7 +129,7 @@ export default class ConfirmIntegration extends React.Component {
                         id='add_outgoing_webhook.token'
                         defaultMessage='<b>Token</b>: {token}'
                         values={{
-                            token: this.state.id
+                            token: IntegrationStore.getOutgoingWebhook(this.props.team.id, this.state.id).token
                         }}
                     />
                 </p>
@@ -233,16 +223,16 @@ export default class ConfirmIntegration extends React.Component {
                     {helpText}
                     {tokenText}
                     <div className='backstage-form__footer'>
-                        <SpinnerButton
+                        <Link
                             className='btn btn-primary'
                             type='submit'
-                            onClick={this.handleDone}
+                            to={'/' + this.props.team.name + '/integrations/' + this.state.type}
                         >
                             <FormattedMessage
                                 id='integrations.done'
                                 defaultMessage='Done'
                             />
-                        </SpinnerButton>
+                        </Link>
                     </div>
                 </div>
             </div>

--- a/webapp/stores/integration_store.jsx
+++ b/webapp/stores/integration_store.jsx
@@ -73,6 +73,10 @@ class IntegrationStore extends EventEmitter {
         return this.outgoingWebhooks.get(teamId) || [];
     }
 
+    getOutgoingWebhook(teamId, id) {
+        return this.getOutgoingWebhooks(teamId).filter((outgoingWebhook) => outgoingWebhook.id === id)[0];
+    }
+
     setOutgoingWebhooks(teamId, outgoingWebhooks) {
         this.outgoingWebhooks.set(teamId, outgoingWebhooks);
     }
@@ -114,6 +118,10 @@ class IntegrationStore extends EventEmitter {
 
     getCommands(teamId) {
         return this.commands.get(teamId) || [];
+    }
+
+    getCommand(teamId, id) {
+        return this.getCommands(teamId).filter((command) => command.id === id)[0];
     }
 
     setCommands(teamId, commands) {


### PR DESCRIPTION
I'm not sure why it worked in one of the cases before, but we were actually passing through the token as the `id` in the URL. I cleaned it up to properly pass the `id` and get the displayed token from the store.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4087

#### Checklist
- Has UI changes
