### PR TITLE
Write Warning to log when a Slack channel import fails.

### DIFF
--- a/api/slackimport.go
+++ b/api/slackimport.go
@@ -312,7 +312,7 @@ func SlackAddChannels(teamId string, slackchannels []SlackChannel, posts map[str
 		if mChannel == nil {
 			// Maybe it already exists?
 			if result := <-Srv.Store.Channel().GetByName(teamId, sChannel.Name); result.Err != nil {
-				l4g.Debug(utils.T("api.slackimport.slack_add_channels.import_failed.debug"), newChannel.DisplayName)
+				l4g.Warn(utils.T("api.slackimport.slack_add_channels.import_failed.warn"), newChannel.DisplayName)
 				log.WriteString(utils.T("api.slackimport.slack_add_channels.import_failed", map[string]interface{}{"DisplayName": newChannel.DisplayName}))
 				continue
 			} else {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1528,8 +1528,8 @@
     "translation": "Failed to import: {{.DisplayName}}\r\n"
   },
   {
-    "id": "api.slackimport.slack_add_channels.import_failed.debug",
-    "translation": "Failed to import: %s"
+    "id": "api.slackimport.slack_add_channels.import_failed.warn",
+    "translation": "Slack Importer: Failed to import channel: %s"
   },
   {
     "id": "api.slackimport.slack_add_channels.merge",


### PR DESCRIPTION
#### Summary

Convert Debug to Warning in logs when channel import fails. As otherwise you might miss it if log level is set to warn, even thought it's definitely a warning-severity message.
#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
