### PR TITLE
PLT-3907 Added a javascript library to prevent the <body> from scrolling on iOS

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4071,3 +4071,22 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+---
+
+This product contains a modified portion of 'iNoBounce', used to prevent overscrolling on iOS devices, built by lazd.
+
+* HOMEPAGE: 
+  * https://github.com/lazd/iNoBounce
+
+* LICENSE: 
+
+Copyright (c) 2013, Lawrence Davis
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/webapp/components/needs_team.jsx
+++ b/webapp/components/needs_team.jsx
@@ -39,6 +39,9 @@ import InviteMemberModal from 'components/invite_member_modal.jsx';
 import LeaveTeamModal from 'components/leave_team_modal.jsx';
 import SelectTeamModal from 'components/admin_console/select_team_modal.jsx';
 
+import iNoBounce from 'inobounce';
+import * as UserAgent from 'utils/user_agent.jsx';
+
 export default class NeedsTeam extends React.Component {
     constructor(params) {
         super(params);
@@ -103,6 +106,11 @@ export default class NeedsTeam extends React.Component {
         });
 
         Utils.applyTheme(this.state.theme);
+
+        if (UserAgent.isIosSafari()) {
+            // Use iNoBounce to prevent scrolling past the boundaries of the page
+            iNoBounce.enable();
+        }
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -116,6 +124,10 @@ export default class NeedsTeam extends React.Component {
         PreferenceStore.removeChangeListener(this.onPreferencesChanged);
         $(window).off('focus');
         $(window).off('blur');
+
+        if (UserAgent.isIosSafari()) {
+            iNoBounce.disable();
+        }
     }
 
     render() {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -12,6 +12,7 @@
     "flux": "2.1.1",
     "font-awesome": "4.6.3",
     "highlight.js": "9.7.0",
+    "inobounce": "0.1.3",
     "intl": "1.2.5",
     "jasny-bootstrap": "3.1.3",
     "jquery": "3.1.1",


### PR DESCRIPTION
If the `<body>` started scrolling (due to the user reaching the top/bottom of the post list and attempting to scroll further), it would prevent the post list from scrolling until the `<body>` returned to its regular position. If the user tried to scroll the post list at this time, it would just keep scrolling the `<body>`, making it appear as if scrolling was broken.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3907