### PR TITLE
Slack api import missing comment related to Slack

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1525,7 +1525,7 @@
   },
   {
     "id": "api.slackimport.slack_add_posts.msg_no_comment.debug",
-    "translation": "File comment message without comment"
+    "translation": "File comment undefined"
   },
   {
     "id": "api.slackimport.slack_add_posts.msg_no_usr.debug",


### PR DESCRIPTION
#### Summary
The English text was confusing and basically untranslatable easily in another language. Leading the translator to read the code to understand what it was about.

The same applies for other debug messages. Most of them do not specify this is related to the slack import tool.
Mork work required before merging.

#### Ticket Link
https://github.com/mattermost/platform/issues/4161

#### Checklist
- [x] Includes text changes and localization files updated
