### PR TITLE
Don't show desktop notifications for messages entering the channel th…

### DIFF
--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -98,9 +98,9 @@ export function notifyMe(title, body, channel, teamId, duration, silent) {
 
     // If notification is meant for the current active channel, don't
     // show the notification
-    let activeChannel = ChannelStore.getCurrent()
-    if(activeChannel.id === channel.id) {
-      return;
+    const activeChannel = ChannelStore.getCurrent();
+    if (activeChannel.id === channel.id) {
+        return;
     }
 
     if (Notification.permission === 'granted' || (Notification.permission === 'default' && !requestedNotificationPermission)) {

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -96,6 +96,13 @@ export function notifyMe(title, body, channel, teamId, duration, silent) {
         notificationDuration = duration;
     }
 
+    // If notification is meant for the current active channel, don't
+    // show the notification
+    let activeChannel = ChannelStore.getCurrent()
+    if(activeChannel.id === channel.id) {
+      return;
+    }
+
     if (Notification.permission === 'granted' || (Notification.permission === 'default' && !requestedNotificationPermission)) {
         requestedNotificationPermission = true;
 


### PR DESCRIPTION
#### Summary
This PR will disable notifications for incoming messages on the channel that the user is currently in. 

#### Ticket Link
JIRA: https://github.com/pepf/platform/tree/PLT-T3267-toggle-mentions-sidebar
Github: https://github.com/mattermost/platform/issues/4141

#### Checklist
none applicable

A possible follow-up step could be showing notifications when the user is currently not focussed on the browser window itself, while still being in the same channel as the notification is.