### PR TITLE
PLT-4179 send push notifications with override_username

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -678,7 +678,11 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 	if post.IsSystemMessage() {
 		senderName = c.T("system.message.name")
 	} else if profile, ok := profileMap[post.UserId]; ok {
-		senderName = profile.Username
+		if value, ok := post.Props["override_username"]; ok && post.Props["from_webhook"] == "true" {
+			senderName = value.(string)
+		} else {
+			senderName = profile.Username
+		}
 		sender = profile
 	}
 


### PR DESCRIPTION
#### Summary
If a webhook overrides username send the notifications with the sender name as the webhook override name

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4179
