### PR TITLE
PLT-1238 on permalink not visible back button points to last channel …

### DIFF
--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -146,7 +146,7 @@ export function doFocusPost(channelId, postId, data) {
     AsyncClient.getPostsAfter(postId, 0, Constants.POST_FOCUS_CONTEXT_RADIUS, true);
 }
 
-export function emitPostFocusEvent(postId) {
+export function emitPostFocusEvent(postId, onSuccess) {
     AsyncClient.getChannels(true);
     Client.getPermalinkTmp(
         postId,
@@ -156,9 +156,21 @@ export function emitPostFocusEvent(postId) {
             }
             const channelId = data.posts[data.order[0]].channel_id;
             doFocusPost(channelId, postId, data);
+
+            if (onSuccess) {
+                onSuccess();
+            }
         },
         () => {
-            browserHistory.push('/error?message=' + encodeURIComponent(Utils.localizeMessage('permalink.error.access', 'Permalink belongs to a deleted message or to a channel to which you do not have access.')));
+            let link = `${TeamStore.getCurrentTeamRelativeUrl()}/channels/`;
+            const channel = ChannelStore.getCurrent();
+            if (channel) {
+                link += channel.name;
+            } else {
+                link += 'town-square';
+            }
+
+            browserHistory.push('/error?message=' + encodeURIComponent(Utils.localizeMessage('permalink.error.access', 'Permalink belongs to a deleted message or to a channel to which you do not have access.')) + '&link=' + encodeURIComponent(link));
         }
     );
 }

--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -132,9 +132,12 @@ function preNeedsTeam(nextState, replace, callback) {
     });
 }
 
-function onPermalinkEnter(nextState) {
+function onPermalinkEnter(nextState, replace, callback) {
     const postId = nextState.params.postid;
-    GlobalActions.emitPostFocusEvent(postId);
+    GlobalActions.emitPostFocusEvent(
+        postId,
+        () => callback()
+    );
 }
 
 export default {


### PR DESCRIPTION
#### Summary
When a user goes to a permalink and does not have permission to a private channel where the permalink is posted or the permalink has been deleted now the Back button returns the user to the last viewed channel or to town-square

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-1238