### PR TITLE
Fix bad merge from #4130

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -546,7 +546,7 @@
   "admin.rate.remoteDescription": "When true, rate limit API access by IP address.",
   "admin.rate.remoteTitle": "Vary rate limit by remote address: ",
   "admin.rate.title": "Rate Limit Settings",
-  "admin.rate.maxBurst": "Max Burst:",
+  "admin.rate.maxBurst": "Maximum Burst Size:",
   "admin.rate.maxBurstExample": "E.g.: \"100\"",
   "admin.rate.maxBurstDescription": "Maximum number of requests allowed beyond the per second query limit.",
   "admin.recycle.button": "Recycle Database Connections",


### PR DESCRIPTION
#### Summary
Fix bad merge from #4130

'Max Burst' --> 'Maximum Burst Size' wasn't updated in `en.json` due to bad merge

#### Ticket Link
N/A

#### Checklist
- [X] Includes text changes and localization files updated

