### PR TITLE
Updated makefiles/scripts/tests to accommodate execution/building in windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,21 +377,24 @@ run-fullmap: run-server run-client-fullmap
 stop-server:
 	@echo Stopping mattermost
 
+ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
+	wmic process where "Caption='go.exe' and CommandLine like '%go.exe run%'" call terminate
+	wmic process where "Caption='mattermost.exe' and CommandLine like '%go-build%'" call terminate
+else
 	@for PID in $$(ps -ef | grep "[g]o run" | awk '{ print $$2 }'); do \
 		echo stopping go $$PID; \
 		kill $$PID; \
 	done
-
 	@for PID in $$(ps -ef | grep "[g]o-build" | awk '{ print $$2 }'); do \
 		echo stopping mattermost $$PID; \
 		kill $$PID; \
 	done
+endif 
 
 stop-client:
 	@echo Stopping mattermost client
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) stop
-
 
 stop: stop-server stop-client
 

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -37,10 +37,14 @@ run-fullmap: .npminstall
 stop:
 	@echo Stopping changes watching
 
+ifeq ($(OS),Windows_NT)
+	wmic process where "Caption='node.exe' and CommandLine like '%webpack%'" call terminate
+else
 	@for PROCID in $$(ps -ef | grep "[n]ode.*[w]ebpack" | awk '{ print $$2 }'); do \
 		echo stopping webpack watch $$PROCID; \
 		kill $$PROCID; \
 	done
+endif
 
 clean:
 	@echo Cleaning Webapp

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -46,6 +46,7 @@
     "babel-preset-react": "6.11.1",
     "babel-preset-stage-0": "6.5.0",
     "copy-webpack-plugin": "3.0.1",
+    "cross-env": "3.0.0",
     "css-loader": "0.25.0",
     "eslint": "3.5.0",
     "eslint-plugin-react": "6.3.0",
@@ -54,8 +55,8 @@
     "file-loader": "0.9.0",
     "html-loader": "0.4.4",
     "html-webpack-plugin": "2.22.0",
-    "imports-loader": "0.6.5",
     "image-webpack-loader": "2.0.0",
+    "imports-loader": "0.6.5",
     "jquery-deferred": "0.3.1",
     "jsdom": "9.5.0",
     "jsdom-global": "2.1.0",
@@ -74,8 +75,8 @@
   },
   "scripts": {
     "check": "eslint --ext \".jsx\" --ignore-pattern node_modules --quiet .",
-    "build": "NODE_ENV=production webpack",
-    "run": "NODE_ENV=production webpack --progress --watch",
+    "build": "cross-env NODE_ENV=production webpack",
+    "run": "cross-env NODE_ENV=production webpack --progress --watch",
     "run-fullmap": "webpack --progress --watch",
     "test": "mocha-webpack --webpack-config webpack.config.js \"**/*.test.jsx\""
   }

