### PR TITLE
Import Slack bot_message type posts.

### DIFF
--- a/api/import.go
+++ b/api/import.go
@@ -6,6 +6,7 @@ package api
 import (
 	"bytes"
 	"io"
+	"regexp"
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/platform/model"
@@ -79,4 +80,58 @@ func ImportFile(file io.Reader, teamId string, channelId string, userId string, 
 	go handleImages(previewPathList, thumbnailPathList, imageDataList)
 
 	return fileInfo, nil
+}
+
+func ImportIncomingWebhookPost(post *model.Post, props model.StringInterface) {
+	linkWithTextRegex := regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
+	post.Message = linkWithTextRegex.ReplaceAllString(post.Message, "[${2}](${1})")
+
+	post.AddProp("from_webhook", "true")
+
+	if _, ok := props["override_username"]; !ok {
+		post.AddProp("override_username", model.DEFAULT_WEBHOOK_USERNAME)
+	}
+
+	if len(props) > 0 {
+		for key, val := range props {
+			if key == "attachments" {
+				if list, success := val.([]interface{}); success {
+					// parse attachment links into Markdown format
+					for i, aInt := range list {
+						attachment := aInt.(map[string]interface{})
+						if aText, ok := attachment["text"].(string); ok {
+							aText = linkWithTextRegex.ReplaceAllString(aText, "[${2}](${1})")
+							attachment["text"] = aText
+							list[i] = attachment
+						}
+						if aText, ok := attachment["pretext"].(string); ok {
+							aText = linkWithTextRegex.ReplaceAllString(aText, "[${2}](${1})")
+							attachment["pretext"] = aText
+							list[i] = attachment
+						}
+						if fVal, ok := attachment["fields"]; ok {
+							if fields, ok := fVal.([]interface{}); ok {
+								// parse attachment field links into Markdown format
+								for j, fInt := range fields {
+									field := fInt.(map[string]interface{})
+									if fValue, ok := field["value"].(string); ok {
+										fValue = linkWithTextRegex.ReplaceAllString(fValue, "[${2}](${1})")
+										field["value"] = fValue
+										fields[j] = field
+									}
+								}
+								attachment["fields"] = fields
+								list[i] = attachment
+							}
+						}
+					}
+					post.AddProp(key, list)
+				}
+			} else if key != "from_webhook" {
+				post.AddProp(key, val)
+			}
+		}
+	}
+
+	ImportPost(post)
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1544,12 +1544,20 @@
     "translation": "Slack bot posts are not imported yet"
   },
   {
+    "id": "api.slackimport.slack_add_posts.bot_user_no_exists.warn",
+    "translation": "Slack Importer: Not importing bot message as the bot-importing user does not exist."
+  },
+  {
     "id": "api.slackimport.slack_add_posts.msg_no_comment.debug",
     "translation": "File comment undefined"
   },
   {
     "id": "api.slackimport.slack_add_posts.msg_no_usr.debug",
     "translation": "Message without user"
+  },
+  {
+    "id": "api.slackimport.slack_add_posts.no_bot_id.warn",
+    "translation": "Slack Importer: Not importing bot message due to lack of BotId field."
   },
   {
     "id": "api.slackimport.slack_add_posts.unsupported.warn",
@@ -1596,6 +1604,14 @@
     "translation": "Unable to import user: {{.Username}}\r\n"
   },
   {
+    "id": "api.slackimport.slack_add_bot_user.email_pwd",
+    "translation": "Slack Bot/Integration Posts Import User: Email, Password: {{.Email}}, {{.Password}}\r\n"
+  },
+  {
+    "id": "api.slackimport.slack_add_bot_user.unable_import",
+    "translation": "Unable to import Slack Bot/Integration Posts Import User: {{.Username}}\r\n"
+  },
+  {
     "id": "api.slackimport.slack_convert_channel_mentions.compile_regexp_failed.warn",
     "translation": "Failed to compile the !channel matching regular expression for Slack channel {{.ChannelID}} {{.ChannelName}}"
   },
@@ -1606,6 +1622,10 @@
   {
     "id": "api.slackimport.slack_convert_user_mentions.compile_regexp_failed.warn",
     "translation": "Failed to compile the @mention matching regular expression for Slack user {{.UserID}} {{.Username}}"
+  },
+  {
+    "id": "api.slackimport.slack_deactivate_bot_user.failed_to_deactivate",
+    "translation": "Slack Importer: Failed to deactivate the bot-importing user."
   },
   {
     "id": "api.slackimport.slack_import.log",


### PR DESCRIPTION
#### Summary

Import Slack bot_message type posts.

This includes all messages from integrations, as far as I can tell.

Messages are "owned" by a special user that is deactivated once the
import completes.

Override User Names are only shown where the individual Slack posts have
a username override in them. Ones set centrally through the Slack Web
Hooks administration, or by Slack-official integrations, aren't known so
we can't set them on the imported posts. Same for icons.

The attachment "colors" aren't imported as Mattermost does not appear to
have any equivalent feature.

*\* Unfortunately there's a huge range of permutations of fields that can be set on Slack message attachments, and I'm not really sure how well they are all handled. I've tested on those I know exist, but there may be more, so the more testing this gets the better. **
#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-48
#### Checklist
- [x] Includes text changes and localization file updates
