### PR TITLE
Fixing OpenLDAP version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ start-docker:
 			-e LDAP_ORGANISATION="Mattermost Test" \
 			-e LDAP_DOMAIN="mm.test.com" \
 			-e LDAP_ADMIN_PASSWORD="mostest" \
-			-d osixia/openldap:1.1.2 > /dev/null;\
+			-d osixia/openldap:1.1.6 > /dev/null;\
 		sleep 10; \
 		docker exec -ti mattermost-openldap bash -c 'echo -e "dn: ou=testusers,dc=mm,dc=test,dc=com\nobjectclass: organizationalunit" | ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest';\
 		docker exec -ti mattermost-openldap bash -c 'echo -e "dn: uid=test.one,ou=testusers,dc=mm,dc=test,dc=com\nobjectclass: iNetOrgPerson\nsn: User\ncn: Test1\nmail: success+testone@simulator.amazonses.com" | ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest';\


### PR DESCRIPTION
#### Summary
Fixing OpenLDAP version in Makefile. The previous version was removed from dockerhub. 
