### PR TITLE
WIP: Read system-level slash commands from configuration

### DIFF
--- a/api/command.go
+++ b/api/command.go
@@ -41,6 +41,8 @@ func GetCommandProvider(name string) CommandProvider {
 func InitCommand() {
 	l4g.Debug(utils.T("api.command.init.debug"))
 
+	InitCommandFromConfig()
+
 	BaseRoutes.Commands.Handle("/execute", ApiUserRequired(executeCommand)).Methods("POST")
 	BaseRoutes.Commands.Handle("/list", ApiUserRequired(listCommands)).Methods("GET")
 
@@ -110,7 +112,9 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if provider != nil {
 		response := provider.DoCommand(c, channelId, message)
-		handleResponse(c, w, response, channelId, provider.GetCommand(c), true)
+		if c.Err == nil {
+			handleResponse(c, w, response, channelId, provider.GetCommand(c), true)
+		}
 		return
 	} else {
 

--- a/api/command_from_config.go
+++ b/api/command_from_config.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api
+
+import (
+	"io/ioutil"
+	"net/url"
+	"net/http"
+	"fmt"
+	"strings"
+	"crypto/tls"
+
+	l4g "github.com/alecthomas/log4go"
+
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+type ConfigCommandProvider struct {
+	model.CommandSetting
+}
+
+func InitCommandFromConfig() {
+	for _, command := range utils.Cfg.CommandSettings {
+		RegisterCommandProvider(&ConfigCommandProvider{command})
+	}
+}
+
+func (me *ConfigCommandProvider) GetTrigger() string {
+	return me.Trigger
+}
+
+func (me *ConfigCommandProvider) GetCommand(c *Context) *model.Command {
+	return &model.Command{
+		Trigger:          me.Trigger,
+		AutoComplete:     me.AutoComplete,
+		AutoCompleteDesc: me.AutoCompleteDesc,
+		AutoCompleteHint: me.AutoCompleteHint,
+		DisplayName:      me.DisplayName,
+	}
+}
+
+func (me *ConfigCommandProvider) DoCommand(c *Context, channelId string, message string) *model.CommandResponse {
+	chanChan := Srv.Store.Channel().Get(channelId)
+	teamChan := Srv.Store.Team().Get(c.TeamId)
+	userChan := Srv.Store.User().Get(c.Session.UserId)
+
+	var team *model.Team
+	if tr := <-teamChan; tr.Err != nil {
+		c.Err = tr.Err
+		return nil
+	} else {
+		team = tr.Data.(*model.Team)
+	}
+
+	var user *model.User
+	if ur := <-userChan; ur.Err != nil {
+		c.Err = ur.Err
+		return nil
+	} else {
+		user = ur.Data.(*model.User)
+	}
+
+	var channel *model.Channel
+	if cr := <-chanChan; cr.Err != nil {
+		c.Err = cr.Err
+		return nil
+	} else {
+		channel = cr.Data.(*model.Channel)
+	}
+
+	l4g.Debug(fmt.Sprintf(utils.T("api.command.execute_command.debug"), me.Trigger, c.Session.UserId))
+
+	p := url.Values{}
+	p.Set("token", me.Token)
+
+	p.Set("team_id", c.TeamId)
+	p.Set("team_domain", team.Name)
+
+	p.Set("channel_id", channel.Id)
+	p.Set("channel_name", channel.Name)
+
+	p.Set("user_id", c.Session.UserId)
+	p.Set("user_name", user.Username)
+
+	p.Set("command", "/"+me.Trigger)
+	p.Set("text", message)
+	p.Set("response_url", "not supported yet")
+
+	method := "POST"
+	if me.Method == model.COMMAND_METHOD_GET {
+		method = "GET"
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: *utils.Cfg.ServiceSettings.EnableInsecureOutgoingConnections},
+	}
+	client := &http.Client{Transport: tr}
+
+	req, _ := http.NewRequest(method, me.URL, strings.NewReader(p.Encode()))
+	req.Header.Set("Accept", "application/json")
+	if me.Method == model.COMMAND_METHOD_POST {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	if resp, err := client.Do(req); err != nil {
+		c.Err = model.NewLocAppError("command", "api.command.execute_command.failed.app_error", map[string]interface{}{"Trigger": me.Trigger}, err.Error())
+		return nil
+	} else {
+		if resp.StatusCode == http.StatusOK {
+			response := model.CommandResponseFromJson(resp.Body)
+			if response == nil {
+				c.Err = model.NewLocAppError("command", "api.command.execute_command.failed_empty.app_error", map[string]interface{}{"Trigger": me.Trigger}, "")
+			} else {
+				return response
+			}
+		} else {
+			defer resp.Body.Close()
+			body, _ := ioutil.ReadAll(resp.Body)
+			c.Err = model.NewLocAppError("command", "api.command.execute_command.failed_resp.app_error", map[string]interface{}{"Trigger": me.Trigger, "Status": resp.Status}, string(body))
+		}
+	}
+	return nil
+}

--- a/api/command_from_config.go
+++ b/api/command_from_config.go
@@ -38,6 +38,8 @@ func (me *ConfigCommandProvider) GetCommand(c *Context) *model.Command {
 		AutoCompleteDesc: me.AutoCompleteDesc,
 		AutoCompleteHint: me.AutoCompleteHint,
 		DisplayName:      me.DisplayName,
+		Username:         me.Username,
+		IconURL:          me.IconURL,
 	}
 }
 

--- a/api/command_from_config.go
+++ b/api/command_from_config.go
@@ -22,7 +22,7 @@ type ConfigCommandProvider struct {
 }
 
 func InitCommandFromConfig() {
-	for _, command := range utils.Cfg.CommandSettings {
+	for _, command := range utils.Cfg.CommandsSettings {
 		RegisterCommandProvider(&ConfigCommandProvider{command})
 	}
 }

--- a/model/config.go
+++ b/model/config.go
@@ -98,6 +98,20 @@ type ClusterSettings struct {
 	InterNodeUrls          []string
 }
 
+type CommandSetting struct {
+	Token            string
+	Trigger          string
+	Method           string
+	Username         string
+	IconURL          string
+	AutoComplete     bool
+	AutoCompleteDesc string
+	AutoCompleteHint string
+	DisplayName      string
+	Description      string
+	URL              string
+}
+
 type SSOSettings struct {
 	Enable          bool
 	Secret          string
@@ -326,6 +340,7 @@ type Config struct {
 	GitLabSettings       SSOSettings
 	GoogleSettings       SSOSettings
 	Office365Settings    SSOSettings
+	CommandSettings      []CommandSetting
 	LdapSettings         LdapSettings
 	ComplianceSettings   ComplianceSettings
 	LocalizationSettings LocalizationSettings

--- a/model/config.go
+++ b/model/config.go
@@ -107,8 +107,6 @@ type CommandSetting struct {
 	AutoComplete     bool
 	AutoCompleteDesc string
 	AutoCompleteHint string
-	DisplayName      string
-	Description      string
 	URL              string
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -107,6 +107,7 @@ type CommandSetting struct {
 	AutoComplete     bool
 	AutoCompleteDesc string
 	AutoCompleteHint string
+	DisplayName      string
 	URL              string
 }
 
@@ -338,7 +339,7 @@ type Config struct {
 	GitLabSettings       SSOSettings
 	GoogleSettings       SSOSettings
 	Office365Settings    SSOSettings
-	CommandSettings      []CommandSetting
+	CommandsSettings     []CommandSetting
 	LdapSettings         LdapSettings
 	ComplianceSettings   ComplianceSettings
 	LocalizationSettings LocalizationSettings


### PR DESCRIPTION
#### Summary

This pull request adds a slash commands as system-level configuration option.

This allows to pre-configure slash commands for all teams.
#### Ticket Link

This is part of this Idea to production story to have seamless integration between GitLab and Mattermost: https://gitlab.com/gitlab-org/gitlab-ce/issues/22893.
#### State of this change

This is proof of concept change. It's proposal, not final implementation. It is more to research how much is needed to do on Mattermost side.
#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
