### PR TITLE
Flush log and exit after CLI Slack Import.

### DIFF
--- a/mattermost.go
+++ b/mattermost.go
@@ -1473,6 +1473,8 @@ func cmdSlackImport() {
 		fmt.Fprintln(os.Stdout, "Running Slack Import. This may take a long time for large teams or teams with many messages.")
 
 		api.SlackImport(fileReader, fileInfo.Size(), team.Id)
+
+		flushLogAndExit(0)
 	}
 }
 


### PR DESCRIPTION
#### Summary

Flush log and exit after CLI Slack Import.

Some log messages were previously being lost at the very end of the
Slack import via CLI process, due to not flushing the logs after
completing.