### PR TITLE
PLT-4298 Remove "Return to ongoing call" indicator

### DIFF
--- a/webapp/components/admin_console/rate_settings.jsx
+++ b/webapp/components/admin_console/rate_settings.jsx
@@ -112,7 +112,7 @@ export default class RateSettings extends AdminSettings {
                     helpText={
                         <FormattedMessage
                             id='admin.rate.maxBurstDescription'
-                            defaultMessage='Maxumum number of requests allowed beyond the per second query limit.'
+                            defaultMessage='Maximum number of requests allowed beyond the per second query limit.'
                         />
                     }
                     value={this.state.maxBurst}

--- a/webapp/components/webrtc/webrtc_controller.jsx
+++ b/webapp/components/webrtc/webrtc_controller.jsx
@@ -734,7 +734,9 @@ export default class WebrtcController extends React.Component {
             this.onSessionError();
             return this.doCleanup();
         }
+
         WebrtcStore.setVideoCallWith(null);
+        WebrtcStore.emitRhsChanged(false);
 
         if (manual) {
             return this.close();

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -545,7 +545,7 @@
   "admin.rate.title": "Rate Limit Settings",
   "admin.rate.maxBurst": "Max Burst:",
   "admin.rate.maxBurstExample": "Ex \"100\"",
-  "admin.rate.maxBurstDescription": "Maxumum number of requests allowed beyond the per second query limit.",
+  "admin.rate.maxBurstDescription": "Maximum number of requests allowed beyond the per second query limit.",
   "admin.recycle.button": "Recycle Database Connections",
   "admin.recycle.loading": " Recycling...",
   "admin.recycle.recycleDescription": "Deployments using multiple databases can switch from one master database to another without restarting the Mattermost server by updating \"config.json\" to the new desired configuration and using the <a href=\"../general/configuration\"><b>Configuration > Reload Configuration from Disk</b></a> feature to load the new settings while the server is running. The administrator should then use <b>Recycle Database Connections</b> feature to recycle the database connections based on the new settings.",


### PR DESCRIPTION
#### Summary
When showing any other view than the webrtc video an indicator saying there is an ongoing call didn't disappear if the call was terminated by the other person

There was a typo in not related to webrtc that I've fixed either way

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4298

#### Checklist
- [x] Includes text changes and localization files updated

