### PR TITLE
Fix !channel linking in Slack import.

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1512,6 +1512,10 @@
     "translation": "Failed to compile the @mention matching regular expression for Slack user {{.UserID}} {{.Username}}"
   },
   {
+    "id": "api.slackimport.slack_convert_channel_mentions.compile_regexp_failed.warn",
+    "translation": "Failed to compile the !channel matching regular expression for Slack channel {{.ChannelID}} {{.ChannelName}}"
+  },
+  {
     "id": "api.slackimport.slack_import.log",
     "translation": "Mattermost Slack Import Log\r\n"
   },


### PR DESCRIPTION
#### Summary

Fix !channel linking in Slack import.

Original version of the patch didn't take into account that, like with
@mentions, there's an "old" and a "new" format in the Slack export files
for channel mentions. This version imports both correctly.

#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-1764

#### Checklist

- [x] Includes text changes and localization files updated