### PR TITLE
Fix bad use of websocket event when a new user is added

### DIFF
--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -198,7 +198,7 @@ function handlePostDeleteEvent(msg) {
 }
 
 function handleNewUserEvent(msg) {
-    AsyncClient.getUser(msg.user_id);
+    AsyncClient.getUser(msg.data.user_id);
     AsyncClient.getChannelStats();
     loadProfilesAndTeamMembersForDMSidebar();
 }


### PR DESCRIPTION
#### Summary
With the new event struct, can't access user id directly.