### PR TITLE
PLT-4304 Add 'm.youtube.com/...' to be recognized as a YouTube link

### DIFF
--- a/webapp/components/youtube_video.jsx
+++ b/webapp/components/youtube_video.jsx
@@ -5,7 +5,7 @@ import ChannelStore from 'stores/channel_store.jsx';
 import WebClient from 'client/web_client.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-const ytRegex = /(?:http|https):\/\/(?:www\.)?(?:(?:youtube\.com\/(?:(?:v\/)|(\/u\/\w\/)|(?:(?:watch|embed\/watch)(?:\/|.*v=))|(?:embed\/)|(?:user\/[^\/]+\/u\/[0-9]\/)))|(?:youtu\.be\/))([^#&\?]*)/;
+const ytRegex = /(?:http|https):\/\/(?:www\.|m\.)?(?:(?:youtube\.com\/(?:(?:v\/)|(?:(?:watch|embed\/watch)(?:\/|.*v=))|(?:embed\/)|(?:user\/[^\/]+\/u\/[0-9]\/)))|(?:youtu\.be\/))([^#&\?]*)/;
 
 import React from 'react';
 


### PR DESCRIPTION
#### Summary
Add the 'm.' subdomain of youtube.com to be recognized as a YouTube link in embedded post content.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4304