### PR TITLE
Close github's ticket #4073.

### DIFF
--- a/model/team_member.go
+++ b/model/team_member.go
@@ -65,7 +65,7 @@ func (o *TeamMember) IsInTeamRole(aRole string) bool {
 }
 
 func (o *TeamMember) IsTeamAdmin() bool {
-	return o.IsInTeamRole("admin")
+	return o.IsInTeamRole("team_admin") // NB: In previous version, it was "admin" so adapt to your targetted version.
 }
 
 func (o *TeamMember) IsValid() *AppError {

--- a/model/team_member.go
+++ b/model/team_member.go
@@ -55,21 +55,17 @@ func TeamMembersFromJson(data io.Reader) []*TeamMember {
 	}
 }
 
-func IsInTeamRole(teamRoles string, inRole string) bool {
-	roles := strings.Split(teamRoles, " ")
-
-	for _, r := range roles {
-		if r == inRole {
+func (o *TeamMember) IsInTeamRole(aRole string) bool {
+	for _, role := range o.GetRoles() {
+		if role == aRole {
 			return true
 		}
-
 	}
-
 	return false
 }
 
 func (o *TeamMember) IsTeamAdmin() bool {
-	return true
+	return o.IsInTeamRole("admin")
 }
 
 func (o *TeamMember) IsValid() *AppError {


### PR DESCRIPTION
#### Summary
Implements TeamMember.IsTeamAdmin properly.

Add TeamMember.IsInTeamRole function, that use GetRoles.
Update implementation TeamMember.IsTeamAdmin by testing role against "admin".

#### Ticket Link
#4073 

#### Checklist
Nothing applicable from the checklist.
Go Client can now reliably use the function because it used to return always true!