### PR TITLE
Fix messages where should be 'use slash command' instead of 'user slash command'

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -57,11 +57,11 @@
   },
   {
     "id": "authentication.permissions.team_use_slash_commands.name",
-    "translation": "User Slash Commands"
+    "translation": "Use Slash Commands"
   },
   {
     "id": "authentication.permissions.team_use_slash_commands.description",
-    "translation": "Ability to user slash commands"
+    "translation": "Ability to use slash commands"
   },
   {
     "id": "api.auth.unable_to_get_user.app_error",


### PR DESCRIPTION
#### Summary
message of "authentication.permissions.team_use_slash_commands.name" and "authentication.permissions.team_use_slash_commands.description" of platform.po should be 'use slash command' instead of 'user slash command'.

#### Ticket Link
None

#### Checklist
- [x] Includes text changes and localization files updated
