### PR TITLE
Fix memory leak

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -271,7 +271,7 @@ func handlePostEvents(c *Context, post *model.Post, triggerWebhooks bool) {
 		channel = result.Data.(*model.Channel)
 	}
 
-	go sendNotifications(c, post, team, channel)
+	sendNotifications(c, post, team, channel)
 
 	var user *model.User
 	if result := <-uchan; result.Err != nil {
@@ -767,7 +767,8 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 		message.Add("mentions", model.ArrayToJson(mentionedUsersList))
 	}
 
-	go Publish(message)
+	Publish(message)
+	return
 }
 
 func sendNotificationEmail(c *Context, post *model.Post, user *model.User, channel *model.Channel, team *model.Team, senderName string, sender *model.User) {

--- a/api/server.go
+++ b/api/server.go
@@ -53,6 +53,7 @@ func NewServer(enableProfiler bool) {
 	Srv.Router = mux.NewRouter()
 	if enableProfiler {
 		AttachProfiler(Srv.Router)
+		l4g.Info("Enabled HTTP Profiler")
 	}
 	Srv.Router.NotFoundHandler = http.HandlerFunc(Handle404)
 }

--- a/api/web_conn.go
+++ b/api/web_conn.go
@@ -100,7 +100,6 @@ func (c *WebConn) writePump() {
 
 				return
 			}
-			msg = nil
 
 		case <-ticker.C:
 			c.WebSocket.SetWriteDeadline(time.Now().Add(WRITE_WAIT))

--- a/api/web_conn.go
+++ b/api/web_conn.go
@@ -100,6 +100,7 @@ func (c *WebConn) writePump() {
 
 				return
 			}
+			msg = nil
 
 		case <-ticker.C:
 			c.WebSocket.SetWriteDeadline(time.Now().Add(WRITE_WAIT))

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -41,6 +41,7 @@ func Publish(message *model.WebSocketEvent) {
 	if einterfaces.GetClusterInterface() != nil {
 		einterfaces.GetClusterInterface().Publish(message)
 	}
+	return
 }
 
 func PublishSkipClusterSend(message *model.WebSocketEvent) {
@@ -127,6 +128,7 @@ func (h *Hub) Start() {
 						}
 					}
 				}
+				msg = nil
 
 			case s := <-h.stop:
 				l4g.Info(utils.T("api.web_hub.start.stopping.debug"), s)

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -128,7 +128,6 @@ func (h *Hub) Start() {
 						}
 					}
 				}
-				msg = nil
 
 			case s := <-h.stop:
 				l4g.Info(utils.T("api.web_hub.start.stopping.debug"), s)


### PR DESCRIPTION
Removed `go func` from sendNotifications and Publish fixes somehow the memory leak, also assigning message to `nil` when no longer needed