### PR TITLE
PLT-4261 Set silent parameter for Notification

### DIFF
--- a/webapp/stores/notification_store.jsx
+++ b/webapp/stores/notification_store.jsx
@@ -7,6 +7,7 @@ import Constants from 'utils/constants.jsx';
 import UserStore from './user_store.jsx';
 import ChannelStore from './channel_store.jsx';
 import PreferenceStore from './preference_store.jsx';
+import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
 const ActionTypes = Constants.ActionTypes;
@@ -97,9 +98,10 @@ class NotificationStoreClass extends EventEmitter {
                 duration = parseInt(user.notify_props.desktop_duration, 10) * 1000;
             }
 
-            Utils.notifyMe(title, body, channel, teamId, duration);
+            const sound = !user.notify_props || user.notify_props.desktop_sound === 'true';
+            Utils.notifyMe(title, body, channel, teamId, duration, !sound);
 
-            if (!user.notify_props || user.notify_props.desktop_sound === 'true') {
+            if (sound && !UserAgent.isWindowsApp() && !UserAgent.isMacApp()) {
                 Utils.ding();
             }
         }

--- a/webapp/utils/user_agent.jsx
+++ b/webapp/utils/user_agent.jsx
@@ -20,6 +20,8 @@ Edge:
 Desktop App:
     Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost/1.2.1 Chrome/49.0.2623.75 Electron/0.37.8 Safari/537.36
     Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586
+    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost/3.4.1 Chrome/53.0.2785.113 Electron/1.4.2 Safari/537.36
+    Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost/3.4.1 Chrome/51.0.2704.106 Electron/1.2.8 Safari/537.36
 
 Android Chrome:
     Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
@@ -98,4 +100,16 @@ export function isInternetExplorer() {
 
 export function isEdge() {
     return userAgent.indexOf('Edge') !== -1;
+}
+
+export function isDesktopApp() {
+    return userAgent.indexOf('Mattermost') !== -1 && userAgent.indexOf('Electron') !== -1;
+}
+
+export function isWindowsApp() {
+    return isDesktopApp() && userAgent.indexOf('Windows') !== -1;
+}
+
+export function isMacApp() {
+    return isDesktopApp() && userAgent.indexOf('Macintosh') !== -1;
 }

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -86,7 +86,7 @@ export function getCookie(name) {
 
 var requestedNotificationPermission = false;
 
-export function notifyMe(title, body, channel, teamId, duration) {
+export function notifyMe(title, body, channel, teamId, duration, silent) {
     if (!('Notification' in window)) {
         return;
     }
@@ -102,7 +102,7 @@ export function notifyMe(title, body, channel, teamId, duration) {
         Notification.requestPermission((permission) => {
             if (permission === 'granted') {
                 try {
-                    var notification = new Notification(title, {body, tag: body, icon: icon50, requireInteraction: notificationDuration === 0});
+                    var notification = new Notification(title, {body, tag: body, icon: icon50, requireInteraction: notificationDuration === 0, silent});
                     notification.onclick = () => {
                         window.focus();
                         if (channel) {


### PR DESCRIPTION
#### Summary
When using desktop notifications,
- Stop using `Utils.ding()` if the browser is the desktop app of Windows or Mac.
- Set `silent` to `new Notification()` if **Notification sound** is set to Off in account settings.

In the desktop app, there are two kinds of sound on notifications, `Utils.ding()` and `new Notification()` on Windows and Mac. This commit stops both if the account setting is set to off.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4261
https://github.com/mattermost/desktop/issues/227

#### Checklist
N/A