### PR TITLE
Re-enable console logging by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,16 +119,16 @@ stop-docker:
 		echo stopping mattermost-postgres; \
 		docker stop mattermost-postgres > /dev/null; \
 	fi
-	
+
 	@if [ $(shell docker ps -a | grep -ci mattermost-openldap) -eq 1 ]; then \
 		echo stopping mattermost-openldap; \
 		docker stop mattermost-openldap > /dev/null; \
 	fi
 
 	@if [ $(shell docker ps -a | grep -ci mattermost-webrtc) -eq 1 ]; then \
-    		echo stopping mattermost-webrtc; \
-    		docker stop mattermost-webrtc > /dev/null; \
-    	fi
+		echo stopping mattermost-webrtc; \
+		docker stop mattermost-webrtc > /dev/null; \
+	fi
 
 clean-docker:
 	@echo Removing docker containers
@@ -152,16 +152,16 @@ clean-docker:
 	fi
 
 	@if [ $(shell docker ps -a | grep -ci mattermost-webrtc) -eq 1 ]; then \
-    		echo removing mattermost-webrtc; \
-    		docker stop mattermost-webrtc > /dev/null; \
-    		docker rm -v mattermost-webrtc > /dev/null; \
-    	fi
+		echo removing mattermost-webrtc; \
+		docker stop mattermost-webrtc > /dev/null; \
+		docker rm -v mattermost-webrtc > /dev/null; \
+	fi
 
 check-client-style:
 	@echo Checking client style
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) check-style
-	
+
 check-server-style:
 	@echo Running GOFMT
 	$(eval GOFMT_OUTPUT := $(shell gofmt -d -s api/ model/ store/ utils/ manualtesting/ einterfaces/ mattermost.go 2>&1))
@@ -295,6 +295,9 @@ package: build build-client
 	cp -RL fonts $(DIST_PATH)
 	cp -RL templates $(DIST_PATH)
 	cp -RL i18n $(DIST_PATH)
+
+	@# Disable developer settings
+	sed -i '' 's|"EnableConsole": true,|"EnableConsole": false,|g' $(DIST_PATH)/config/config.json;
 
 	@# Package webapp
 	mkdir -p $(DIST_PATH)/webapp/dist

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ package: build build-client
 	cp -RL i18n $(DIST_PATH)
 
 	@# Disable developer settings
-	sed -i '' 's|"EnableConsole": true,|"EnableConsole": false,|g' $(DIST_PATH)/config/config.json;
+	sed -i'' 's|"ConsoleLevel": "DEBUG",|"ConsoleLevel": "INFO",|g' $(DIST_PATH)/config/config.json;
 
 	@# Package webapp
 	mkdir -p $(DIST_PATH)/webapp/dist

--- a/config/config.json
+++ b/config/config.json
@@ -125,8 +125,9 @@
         "EmailBatchingInterval": 30
     },
     "RateLimitSettings": {
-        "EnableRateLimiter": true,
+        "Enable": false,
         "PerSec": 10,
+        "MaxBurst": 100,
         "MemoryStoreSize": 10000,
         "VaryByRemoteAddr": true,
         "VaryByHeader": ""

--- a/config/config.json
+++ b/config/config.json
@@ -63,7 +63,7 @@
         "AtRestEncryptKey": ""
     },
     "LogSettings": {
-        "EnableConsole": false,
+        "EnableConsole": true,
         "ConsoleLevel": "DEBUG",
         "EnableFile": true,
         "FileLevel": "INFO",


### PR DESCRIPTION
I know we had this turned off by default for performance reasons, but I think we should just turn it off when we're testing performance. Having it off by default makes debugging difficult.