### PR TITLE
PLT-4138 Fix /join command for non-admin accounts

### DIFF
--- a/api/command_join.go
+++ b/api/command_join.go
@@ -46,7 +46,7 @@ func (me *JoinProvider) DoCommand(c *Context, channelId string, message string) 
 					return &model.CommandResponse{Text: c.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 				}
 
-				if err, _ := JoinChannelById(c, c.Session.UserId, channelId); err != nil {
+				if err, _ := JoinChannelById(c, c.Session.UserId, v.Id); err != nil {
 					return &model.CommandResponse{Text: c.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 				}
 

--- a/api/command_join_test.go
+++ b/api/command_join_test.go
@@ -41,7 +41,14 @@ func TestJoinCommands(t *testing.T) {
 
 	c1 := Client.Must(Client.GetChannels("")).Data.(*model.ChannelList)
 
-	if len(c1.Channels) != 5 {
-		t.Fatal("didn't join channel")
+	found := false
+	for _, c := range c1.Channels {
+		if c.Id == channel2.Id {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatal("did not join channel")
 	}
 }


### PR DESCRIPTION
#### Summary
We were using the channel ID the command was executed in, not the channel ID of the channel we wanted to join.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4138
