### PR TITLE
PLT-4097 Stopped automatically focusing user list search box on mobile

### DIFF
--- a/webapp/components/filtered_user_list.jsx
+++ b/webapp/components/filtered_user_list.jsx
@@ -3,6 +3,7 @@
 
 import $ from 'jquery';
 import ReactDOM from 'react-dom';
+import * as UserAgent from 'utils/user_agent.jsx';
 import UserList from './user_list.jsx';
 
 import {intlShape, injectIntl, defineMessages, FormattedMessage} from 'react-intl';
@@ -60,7 +61,10 @@ class FilteredUserList extends React.Component {
     }
 
     componentDidMount() {
-        ReactDOM.findDOMNode(this.refs.filter).focus();
+        // only focus the search box on desktop so that we don't cause the keyboard to open on mobile
+        if (!UserAgent.isMobileApp()) {
+            ReactDOM.findDOMNode(this.refs.filter).focus();
+        }
     }
 
     componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
The search being focused when it opens seems to be messing up the size calculations for the modal on Android. 

@asaadmahmood Once this goes in (or I get my spinmint running), can you test this on your phone? I don't have an Android device yet so I can't see if it works there.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4097

#### Checklist
- Has UI changes

