### PR TITLE
PLT-4200/3708 Fixed outside team DM switching, allowed switching to uncreated DMs

### DIFF
--- a/webapp/components/channel_switch_modal.jsx
+++ b/webapp/components/channel_switch_modal.jsx
@@ -27,12 +27,28 @@ export default class SwitchChannelModal extends React.Component {
         this.onExited = this.onExited.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
+        this.handleDmUserChange = this.handleDmUserChange.bind(this);
         this.suggestionProviders = [new SwitchChannelProvider()];
 
         this.state = {
+            dmUsers: UserStore.getDirectProfiles(),
             text: '',
             error: ''
         };
+    }
+
+    componentDidMount() {
+        UserStore.addDmListChangeListener(this.handleDmUserChange);
+    }
+
+    componentWillUnmount() {
+        UserStore.removeDmListChangeListener(this.handleDmUserChange);
+    }
+
+    handleDmUserChange() {
+        this.setState({
+            dmUsers: UserStore.getDirectProfiles(),
+        });
     }
 
     componentDidUpdate(prevProps) {
@@ -83,7 +99,25 @@ export default class SwitchChannelModal extends React.Component {
 
         if (name.indexOf(Utils.localizeMessage('channel_switch_modal.dm', '(Direct Message)')) > 0) {
             const dmUsername = name.substr(0, name.indexOf(Utils.localizeMessage('channel_switch_modal.dm', '(Direct Message)')) - 1);
-            channel = ChannelStore.getByName(Utils.getDirectChannelNameByUsername(dmUsername, UserStore.getCurrentUser().username).trim());
+            let user = null;
+            for (const id in this.state.dmUsers) {
+                if (this.state.dmUsers[id].username === dmUsername) {
+                    user = this.state.dmUsers[id];
+                    break;
+                }
+            }
+
+            if (user) {
+                Utils.openDirectChannelToUser(
+                    user,
+                    (ch) => {
+                        channel = ch;
+                    },
+                    () => {
+                        channel = null;
+                    }
+                );
+            }
         } else {
             channel = ChannelStore.getByName(this.state.text.trim());
         }

--- a/webapp/components/channel_switch_modal.jsx
+++ b/webapp/components/channel_switch_modal.jsx
@@ -47,7 +47,7 @@ export default class SwitchChannelModal extends React.Component {
 
     handleDmUserChange() {
         this.setState({
-            dmUsers: UserStore.getDirectProfiles(),
+            dmUsers: UserStore.getDirectProfiles()
         });
     }
 

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -1045,13 +1045,6 @@ export function getDirectChannelName(id, otherId) {
     return handle;
 }
 
-export function getDirectChannelNameByUsername(username, otherUsername) {
-    const id = UserStore.getProfileByUsername(username).id;
-    const otherId = UserStore.getProfileByUsername(otherUsername).id;
-
-    return getDirectChannelName(id, otherId);
-}
-
 // Used to get the id of the other user from a DM channel
 export function getUserIdFromChannelName(channel) {
     var ids = channel.name.split('__');


### PR DESCRIPTION
#### Summary
- Switching to a DM channel outside your current team now works as intended
- All users in your sidebar should be switchable (for new accounts)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3708
https://mattermost.atlassian.net/browse/PLT-4200

