### PR TITLE
PLT-3734 Cleaning up shouldSendEvent function

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -167,7 +167,7 @@ func CreateDirectChannel(userId string, otherUserId string) (*model.Channel, *mo
 			return nil, result.Err
 		}
 	} else {
-		message := model.NewWebSocketEvent("", channel.Id, userId, model.WEBSOCKET_EVENT_DIRECT_ADDED)
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_DIRECT_ADDED, "", channel.Id, "", nil)
 		message.Add("teammate_id", otherUserId)
 		go Publish(message)
 
@@ -579,7 +579,9 @@ func AddUserToChannel(user *model.User, channel *model.Channel) (*model.ChannelM
 	go func() {
 		InvalidateCacheForUser(user.Id)
 
-		message := model.NewWebSocketEvent(channel.TeamId, channel.Id, user.Id, model.WEBSOCKET_EVENT_USER_ADDED)
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_ADDED, "", channel.Id, "", nil)
+		message.Add("user_id", user.Id)
+		message.Add("team_id", channel.TeamId)
 		go Publish(message)
 	}()
 
@@ -789,7 +791,8 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		go func() {
 			InvalidateCacheForChannel(channel.Id)
-			message := model.NewWebSocketEvent(c.TeamId, channel.Id, c.Session.UserId, model.WEBSOCKET_EVENT_CHANNEL_DELETED)
+			message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_DELETED, c.TeamId, "", "", nil)
+			message.Add("channel_id", channel.Id)
 			go Publish(message)
 
 			post := &model.Post{
@@ -827,7 +830,7 @@ func setLastViewedAt(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	Srv.Store.Preference().Save(&model.Preferences{preference})
 
-	message := model.NewWebSocketEvent(c.TeamId, id, c.Session.UserId, model.WEBSOCKET_EVENT_CHANNEL_VIEWED)
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_VIEWED, c.TeamId, "", c.Session.UserId, nil)
 	message.Add("channel_id", id)
 
 	go Publish(message)
@@ -882,7 +885,7 @@ func updateLastViewedAt(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	Srv.Store.Preference().Save(&model.Preferences{preference})
 
-	message := model.NewWebSocketEvent(c.TeamId, id, c.Session.UserId, model.WEBSOCKET_EVENT_CHANNEL_VIEWED)
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_VIEWED, c.TeamId, "", c.Session.UserId, nil)
 	message.Add("channel_id", id)
 
 	go Publish(message)
@@ -1111,9 +1114,16 @@ func RemoveUserFromChannel(userIdToRemove string, removerUserId string, channel 
 
 	InvalidateCacheForUser(userIdToRemove)
 
-	message := model.NewWebSocketEvent(channel.TeamId, channel.Id, userIdToRemove, model.WEBSOCKET_EVENT_USER_REMOVED)
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_REMOVED, "", channel.Id, "", nil)
+	message.Add("user_id", userIdToRemove)
 	message.Add("remover_id", removerUserId)
 	go Publish(message)
+
+	// because the removed user no longer belongs to the channel we need to send a separate websocket event
+	userMsg := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_REMOVED, "", "", userIdToRemove, nil)
+	userMsg.Add("channel_id", channel.Id)
+	userMsg.Add("remover_id", removerUserId)
+	go Publish(userMsg)
 
 	return nil
 }

