### PR TITLE
Refactored statuses to be queried by the client rather than broadcast by the server

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -206,7 +206,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if c.Err == nil && h.isUserActivity && token != "" && len(c.Session.UserId) > 0 {
-		//SetStatusOnline(c.Session.UserId, c.Session.Id, false)
+		SetStatusOnline(c.Session.UserId, c.Session.Id, false)
 	}
 
 	if c.Err == nil {
@@ -220,7 +220,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		c.LogError(c.Err)
 		c.Err.Where = r.URL.Path
 
-		// Block out detailed error whenn not in developer mode
+		// Block out detailed error when not in developer mode
 		if !*utils.Cfg.ServiceSettings.EnableDeveloper {
 			c.Err.DetailedError = ""
 		}

--- a/api/status.go
+++ b/api/status.go
@@ -32,6 +32,7 @@ func InitStatus() {
 	l4g.Debug(utils.T("api.status.init.debug"))
 
 	BaseRoutes.Users.Handle("/status", ApiUserRequired(getStatusesHttp)).Methods("GET")
+	BaseRoutes.Users.Handle("/status/ids", ApiUserRequired(getStatusesByIdsHttp)).Methods("POST")
 	BaseRoutes.Users.Handle("/status/set_active_channel", ApiUserRequired(setActiveChannel)).Methods("POST")
 	BaseRoutes.WebSocket.Handle("get_statuses", ApiWebSocketHandler(getStatusesWebSocket))
 	BaseRoutes.WebSocket.Handle("get_statuses_by_ids", ApiWebSocketHandler(getStatusesByIdsWebSocket))
@@ -70,6 +71,23 @@ func GetAllStatuses() (map[string]interface{}, *model.AppError) {
 
 		return statusMap, nil
 	}
+}
+
+func getStatusesByIdsHttp(c *Context, w http.ResponseWriter, r *http.Request) {
+	userIds := model.ArrayFromJson(r.Body)
+
+	if len(userIds) == 0 {
+		c.SetInvalidParam("getStatusesByIdsHttp", "user_ids")
+		return
+	}
+
+	statusMap, err := GetStatusesByIds(userIds)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	w.Write([]byte(model.StringInterfaceToJson(statusMap)))
 }
 
 func getStatusesByIdsWebSocket(req *model.WebSocketRequest) (map[string]interface{}, *model.AppError) {

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -116,8 +116,8 @@ func TestStatuses(t *testing.T) {
 			t.Fatal("bad sequence number")
 		}
 
-		if len(resp.Data) != 0 {
-			t.Fatal("no status should be returned")
+		if len(resp.Data) != 2 {
+			t.Fatal("2 statuses should be returned")
 		}
 	}
 

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -4,156 +4,197 @@
 package api
 
 import (
-	// "strings"
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/store"
+	"github.com/mattermost/platform/utils"
+	"strings"
 	"testing"
-	// "time"
-	// "github.com/mattermost/platform/model"
-	// "github.com/mattermost/platform/store"
-	// "github.com/mattermost/platform/utils"
+	"time"
 )
 
 func TestStatuses(t *testing.T) {
+	th := Setup().InitBasic()
+	Client := th.BasicClient
+	WebSocketClient, err := th.CreateWebSocketClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer WebSocketClient.Close()
+	WebSocketClient.Listen()
 
-	// TODO XXX FIXME - reimplement once status is fixed
+	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	rteam, _ := Client.CreateTeam(&team)
 
-	// th := Setup().InitBasic()
-	// Client := th.BasicClient
-	// WebSocketClient, err := th.CreateWebSocketClient()
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-	// defer WebSocketClient.Close()
-	// WebSocketClient.Listen()
+	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
+	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
+	LinkUserToTeam(ruser, rteam.Data.(*model.Team))
+	store.Must(Srv.Store.User().VerifyEmail(ruser.Id))
 
-	// team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
-	// rteam, _ := Client.CreateTeam(&team)
+	user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
+	ruser2 := Client.Must(Client.CreateUser(&user2, "")).Data.(*model.User)
+	LinkUserToTeam(ruser2, rteam.Data.(*model.Team))
+	store.Must(Srv.Store.User().VerifyEmail(ruser2.Id))
 
-	// user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
-	// ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
-	// LinkUserToTeam(ruser, rteam.Data.(*model.Team))
-	// store.Must(Srv.Store.User().VerifyEmail(ruser.Id))
+	Client.Login(user.Email, user.Password)
+	Client.SetTeamId(team.Id)
 
-	// user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
-	// ruser2 := Client.Must(Client.CreateUser(&user2, "")).Data.(*model.User)
-	// LinkUserToTeam(ruser2, rteam.Data.(*model.Team))
-	// store.Must(Srv.Store.User().VerifyEmail(ruser2.Id))
+	r1, err := Client.GetStatuses()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// Client.Login(user.Email, user.Password)
-	// Client.SetTeamId(team.Id)
+	statuses := r1.Data.(map[string]string)
 
-	// r1, err := Client.GetStatuses()
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
+	for _, status := range statuses {
+		if status != model.STATUS_OFFLINE && status != model.STATUS_AWAY && status != model.STATUS_ONLINE {
+			t.Fatal("one of the statuses had an invalid value")
+		}
+	}
 
-	// statuses := r1.Data.(map[string]string)
+	th.LoginBasic2()
 
-	// for _, status := range statuses {
-	// 	if status != model.STATUS_OFFLINE && status != model.STATUS_AWAY && status != model.STATUS_ONLINE {
-	// 		t.Fatal("one of the statuses had an invalid value")
-	// 	}
-	// }
+	WebSocketClient2, err2 := th.CreateWebSocketClient()
+	if err2 != nil {
+		t.Fatal(err2)
+	}
 
-	// th.LoginBasic2()
+	time.Sleep(300 * time.Millisecond)
 
-	// WebSocketClient2, err2 := th.CreateWebSocketClient()
-	// if err2 != nil {
-	// 	t.Fatal(err2)
-	// }
+	WebSocketClient.GetStatuses()
+	if resp := <-WebSocketClient.ResponseChannel; resp.Error != nil {
+		t.Fatal(resp.Error)
+	} else {
+		if resp.SeqReply != WebSocketClient.Sequence-1 {
+			t.Fatal("bad sequence number")
+		}
 
-	// time.Sleep(300 * time.Millisecond)
+		for _, status := range resp.Data {
+			if status != model.STATUS_OFFLINE && status != model.STATUS_AWAY && status != model.STATUS_ONLINE {
+				t.Fatal("one of the statuses had an invalid value")
+			}
+		}
 
-	// WebSocketClient.GetStatuses()
-	// if resp := <-WebSocketClient.ResponseChannel; resp.Error != nil {
-	// 	t.Fatal(resp.Error)
-	// } else {
-	// 	if resp.SeqReply != WebSocketClient.Sequence-1 {
-	// 		t.Fatal("bad sequence number")
-	// 	}
+		if status, ok := resp.Data[th.BasicUser2.Id]; !ok {
+			t.Log(len(resp.Data))
+			t.Fatal("should have had user status")
+		} else if status != model.STATUS_ONLINE {
+			t.Log(status)
+			t.Fatal("status should have been online")
+		}
+	}
 
-	// 	for _, status := range resp.Data {
-	// 		if status != model.STATUS_OFFLINE && status != model.STATUS_AWAY && status != model.STATUS_ONLINE {
-	// 			t.Fatal("one of the statuses had an invalid value")
-	// 		}
-	// 	}
+	WebSocketClient.GetStatusesByIds([]string{th.BasicUser2.Id})
+	if resp := <-WebSocketClient.ResponseChannel; resp.Error != nil {
+		t.Fatal(resp.Error)
+	} else {
+		if resp.SeqReply != WebSocketClient.Sequence-1 {
+			t.Fatal("bad sequence number")
+		}
 
-	// 	if status, ok := resp.Data[th.BasicUser2.Id]; !ok {
-	// 		t.Fatal("should have had user status")
-	// 	} else if status != model.STATUS_ONLINE {
-	// 		t.Log(status)
-	// 		t.Fatal("status should have been online")
-	// 	}
-	// }
+		for _, status := range resp.Data {
+			if status != model.STATUS_OFFLINE && status != model.STATUS_AWAY && status != model.STATUS_ONLINE {
+				t.Fatal("one of the statuses had an invalid value")
+			}
+		}
 
-	// SetStatusAwayIfNeeded(th.BasicUser2.Id, false)
+		if status, ok := resp.Data[th.BasicUser2.Id]; !ok {
+			t.Log(len(resp.Data))
+			t.Fatal("should have had user status")
+		} else if status != model.STATUS_ONLINE {
+			t.Log(status)
+			t.Fatal("status should have been online")
+		} else if len(resp.Data) != 1 {
+			t.Fatal("only 1 status should be returned")
+		}
+	}
 
-	// awayTimeout := *utils.Cfg.TeamSettings.UserStatusAwayTimeout
-	// defer func() {
-	// 	*utils.Cfg.TeamSettings.UserStatusAwayTimeout = awayTimeout
-	// }()
-	// *utils.Cfg.TeamSettings.UserStatusAwayTimeout = 1
+	WebSocketClient.GetStatusesByIds([]string{ruser2.Id, "junk"})
+	if resp := <-WebSocketClient.ResponseChannel; resp.Error != nil {
+		t.Fatal(resp.Error)
+	} else {
+		if resp.SeqReply != WebSocketClient.Sequence-1 {
+			t.Fatal("bad sequence number")
+		}
 
-	// time.Sleep(1500 * time.Millisecond)
+		if len(resp.Data) != 0 {
+			t.Fatal("no status should be returned")
+		}
+	}
 
-	// SetStatusAwayIfNeeded(th.BasicUser2.Id, false)
-	// SetStatusAwayIfNeeded(th.BasicUser2.Id, false)
+	WebSocketClient.GetStatusesByIds([]string{})
+	if resp := <-WebSocketClient.ResponseChannel; resp.Error == nil {
+		if resp.SeqReply != WebSocketClient.Sequence-1 {
+			t.Fatal("bad sequence number")
+		}
+		t.Fatal("should have errored - empty user ids")
+	}
 
-	// WebSocketClient2.Close()
-	// time.Sleep(300 * time.Millisecond)
+	WebSocketClient2.Close()
 
-	// WebSocketClient.GetStatuses()
-	// if resp := <-WebSocketClient.ResponseChannel; resp.Error != nil {
-	// 	t.Fatal(resp.Error)
-	// } else {
-	// 	if resp.SeqReply != WebSocketClient.Sequence-1 {
-	// 		t.Fatal("bad sequence number")
-	// 	}
+	SetStatusAwayIfNeeded(th.BasicUser.Id, false)
 
-	// 	if _, ok := resp.Data[th.BasicUser2.Id]; ok {
-	// 		t.Fatal("should not have had user status")
-	// 	}
-	// }
+	awayTimeout := *utils.Cfg.TeamSettings.UserStatusAwayTimeout
+	defer func() {
+		*utils.Cfg.TeamSettings.UserStatusAwayTimeout = awayTimeout
+	}()
+	*utils.Cfg.TeamSettings.UserStatusAwayTimeout = 1
 
-	// stop := make(chan bool)
-	// onlineHit := false
-	// awayHit := false
-	// offlineHit := false
+	time.Sleep(1500 * time.Millisecond)
 
-	// go func() {
-	// 	for {
-	// 		select {
-	// 		case resp := <-WebSocketClient.EventChannel:
-	// 			if resp.Event == model.WEBSOCKET_EVENT_STATUS_CHANGE && resp.Data["user_id"].(string) == th.BasicUser2.Id {
-	// 				status := resp.Data["status"].(string)
-	// 				if status == model.STATUS_ONLINE {
-	// 					onlineHit = true
-	// 				} else if status == model.STATUS_AWAY {
-	// 					awayHit = true
-	// 				} else if status == model.STATUS_OFFLINE {
-	// 					offlineHit = true
-	// 				}
-	// 			}
-	// 		case <-stop:
-	// 			return
-	// 		}
-	// 	}
-	// }()
+	SetStatusAwayIfNeeded(th.BasicUser.Id, false)
+	SetStatusOnline(th.BasicUser.Id, "junk", false)
 
-	// time.Sleep(500 * time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
 
-	// stop <- true
+	WebSocketClient.GetStatuses()
+	if resp := <-WebSocketClient.ResponseChannel; resp.Error != nil {
+		t.Fatal(resp.Error)
+	} else {
+		if resp.SeqReply != WebSocketClient.Sequence-1 {
+			t.Fatal("bad sequence number")
+		}
 
-	// if !onlineHit {
-	// 	t.Fatal("didn't get online event")
-	// }
-	// if !awayHit {
-	// 	t.Fatal("didn't get away event")
-	// }
-	// if !offlineHit {
-	// 	t.Fatal("didn't get offline event")
-	// }
+		if _, ok := resp.Data[th.BasicUser2.Id]; ok {
+			t.Fatal("should not have had user status")
+		}
+	}
 
-	// time.Sleep(500 * time.Millisecond)
+	stop := make(chan bool)
+	onlineHit := false
+	awayHit := false
+
+	go func() {
+		for {
+			select {
+			case resp := <-WebSocketClient.EventChannel:
+				if resp.Event == model.WEBSOCKET_EVENT_STATUS_CHANGE && resp.Data["user_id"].(string) == th.BasicUser.Id {
+					status := resp.Data["status"].(string)
+					if status == model.STATUS_ONLINE {
+						onlineHit = true
+					} else if status == model.STATUS_AWAY {
+						awayHit = true
+					}
+				}
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	stop <- true
+
+	if !onlineHit {
+		t.Fatal("didn't get online event")
+	}
+	if !awayHit {
+		t.Fatal("didn't get away event")
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	WebSocketClient.Close()
 }
 
 /*
@@ -190,7 +231,7 @@ func TestSetActiveChannel(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	status, _ = GetStatus(th.BasicUser.Id)
-	// need to check if offline to catch race
+	 need to check if offline to catch race
 	if status.Status != model.STATUS_OFFLINE && status.ActiveChannel != th.BasicChannel.Id {
 		t.Fatal("active channel should be set")
 	}

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -197,6 +197,33 @@ func TestStatuses(t *testing.T) {
 	WebSocketClient.Close()
 }
 
+func TestGetStatusesByIds(t *testing.T) {
+	th := Setup().InitBasic()
+	Client := th.BasicClient
+
+	if result, err := Client.GetStatusesByIds([]string{th.BasicUser.Id}); err != nil {
+		t.Fatal(err)
+	} else {
+		statuses := result.Data.(map[string]string)
+		if len(statuses) != 1 {
+			t.Fatal("should only have 1 status")
+		}
+	}
+
+	if result, err := Client.GetStatusesByIds([]string{th.BasicUser.Id, th.BasicUser2.Id, "junk"}); err != nil {
+		t.Fatal(err)
+	} else {
+		statuses := result.Data.(map[string]string)
+		if len(statuses) != 3 {
+			t.Fatal("should have 3 statuses")
+		}
+	}
+
+	if _, err := Client.GetStatusesByIds([]string{}); err == nil {
+		t.Fatal("should have errored")
+	}
+}
+
 /*
 func TestSetActiveChannel(t *testing.T) {
 	th := Setup().InitBasic()

--- a/api/user.go
+++ b/api/user.go
@@ -2635,6 +2635,11 @@ func searchUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 func getProfilesByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 	userIds := model.ArrayFromJson(r.Body)
 
+	if len(userIds) == 0 {
+		c.SetInvalidParam("getProfilesByIds", "user_ids")
+		return
+	}
+
 	if result := <-Srv.Store.User().GetProfileByIds(userIds); result.Err != nil {
 		c.Err = result.Err
 		return

--- a/api/web_conn.go
+++ b/api/web_conn.go
@@ -30,7 +30,7 @@ type WebConn struct {
 }
 
 func NewWebConn(c *Context, ws *websocket.Conn) *WebConn {
-	//go SetStatusOnline(c.Session.UserId, c.Session.Id, false)
+	go SetStatusOnline(c.Session.UserId, c.Session.Id, false)
 
 	return &WebConn{
 		Send:         make(chan model.WebSocketMessage, 64),

--- a/api/web_conn.go
+++ b/api/web_conn.go
@@ -51,7 +51,7 @@ func (c *WebConn) readPump() {
 	c.WebSocket.SetReadDeadline(time.Now().Add(PONG_WAIT))
 	c.WebSocket.SetPongHandler(func(string) error {
 		c.WebSocket.SetReadDeadline(time.Now().Add(PONG_WAIT))
-		//go SetStatusAwayIfNeeded(c.UserId, false)
+		go SetStatusAwayIfNeeded(c.UserId, false)
 		return nil
 	})
 

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -143,12 +143,6 @@ func (h *Hub) Start() {
 }
 
 func shouldSendEvent(webCon *WebConn, msg *model.WebSocketEvent) bool {
-
-	// TODO XXX FIXE ME - remove once status is refactored
-	if msg.Event == model.WEBSOCKET_EVENT_STATUS_CHANGE {
-		return false
-	}
-
 	// If the event is destined to a specific user
 	if len(msg.Broadcast.UserId) > 0 && webCon.UserId != msg.Broadcast.UserId {
 		return false

--- a/model/client.go
+++ b/model/client.go
@@ -1577,6 +1577,18 @@ func (c *Client) GetStatuses() (*Result, *AppError) {
 	}
 }
 
+// GetStatusesByIds returns a map of string statuses using user id as the key,
+// based on the provided user ids
+func (c *Client) GetStatusesByIds(userIds []string) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/users/status/ids", ArrayToJson(userIds)); err != nil {
+		return nil, err
+	} else {
+		defer closeBody(r)
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), MapFromJson(r.Body)}, nil
+	}
+}
+
 // SetActiveChannel sets the the channel id the user is currently viewing.
 // The channelId key is required but the value can be blank. Returns standard
 // response.

--- a/model/utils.go
+++ b/model/utils.go
@@ -175,6 +175,23 @@ func ArrayFromJson(data io.Reader) []string {
 	}
 }
 
+func ArrayFromInterface(data interface{}) []string {
+	stringArray := []string{}
+
+	dataArray, ok := data.([]interface{})
+	if !ok {
+		return stringArray
+	}
+
+	for _, v := range dataArray {
+		if str, ok := v.(string); ok {
+			stringArray = append(stringArray, str)
+		}
+	}
+
+	return stringArray
+}
+
 func StringInterfaceToJson(objmap map[string]interface{}) string {
 	if b, err := json.Marshal(objmap); err != nil {
 		return ""

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -119,3 +119,12 @@ func (wsc *WebSocketClient) UserTyping(channelId, parentId string) {
 func (wsc *WebSocketClient) GetStatuses() {
 	wsc.SendMessage("get_statuses", nil)
 }
+
+// GetStatusesByIds will fetch certain user statuses based on ids and return
+// a map of string statuses using user id as the key
+func (wsc *WebSocketClient) GetStatusesByIds(userIds []string) {
+	data := map[string]interface{}{
+		"user_ids": userIds,
+	}
+	wsc.SendMessage("get_statuses_by_ids", data)
+}

--- a/store/sql_status_store_test.go
+++ b/store/sql_status_store_test.go
@@ -60,6 +60,15 @@ func TestSqlStatusStore(t *testing.T) {
 		}
 	}
 
+	if result := <-store.Status().GetByIds([]string{status.UserId, "junk"}); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		statuses := result.Data.([]*model.Status)
+		if len(statuses) != 1 {
+			t.Fatal("should only have 1 status")
+		}
+	}
+
 	if err := (<-store.Status().ResetAll()).Err; err != nil {
 		t.Fatal(err)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -284,6 +284,7 @@ type EmojiStore interface {
 type StatusStore interface {
 	SaveOrUpdate(status *model.Status) StoreChannel
 	Get(userId string) StoreChannel
+	GetByIds(userIds []string) StoreChannel
 	GetOnlineAway() StoreChannel
 	GetOnline() StoreChannel
 	GetAllFromTeam(teamId string) StoreChannel

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -8,6 +8,8 @@ import PostStore from 'stores/post_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
+import {loadStatusesForChannel} from 'actions/status_actions.jsx';
+
 import * as PostUtils from 'utils/post_utils.jsx';
 import Client from 'client/web_client.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
@@ -186,6 +188,7 @@ export function loadPosts(channelId = ChannelStore.getCurrentId()) {
             });
 
             loadProfilesForPosts(data.posts);
+            loadStatusesForChannel(channelId);
         },
         (err) => {
             AsyncClient.dispatchError(err, 'loadPosts');
@@ -219,6 +222,7 @@ export function loadPostsPage(channelId = ChannelStore.getCurrentId(), max = Con
             });
 
             loadProfilesForPosts(data.posts);
+            loadStatusesForChannel(channelId);
         },
         (err) => {
             AsyncClient.dispatchError(err, 'loadPostsPage');
@@ -248,6 +252,7 @@ export function loadPostsBefore(postId, offset, numPost, isPost) {
             });
 
             loadProfilesForPosts(data.posts);
+            loadStatusesForChannel(channelId);
         },
         (err) => {
             AsyncClient.dispatchError(err, 'loadPostsBefore');
@@ -277,6 +282,7 @@ export function loadPostsAfter(postId, offset, numPost, isPost) {
             });
 
             loadProfilesForPosts(data.posts);
+            loadStatusesForChannel(channelId);
         },
         (err) => {
             AsyncClient.dispatchError(err, 'loadPostsAfter');

--- a/webapp/actions/status_actions.jsx
+++ b/webapp/actions/status_actions.jsx
@@ -1,0 +1,133 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
+
+import ChannelStore from 'stores/channel_store.jsx';
+import PostStore from 'stores/post_store.jsx';
+import PreferenceStore from 'stores/preference_store.jsx';
+
+import WebSocketClient from 'client/web_websocket_client.jsx';
+
+import {ActionTypes, Preferences, Constants} from 'utils/constants.jsx';
+
+export function loadStatusesForChannel(channelId = ChannelStore.getCurrentId()) {
+    const postList = PostStore.getVisiblePosts(channelId);
+    if (!postList || !postList.posts) {
+        return;
+    }
+
+    const statusesToLoad = {};
+    for (const pid in postList.posts) {
+        if (!postList.posts.hasOwnProperty(pid)) {
+            continue;
+        }
+
+        const post = postList.posts[pid];
+        statusesToLoad[post.user_id] = true;
+    }
+
+    loadStatusesByIds(Object.keys(statusesToLoad));
+}
+
+export function loadStatusesForDMSidebar() {
+    const dmPrefs = PreferenceStore.getCategory(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW);
+    const statusesToLoad = [];
+
+    for (const [key, value] of dmPrefs) {
+        if (value === 'true') {
+            statusesToLoad.push(key);
+        }
+    }
+
+    loadStatusesByIds(statusesToLoad);
+}
+
+export function loadStatusesForChannelAndSidebar() {
+    const statusesToLoad = {};
+
+    const channelId = ChannelStore.getCurrentId();
+    const postList = PostStore.getVisiblePosts(channelId);
+    if (postList && postList.posts) {
+        for (const pid in postList.posts) {
+            if (!postList.posts.hasOwnProperty(pid)) {
+                continue;
+            }
+
+            const post = postList.posts[pid];
+            statusesToLoad[post.user_id] = true;
+        }
+    }
+
+    const dmPrefs = PreferenceStore.getCategory(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW);
+
+    for (const [key, value] of dmPrefs) {
+        if (value === 'true') {
+            statusesToLoad[key] = true;
+        }
+    }
+
+    loadStatusesByIds(Object.keys(statusesToLoad));
+}
+
+export function loadStatusesForProfilesList(users) {
+    if (users == null) {
+        return;
+    }
+
+    const statusesToLoad = [];
+    for (let i = 0; i < users.length; i++) {
+        statusesToLoad.push(users[i].id);
+    }
+
+    loadStatusesByIds(statusesToLoad);
+}
+
+export function loadStatusesForProfilesMap(users) {
+    if (users == null) {
+        return;
+    }
+
+    const statusesToLoad = [];
+    for (const userId in users) {
+        if (!users.hasOwnProperty(userId)) {
+            return;
+        }
+        statusesToLoad.push(userId);
+    }
+
+    loadStatusesByIds(statusesToLoad);
+}
+
+export function loadStatusesByIds(userIds) {
+    if (userIds.length === 0) {
+        return;
+    }
+
+    WebSocketClient.getStatusesByIds(
+        userIds,
+        (resp) => {
+            AppDispatcher.handleServerAction({
+                type: ActionTypes.RECEIVED_STATUSES,
+                statuses: resp.data
+            });
+        }
+    );
+}
+
+let intervalId = '';
+
+export function startPeriodicStatusUpdates() {
+    clearInterval(intervalId);
+
+    intervalId = setInterval(
+        () => {
+            loadStatusesForChannelAndSidebar();
+        },
+        Constants.STATUS_INTERVAL
+    );
+}
+
+export function stopPeriodicStatusUpdates() {
+    clearInterval(intervalId);
+}

--- a/webapp/actions/status_actions.jsx
+++ b/webapp/actions/status_actions.jsx
@@ -7,7 +7,7 @@ import ChannelStore from 'stores/channel_store.jsx';
 import PostStore from 'stores/post_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 
-import WebSocketClient from 'client/web_websocket_client.jsx';
+import Client from 'client/web_client.jsx';
 
 import {ActionTypes, Preferences, Constants} from 'utils/constants.jsx';
 
@@ -104,12 +104,12 @@ export function loadStatusesByIds(userIds) {
         return;
     }
 
-    WebSocketClient.getStatusesByIds(
+    Client.getStatusesByIds(
         userIds,
-        (resp) => {
+        (data) => {
             AppDispatcher.handleServerAction({
                 type: ActionTypes.RECEIVED_STATUSES,
-                statuses: resp.data
+                statuses: data
             });
         }
     );

--- a/webapp/actions/user_actions.jsx
+++ b/webapp/actions/user_actions.jsx
@@ -8,6 +8,8 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 
+import {loadStatusesForProfilesList, loadStatusesForProfilesMap} from 'actions/status_actions.jsx';
+
 import {getDirectChannelName} from 'utils/utils.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
 import Client from 'client/web_client.jsx';
@@ -47,6 +49,7 @@ export function loadProfilesAndTeamMembers(offset, limit, teamId = TeamStore.get
             });
 
             loadTeamMembersForProfilesMap(data, teamId, success, error);
+            loadStatusesForProfilesMap(data);
         },
         (err) => {
             AsyncClient.dispatchError(err, 'getProfilesInTeam');
@@ -261,6 +264,8 @@ export function searchUsers(term, teamId = TeamStore.getCurrentId(), options = {
         teamId,
         options,
         (data) => {
+            loadStatusesForProfilesList(data);
+
             if (success) {
                 success(data);
             }

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -3,8 +3,6 @@
 
 import $ from 'jquery';
 
-import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
-
 import UserStore from 'stores/user_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import PostStore from 'stores/post_store.jsx';
@@ -22,8 +20,9 @@ import * as AsyncClient from 'utils/async_client.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {handleNewPost, loadPosts} from 'actions/post_actions.jsx';
 import {loadProfilesAndTeamMembersForDMSidebar} from 'actions/user_actions.jsx';
+import * as StatusActions from 'actions/status_actions.jsx';
 
-import {Constants, SocketEvents, ActionTypes} from 'utils/constants.jsx';
+import {Constants, SocketEvents, UserStatuses} from 'utils/constants.jsx';
 
 import {browserHistory} from 'react-router/es6';
 
@@ -61,22 +60,17 @@ export function initialize() {
 }
 
 export function close() {
+    StatusActions.stopPeriodicStatusUpdates();
     WebSocketClient.close();
 }
 
 export function getStatuses() {
-    WebSocketClient.getStatuses(
-        (resp) => {
-            AppDispatcher.handleServerAction({
-                type: ActionTypes.RECEIVED_STATUSES,
-                statuses: resp.data
-            });
-        }
-    );
+    StatusActions.loadStatusesForChannelAndSidebar();
 }
 
 function handleFirstConnect() {
     getStatuses();
+    StatusActions.startPeriodicStatusUpdates();
     ErrorStore.clearLastError();
     ErrorStore.emitChange();
 }
@@ -88,6 +82,7 @@ function handleReconnect() {
     }
 
     getStatuses();
+    StatusActions.startPeriodicStatusUpdates();
     ErrorStore.clearLastError();
     ErrorStore.emitChange();
 }
@@ -175,6 +170,10 @@ function handleEvent(msg) {
 function handleNewPostEvent(msg) {
     const post = JSON.parse(msg.data.post);
     handleNewPost(post, msg);
+
+    if (UserStore.getStatus(post.user_id) !== UserStatuses.ONLINE) {
+        StatusActions.loadStatusesByIds([post.user_id]);
+    }
 }
 
 function handlePostEditEvent(msg) {
@@ -289,6 +288,10 @@ function handlePreferenceChangedEvent(msg) {
 
 function handleUserTypingEvent(msg) {
     GlobalActions.emitRemoteUserTypingEvent(msg.broadcast.channel_id, msg.data.user_id, msg.data.parent_id);
+
+    if (UserStore.getStatus(msg.data.user_id) !== UserStatuses.ONLINE) {
+        StatusActions.loadStatusesByIds([msg.data.user_id]);
+    }
 }
 
 function handleStatusChangedEvent(msg) {

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -60,7 +60,6 @@ export function initialize() {
 }
 
 export function close() {
-    StatusActions.stopPeriodicStatusUpdates();
     WebSocketClient.close();
 }
 
@@ -70,7 +69,6 @@ export function getStatuses() {
 
 function handleFirstConnect() {
     getStatuses();
-    StatusActions.startPeriodicStatusUpdates();
     ErrorStore.clearLastError();
     ErrorStore.emitChange();
 }
@@ -82,7 +80,6 @@ function handleReconnect() {
     }
 
     getStatuses();
-    StatusActions.startPeriodicStatusUpdates();
     ErrorStore.clearLastError();
     ErrorStore.emitChange();
 }

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -1092,6 +1092,16 @@ export default class Client {
             end(this.handleResponse.bind(this, 'getStatuses', success, error));
     }
 
+    getStatusesByIds(userIds, success, error) {
+        request.
+            post(`${this.getUsersRoute()}/status/ids`).
+            set(this.defaultHeaders).
+            type('application/json').
+            accept('application/json').
+            send(userIds).
+            end(this.handleResponse.bind(this, 'getStatuses', success, error));
+    }
+
     setActiveChannel(id, success, error) {
         request.
             post(`${this.getUsersRoute()}/status/set_active_channel`).

--- a/webapp/client/websocket_client.jsx
+++ b/webapp/client/websocket_client.jsx
@@ -163,4 +163,10 @@ export default class WebSocketClient {
     getStatuses(callback) {
         this.sendMessage('get_statuses', null, callback);
     }
+
+    getStatusesByIds(userIds, callback) {
+        const data = {};
+        data.user_ids = userIds;
+        this.sendMessage('get_statuses_by_ids', data, callback);
+    }
 }

--- a/webapp/components/channel_invite_modal.jsx
+++ b/webapp/components/channel_invite_modal.jsx
@@ -32,7 +32,7 @@ export default class ChannelInviteModal extends React.Component {
         this.term = '';
 
         const channelStats = ChannelStore.getStats(props.channel.id);
-        const teamStats = TeamStore.getStats();
+        const teamStats = TeamStore.getCurrentStats();
 
         this.state = {
             users: [],
@@ -43,14 +43,19 @@ export default class ChannelInviteModal extends React.Component {
 
     componentWillReceiveProps(nextProps) {
         if (!this.props.show && nextProps.show) {
+            TeamStore.addStatsChangeListener(this.onChange);
             ChannelStore.addStatsChangeListener(this.onChange);
             UserStore.addNotInChannelChangeListener(this.onChange);
+            UserStore.addStatusesChangeListener(this.onChange);
 
             this.onChange();
             AsyncClient.getProfilesNotInChannel(this.props.channel.id, 0);
+            AsyncClient.getTeamStats(TeamStore.getCurrentId());
         } else if (this.props.show && !nextProps.show) {
+            TeamStore.removeStatsChangeListener(this.onChange);
             ChannelStore.removeStatsChangeListener(this.onChange);
             UserStore.removeNotInChannelChangeListener(this.onChange);
+            UserStore.removeStatusesChangeListener(this.onChange);
         }
     }
 
@@ -67,7 +72,7 @@ export default class ChannelInviteModal extends React.Component {
         }
 
         const channelStats = ChannelStore.getStats(this.props.channel.id);
-        const teamStats = TeamStore.getStats();
+        const teamStats = TeamStore.getCurrentStats();
 
         this.setState({
             users: UserStore.getProfileListNotInChannel(this.props.channel.id),

--- a/webapp/components/channel_members_modal.jsx
+++ b/webapp/components/channel_members_modal.jsx
@@ -47,12 +47,14 @@ export default class ChannelMembersModal extends React.Component {
         if (!this.props.show && nextProps.show) {
             ChannelStore.addStatsChangeListener(this.onChange);
             UserStore.addInChannelChangeListener(this.onChange);
+            UserStore.addStatusesChangeListener(this.onChange);
 
             this.onChange();
             AsyncClient.getProfilesInChannel(this.props.channel.id, 0);
         } else if (this.props.show && !nextProps.show) {
             ChannelStore.removeStatsChangeListener(this.onChange);
             UserStore.removeInChannelChangeListener(this.onChange);
+            UserStore.removeStatusesChangeListener(this.onChange);
         }
     }
 

--- a/webapp/components/member_list_team.jsx
+++ b/webapp/components/member_list_team.jsx
@@ -38,6 +38,7 @@ export default class MemberListTeam extends React.Component {
 
     componentDidMount() {
         UserStore.addInTeamChangeListener(this.onChange);
+        UserStore.addStatusesChangeListener(this.onChange);
         TeamStore.addChangeListener(this.onChange);
         TeamStore.addStatsChangeListener(this.onStatsChange);
 
@@ -47,6 +48,7 @@ export default class MemberListTeam extends React.Component {
 
     componentWillUnmount() {
         UserStore.removeInTeamChangeListener(this.onChange);
+        UserStore.removeStatusesChangeListener(this.onChange);
         TeamStore.removeChangeListener(this.onChange);
         TeamStore.removeStatsChangeListener(this.onStatsChange);
     }

--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -46,6 +46,7 @@ export default class MoreDirectChannels extends React.Component {
     componentDidMount() {
         UserStore.addChangeListener(this.onChange);
         UserStore.addInTeamChangeListener(this.onChange);
+        UserStore.addStatusesChangeListener(this.onChange);
         TeamStore.addChangeListener(this.onChange);
 
         AsyncClient.getProfiles(0, Constants.PROFILE_CHUNK_SIZE);
@@ -55,6 +56,7 @@ export default class MoreDirectChannels extends React.Component {
     componentWillUnmount() {
         UserStore.removeChangeListener(this.onChange);
         UserStore.removeInTeamChangeListener(this.onChange);
+        UserStore.removeStatusesChangeListener(this.onChange);
         TeamStore.removeChangeListener(this.onChange);
     }
 

--- a/webapp/components/needs_team.jsx
+++ b/webapp/components/needs_team.jsx
@@ -13,6 +13,7 @@ import UserStore from 'stores/user_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
+import {startPeriodicStatusUpdates, stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
 import Constants from 'utils/constants.jsx';
 const TutorialSteps = Constants.TutorialSteps;
 const Preferences = Constants.Preferences;
@@ -80,6 +81,7 @@ export default class NeedsTeam extends React.Component {
         if (tutorialStep <= TutorialSteps.INTRO_SCREENS) {
             browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/tutorial');
         }
+        stopPeriodicStatusUpdates();
     }
 
     componentDidMount() {
@@ -88,6 +90,8 @@ export default class NeedsTeam extends React.Component {
 
         // Emit view action
         GlobalActions.viewLoggedIn();
+
+        startPeriodicStatusUpdates();
 
         // Set up tracking for whether the window is active
         window.isActive = true;

--- a/webapp/components/popover_list_members.jsx
+++ b/webapp/components/popover_list_members.jsx
@@ -90,12 +90,6 @@ export default class PopoverListMembers extends React.Component {
                 }
 
                 if (name) {
-                    let status;
-                    if (m.status) {
-                        status = m.status;
-                    } else {
-                        status = UserStore.getStatus(m.id);
-                    }
                     popoverHtml.push(
                         <div
                             className='more-modal__row'
@@ -103,7 +97,6 @@ export default class PopoverListMembers extends React.Component {
                         >
                             <ProfilePicture
                                 src={`${Client.getUsersRoute()}/${m.id}/image?time=${m.update_at}`}
-                                status={status}
                                 width='26'
                                 height='26'
                             />

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -178,15 +178,15 @@ class PostStoreClass extends EventEmitter {
     }
 
     // Returns true if posts need to be fetched
-    requestVisibilityIncrease(id, ammount) {
+    requestVisibilityIncrease(id, amount) {
         const endVisible = this.postsInfo[id].endVisible;
         const postList = this.postsInfo[id].postList;
         if (this.getVisibilityAtTop(id)) {
             return false;
         }
-        this.postsInfo[id].endVisible += ammount;
+        this.postsInfo[id].endVisible += amount;
         this.emitChange();
-        return endVisible + ammount > postList.order.length;
+        return endVisible + amount > postList.order.length;
     }
 
     getFocusedPostId() {

--- a/webapp/tests/client_user.test.jsx
+++ b/webapp/tests/client_user.test.jsx
@@ -543,16 +543,15 @@ describe('Client.User', function() {
         });
     });
 
-    /* TODO: FIX THIS TEST
-    it('getStatuses', function(done) {
+    it('getStatusesByIds', function(done) {
         TestHelper.initBasic(() => {
             var ids = [];
             ids.push(TestHelper.basicUser().id);
 
-            TestHelper.basicClient().getStatuses(
+            TestHelper.basicClient().getStatusesByIds(
                 ids,
                 function(data) {
-                    assert.equal(data[TestHelper.basicUser().id], 'online');
+                    assert.equal(data[TestHelper.basicUser().id] != null, true);
                     done();
                 },
                 function(err) {
@@ -561,7 +560,6 @@ describe('Client.User', function() {
             );
         });
     });
-    */
 
     it('setActiveChannel', function(done) {
         TestHelper.initBasic(() => {

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -8,6 +8,7 @@ import TeamStore from 'stores/team_store.jsx';
 import ErrorStore from 'stores/error_store.jsx';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
+import {loadStatusesForProfilesMap} from 'actions/status_actions.jsx';
 
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import Client from 'client/web_client.jsx';
@@ -360,6 +361,8 @@ export function getProfilesInChannel(channelId = ChannelStore.getCurrentId(), of
                 offset,
                 count: Object.keys(data).length
             });
+
+            loadStatusesForProfilesMap(data);
         },
         (err) => {
             callTracker[`getProfilesInChannel${offset}${limit}`] = 0;
@@ -388,6 +391,8 @@ export function getProfilesNotInChannel(channelId = ChannelStore.getCurrentId(),
                 offset,
                 count: Object.keys(data).length
             });
+
+            loadStatusesForProfilesMap(data);
         },
         (err) => {
             callTracker[`getProfilesNotInChannel${offset}${limit}`] = 0;

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -849,7 +849,8 @@ export const Constants = {
     MENTION_MEMBERS: 'mention.members',
     MENTION_NONMEMBERS: 'mention.nonmembers',
     MENTION_SPECIAL: 'mention.special',
-    DEFAULT_NOTIFICATION_DURATION: 5000
+    DEFAULT_NOTIFICATION_DURATION: 5000,
+    STATUS_INTERVAL: 15000
 };
 
 export default Constants;

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -850,7 +850,7 @@ export const Constants = {
     MENTION_NONMEMBERS: 'mention.nonmembers',
     MENTION_SPECIAL: 'mention.special',
     DEFAULT_NOTIFICATION_DURATION: 5000,
-    STATUS_INTERVAL: 15000
+    STATUS_INTERVAL: 60000
 };
 
 export default Constants;


### PR DESCRIPTION
#### Summary
This PR contains the following changes to statuses:
* Existing `/users/status` route will return a maximum of 300 statuses, might remove or add paging to this route later on
* Added a new WebSocket API `get_statuses_by_ids` to allow requesting statuses based on user IDs
* The client will request statuses for author's of posts in the current channel and the DM sidebar every 15 seconds
* The client will request the status for a user who has just made a post or is typing if that user is not already recognized as online by the client
* The server will still broadcast a user their own status changes
* Modals that show statuses will request the statuses for the users it has but __will not__ periodically grab updates to those

To Dos for Later:

2. Add a REST API to get statuses by user IDs (to match the websocket API) ([ticket](https://mattermost.atlassian.net/browse/PLT-4385))
2. Move `SetStatusAwayIfNeeded` out of the WS pong handler if it starts causing issues
1. Possibly add periodic querying of statuses for modals (not sure if it's worth it)
3. Investigate adding smart status broadcasts from the server based on the users the client has been requesting statuses for

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers
- [x] Has UI changes
