### PR TITLE
PLT-4282 Show statuses correctly for cached post views

### DIFF
--- a/webapp/components/post_view/post_view_controller.jsx
+++ b/webapp/components/post_view/post_view_controller.jsx
@@ -177,11 +177,14 @@ export default class PostViewController extends React.Component {
 
             const joinLeaveEnabled = PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave', true);
 
+            const statuses = Object.assign({}, UserStore.getStatuses());
+
             this.setState({
                 channel,
                 lastViewed,
                 ownNewMessage: false,
                 profiles: JSON.parse(JSON.stringify(profiles)),
+                statuses,
                 postList: PostStore.filterPosts(channel.id, joinLeaveEnabled),
                 displayNameType: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, 'name_format', 'false'),
                 displayPostsInCenter: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_CENTERED,


### PR DESCRIPTION
#### Summary
Statuses wouldn't immediately update when switching to a cached post view, this fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4282