### PR TITLE
PLT-4155 Show correct login method in system console

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -1007,11 +1007,8 @@ func getProfiles(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	etag := (<-Srv.Store.User().GetEtagForProfiles(id)).Data.(string)
-	if !HasPermissionToContext(c, model.PERMISSION_MANAGE_SYSTEM) {
-		c.Err = nil
-		if HandleEtag(etag, w, r) {
-			return
-		}
+	if HandleEtag(etag, w, r) {
+		return
 	}
 
 	if result := <-Srv.Store.User().GetProfiles(id); result.Err != nil {

--- a/api/user.go
+++ b/api/user.go
@@ -1007,8 +1007,11 @@ func getProfiles(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	etag := (<-Srv.Store.User().GetEtagForProfiles(id)).Data.(string)
-	if HandleEtag(etag, w, r) {
-		return
+	if !HasPermissionToContext(c, model.PERMISSION_MANAGE_SYSTEM) {
+		c.Err = nil
+		if HandleEtag(etag, w, r) {
+			return
+		}
 	}
 
 	if result := <-Srv.Store.User().GetProfiles(id); result.Err != nil {
@@ -2518,6 +2521,7 @@ func sanitizeProfile(c *Context, user *model.User) *model.User {
 	if HasPermissionToContext(c, model.PERMISSION_MANAGE_SYSTEM) {
 		options["email"] = true
 		options["fullname"] = true
+		options["authservice"] = true
 	}
 	c.Err = nil
 

--- a/model/user.go
+++ b/model/user.go
@@ -232,13 +232,15 @@ func (u *User) Sanitize(options map[string]bool) {
 	if len(options) != 0 && !options["passwordupdate"] {
 		u.LastPasswordUpdate = 0
 	}
+	if len(options) != 0 && !options["authservice"] {
+		u.AuthService = ""
+	}
 }
 
 func (u *User) ClearNonProfileFields() {
 	u.Password = ""
 	u.AuthData = new(string)
 	*u.AuthData = ""
-	u.AuthService = ""
 	u.MfaActive = false
 	u.MfaSecret = ""
 	u.EmailVerified = false


### PR DESCRIPTION
#### Summary
The login method in the system console always showed the login method as "Email" cause the authservice was always sanitised and if the profiles where cached by an etag it wouldn't even update.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4155

