### PR TITLE
Changed user diagnostic naming

### DIFF
--- a/mattermost.go
+++ b/mattermost.go
@@ -306,9 +306,9 @@ func sendServerDiagnostics() {
 	}
 
 	utils.SendDiagnostic(utils.TRACK_ACTIVITY, map[string]interface{}{
-		"users":        userCount,
-		"active_users": activeUserCount,
-		"teams":        teamCount,
+		"registered_users": userCount,
+		"active_users":     activeUserCount,
+		"teams":            teamCount,
 	})
 
 	edition := model.BuildEnterpriseReady


### PR DESCRIPTION
#### Summary
Renamed `users` to `registered_users` as the count included inactive users. A separate ticket has been created to distinguish inactive users.