### PR TITLE
PLT-4136 Fix missing confirm password error on LDAP claim page

### DIFF
--- a/webapp/components/claim/components/ldap_to_email.jsx
+++ b/webapp/components/claim/components/ldap_to_email.jsx
@@ -6,7 +6,6 @@ import * as Utils from 'utils/utils.jsx';
 import {switchFromLdapToEmail} from 'actions/user_actions.jsx';
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {FormattedMessage} from 'react-intl';
 
 export default class LDAPToEmail extends React.Component {
@@ -32,14 +31,14 @@ export default class LDAPToEmail extends React.Component {
             serverError: ''
         };
 
-        const ldapPassword = ReactDOM.findDOMNode(this.refs.ldappassword).value;
+        const ldapPassword = this.refs.ldappassword.value;
         if (!ldapPassword) {
             state.ldapPasswordError = Utils.localizeMessage('claim.ldap_to_email.ldapPasswordError', 'Please enter your AD/LDAP password.');
             this.setState(state);
             return;
         }
 
-        const password = ReactDOM.findDOMNode(this.refs.password).value;
+        const password = this.refs.password.value;
         if (!password) {
             state.passwordError = Utils.localizeMessage('claim.ldap_to_email.pwdError', 'Please enter your password.');
             this.setState(state);
@@ -54,9 +53,9 @@ export default class LDAPToEmail extends React.Component {
             return;
         }
 
-        const confirmPassword = ReactDOM.findDOMNode(this.refs.passwordconfirm).value;
+        const confirmPassword = this.refs.passwordconfirm.value;
         if (!confirmPassword || password !== confirmPassword) {
-            state.error = Utils.localizeMessage('claim.ldap_to_email.pwdNotMatch', 'Passwords do not match.');
+            state.confirmError = Utils.localizeMessage('claim.ldap_to_email.pwdNotMatch', 'Passwords do not match.');
             this.setState(state);
             return;
         }


### PR DESCRIPTION
#### Summary
On the LDAP claim page, the confirm password error was not showing up. This fixes it.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4136