### PR TITLE
Increased ChannelStore max listeners to match other stores

### DIFF
--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -19,7 +19,7 @@ class ChannelStoreClass extends EventEmitter {
     constructor(props) {
         super(props);
 
-        this.setMaxListeners(15);
+        this.setMaxListeners(600);
 
         this.currentId = null;
         this.postMode = this.POST_MODE_CHANNEL;


### PR DESCRIPTION
This is to get rid of those warnings that people keep thinking are errors. The ChannelStore is listened to by every post component, so I set it to match the EmojiStore and UserStore.