### PR TITLE
Fixing marking channels unread, again

### DIFF
--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -325,7 +325,7 @@ class ChannelStoreClass extends EventEmitter {
         const ch = this.get(id);
         const chMember = this.getMember(id);
 
-        let chMentionCount = chMember.mention_count;
+        const chMentionCount = chMember.mention_count;
         let chUnreadCount = ch.total_msg_count - chMember.msg_count;
 
         if (chMember.notify_props && chMember.notify_props.mark_unread === NotificationPrefs.MENTION) {

--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -328,10 +328,7 @@ class ChannelStoreClass extends EventEmitter {
         let chMentionCount = chMember.mention_count;
         let chUnreadCount = ch.total_msg_count - chMember.msg_count;
 
-        // Temporary workaround for DM channels having wrong unread values
-        if (ch.type === 'D') {
-            chMentionCount = 0;
-        } else if (chMember.notify_props && chMember.notify_props.mark_unread === NotificationPrefs.MENTION) {
+        if (chMember.notify_props && chMember.notify_props.mark_unread === NotificationPrefs.MENTION) {
             chUnreadCount = 0;
         }
 


### PR DESCRIPTION
#### Summary
- Marking channels unread no longer causes DM jewels to disappear