### PR TITLE
Fixing manage members dialog not opening

### DIFF
--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -251,7 +251,6 @@ export default class SidebarHeaderDropdown extends React.Component {
                 <ToggleModalButton
                     dialogType={TeamMembersModal}
                     dialogProps={{isAdmin}}
-                    onClick={this.toggleDropdown}
                 >
                     {membersName}
                 </ToggleModalButton>


### PR DESCRIPTION
Caused by changing the sidebar header to react-bootstrap.