### PR TITLE
Trim trailing slashes to prevent OAuth2 URI mismatch errors

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -364,7 +364,7 @@ func (c *Context) SetTeamURLFromSession() {
 }
 
 func (c *Context) SetSiteURL(url string) {
-	c.siteURL = url
+	c.siteURL = strings.TrimRight(url, "/")
 }
 
 func (c *Context) GetTeamURLFromTeam(team *model.Team) string {

--- a/api/context_test.go
+++ b/api/context_test.go
@@ -29,3 +29,24 @@ func TestCache(t *testing.T) {
 		t.Fatal("should have one less")
 	}
 }
+
+func TestSiteURL(t *testing.T) {
+	c := &Context{}
+
+	testCases := []struct {
+		url  string
+		want string
+	}{
+		{"http://mattermost.com/", "http://mattermost.com"},
+		{"http://mattermost.com", "http://mattermost.com"},
+	}
+
+	for _, tc := range testCases {
+		c.SetSiteURL(tc.url)
+
+		if c.siteURL != tc.want {
+			t.Fatalf("expected %s, got %s", tc.want, c.siteURL)
+		}
+	}
+
+}


### PR DESCRIPTION
#### Summary

This pull request removes any trailing slashes to the site URL. This was already done when `SiteURL` was configured, but not if the hostname was provided from the request `Host` header.

This was causing a customer OAuth2 invalid URL mismatch issue, since Mattermost always appends a slash when generating `redirect_uri`.

#### Ticket Link

https://gitlab.com/gitlab-org/gitlab-mattermost/issues/84

#### Checklist
- [X] Added or updated unit tests (required for all new features)
- [X] Touches critical sections of the codebase (auth, upgrade, etc.)

Closes https://gitlab.com/gitlab-org/gitlab-mattermost/issues/84