### PR TITLE
Changed ConsoleLogLevel back to DEBUG during development

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -64,7 +64,7 @@
     },
     "LogSettings": {
         "EnableConsole": true,
-        "ConsoleLevel": "INFO",
+        "ConsoleLevel": "DEBUG",
         "EnableFile": true,
         "FileLevel": "INFO",
         "FileFormat": "",


### PR DESCRIPTION
It got overwritten by the performance branch that had it set to INFO. Once I look at [PLT-3483](https://mattermost.atlassian.net/browse/PLT-4384), I'll stop complaining about the defaults for this setting. :)