### PR TITLE
GH-4185 Create direct channel during incoming webhook if not exists

### DIFF
--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -597,8 +597,6 @@ func TestIncomingWebhooks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	Client.Must(Client.CreateDirectChannel(user2.Id))
-
 	if _, err := Client.DoPost(url, fmt.Sprintf("{\"text\":\"this is a test\", \"channel\":\"@%s\"}", user2.Username), "application/json"); err != nil {
 		t.Fatal(err)
 	}

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -83,6 +83,29 @@ func (s SqlChannelStore) Save(channel *model.Channel) StoreChannel {
 	return storeChannel
 }
 
+func (s SqlChannelStore) CreateDirectChannel(userId string, otherUserId string) StoreChannel {
+	channel := new(model.Channel)
+
+	channel.DisplayName = ""
+	channel.Name = model.GetDMNameFromIds(otherUserId, userId)
+
+	channel.Header = ""
+	channel.Type = model.CHANNEL_DIRECT
+
+	cm1 := &model.ChannelMember{
+		UserId:      userId,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+		Roles:       model.ROLE_CHANNEL_USER.Id,
+	}
+	cm2 := &model.ChannelMember{
+		UserId:      otherUserId,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+		Roles:       model.ROLE_CHANNEL_USER.Id,
+	}
+
+	return s.SaveDirectChannel(channel, cm1, cm2)
+}
+
 func (s SqlChannelStore) SaveDirectChannel(directchannel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) StoreChannel {
 	storeChannel := make(StoreChannel, 1)
 

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -94,7 +94,34 @@ func TestChannelStoreSaveDirectChannel(t *testing.T) {
 	if err := (<-store.Channel().SaveDirectChannel(&o1, &m1, &m2)).Err; err == nil {
 		t.Fatal("Should not be able to save non-direct channel")
 	}
+}
 
+func TestChannelStoreCreateDirectChannel(t *testing.T) {
+	Setup()
+
+	u1 := &model.User{}
+	u1.Email = model.NewId()
+	u1.Nickname = model.NewId()
+	Must(store.User().Save(u1))
+	Must(store.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}))
+
+	u2 := &model.User{}
+	u2.Email = model.NewId()
+	u2.Nickname = model.NewId()
+	Must(store.User().Save(u2))
+	Must(store.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u2.Id}))
+
+	res := <-store.Channel().CreateDirectChannel(u1.Id, u2.Id)
+	if res.Err != nil {
+		t.Fatal("couldn't create direct channel", res.Err)
+	}
+
+	c1 := res.Data.(*model.Channel)
+
+	members := (<-store.Channel().GetMembers(c1.Id)).Data.([]model.ChannelMember)
+	if len(members) != 2 {
+		t.Fatal("should have saved 2 members")
+	}
 }
 
 func TestChannelStoreUpdate(t *testing.T) {

--- a/store/store.go
+++ b/store/store.go
@@ -75,6 +75,7 @@ type TeamStore interface {
 
 type ChannelStore interface {
 	Save(channel *model.Channel) StoreChannel
+	CreateDirectChannel(userId string, otherUserId string) StoreChannel
 	SaveDirectChannel(channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) StoreChannel
 	Update(channel *model.Channel) StoreChannel
 	Get(id string) StoreChannel


### PR DESCRIPTION
#### Summary
Added additional method to **ChannelStore**  that encapsulate logic of direct channel instantiation. Reuse newly added method in API.

#### Ticket Link
#4185  

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

