### PR TITLE
GH-4087 added extra fields to Props in header update system message

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -338,7 +338,12 @@ func PostUpdateChannelHeaderMessage(c *Context, channelId string, oldChannelHead
 			Message:   message,
 			Type:      model.POST_HEADER_CHANGE,
 			UserId:    c.Session.UserId,
+			Props: model.StringInterface{
+				"old_header": oldChannelHeader,
+				"new_header": newChannelHeader,
+			},
 		}
+
 		if _, err := CreatePost(c, post, false); err != nil {
 			l4g.Error(utils.T("api.channel.post_update_channel_header_message_and_forget.join_leave.error"), err)
 		}

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -379,6 +379,15 @@ func TestUpdateChannelHeader(t *testing.T) {
 		upChannel1 = result.Data.(*model.Channel)
 	}
 
+	r1 := Client.Must(Client.GetPosts(channel1.Id, 0, 1, "")).Data.(*model.PostList)
+	if len(r1.Order) != 1 {
+		t.Fatal("Header update system message was not found")
+	} else if val, ok := r1.Posts[r1.Order[0]].Props["old_header"]; !ok || val != "" {
+		t.Fatal("Props should contain old_header with old header value")
+	} else if val, ok := r1.Posts[r1.Order[0]].Props["new_header"]; !ok || val != "new header" {
+		t.Fatal("Props should contain new_header with new header value")
+	}
+
 	if upChannel1.Header != data["channel_header"] {
 		t.Fatal("Failed to update header")
 	}


### PR DESCRIPTION
#### Summary
Added following fields to Post.Props: "new_header", "old_header" which contain correspondent values  as was disscussed in Developers channel

#### Ticket Link
#4087 

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)