### PR TITLE
PLT-4242 Stop websockets and set status offline when deactivating users

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -485,6 +485,8 @@ func RemoveAllSessionsForUserId(userId string) {
 		}
 	}
 
+	StopWebSocketsForUser(userId)
+
 	if einterfaces.GetClusterInterface() != nil {
 		einterfaces.GetClusterInterface().RemoveAllSessionsForUserId(userId)
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -776,8 +776,14 @@ func RevokeAllSession(c *Context, userId string) {
 				}
 			}
 
+			StopWebSocketsForUser(userId)
+
 			if webrtcInterface := einterfaces.GetWebrtcInterface(); webrtcInterface != nil {
 				webrtcInterface.RevokeToken(session.Id)
+			}
+
+			if einterfaces.GetClusterInterface() != nil {
+				einterfaces.GetClusterInterface().RemoveAllSessionsForUserId(userId)
 			}
 		}
 	}
@@ -801,8 +807,14 @@ func RevokeAllSessionsNoContext(userId string) *model.AppError {
 				}
 			}
 
+			StopWebSocketsForUser(userId)
+
 			if webrtcInterface := einterfaces.GetWebrtcInterface(); webrtcInterface != nil {
 				webrtcInterface.RevokeToken(session.Id)
+			}
+
+			if einterfaces.GetClusterInterface() != nil {
+				einterfaces.GetClusterInterface().RemoveAllSessionsForUserId(userId)
 			}
 		}
 	}


### PR DESCRIPTION
#### Summary
Immediately stop all the WebSockets for a user when their account is deactivated and set their status to offline. Also propagate RevokeAllSessions method across HA servers.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4242