### PR TITLE
PLT-3338 Show username on Direct message search result

### DIFF
--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -72,7 +72,10 @@ export default class SearchResultsItem extends React.Component {
                 channelName = (
                     <FormattedMessage
                         id='search_item.direct'
-                        defaultMessage='Direct Message'
+                        defaultMessage='Direct Message (with {username})'
+                        values={{
+                            username: Utils.displayUsernameForUser(Utils.getDirectTeammate(channel.id))
+                        }}
                     />
                 );
             }

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1595,7 +1595,7 @@
   "search_header.results": "Search Results",
   "search_header.title2": "Recent Mentions",
   "search_header.title3": "Flagged Posts",
-  "search_item.direct": "Direct Message",
+  "search_item.direct": "Direct Message (with {username})",
   "search_item.jump": "Jump",
   "search_results.because": "<ul><li>If you're searching a partial phrase (ex. searching \"rea\", looking for \"reach\" or \"reaction\"), append a * to your search term.</li><li>Two letter searches and common words like \"this\", \"a\" and \"is\" won't appear in search results due to excessive results returned.</li></ul>",
   "search_results.noResults": "No results found. Try again?",


### PR DESCRIPTION
#### Summary
On a search that return results for direct messages have the Direct Message title include the other user as the channel name

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3338

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Includes text changes and localization files updated

