### PR TITLE
PLT-4192 Switched SidebarHeaderDropdown to use react-bootstrap

### DIFF
--- a/webapp/components/admin_console/admin_navbar_dropdown.jsx
+++ b/webapp/components/admin_console/admin_navbar_dropdown.jsx
@@ -82,20 +82,20 @@ export default class AdminNavbarDropdown extends React.Component {
         }
 
         return (
-            <ul className='nav navbar-nav navbar-right'>
+            <ul className='nav navbar-nav navbar-right admin-navbar-dropdown'>
                 <li
                     ref='dropdown'
                     className='dropdown'
                 >
                     <a
                         href='#'
-                        className='dropdown-toggle'
+                        className='dropdown-toggle admin-navbar-dropdown__toggle'
                         data-toggle='dropdown'
                         role='button'
                         aria-expanded='false'
                     >
                         <span
-                            className='dropdown__icon'
+                            className='dropdown__icon admin-navbar-dropdown__icon'
                             dangerouslySetInnerHTML={{__html: Constants.MENU_ICON}}
                         />
                     </a>

--- a/webapp/components/sidebar_header.jsx
+++ b/webapp/components/sidebar_header.jsx
@@ -1,23 +1,17 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import NavbarDropdown from './navbar_dropdown.jsx';
-import 'bootstrap';
+import React from 'react';
 
-import PreferenceStore from 'stores/preference_store.jsx';
-
-import * as Utils from 'utils/utils.jsx';
 import Client from 'client/web_client.jsx';
-import Constants from 'utils/constants.jsx';
+import PreferenceStore from 'stores/preference_store.jsx';
+import * as Utils from 'utils/utils.jsx';
 
-const Preferences = Constants.Preferences;
-const TutorialSteps = Constants.TutorialSteps;
-
+import SidebarHeaderDropdown from './sidebar_header_dropdown.jsx';
 import {Tooltip, OverlayTrigger} from 'react-bootstrap';
 
+import {Preferences, TutorialSteps} from 'utils/constants.jsx';
 import {createMenuTip} from 'components/tutorial/tutorial_tip.jsx';
-
-import React from 'react';
 
 export default class SidebarHeader extends React.Component {
     constructor(props) {
@@ -28,34 +22,31 @@ export default class SidebarHeader extends React.Component {
 
         this.state = this.getStateFromStores();
     }
+
     componentDidMount() {
         PreferenceStore.addChangeListener(this.onPreferenceChange);
     }
+
     componentWillUnmount() {
         PreferenceStore.removeChangeListener(this.onPreferenceChange);
     }
+
     getStateFromStores() {
         const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, this.props.currentUser.id, 999);
 
         return {showTutorialTip: tutorialStep === TutorialSteps.MENU_POPOVER && !Utils.isMobile()};
     }
+
     onPreferenceChange() {
         this.setState(this.getStateFromStores());
     }
+
     toggleDropdown(e) {
         e.preventDefault();
-        if (this.refs.dropdown.blockToggle) {
-            this.refs.dropdown.blockToggle = false;
-            return;
-        }
-        const menu = document.querySelector('.team__header .dropdown-toggle');
-        const isOpen = menu.parentElement.classList.toggle('open');
-        menu.setAttribute('aria-expanded', isOpen);
 
-        if (!isOpen) {
-            document.querySelector('.sidebar--left .dropdown-menu').scrollTop = 0;
-        }
+        this.refs.dropdown.toggleDropdown();
     }
+
     render() {
         var me = this.props.currentUser;
         var profilePicture = null;
@@ -99,13 +90,12 @@ export default class SidebarHeader extends React.Component {
                         </OverlayTrigger>
                     </div>
                 </a>
-                <NavbarDropdown
+                <SidebarHeaderDropdown
                     ref='dropdown'
                     teamType={this.props.teamType}
                     teamDisplayName={this.props.teamDisplayName}
                     teamName={this.props.teamName}
                     currentUser={this.props.currentUser}
-                    toggleDropdown={this.toggleDropdown}
                 />
             </div>
         );

--- a/webapp/sass/layout/_headers.scss
+++ b/webapp/sass/layout/_headers.scss
@@ -244,12 +244,14 @@
                 @include alpha-property(background, $black, .1);
             }
 
-            a {
-                text-decoration: none;
-            }
-
             .user__name {
                 color: $white;
+            }
+
+            .sidebar-header-dropdown {
+                .sidebar-header-dropdown__toggle {
+                    @include opacity(1);
+                }
             }
 
             .navbar-right {
@@ -259,16 +261,28 @@
             }
         }
 
-        .navbar-right {
+        a {
+            text-decoration: none;
+        }
+
+        .sidebar-header-dropdown,
+        .admin-navbar-dropdown {
             font-size: .85em;
             position: absolute;
+            margin-right: -15px;
             right: 22px;
             top: 10px;
             z-index: 5;
 
-            .dropdown-toggle {
+            .sidebar-header-dropdown__toggle,
+            .admin-navbar-dropdown__toggle {
                 @include opacity(.8);
                 @include single-transition(all, .1s, linear);
+                background: none;
+                color: $white;
+                float: right;
+                font-size: 1em;
+                line-height: 1.8;
                 padding: 10px;
             }
 
@@ -284,8 +298,13 @@
                 }
             }
 
-            .dropdown__icon {
+            .sidebar-header-dropdown__icon,
+            .admin-navbar-dropdown__icon {
                 fill: $white;
+            }
+
+            .divider + .divider {
+                display: none;
             }
         }
 
@@ -329,22 +348,6 @@
             font-size: 14px;
             font-weight: 400;
             line-height: 18px;
-        }
-
-        > .nav {
-            > li {
-                > a {
-                    background: none;
-                    float: right;
-                    padding: 2px;
-                }
-
-                .dropdown-toggle {
-                    color: $white;
-                    font-size: 1em;
-                    line-height: 1.8;
-                }
-            }
         }
     }
 

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -824,7 +824,7 @@
                 margin: 10px 0;
             }
 