--- a/api/command_expand_collapse.go
+++ b/api/command_expand_collapse.go
@@ -69,7 +69,7 @@ func setCollapsePreference(c *Context, value string) *model.CommandResponse {
 		return &model.CommandResponse{Text: c.T("api.command_expand_collapse.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	socketMessage := model.NewWebSocketEvent("", "", c.Session.UserId, model.WEBSOCKET_EVENT_PREFERENCE_CHANGED)
+	socketMessage := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_PREFERENCE_CHANGED, "", "", c.Session.UserId, nil)
 	socketMessage.Add("preference", pref.ToJson())
 	go Publish(socketMessage)
 

--- a/api/command_msg.go
+++ b/api/command_msg.go
@@ -79,7 +79,7 @@ func (me *msgProvider) DoCommand(c *Context, channelId string, message string) *
 					targetChannelId = channel.Data.(*model.Channel).Id
 				}
 
-				makeDirectChannelVisible(c.TeamId, targetChannelId)
+				makeDirectChannelVisible(targetChannelId)
 				if len(parsedMessage) > 0 {
 					post := &model.Post{}
 					post.Message = parsedMessage

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -837,7 +837,7 @@ func TestMakeDirectChannelVisible(t *testing.T) {
 
 	channel := Client.Must(Client.CreateDirectChannel(user2.Id)).Data.(*model.Channel)
 
-	makeDirectChannelVisible(team.Id, channel.Id)
+	makeDirectChannelVisible(channel.Id)
 
 	if result, err := Client.GetPreference(model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW, user2.Id); err != nil {
 		t.Fatal("Errored trying to set direct channel to be visible for user1")

--- a/api/status.go
+++ b/api/status.go
@@ -110,8 +110,9 @@ func SetStatusOnline(userId string, sessionId string, manual bool) {
 	}
 
 	if broadcast {
-		event := model.NewWebSocketEvent("", "", status.UserId, model.WEBSOCKET_EVENT_STATUS_CHANGE)
+		event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_STATUS_CHANGE, "", "", "", nil)
 		event.Add("status", model.STATUS_ONLINE)
+		event.Add("user_id", status.UserId)
 		go Publish(event)
 	}
 }
@@ -130,8 +131,9 @@ func SetStatusOffline(userId string, manual bool) {
 		l4g.Error(utils.T("api.status.save_status.error"), userId, result.Err)
 	}
 
-	event := model.NewWebSocketEvent("", "", status.UserId, model.WEBSOCKET_EVENT_STATUS_CHANGE)
+	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_STATUS_CHANGE, "", "", "", nil)
 	event.Add("status", model.STATUS_OFFLINE)
+	event.Add("user_id", status.UserId)
 	go Publish(event)
 }
 
@@ -166,8 +168,9 @@ func SetStatusAwayIfNeeded(userId string, manual bool) {
 		l4g.Error(utils.T("api.status.save_status.error"), userId, result.Err)
 	}
 
-	event := model.NewWebSocketEvent("", "", status.UserId, model.WEBSOCKET_EVENT_STATUS_CHANGE)
+	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_STATUS_CHANGE, "", "", "", nil)
 	event.Add("status", model.STATUS_AWAY)
