### PR TITLE
PLT-4068: Add .zip to build process & convert config.json to use CRLF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ else
 	cp $(GOPATH)/bin/windows_amd64/platform.exe $(DIST_PATH)/bin # from cross-compiled bin dir
 endif
 	@# Package
-	tar -C dist -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-windows-amd64.tar.gz mattermost
+	cd $(DIST_ROOT) && zip -9 -r -q -l mattermost-$(BUILD_TYPE_NAME)-windows-amd64.zip mattermost && cd ..
 	@# Cleanup
 	rm -f $(DIST_PATH)/bin/platform.exe
 


### PR DESCRIPTION
#### Summary

Modifies the `makefile` to generate a windows-friendly archive (e.g. zipfile) instead of a tar file for the windows distribution.  Also, to align w/ windows-friendliness, a flag is included in the zip operation to convert LF's to CRLF's (which will enable an easier experience when updating `config.json`.

Note that if the system executing _does not_ have the `zip` command/package available, the build will gracefully fallback to the standard tar packaging.
#### Ticket Links

[PLT-4068: Add .zip to build process for Windows and update config.json so it renders properly in Notepad](https://mattermost.atlassian.net/browse/PLT-4068)

[DOCS/PR-483: Windows Installation/Deployment Guide](https://github.com/mattermost/docs/pull/483)
#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