-            .navbar-right {
+            .sidebar-header-dropdown {
                 display: none;
             }
         }

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -197,12 +197,20 @@ export const SocketEvents = {
     WEBRTC: 'webrtc'
 };
 
+export const TutorialSteps = {
+    INTRO_SCREENS: 0,
+    POST_POPOVER: 1,
+    CHANNEL_POPOVER: 2,
+    MENU_POPOVER: 3
+};
+
 export const Constants = {
     Preferences,
     SocketEvents,
     ActionTypes,
     WebrtcActionTypes,
     UserStatuses,
+    TutorialSteps,
 
     PayloadSources: keyMirror({
         SERVER_ACTION: null,
@@ -614,12 +622,6 @@ export const Constants = {
         Ubuntu: 'font--ubuntu'
     },
     DEFAULT_FONT: 'Open Sans',
-    TutorialSteps: {
-        INTRO_SCREENS: 0,
-        POST_POPOVER: 1,
-        CHANNEL_POPOVER: 2,
-        MENU_POPOVER: 3
-    },
     KeyCodes: {
         BACKSPACE: 8,
         TAB: 9,

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -522,7 +522,7 @@ export function applyTheme(theme) {
 
     if (theme.sidebarHeaderTextColor) {
         changeCss('.app__body .sidebar--left .team__header .header__info, .app__body .sidebar--menu .team__header .header__info, .app__body .post-list__timestamp > div', 'color:' + theme.sidebarHeaderTextColor, 1);
-        changeCss('.app__body .sidebar--left .team__header .navbar-right .dropdown__icon, .app__body .sidebar--menu .team__header .navbar-right .dropdown__icon', 'fill:' + theme.sidebarHeaderTextColor, 1);
+        changeCss('.app__body .sidebar-header-dropdown__icon', 'fill:' + theme.sidebarHeaderTextColor, 1);
         changeCss('.app__body .sidebar--left .team__header .user__name, .app__body .sidebar--menu .team__header .user__name', 'color:' + changeOpacity(theme.sidebarHeaderTextColor, 0.8), 1);
         changeCss('.app__body .sidebar--left .team__header:hover .user__name, .app__body .sidebar--menu .team__header:hover .user__name', 'color:' + theme.sidebarHeaderTextColor, 1);
         changeCss('.app__body .modal .modal-header .modal-title, .app__body .modal .modal-header .modal-title .name, .app__body .modal .modal-header button.close', 'color:' + theme.sidebarHeaderTextColor, 1);


### PR DESCRIPTION
Switched the SidebarHeaderDropdown (previously called the NavbarDropdown) to use react-bootstrap and cleaned up its CSS to be independent of regular bootstrap. This gives us back the behaviour where it closes when you click outside of it and makes it easier to control programatically.

@asaadmahmood, if you get a chance, can you skim over the CSS to make sure I didn't do anything horribly wrong?

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4192

#### Checklist
- Has UI changes