### PR TITLE
PLT-3105 Fixed bugs with FileInfos migration, including duplicate FileInfos being saved

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -902,8 +902,20 @@
     "translation": "Unable to find file when migrating post to use FileInfos, post_id=%v, filename=%v, path=%v, err=%v"
   },
   {
+    "id": "api.file.migrate_filenames_to_file_infos.get_file_infos_again.warn",
+    "translation": "Unable to get FileInfos for post after migratio, post_id=%v, err=%v"
+  },
+  {
+    "id": "api.file.migrate_filenames_to_file_infos.get_post_again.warn",
+    "translation": "Unable to get post when migrating to use FileInfos, post_id=%v, err=%v"
+  },
+  {
     "id": "api.file.migrate_filenames_to_file_infos.info.app_error",
     "translation": "Unable to fully decode file info when migrating post to use FileInfos, post_id=%v, filename=%v, err=%v"
+  },
+  {
+    "id": "api.file.migrate_filenames_to_file_infos.migrating_post.debug",
+    "translation": "Migrating post to use FileInfos, post_id=%v, err=%v"
   },
   {
     "id": "api.file.migrate_filenames_to_file_infos.mismatched_filename.warn",
@@ -914,8 +926,12 @@
     "translation": "Unable to migrate post to use FileInfos with an empty Filenames field, post_id=%v"
   },
   {
+    "id": "api.file.migrate_filenames_to_file_infos.not_migrating_post.debug",
+    "translation": "Post already migrated to use FileInfos, post_id=%v, err=%v"
+  },
+  {
     "id": "api.file.migrate_filenames_to_file_infos.save_file_info.warn",
-    "translation": "Unable to save post when migrating post to use FileInfos, post_id=%v, new_file_ids=%v, old_filenames=%v, err=%v"
+    "translation": "Unable to save post when migrating post to use FileInfos, post_id=%v, file_id=%v, path=%v, err=%v"
   },
   {
     "id": "api.file.migrate_filenames_to_file_infos.save_post.warn",

--- a/store/sql_file_info_store.go
+++ b/store/sql_file_info_store.go
@@ -101,7 +101,8 @@ func (fs SqlFileInfoStore) GetByPath(path string) StoreChannel {
 				FileInfo
 			WHERE
 				Path = :Path
-				AND DeleteAt = 0`, map[string]interface{}{"Path": path}); err != nil {
+				AND DeleteAt = 0
+			LIMIT 1`, map[string]interface{}{"Path": path}); err != nil {
 			result.Err = model.NewLocAppError("SqlFileInfoStore.GetByPath", "store.sql_file_info.get_by_path.app_error", nil, "path="+path+", "+err.Error())
 		} else {
 			result.Data = info

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -318,7 +318,7 @@ class PostStoreClass extends EventEmitter {
             // make sure to copy the post so that component state changes work properly
             postList.posts[post.id] = Object.assign({}, post, {
                 state: Constants.POST_DELETED,
-                fileIds: []
+                file_ids: []
             });
         }
     }

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -722,6 +722,7 @@ export function getFileInfosForPost(channelId, postId) {
         return;
     }
 
+    callTracker[callName] = utils.getTimestamp();
     Client.getFileInfosForPost(
         channelId,
         postId,


### PR DESCRIPTION
- Fixed an issue that I found where the SQL query in `SqlFileInfoStore.GetByPath` would sometimes return multiple entries. This would only ever occur for migrated files in the past that happened to have been attached to two posts somehow.
- Fixed files for deleted posts still being shown until the page was refreshed.
- Added a lock to prevent multiple calls to `migrateFilenamesToFileInfos` from saving data for a single post at the same time. This resulted in duplicate FileInfos being created for a given post if two people logged into the newly-upgraded instance at the same time.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3105