### PR TITLE
Add text banner to SAML System Console settings

### DIFF
--- a/webapp/components/admin_console/saml_settings.jsx
+++ b/webapp/components/admin_console/saml_settings.jsx
@@ -292,14 +292,14 @@ export default class SamlSettings extends AdminSettings {
 
         return (
             <SettingsGroup>
-                <Banner
-                    description={
+                <div className='banner'>
+                    <div className='banner__content'>
                         <FormattedMessage
                             id='admin.saml.bannerDesc'
                             defaultMessage='If a user attribute changes on the SAML server it will be updated the next time the user enters their credentials to log in to Mattermost. This includes if a user is made inactive or removed from a SAML Identity Provider. Remote logout with SAML servers is considered in a future release.'
                         />
-                    }
-                />
+                    </div>
+                </div>
                 <BooleanSetting
                     id='enable'
                     label={

--- a/webapp/components/admin_console/saml_settings.jsx
+++ b/webapp/components/admin_console/saml_settings.jsx
@@ -292,6 +292,14 @@ export default class SamlSettings extends AdminSettings {
 
         return (
             <SettingsGroup>
+                <Banner
+                    description={
+                        <FormattedMessage
+                            id='admin.saml.bannerDesc'
+                            defaultMessage='If a user attribute changes on the SAML server it will be updated the next time the user enters their credentials to log in to Mattermost. This includes if a user is made inactive or removed from a SAML Identity Provider. Remote logout with SAML servers is planned in a future release.'
+                        />
+                    }
+                />
                 <BooleanSetting
                     id='enable'
                     label={

--- a/webapp/components/admin_console/saml_settings.jsx
+++ b/webapp/components/admin_console/saml_settings.jsx
@@ -296,7 +296,7 @@ export default class SamlSettings extends AdminSettings {
                     description={
                         <FormattedMessage
                             id='admin.saml.bannerDesc'
-                            defaultMessage='If a user attribute changes on the SAML server it will be updated the next time the user enters their credentials to log in to Mattermost. This includes if a user is made inactive or removed from a SAML Identity Provider. Remote logout with SAML servers is planned in a future release.'
+                            defaultMessage='If a user attribute changes on the SAML server it will be updated the next time the user enters their credentials to log in to Mattermost. This includes if a user is made inactive or removed from a SAML Identity Provider. Remote logout with SAML servers is considered in a future release.'
                         />
                     }
                 />

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -567,6 +567,7 @@
   "admin.saml.assertionConsumerServiceURLDesc": "Enter https://<your-mattermost-url>/login/sso/saml. Make sure you use HTTP or HTTPS in your URL depending on your server configuration. This field is also known as the Assertion Consumer Service URL.",
   "admin.saml.assertionConsumerServiceURLEx": "E.g.: \"https://<your-mattermost-url>/login/sso/saml\"",
   "admin.saml.assertionConsumerServiceURLTitle": "Service Provider Login URL:",
+  "admin.saml.bannerDesc": "If a user attribute changes on the SAML server it will be updated the next time the user enters their credentials to log in to Mattermost. This includes if a user is made inactive or removed from a SAML Identity Provider. Remote logout with SAML servers is considered in a future release."
   "admin.saml.emailAttrDesc": "The attribute in the SAML Assertion that will be used to populate the email addresses of users in Mattermost.",
   "admin.saml.emailAttrEx": "E.g.: \"Email\" or \"PrimaryEmail\"",
   "admin.saml.emailAttrTitle": "Email Attribute:",

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -567,7 +567,7 @@
   "admin.saml.assertionConsumerServiceURLDesc": "Enter https://<your-mattermost-url>/login/sso/saml. Make sure you use HTTP or HTTPS in your URL depending on your server configuration. This field is also known as the Assertion Consumer Service URL.",
   "admin.saml.assertionConsumerServiceURLEx": "E.g.: \"https://<your-mattermost-url>/login/sso/saml\"",
   "admin.saml.assertionConsumerServiceURLTitle": "Service Provider Login URL:",
-  "admin.saml.bannerDesc": "If a user attribute changes on the SAML server it will be updated the next time the user enters their credentials to log in to Mattermost. This includes if a user is made inactive or removed from a SAML Identity Provider. Remote logout with SAML servers is considered in a future release."
+  "admin.saml.bannerDesc": "If a user attribute changes on the SAML server it will be updated the next time the user enters their credentials to log in to Mattermost. This includes if a user is made inactive or removed from a SAML Identity Provider. Remote logout with SAML servers is considered in a future release.",
   "admin.saml.emailAttrDesc": "The attribute in the SAML Assertion that will be used to populate the email addresses of users in Mattermost.",
   "admin.saml.emailAttrEx": "E.g.: \"Email\" or \"PrimaryEmail\"",
   "admin.saml.emailAttrTitle": "Email Attribute:",


### PR DESCRIPTION
#### Summary
Add a note to SAML System Console settings that SAML sync isn't yet supported and remote logout is considered in a future release.

#### Ticket Link
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Includes text changes and localization files updated
