### PR TITLE
PLT-3785 Re-enabled marking messages unread

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -625,11 +625,11 @@
   },
   {
     "id": "api.command_shortcuts.msgs",
-    "translation": "#### Messages\n\nESC: Mark all messages in the current channel as read\nCTRL+UP (in empty input field): Reprint the previous message or slash command you entered\nCTRL+DOWN (in empty input field): Reprint the next message or slash command you entered\nUP (in empty input field): Edit your last message in the current channel\n@[character]+TAB: Autocomplete @username beginning with [character]\n:[character]+TAB: Autocomplete emoji beginning with [character]\n\n"
+    "translation": "#### Messages\n\n#### Messages\n\nALT+[click on a message]: Set a message as your oldest unread message in the current channel\nESC: Mark all messages in the current channel as read\nCTRL+UP (in empty input field): Reprint the previous message or slash command you entered\nCTRL+DOWN (in empty input field): Reprint the next message or slash command you entered\nUP (in empty input field): Edit your last message in the current channel\n@[character]+TAB: Autocomplete @username beginning with [character]\n:[character]+TAB: Autocomplete emoji beginning with [character]\n\n"
   },
   {
     "id": "api.command_shortcuts.msgs_mac",
-    "translation": "#### Messages\n\nESC: Mark all messages in the current channel as read\nCMD+UP (in empty input field): Reprint the previous message or slash command you entered\nCMD+DOWN (in empty input field): Reprint the next message or slash command you entered\nUP (in empty input field): Edit your last message in the current channel\n@[character]+TAB: Autocomplete @username beginning with [character]\n:[character]+TAB: Autocomplete emoji beginning with [character]\n\n"
+    "translation": "#### Messages\n\nALT+[click on a message]: Set a message as your oldest unread message in the current channel\nESC: Mark all messages in the current channel as read\nCMD+UP (in empty input field): Reprint the previous message or slash command you entered\nCMD+DOWN (in empty input field): Reprint the next message or slash command you entered\nUP (in empty input field): Edit your last message in the current channel\n@[character]+TAB: Autocomplete @username beginning with [character]\n:[character]+TAB: Autocomplete emoji beginning with [character]\n\n"
   },
   {
     "id": "api.command_shortcuts.name",

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -73,6 +73,7 @@ export function setUnreadPost(channelId, postId) {
     let ownNewMessage = false;
     const post = PostStore.getPost(channelId, postId);
     const posts = PostStore.getVisiblePosts(channelId).posts;
+    const currentChannel = ChannelStore.getCurrent();
     var currentUsedId = UserStore.getCurrentId();
     if (currentUsedId === post.user_id || PostUtils.isSystemMessage(post)) {
         for (const otherPostId in posts) {
@@ -103,6 +104,12 @@ export function setUnreadPost(channelId, postId) {
                 unreadPosts += 1;
             }
         }
+
+        // Temporary workaround for DM channels having wrong unread values
+        if (currentChannel.type === Constants.DM_CHANNEL) {
+            unreadPosts = 0;
+        }
+
         const member = ChannelStore.getMember(channelId);
         const channel = ChannelStore.get(channelId);
         member.last_viewed_at = lastViewed;

--- a/webapp/components/post_view/components/post.jsx
+++ b/webapp/components/post_view/components/post.jsx
@@ -4,6 +4,7 @@
 import PostHeader from './post_header.jsx';
 import PostBody from './post_body.jsx';
 import ProfilePicture from 'components/profile_picture.jsx';
+import * as PostActions from 'actions/post_actions.jsx';
 
 import Constants from 'utils/constants.jsx';
 const ActionTypes = Constants.ActionTypes;
@@ -49,13 +50,11 @@ export default class Post extends React.Component {
         this.refs.info.forceUpdate();
         this.refs.header.forceUpdate();
     }
-    handlePostClick() {
-        /* Disabled do to a bug: https://mattermost.atlassian.net/browse/PLT-3785
+    handlePostClick(e) {
         if (e.altKey) {
             e.preventDefault();
             PostActions.setUnreadPost(this.props.post.channel_id, this.props.post.id);
         }
-        */
     }
     shouldComponentUpdate(nextProps, nextState) {
         if (!Utils.areObjectsEqual(nextProps.post, this.props.post)) {

--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -328,8 +328,9 @@ class ChannelStoreClass extends EventEmitter {
         let chMentionCount = chMember.mention_count;
         let chUnreadCount = ch.total_msg_count - chMember.msg_count;
 
+        // Temporary workaround for DM channels having wrong unread values
         if (ch.type === 'D') {
-            chMentionCount = chUnreadCount;
+            chMentionCount = 0;
         } else if (chMember.notify_props && chMember.notify_props.mark_unread === NotificationPrefs.MENTION) {
             chUnreadCount = 0;
         }


### PR DESCRIPTION
#### Summary
- Created a temporary workaround (proposed in ticket) for marking messages unread returning the wrong mention count on DM values: simply set the mention count to 0
- Added back `ALT+click` to `/shortcuts` messages

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3785

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization files updated
