### PR TITLE
Fix HA User Typing bug

### DIFF
--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -36,7 +36,7 @@ type WebSocketMessage interface {
 }
 
 type WebsocketBroadcast struct {
-	OmitUsers map[string]bool `json:"-"`          // broadcast is omitted for users listed here
+	OmitUsers map[string]bool `json:"omit_users"` // broadcast is omitted for users listed here
 	UserId    string          `json:"user_id"`    // broadcast only occurs for this user
 	ChannelId string          `json:"channel_id"` // broadcast only occurs for users in this channel
 	TeamId    string          `json:"team_id"`    // broadcast only occurs for users in this team


### PR DESCRIPTION
#### Summary
When running in HA mode the websocket event was broadcast but the omit_users weren't included in the message sent to the cluster