--- a/webapp/tests/client_emoji.test.jsx
+++ b/webapp/tests/client_emoji.test.jsx
@@ -9,16 +9,17 @@ const fs = require('fs');
 describe('Client.Emoji', function() {
     this.timeout(100000);
 
+    const testGifFileName = 'testEmoji.gif';
+
     before(function() {
         // write a temporary file so that we have something to upload for testing
         const buffer = new Buffer('R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=', 'base64');
-
-        const testGif = fs.openSync('test.gif', 'w+');
+        const testGif = fs.openSync(testGifFileName, 'w+');
         fs.writeFileSync(testGif, buffer);
     });
 
     after(function() {
-        fs.unlinkSync('test.gif');
+        fs.unlinkSync(testGifFileName);
     });
 
     it('addEmoji', function(done) {
@@ -27,7 +28,7 @@ describe('Client.Emoji', function() {
 
             TestHelper.basicClient().addEmoji(
                 {creator_id: TestHelper.basicUser().id, name},
-                fs.createReadStream('test.gif'),
+                fs.createReadStream(testGifFileName),
                 function(data) {
                     assert.equal(data.name, name);
                     assert.notEqual(data.id, null);
@@ -46,7 +47,7 @@ describe('Client.Emoji', function() {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().addEmoji(
                 {creator_id: TestHelper.basicUser().id, name: TestHelper.generateId()},
-                fs.createReadStream('test.gif'),
+                fs.createReadStream(testGifFileName),
                 function(data) {
                     TestHelper.basicClient().deleteEmoji(
                         data.id,
@@ -70,7 +71,7 @@ describe('Client.Emoji', function() {
             const name = TestHelper.generateId();
             TestHelper.basicClient().addEmoji(
                 {creator_id: TestHelper.basicUser().id, name},
-                fs.createReadStream('test.gif'),
+                fs.createReadStream(testGifFileName),
                 function() {
                     TestHelper.basicClient().listEmoji(
                         function(data) {

--- a/webapp/tests/client_file.test.jsx
+++ b/webapp/tests/client_file.test.jsx
@@ -9,16 +9,18 @@ const fs = require('fs');
 describe('Client.File', function() {
     this.timeout(100000);
 
+    const testGifFileName = 'testFile.gif';
+
     before(function() {
         // write a temporary file so that we have something to upload for testing
         const buffer = new Buffer('R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=', 'base64');
 
-        const testGif = fs.openSync('test.gif', 'w+');
+        const testGif = fs.openSync(testGifFileName, 'w+');
         fs.writeFileSync(testGif, buffer);
     });
 
     after(function() {
-        fs.unlinkSync('test.gif');
+        fs.unlinkSync(testGifFileName);
     });
 
     it('uploadFile', function(done) {
@@ -26,8 +28,8 @@ describe('Client.File', function() {
             const clientId = TestHelper.generateId();
 
             TestHelper.basicClient().uploadFile(
-                fs.createReadStream('test.gif'),
-                'test.gif',
+                fs.createReadStream(testGifFileName),
+                testGifFileName,
                 TestHelper.basicChannel().id,
                 clientId,
                 function(resp) {
@@ -47,8 +49,8 @@ describe('Client.File', function() {
     it('getFile', function(done) {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().uploadFile(
-                fs.createReadStream('test.gif'),
-                'test.gif',
+                fs.createReadStream(testGifFileName),
+                testGifFileName,
                 TestHelper.basicChannel().id,
                 '',
                 function(resp) {
@@ -72,8 +74,8 @@ describe('Client.File', function() {
     it('getFileThumbnail', function(done) {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().uploadFile(
-                fs.createReadStream('test.gif'),
-                'test.gif',
+                fs.createReadStream(testGifFileName),
+                testGifFileName,
                 TestHelper.basicChannel().id,
                 '',
                 function(resp) {
@@ -97,8 +99,8 @@ describe('Client.File', function() {
     it('getFilePreview', function(done) {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().uploadFile(
-                fs.createReadStream('test.gif'),
-                'test.gif',
+                fs.createReadStream(testGifFileName),
+                testGifFileName,
                 TestHelper.basicChannel().id,
                 '',
                 function(resp) {
@@ -122,8 +124,8 @@ describe('Client.File', function() {
     it('getFileInfo', function(done) {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().uploadFile(
-                fs.createReadStream('test.gif'),
-                'test.gif',
+                fs.createReadStream(testGifFileName),
+                testGifFileName,
                 TestHelper.basicChannel().id,
                 '',
                 function(resp) {
@@ -133,7 +135,7 @@ describe('Client.File', function() {
                         fileId,
                         function(info) {
                             assert.equal(info.id, fileId);
-                            assert.equal(info.name, 'test.gif');
+                            assert.equal(info.name, testGifFileName);
 
                             done();
                         },
@@ -152,8 +154,8 @@ describe('Client.File', function() {
     it('getPublicLink', function(done) {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().uploadFile(
-                fs.createReadStream('test.gif'),
-                'test.gif',
+                fs.createReadStream(testGifFileName),
+                testGifFileName,
                 TestHelper.basicChannel().id,
                 '',
                 function(resp) {
@@ -206,8 +208,8 @@ describe('Client.File', function() {
     it('getFileInfosForPost', function(done) {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().uploadFile(
-                fs.createReadStream('test.gif'),
-                'test.gif',
+                fs.createReadStream(testGifFileName),
+                testGifFileName,
                 TestHelper.basicChannel().id,
                 '',
                 function(resp) {

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -56,7 +56,7 @@ var config = {
                 loader: 'file?name=files/[hash].[ext]'
             },
             {
-                test: /(node_modules|non_npm_dependencies)\/.+\.(js|jsx)$/,
+                test: /(node_modules|non_npm_dependencies)(\\|\/).+\.(js|jsx)$/,
                 loader: 'imports',
                 query: {
                     $: 'jquery',


### PR DESCRIPTION
#### Summary
This PR updates the makefiles and npm scripts to be platform agnostic (or rather, allows execution in linux/mac AND windows).  Issues running in windows were identified by @chikei who put together the windows developer's guide.  This PR will prevent the need for windows developer's to maintain local patches to build/run mattermost.

#### Changes
1. Windows does not support setting environment variables inline the same way that linux/mac allows.  Updated the `package.json` scripts to use the `cross-env`  tool to set the NODE_ENV variable inline.
2. When executing the `ps` command in Windows through an emulator such as cygwin/babun/etc, ps is not able to return the arguments used during the execution of the process.  To enable the `stop` command to properly identify processes to kill, added a conditional so that the `wmic` command is used to identify and kill the necessary processes.
3. Updated the "import" webpack loader to accommodate linux and windows path separators in the test expression.
4. Two client-test cases utilized a common temporarily filename.  In linux, calls to unlink() are immediate; while in Windows these calls are staged and not executed UNTIL the process dies.  Since it's not immediate, a subsequent call to open the file (that unlink() has been called on) causes a EPERM error to occur.  In order for unlink() to be immediate in Windows, we have to ensure we call close() first.  Instead of maintaining the file descriptor in a higher scope so that we can formally close the file, I took the easier route and just modified the two test groups to use different test-file names (e.g. test.gif --> testEmoji.gif/testFile.gif).  These were the only two test cases that did not execute in windows properly.

#### Ticket Link
[PLT-3011: Dev setup guide for Windows using Docker](https://mattermost.atlassian.net/browse/PLT-3011)
[PR-439: Dev setup guide for Windows using Docker](https://github.com/mattermost/docs/pull/439)

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

These changes will ideally need to be tested on all platforms to ensure the changes do not _break_ use on linux/mac.