### PR TITLE
Import Slack uploads if present in zip archive.

### DIFF
--- a/api/slackimport.go
+++ b/api/slackimport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/platform/utils"
 	"io"
 	"mime/multipart"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -31,6 +32,11 @@ type SlackUser struct {
 	Profile  map[string]string `json:"profile"`
 }
 
+type SlackFile struct {
+	Id    string `json:"id"`
+	Title string `json:"title"`
+}
+
 type SlackPost struct {
 	User        string        `json:"user"`
 	BotId       string        `json:"bot_id"`
@@ -40,6 +46,8 @@ type SlackPost struct {
 	Type        string        `json:"type"`
 	SubType     string        `json:"subtype"`
 	Comment     *SlackComment `json:"comment"`
+	Upload      bool          `json:"upload"`
+	File        *SlackFile    `json:"file"`
 }
 
 type SlackComment struct {
@@ -159,7 +167,7 @@ func SlackAddUsers(teamId string, slackusers []SlackUser, log *bytes.Buffer) map
 	return addedUsers
 }
 
-func SlackAddPosts(channel *model.Channel, posts []SlackPost, users map[string]*model.User) {
+func SlackAddPosts(teamId string, channel *model.Channel, posts []SlackPost, users map[string]*model.User, uploads map[string]*zip.File) {
 	for _, sPost := range posts {
 		switch {
 		case sPost.Type == "message" && (sPost.SubType == "" || sPost.SubType == "file_share"):
@@ -175,6 +183,12 @@ func SlackAddPosts(channel *model.Channel, posts []SlackPost, users map[string]*
 				ChannelId: channel.Id,
 				Message:   sPost.Text,
 				CreateAt:  SlackConvertTimeStamp(sPost.TimeStamp),
+			}
+			if sPost.Upload {
+				if filename, ok := SlackUploadFile(sPost, uploads, teamId, newPost.ChannelId, newPost.UserId); ok == true {
+					newPost.Filenames = append(newPost.Filenames, filename)
+					newPost.Message = sPost.File.Title
+				}
 			}
 			ImportPost(&newPost)
 		case sPost.Type == "message" && sPost.SubType == "file_comment":
@@ -219,6 +233,33 @@ func SlackAddPosts(channel *model.Channel, posts []SlackPost, users map[string]*
 	}
 }
 
+func SlackUploadFile(sPost SlackPost, uploads map[string]*zip.File, teamId string, channelId string, userId string) (string, bool) {
+	if sPost.File != nil {
+		if file, ok := uploads[sPost.File.Id]; ok == true {
+			openFile, err := file.Open()
+			if err != nil {
+				l4g.Warn(utils.T("api.slackimport.slack_add_posts.upload_file_open_failed.warn", map[string]interface{}{"FileId": sPost.File.Id, "Error": err.Error()}))
+				return "", false
+			}
+			defer openFile.Close()
+
+			uploadedFile, err := ImportFile(openFile, teamId, channelId, userId, filepath.Base(file.Name))
+			if err != nil {
+				l4g.Warn(utils.T("api.slackimport.slack_add_posts.upload_file_upload_failed.warn", map[string]interface{}{"FileId": sPost.File.Id, "Error": err.Error()}))
+				return "", false
+			}
+
+			return uploadedFile, true
+		} else {
+			l4g.Warn(utils.T("api.slackimport.slack_add_posts.upload_file_not_found.warn", map[string]interface{}{"FileId": sPost.File.Id}))
+			return "", false
+		}
+	} else {
+		l4g.Warn(utils.T("api.slackimport.slack_add_posts.upload_file_not_in_json.warn"))
+		return "", false
+	}
+}
+
 func addSlackUsersToChannel(members []string, users map[string]*model.User, channel *model.Channel, log *bytes.Buffer) {
 	for _, member := range members {
 		if user, ok := users[member]; !ok {
@@ -231,7 +272,7 @@ func addSlackUsersToChannel(members []string, users map[string]*model.User, chan
 	}
 }
 
-func SlackAddChannels(teamId string, slackchannels []SlackChannel, posts map[string][]SlackPost, users map[string]*model.User, log *bytes.Buffer) map[string]*model.Channel {
+func SlackAddChannels(teamId string, slackchannels []SlackChannel, posts map[string][]SlackPost, users map[string]*model.User, uploads map[string]*zip.File, log *bytes.Buffer) map[string]*model.Channel {
 	// Write Header
 	log.WriteString(utils.T("api.slackimport.slack_add_channels.added"))
 	log.WriteString("=================\r\n\r\n")
@@ -261,7 +302,7 @@ func SlackAddChannels(teamId string, slackchannels []SlackChannel, posts map[str
 		addSlackUsersToChannel(sChannel.Members, users, mChannel, log)
 		log.WriteString(newChannel.DisplayName + "\r\n")
 		addedChannels[sChannel.Id] = mChannel
-		SlackAddPosts(mChannel, posts[sChannel.Name], users)
+		SlackAddPosts(teamId, mChannel, posts[sChannel.Name], users, uploads)
 	}
 
 	return addedChannels
@@ -331,6 +372,7 @@ func SlackImport(fileData multipart.File, fileSize int64, teamID string) (*model
 	var channels []SlackChannel
 	var users []SlackUser
 	posts := make(map[string][]SlackPost)
+	uploads := make(map[string]*zip.File)
 	for _, file := range zipreader.File {
 		reader, err := file.Open()
 		if err != nil {
@@ -351,8 +393,9 @@ func SlackImport(fileData multipart.File, fileSize int64, teamID string) (*model
 				} else {
 					posts[channel] = append(posts[channel], newposts...)
 				}
+			} else if len(spl) == 3 && spl[0] == "__uploads" {
+				uploads[spl[1]] = file
 			}
-
 		}
 	}
 
@@ -360,7 +403,7 @@ func SlackImport(fileData multipart.File, fileSize int64, teamID string) (*model
 	posts = SlackConvertChannelMentions(channels, posts)
 
 	addedUsers := SlackAddUsers(teamID, users, log)
-	SlackAddChannels(teamID, channels, posts, addedUsers, log)
+	SlackAddChannels(teamID, channels, posts, addedUsers, uploads, log)
 
 	log.WriteString(utils.T("api.slackimport.slack_import.notes"))
 	log.WriteString("=======\r\n\r\n")

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1552,6 +1552,22 @@
     "translation": "Unsupported post type: %v, %v"
   },
   {
+    "id": "api.slackimport.slack_add_posts.upload_file_not_found.warn",
+    "translation": "No file found in Slack export for file upload message with file ID {{.FileId}}"
+  },
+  {
+    "id": "api.slackimport.slack_add_posts.upload_file_not_in_json.warn",
+    "translation": "Cannot import file for upload post with no \"file\" section present in export."
+  },
+  {
+    "id": "api.slackimport.slack_add_posts.upload_file_open_failed.warn",
+    "translation": "Could not open the upload file with ID {{.FileId}} in the export archive with error: {{.Error}}"
+  },
+  {
+    "id": "api.slackimport.slack_add_posts.upload_file_upload_failed.warn",
+    "translation": "Uploading the file for upload message with file ID {{.FileId}} failed with error: {{.Error}}"
+  },
+  {
     "id": "api.slackimport.slack_add_posts.user_no_exists.debug",
     "translation": "User: %v does not exist!"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1536,6 +1536,10 @@
     "translation": "Merged with existing channel: {{.DisplayName}}\r\n"
   },
   {
+    "id": "api.slackimport.slack_add_posts.attach_files.error",
+    "translation": "Encountered error attaching files to post, post_id=%s, file_ids=%v, err=%v"
+  },
+  {
     "id": "api.slackimport.slack_add_posts.bot.warn",
     "translation": "Slack bot posts are not imported yet"
   },


### PR DESCRIPTION
#### Summary
This is part 3 of PLT-4280, to support importing file uploads when importing from Slack. (Part 1 is already merged and Part 2 is in the slack-advanced-exporter repository).

It is assumed the uploads in the zip archive will be present as per the output of [slack-advanced-exporter](https://github.com/grundleborg/slack-advanced-exporter).

If the uploads are not present (ie. this is a vanilla Slack export archive) uploads are treated in the same way as before this patch, providing only a link to the upload on Slack's servers in the message body.

To test it out, you will need a vanilla Slack export zip archive, and then to run it through the [slack-advanced-exporter](https://github.com/grundleborg/slack-advanced-exporter) to get the uploaded files and add them to the archive. Then try importing that to Mattermost, either through the web UI or the command line (both should work exactly the same).

This needs a decent amount of testing to make sure the appropriate Slack message types are handled correctly, as I've only got a couple of export archives to go on for testing myself.

#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-4280

#### Checklist
- [x] Includes text changes and localization files updated
