### PR TITLE
Fix incorrect id + typos in en.json

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1473,11 +1473,11 @@
   },
   {
     "id": "api.server.start_server.rate_limiting_memory_store",
-    "translation": "Unable to initalize rate limiting memory store. Check MemoryStoreSize config setting."
+    "translation": "Unable to initialize rate limiting memory store. Check MemoryStoreSize config setting."
   },
   {
-    "id": "api.server.start_server.rate_limiting_memory_store",
-    "translation": "Unable to initalize rate limiting."
+    "id": "api.server.start_server.rate_limiting_rate_limiter",
+    "translation": "Unable to initialize rate limiting."
   },
   {
     "id": "api.server.start_server.starting.critical",


### PR DESCRIPTION
#### Summary
Fix incorrect id + typos in en.json

1. `api.server.start_server.rate_limiting_memory_store` is repeated twice, one of them should be `api.server.start_server.rate_limiting_rate_limiter` as called [here in server.go](https://github.com/mattermost/platform/blob/7fcc004beb9f6ef022f755e8e2f2a958c976c637/api/server.go#L90)
2. Fix `initalize` --> `initialize` typo

#### Ticket Link
N/A

#### Checklist
- [X] Includes text changes and localization files updated

