### PR TITLE
PLT-4116 Fix weird typing behaviour on LDAP signup page on IE11

### DIFF
--- a/webapp/components/signup/components/signup_ldap.jsx
+++ b/webapp/components/signup/components/signup_ldap.jsx
@@ -39,16 +39,12 @@ export default class SignupLdap extends React.Component {
     }
 
     handleLdapIdChange(e) {
-        e.preventDefault();
-
         this.setState({
             ldapId: e.target.value
         });
     }
 
     handleLdapPasswordChange(e) {
-        e.preventDefault();
-
         this.setState({
             ldapPassword: e.target.value
         });


### PR DESCRIPTION
This is a friendly reminder to not call `preventDefault` on key handlers in text boxes. It makes them perform strangely on IE11.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4116
