### PR TITLE
PLT-4242 Stop websockets and set status offline when deactivating users

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -485,6 +485,8 @@ func RemoveAllSessionsForUserId(userId string) {
 		}
 	}
 
+	StopWebSocketsForUser(userId)
+
 	if einterfaces.GetClusterInterface() != nil {
 		einterfaces.GetClusterInterface().RemoveAllSessionsForUserId(userId)
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -776,8 +776,14 @@ func RevokeAllSession(c *Context, userId string) {
 				}
 			}
 
+			StopWebSocketsForUser(userId)
+
 			if webrtcInterface := einterfaces.GetWebrtcInterface(); webrtcInterface != nil {
 				webrtcInterface.RevokeToken(session.Id)
+			}
+
+			if einterfaces.GetClusterInterface() != nil {
+				einterfaces.GetClusterInterface().RemoveAllSessionsForUserId(userId)
 			}
 		}
 	}
@@ -801,8 +807,14 @@ func RevokeAllSessionsNoContext(userId string) *model.AppError {
 				}
 			}
 
+			StopWebSocketsForUser(userId)
+
 			if webrtcInterface := einterfaces.GetWebrtcInterface(); webrtcInterface != nil {
 				webrtcInterface.RevokeToken(session.Id)
+			}
+
+			if einterfaces.GetClusterInterface() != nil {
+				einterfaces.GetClusterInterface().RemoveAllSessionsForUserId(userId)
 			}
 		}
 	}

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -21,6 +21,7 @@ type Hub struct {
 	unregister     chan *WebConn
 	broadcast      chan *model.WebSocketEvent
 	stop           chan string
+	stopAllForUser chan string
 	invalidateUser chan string
 }
 
@@ -33,6 +34,7 @@ func NewWebHub() *Hub {
 		connections:    make(map[*WebConn]bool, model.SESSION_CACHE_SIZE),
 		broadcast:      make(chan *model.WebSocketEvent, 4096),
 		stop:           make(chan string),
+		stopAllForUser: make(chan string),
 		invalidateUser: make(chan string),
 	}
 }
@@ -127,6 +129,14 @@ func InvalidateCacheForChannel(channelId string) {
 	// }
 }
 
+func StopWebSocketsForUser(userId string) {
+	l4g.Info("StopWebSocketsForUser")
+	for _, hub := range hubs {
+		hub.stopAllForUser <- userId
+	}
+	SetStatusOffline(userId, false)
+}
+
 func (h *Hub) Register(webConn *WebConn) {
 	h.register <- webConn
 
@@ -196,6 +206,15 @@ func (h *Hub) Start() {
 							close(webCon.Send)
 							delete(h.connections, webCon)
 						}
+					}
+				}
+
+			case userId := <-h.stopAllForUser:
+				for webCon := range h.connections {
+					if webCon.UserId == userId {
+						webCon.WebSocket.Close()
+						close(webCon.Send)
+						delete(h.connections, webCon)
 					}
 				}
 


### PR DESCRIPTION
#### Summary

Immediately stop all the WebSockets for a user when their account is deactivated and set their status to offline. Also propagate RevokeAllSessions method across HA servers.
#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-4242
