### PR TITLE
PLT-4363 Remove WebRTC from "pre-view" features

### DIFF
--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -39,8 +39,6 @@ import {FormattedMessage} from 'react-intl';
 import {browserHistory} from 'react-router/es6';
 import {Tooltip, OverlayTrigger, Popover} from 'react-bootstrap';
 
-const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
-
 export default class ChannelHeader extends React.Component {
     constructor(props) {
         super(props);
@@ -284,7 +282,7 @@ export default class ChannelHeader extends React.Component {
             }
 
             const webrtcEnabled = global.mm_config.EnableWebrtc === 'true' && global.mm_license.Webrtc === 'true' &&
-                global.mm_config.EnableDeveloper === 'true' && userMedia && Utils.isFeatureEnabled(PreReleaseFeatures.WEBRTC_PREVIEW);
+                global.mm_config.EnableDeveloper === 'true' && userMedia;
 
             if (webrtcEnabled) {
                 const isOffline = UserStore.getStatus(contact.id) === UserStatuses.OFFLINE;

--- a/webapp/components/user_profile.jsx
+++ b/webapp/components/user_profile.jsx
@@ -9,7 +9,6 @@ import * as GlobalActions from 'actions/global_actions.jsx';
 import * as WebrtcActions from 'actions/webrtc_actions.jsx';
 import Constants from 'utils/constants.jsx';
 const UserStatuses = Constants.UserStatuses;
-const PreReleaseFeatures = Constants.PRE_RELEASE_FEATURES;
 
 import {Popover, OverlayTrigger} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
@@ -91,7 +90,7 @@ export default class UserProfile extends React.Component {
         const userMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
 
         const webrtcEnabled = global.mm_config.EnableWebrtc === 'true' && global.mm_license.Webrtc === 'true' &&
-            global.mm_config.EnableDeveloper === 'true' && userMedia && Utils.isFeatureEnabled(PreReleaseFeatures.WEBRTC_PREVIEW);
+            global.mm_config.EnableDeveloper === 'true' && userMedia;
 
         if (webrtcEnabled && this.props.user.id !== this.state.currentUserId) {
             const isOnline = this.props.status !== UserStatuses.OFFLINE;

--- a/webapp/components/user_settings/user_settings_advanced.jsx
+++ b/webapp/components/user_settings/user_settings_advanced.jsx
@@ -33,7 +33,7 @@ export default class AdvancedSettingsDisplay extends React.Component {
     }
 
     getStateFromStores() {
-        let preReleaseFeaturesKeys = Object.keys(PreReleaseFeatures);
+        const preReleaseFeaturesKeys = Object.keys(PreReleaseFeatures);
         const advancedSettings = PreferenceStore.getCategory(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS);
         const settings = {
             send_on_ctrl_enter: PreferenceStore.get(
@@ -55,13 +55,6 @@ export default class AdvancedSettingsDisplay extends React.Component {
 
         let enabledFeatures = 0;
         for (const [name, value] of advancedSettings) {
-            const webrtcEnabled = global.mm_config.EnableWebrtc === 'true' && global.mm_license.Webrtc === 'true' &&
-                global.mm_config.EnableDeveloper === 'true';
-
-            if (!webrtcEnabled) {
-                preReleaseFeaturesKeys = preReleaseFeaturesKeys.filter((f) => f !== 'WEBRTC_PREVIEW');
-            }
-
             for (const key of preReleaseFeaturesKeys) {
                 const feature = PreReleaseFeatures[key];
 
@@ -334,13 +327,6 @@ export default class AdvancedSettingsDisplay extends React.Component {
                 <FormattedMessage
                     id='user.settings.advance.embed_preview'
                     defaultMessage='Show experimental previews of link content, when available'
-                />
-            );
-        case 'WEBRTC_PREVIEW':
-            return (
-                <FormattedMessage
-                    id='user.settings.advance.webrtc_preview'
-                    defaultMessage='Enable the ability to make and receive one-on-one WebRTC calls'
                 />
             );
         default:

--- a/webapp/i18n/de.json
+++ b/webapp/i18n/de.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "Sende Nachrichten mit Strg + Enter",
   "user.settings.advance.slashCmd_autocmp": "Erlaube externe Anwendung Slash Autovervollständigung anzubieten",
   "user.settings.advance.title": "Erweiterte Einstellungen",
-  "user.settings.advance.webrtc_preview": "Enable the ability to make and receive one-on-one WebRTC calls",
   "user.settings.custom_theme.awayIndicator": "Abwesend Anzeige",
   "user.settings.custom_theme.buttonBg": "Button Hintergrund",
   "user.settings.custom_theme.buttonColor": "Button Text",

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "Send messages on CTRL + ENTER",
   "user.settings.advance.slashCmd_autocmp": "Enable external application to offer slash command autocomplete",
   "user.settings.advance.title": "Advanced Settings",
-  "user.settings.advance.webrtc_preview": "Enable the ability to make and receive one-on-one WebRTC calls",
   "user.settings.custom_theme.awayIndicator": "Away Indicator",
   "user.settings.custom_theme.buttonBg": "Button BG",
   "user.settings.custom_theme.buttonColor": "Button Text",

--- a/webapp/i18n/es.json
+++ b/webapp/i18n/es.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "Enviar mensajes con Ctrl + RETORNO",
   "user.settings.advance.slashCmd_autocmp": "Habilitar que una aplicación externa ofrezca el autocompletado de los comandos de barra",
   "user.settings.advance.title": "Configuración Avanzada",
-  "user.settings.advance.webrtc_preview": "Habilitar la capacidad para hacer y recibir llamadas WebRTC uno-a-uno",
   "user.settings.custom_theme.awayIndicator": "Indicador Ausente",
   "user.settings.custom_theme.buttonBg": "Fondo Botón",
   "user.settings.custom_theme.buttonColor": "Texto Botón",

--- a/webapp/i18n/fr.json
+++ b/webapp/i18n/fr.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "Envoyer vos messages avec Ctrl+Entrée",
   "user.settings.advance.slashCmd_autocmp": "Autoriser les applications externes à propose l'auto-complétion",
   "user.settings.advance.title": "Paramètres avancés",
-  "user.settings.advance.webrtc_preview": "Activer la possibilité de passer et de recevoir des appels WebRTC en tête-à-tête",
   "user.settings.custom_theme.awayIndicator": "Indicateur \"absent\"",
   "user.settings.custom_theme.buttonBg": "Fond de bouton",
   "user.settings.custom_theme.buttonColor": "Texte de bouton",

--- a/webapp/i18n/ja.json
+++ b/webapp/i18n/ja.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "CTRL + ENTERでメッセージを投稿する",
   "user.settings.advance.slashCmd_autocmp": "スラッシュコマンドの自動補完をするために外部のアプリケーションを有効にする",
   "user.settings.advance.title": "詳細の設定",
-  "user.settings.advance.webrtc_preview": "1対1のWebRTC通話をかけたり受けたりすることを可能にします",
   "user.settings.custom_theme.awayIndicator": "離席表示",
   "user.settings.custom_theme.buttonBg": "ボタンBG",
   "user.settings.custom_theme.buttonColor": "ボタンテキスト",

--- a/webapp/i18n/ko.json
+++ b/webapp/i18n/ko.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "Ctrl + Enter로 메시지 보내기",
   "user.settings.advance.slashCmd_autocmp": "외부 어플리케이션을 활성화하면 슬래시 명령어 자동 완성을 제안할 수 있습니다",
   "user.settings.advance.title": "고급 설정",
-  "user.settings.advance.webrtc_preview": "Enable the ability to make and receive one-on-one WebRTC calls",
   "user.settings.custom_theme.awayIndicator": "Away Indicator",
   "user.settings.custom_theme.buttonBg": "Button BG",
   "user.settings.custom_theme.buttonColor": "Button Text",

--- a/webapp/i18n/nl.json
+++ b/webapp/i18n/nl.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "Stuur berichten wanner u op CTRL + ENTER drukt",
   "user.settings.advance.slashCmd_autocmp": "Aanzetten van externe applicatie om slash commando autocomplete te gebruiken",
   "user.settings.advance.title": "Geavanceerde instellingen",
-  "user.settings.advance.webrtc_preview": "Enable the ability to make and receive one-on-one WebRTC calls",
   "user.settings.custom_theme.awayIndicator": "Weg Indicator",
   "user.settings.custom_theme.buttonBg": "Knop achtergrond",
   "user.settings.custom_theme.buttonColor": "Knoptekst",

--- a/webapp/i18n/pt-BR.json
+++ b/webapp/i18n/pt-BR.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "Enviar mensagens com CTRL + ENTER",
   "user.settings.advance.slashCmd_autocmp": "Ativar aplicação externa para autocompletar comandos slash",
   "user.settings.advance.title": "Configurações Avançadas",
-  "user.settings.advance.webrtc_preview": "Ativar a capacidade de fazer e receber chamadas WebRTC um-pra-um",
   "user.settings.custom_theme.awayIndicator": "Indicador de Afastamento",
   "user.settings.custom_theme.buttonBg": "Fundo Botão",
   "user.settings.custom_theme.buttonColor": "Texto do Botão",

--- a/webapp/i18n/ru.json
+++ b/webapp/i18n/ru.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "Отправлять сообщения сочетанием клавиш CTRL + ENTER",
   "user.settings.advance.slashCmd_autocmp": "Enable external application to offer slash command autocomplete",
   "user.settings.advance.title": "Дополнительные параметры",
-  "user.settings.advance.webrtc_preview": "Включить возможность совершать и принимать WebRTC звонки.",
   "user.settings.custom_theme.awayIndicator": "Индикатор отсутствия",
   "user.settings.custom_theme.buttonBg": "Button BG",
   "user.settings.custom_theme.buttonColor": "Button Text",

--- a/webapp/i18n/zh_CN.json
+++ b/webapp/i18n/zh_CN.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "按 Ctrl+Enter 发送消息",
   "user.settings.advance.slashCmd_autocmp": "启用外部应用程序提供斜杠命令的自动补全功能",
   "user.settings.advance.title": "高级设置",
-  "user.settings.advance.webrtc_preview": "开启使用 WebRTC 的一对一通话",
   "user.settings.custom_theme.awayIndicator": "离开显示",
   "user.settings.custom_theme.buttonBg": "按钮BG",
   "user.settings.custom_theme.buttonColor": "文本按钮",

--- a/webapp/i18n/zh_TW.json
+++ b/webapp/i18n/zh_TW.json
@@ -1784,7 +1784,6 @@
   "user.settings.advance.sendTitle": "用 Ctrl + Enter 貼文",
   "user.settings.advance.slashCmd_autocmp": "啟用外部程式以提供自動完成斜線命令",
   "user.settings.advance.title": "進階設定",
-  "user.settings.advance.webrtc_preview": "啟用此功能以撥打或接收一對一的 WebRTC 通訊",
   "user.settings.custom_theme.awayIndicator": "離開標識",
   "user.settings.custom_theme.buttonBg": "按鈕 BG",
   "user.settings.custom_theme.buttonColor": "按鈕文字",

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -802,10 +802,6 @@ export const Constants = {
         EMBED_PREVIEW: {
             label: 'embed_preview',
             description: 'Show preview snippet of links below message'
-        },
-        WEBRTC_PREVIEW: {
-            label: 'webrtc_preview',
-            description: 'Enable WebRTC one on one calls'
         }
     },
     OVERLAY_TIME_DELAY: 400,


### PR DESCRIPTION
#### Summary
Remove WebRTC from **Account Settings > Advanced > Preview pre-release features** and have it available to all users if enabled in the System Console.

The feature will still be labeled as Beta and only available to E20 customers.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4363

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization files updated
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

