### PR TITLE
Added -e to sed command in Makefile to make it work on all platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ package: build build-client
 	cp -RL i18n $(DIST_PATH)
 
 	@# Disable developer settings
-	sed -i'' 's|"ConsoleLevel": "DEBUG",|"ConsoleLevel": "INFO",|g' $(DIST_PATH)/config/config.json;
+	sed -i'' -e 's|"ConsoleLevel": "DEBUG"|"ConsoleLevel": "INFO"|g' $(DIST_PATH)/config/config.json
 
 	@# Package webapp
 	mkdir -p $(DIST_PATH)/webapp/dist


### PR DESCRIPTION
GNU sed and Mac OS X's sed disagree on how an empty `-i` is treated without the space (which can't have a space because of how GNU sed treats an empty `-i` argument), but an explicit `-e` fixes that.