### PR TITLE
PLT-4387 Update browser tab when switching to System Console

### DIFF
--- a/webapp/components/admin_console/admin_sidebar.jsx
+++ b/webapp/components/admin_console/admin_sidebar.jsx
@@ -35,6 +35,8 @@ export default class AdminSidebar extends React.Component {
         this.teamSelectedModal = this.teamSelectedModal.bind(this);
         this.teamSelectedModalDismissed = this.teamSelectedModalDismissed.bind(this);
 
+        this.updateTitle = this.updateTitle.bind(this);
+
         this.renderAddTeamButton = this.renderAddTeamButton.bind(this);
         this.renderTeams = this.renderTeams.bind(this);
 
@@ -48,6 +50,8 @@ export default class AdminSidebar extends React.Component {
     componentDidMount() {
         AdminStore.addAllTeamsChangeListener(this.handleAllTeamsChange);
         AsyncClient.getAllTeams();
+
+        this.updateTitle();
     }
 
     componentDidUpdate() {
@@ -99,6 +103,15 @@ export default class AdminSidebar extends React.Component {
 
     teamSelectedModalDismissed() {
         this.setState({showSelectModal: false});
+    }
+
+    updateTitle() {
+        let currentSiteName = '';
+        if (global.window.mm_config.SiteName != null) {
+            currentSiteName = global.window.mm_config.SiteName;
+        }
+
+        document.title = Utils.localizeMessage('sidebar_right_menu.console', 'System Console') + ' - ' + currentSiteName;
     }
 
     renderAddTeamButton() {


### PR DESCRIPTION
#### Summary
Add updateTtile to AdminSidebar, update browser tab title when componentDidMount.
Use injectIntl in order to localize "System Console" text.

#### Ticket Link
[PLT-4387: Browser tab title does not update when switching to System Console](https://mattermost.atlassian.net/browse/PLT-4387)
Github: #4218 

#### Checklist
None applicable
