### PR TITLE
Fix import of Slack file_comment messages.

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1476,6 +1476,10 @@
     "translation": "Slack bot posts are not imported yet"
   },
   {
+    "id": "api.slackimport.slack_add_posts.msg_no_comment.debug",
+    "translation": "File comment message without comment"
+  },
+  {
     "id": "api.slackimport.slack_add_posts.msg_no_usr.debug",
     "translation": "Message without user"
   },


### PR DESCRIPTION
#### Summary

Fix import of Slack file_comment messages.

At the moment, the importer fails to parse the JSON of these types of
message, and so ignores them.

This fix means they are now parsed and imported just as if they were
standalone messages (not file comments), which is better, and what the
existing code clearly intended to happen.

For the future, they should probably be changed to be imported as
replies to the message with the file attached that they are commenting
on.

#### Ticket Link

#4131 

#### Checklist
- [x] Includes text changes and localization files updated