+	event.Add("user_id", status.UserId)
 	go Publish(event)
 }
 

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -121,7 +121,7 @@ func TestStatuses(t *testing.T) {
 		for {
 			select {
 			case resp := <-WebSocketClient.EventChannel:
-				if resp.Event == model.WEBSOCKET_EVENT_STATUS_CHANGE && resp.UserId == th.BasicUser2.Id {
+				if resp.Event == model.WEBSOCKET_EVENT_STATUS_CHANGE && resp.Data["user_id"].(string) == th.BasicUser2.Id {
 					status := resp.Data["status"].(string)
 					if status == model.STATUS_ONLINE {
 						onlineHit = true

--- a/api/team.go
+++ b/api/team.go
@@ -304,8 +304,8 @@ func JoinUserToTeam(team *model.Team, user *model.User) *model.AppError {
 	RemoveAllSessionsForUserId(user.Id)
 	InvalidateCacheForUser(user.Id)
 
-	// This message goes to every channel, so the channelId is irrelevant
-	go Publish(model.NewWebSocketEvent("", "", user.Id, model.WEBSOCKET_EVENT_NEW_USER))
+	// This message goes to everyone, so the teamId, channelId and userId are irrelevant
+	go Publish(model.NewWebSocketEvent(model.WEBSOCKET_EVENT_NEW_USER, "", "", "", nil))
 
 	return nil
 }
@@ -357,7 +357,9 @@ func LeaveTeam(team *model.Team, user *model.User) *model.AppError {
 	RemoveAllSessionsForUserId(user.Id)
 	InvalidateCacheForUser(user.Id)
 
-	go Publish(model.NewWebSocketEvent(team.Id, "", user.Id, model.WEBSOCKET_EVENT_LEAVE_TEAM))
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_LEAVE_TEAM, team.Id, "", "", nil)
+	message.Add("user_id", user.Id)
+	go Publish(message)
 
 	return nil
 }

--- a/api/user.go
+++ b/api/user.go
@@ -269,8 +269,8 @@ func CreateUser(user *model.User) (*model.User, *model.AppError) {
 
 		ruser.Sanitize(map[string]bool{})
 
-		// This message goes to every channel, so the channelId is irrelevant
-		go Publish(model.NewWebSocketEvent("", "", ruser.Id, model.WEBSOCKET_EVENT_NEW_USER))
+		// This message goes to everyone, so the teamId, channelId and userId are irrelevant
+		go Publish(model.NewWebSocketEvent(model.WEBSOCKET_EVENT_NEW_USER, "", "", "", nil))
 
 		return ruser, nil
 	}
@@ -1289,8 +1289,11 @@ func uploadProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		user := result.Data.(*model.User)
 		user = sanitizeProfile(c, user)
-		message := model.NewWebSocketEvent("", "", c.Session.UserId, model.WEBSOCKET_EVENT_USER_UPDATED)
+		omitUsers := make(map[string]bool, 1)
+		omitUsers[user.Id] = true
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", omitUsers)
 		message.Add("user", user)
+
 		go Publish(message)
 	}
 
@@ -1340,7 +1343,9 @@ func updateUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		updatedUser := rusers[0]
 		updatedUser = sanitizeProfile(c, updatedUser)
 
-		message := model.NewWebSocketEvent("", "", user.Id, model.WEBSOCKET_EVENT_USER_UPDATED)
+		omitUsers := make(map[string]bool, 1)
+		omitUsers[user.Id] = true
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", omitUsers)
 		message.Add("user", updatedUser)
 		go Publish(message)
 
@@ -2496,8 +2501,12 @@ func userTyping(req *model.WebSocketRequest) (map[string]interface{}, *model.App
 		parentId = ""
 	}
 
-	event := model.NewWebSocketEvent("", channelId, req.Session.UserId, model.WEBSOCKET_EVENT_TYPING)
+	omitUsers := make(map[string]bool, 1)
+	omitUsers[req.Session.UserId] = true
+
+	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_TYPING, "", channelId, "", omitUsers)
 	event.Add("parent_id", parentId)
+	event.Add("user_id", req.Session.UserId)
 	go Publish(event)
 
 	return nil, nil

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1793,7 +1793,7 @@ func TestUserTyping(t *testing.T) {
 		for {
 			select {
 			case resp := <-WebSocketClient2.EventChannel:
-				if resp.Event == model.WEBSOCKET_EVENT_TYPING && resp.UserId == th.BasicUser.Id {
+				if resp.Event == model.WEBSOCKET_EVENT_TYPING && resp.Data["user_id"].(string) == th.BasicUser.Id {
 					eventHit = true
 				}
 			case <-stop:

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -64,7 +64,7 @@ func InvalidateCacheForChannel(channelId string) {
 func (h *Hub) Register(webConn *WebConn) {
 	h.register <- webConn
 
-	msg := model.NewWebSocketEvent("", "", webConn.UserId, model.WEBSOCKET_EVENT_HELLO)
+	msg := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_HELLO, "", "", webConn.UserId, nil)
 	msg.Add("server_version", fmt.Sprintf("%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash))
 	go Publish(msg)
 }
@@ -146,52 +146,25 @@ func (h *Hub) Start() {
 }
 
 func shouldSendEvent(webCon *WebConn, msg *model.WebSocketEvent) bool {
-	if webCon.UserId == msg.UserId {
-		// Don't need to tell the user they are typing
-		if msg.Event == model.WEBSOCKET_EVENT_TYPING {
-			return false
-		}
+	// If the event is destined to a specific user
+	if len(msg.Broadcast.UserId) > 0 && webCon.UserId != msg.Broadcast.UserId {
+		return false
+	}
 
-		// We have to make sure the user is in the channel. Otherwise system messages that
-		// post about users in channels they are not in trigger warnings.
-		if len(msg.ChannelId) > 0 {
-			allowed := webCon.IsMemberOfChannel(msg.ChannelId)
+	// if the user is omitted don't send the message
+	if _, ok := msg.Broadcast.OmitUsers[webCon.UserId]; ok {
+		return false
+	}
 
-			if !allowed {
-				return false
-			}
-		}
-	} else {
-		// Don't share a user's view or preference events with other users
-		if msg.Event == model.WEBSOCKET_EVENT_CHANNEL_VIEWED {
-			return false
-		} else if msg.Event == model.WEBSOCKET_EVENT_PREFERENCE_CHANGED {
-			return false
-		} else if msg.Event == model.WEBSOCKET_EVENT_EPHEMERAL_MESSAGE {
-			// For now, ephemeral messages are sent directly to individual users
-			return false
-		} else if msg.Event == model.WEBSOCKET_EVENT_WEBRTC {
-			// No need to tell anyone that a webrtc event is going on
-			return false
-		}
+	// Only report events to users who are in the channel for the event
+	if len(msg.Broadcast.ChannelId) > 0 {
+		return webCon.HasPermissionsToChannel(msg.Broadcast.ChannelId)
+	}
 
-		// Only report events to users who are in the team for the event
-		if len(msg.TeamId) > 0 {
-			allowed := webCon.IsMemberOfTeam(msg.TeamId)
+	// Only report events to users who are in the team for the event
+	if len(msg.Broadcast.TeamId) > 0 {
+		return webCon.HasPermissionsToTeam(msg.Broadcast.TeamId)
 
-			if !allowed {
-				return false
-			}
-		}
-
-		// Only report events to users who are in the channel for the event execept deleted events
-		if len(msg.ChannelId) > 0 && msg.Event != model.WEBSOCKET_EVENT_CHANNEL_DELETED {
-			allowed := webCon.IsMemberOfChannel(msg.ChannelId)
-
-			if !allowed {
-				return false
-			}
-		}
 	}
 
 	return true

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -158,12 +158,12 @@ func shouldSendEvent(webCon *WebConn, msg *model.WebSocketEvent) bool {
 
 	// Only report events to users who are in the channel for the event
 	if len(msg.Broadcast.ChannelId) > 0 {
-		return webCon.HasPermissionsToChannel(msg.Broadcast.ChannelId)
+		return webCon.IsMemberOfChannel(msg.Broadcast.ChannelId)
 	}
 
 	// Only report events to users who are in the team for the event
 	if len(msg.Broadcast.TeamId) > 0 {
-		return webCon.HasPermissionsToTeam(msg.Broadcast.TeamId)
+		return webCon.IsMemberOfTeam(msg.Broadcast.TeamId)
 
 	}
 

--- a/api/webrtc.go
+++ b/api/webrtc.go
@@ -43,7 +43,7 @@ func webrtcMessage(req *model.WebSocketRequest) (map[string]interface{}, *model.
 		return nil, NewInvalidWebSocketParamError(req.Action, "to_user_id")
 	}
 
-	event := model.NewWebSocketEvent("", "", toUserId, model.WEBSOCKET_EVENT_WEBRTC)
+	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_WEBRTC, "", "", toUserId, nil)
 	event.Data = req.Data
 	go Publish(event)
 

--- a/api/websocket_test.go
+++ b/api/websocket_test.go
@@ -78,7 +78,10 @@ func TestWebSocketEvent(t *testing.T) {
 
 	WebSocketClient.Listen()
 
-	evt1 := model.NewWebSocketEvent(th.BasicTeam.Id, th.BasicChannel.Id, "somerandomid", model.WEBSOCKET_EVENT_TYPING)
+	omitUser := make(map[string]bool, 1)
+	omitUser["somerandomid"] = true
+	evt1 := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_TYPING, "", th.BasicChannel.Id, "", omitUser)
+	evt1.Add("user_id", "somerandomid")
 	go Publish(evt1)
 	time.Sleep(300 * time.Millisecond)
 
@@ -89,7 +92,7 @@ func TestWebSocketEvent(t *testing.T) {
 		for {
 			select {
 			case resp := <-WebSocketClient.EventChannel:
-				if resp.Event == model.WEBSOCKET_EVENT_TYPING && resp.UserId == "somerandomid" {
+				if resp.Event == model.WEBSOCKET_EVENT_TYPING && resp.Data["user_id"].(string) == "somerandomid" {
 					eventHit = true
 				}
 			case <-stop:
@@ -106,7 +109,7 @@ func TestWebSocketEvent(t *testing.T) {
 		t.Fatal("did not receive typing event")
 	}
 
-	evt2 := model.NewWebSocketEvent(th.BasicTeam.Id, "somerandomid", "somerandomid", model.WEBSOCKET_EVENT_TYPING)
+	evt2 := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_TYPING, "", "somerandomid", "", nil)
 	go Publish(evt2)
 	time.Sleep(300 * time.Millisecond)
 

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -33,20 +33,26 @@ type WebSocketMessage interface {
 	IsValid() bool
 }
 
+type WebsocketBroadcast struct {
+	OmitUsers map[string]bool `json:"-"`          // broadcast is omitted for users listed here
+	UserId    string          `json:"user_id"`    // broadcast only occurs for this user
+	ChannelId string          `json:"channel_id"` // broadcast only occurs for users in this channel
+	TeamId    string          `json:"team_id"`    // broadcast only occurs for users in this team
+}
+
 type WebSocketEvent struct {
-	TeamId    string                 `json:"team_id"`
-	ChannelId string                 `json:"channel_id"`
-	UserId    string                 `json:"user_id"`
 	Event     string                 `json:"event"`
 	Data      map[string]interface{} `json:"data"`
+	Broadcast *WebsocketBroadcast    `json:"broadcast"`
 }
 
 func (m *WebSocketEvent) Add(key string, value interface{}) {
 	m.Data[key] = value
 }
 
-func NewWebSocketEvent(teamId string, channelId string, userId string, event string) *WebSocketEvent {
-	return &WebSocketEvent{TeamId: teamId, ChannelId: channelId, UserId: userId, Event: event, Data: make(map[string]interface{})}
+func NewWebSocketEvent(event, teamId, channelId, userId string, omitUsers map[string]bool) *WebSocketEvent {
+	return &WebSocketEvent{Event: event, Data: make(map[string]interface{}),
+		Broadcast: &WebsocketBroadcast{TeamId: teamId, ChannelId: channelId, UserId: userId, OmitUsers: omitUsers}}
 }
 
 func (o *WebSocketEvent) IsValid() bool {

--- a/model/websocket_message_test.go
+++ b/model/websocket_message_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWebSocketEvent(t *testing.T) {
-	m := NewWebSocketEvent(NewId(), NewId(), NewId(), "some_event")
+	m := NewWebSocketEvent("some_event", NewId(), NewId(), NewId(), nil)
 	m.Add("RootId", NewId())
 	json := m.ToJson()
 	result := WebSocketEventFromJson(strings.NewReader(json))
@@ -23,7 +23,7 @@ func TestWebSocketEvent(t *testing.T) {
 		t.Fatal("should be valid")
 	}
 
-	if m.TeamId != result.TeamId {
+	if m.Broadcast.TeamId != result.Broadcast.TeamId {
 		t.Fatal("Ids do not match")
 	}
 

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -23,7 +23,7 @@ export function handleNewPost(post, msg) {
         } else {
             AsyncClient.getChannel(post.channel_id);
         }
-    } else if (msg && (TeamStore.getCurrentId() === msg.team_id || msg.data.channel_type === Constants.DM_CHANNEL)) {
+    } else if (msg && (TeamStore.getCurrentId() === msg.data.team_id || msg.data.channel_type === Constants.DM_CHANNEL)) {
         if (Client.teamId) {
             AsyncClient.getChannel(post.channel_id);
         }


### PR DESCRIPTION
#### Summary
Websocket shouldSendEvent and the WebsocketEvent model has been change to support the broadcast of events for a particular user, channel or team, it also has the ability to omit certain users and if everything is set blank then the event will be sent to everyone.

**This PR should be tested in order to determine that every websocket event is working correctly**

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3734

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [x] Has enterprise changes (https://github.com/mattermost/enterprise/pull/58)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

