### PR TITLE
PLT-4201 Fixed ALT+SHIFT+UP breaking ALT+UP with no unreads

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -346,8 +346,8 @@ export default class Sidebar extends React.Component {
                 nextChannel = allChannels[nextIndex];
                 ChannelActions.goToChannel(nextChannel);
                 this.updateScrollbarOnChannelChange(nextChannel);
-                this.isSwitchingChannel = false;
             }
+            this.isSwitchingChannel = false;
         }
     }
 


### PR DESCRIPTION
#### Summary
- Moved `isSwitchingChannel` outside of the success condition for ALT+SHIFT+UP
- Ensured that ALT+SHIFT+UP with no unreads did not break ALT+UP/DOWN

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4201
