### PR TITLE
PLT-3562 Switch websocket over to post-connect authentication

### DIFF
--- a/api/status_test.go
+++ b/api/status_test.go
@@ -22,6 +22,11 @@ func TestStatuses(t *testing.T) {
 	defer WebSocketClient.Close()
 	WebSocketClient.Listen()
 
+	time.Sleep(300 * time.Millisecond)
+	if resp := <-WebSocketClient.ResponseChannel; resp.Status != model.STATUS_OK {
+		t.Fatal("should have responded OK to authentication challenge")
+	}
+
 	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
 
@@ -75,7 +80,7 @@ func TestStatuses(t *testing.T) {
 		}
 
 		if status, ok := resp.Data[th.BasicUser2.Id]; !ok {
-			t.Log(len(resp.Data))
+			t.Log(resp.Data)
 			t.Fatal("should have had user status")
 		} else if status != model.STATUS_ONLINE {
 			t.Log(status)

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1794,6 +1794,11 @@ func TestUserTyping(t *testing.T) {
 	defer WebSocketClient.Close()
 	WebSocketClient.Listen()
 
+	time.Sleep(300 * time.Millisecond)
+	if resp := <-WebSocketClient.ResponseChannel; resp.Status != model.STATUS_OK {
+		t.Fatal("should have responded OK to authentication challenge")
+	}
+
 	WebSocketClient.UserTyping("", "")
 	time.Sleep(300 * time.Millisecond)
 	if resp := <-WebSocketClient.ResponseChannel; resp.Error.Id != "api.websocket_handler.invalid_param.app_error" {

--- a/api/web_conn.go
+++ b/api/web_conn.go
@@ -56,7 +56,9 @@ func (c *WebConn) readPump() {
 	c.WebSocket.SetReadDeadline(time.Now().Add(PONG_WAIT))
 	c.WebSocket.SetPongHandler(func(string) error {
 		c.WebSocket.SetReadDeadline(time.Now().Add(PONG_WAIT))
-		go SetStatusAwayIfNeeded(c.UserId, false)
+		if c.isAuthenticated() {
+			go SetStatusAwayIfNeeded(c.UserId, false)
+		}
 		return nil
 	})
 
@@ -134,12 +136,15 @@ func (c *WebConn) writePump() {
 func (webCon *WebConn) InvalidateCache() {
 	webCon.AllChannelMembers = nil
 	webCon.LastAllChannelMembersTime = 0
+}
 
+func (webCon *WebConn) isAuthenticated() bool {
+	return webCon.SessionToken != ""
 }
 
 func (webCon *WebConn) ShouldSendEvent(msg *model.WebSocketEvent) bool {
 	// IMPORTANT: Do not send event if WebConn does not have a session
-	if webCon.SessionToken == "" {
+	if !webCon.isAuthenticated() {
 		return false
 	}
 

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -156,6 +156,10 @@ func (h *Hub) Start() {
 					close(webCon.Send)
 				}
 
+				if len(userId) == 0 {
+					continue
+				}
+
 				found := false
 				for webCon := range h.connections {
 					if userId == webCon.UserId {

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -17,7 +17,7 @@ const (
 
 func InitWebSocket() {
 	l4g.Debug(utils.T("api.web_socket.init.debug"))
-	BaseRoutes.Users.Handle("/websocket", ApiAppHandler(connect)).Methods("GET")
+	BaseRoutes.Users.Handle("/websocket", ApiAppHandlerTrustRequester(connect)).Methods("GET")
 	HubStart()
 }
 
@@ -38,6 +38,7 @@ func connect(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	wc := NewWebConn(c, ws)
+	HubRegister(wc)
 	go wc.writePump()
 	wc.readPump()
 }

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -17,7 +17,7 @@ const (
 
 func InitWebSocket() {
 	l4g.Debug(utils.T("api.web_socket.init.debug"))
-	BaseRoutes.Users.Handle("/websocket", ApiUserRequiredTrustRequester(connect)).Methods("GET")
+	BaseRoutes.Users.Handle("/websocket", ApiAppHandler(connect)).Methods("GET")
 	HubStart()
 }
 
@@ -38,7 +38,6 @@ func connect(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	wc := NewWebConn(c, ws)
-	HubRegister(wc)
 	go wc.writePump()
 	wc.readPump()
 }

--- a/api/websocket_router.go
+++ b/api/websocket_router.go
@@ -49,14 +49,14 @@ func (wr *WebSocketRouter) ServeWebSocket(conn *WebConn, r *model.WebSocketReque
 		if session == nil || session.IsExpired() {
 			conn.WebSocket.Close()
 		} else {
+			go SetStatusOnline(session.UserId, session.Id, false)
+
 			conn.SessionToken = session.Token
 			conn.UserId = session.UserId
 
 			resp := model.NewWebSocketResponse(model.STATUS_OK, r.Seq, nil)
 			resp.DoPreComputeJson()
 			conn.Send <- resp
-
-			HubRegister(conn)
 		}
 
 		return

--- a/api/websocket_router.go
+++ b/api/websocket_router.go
@@ -37,6 +37,37 @@ func (wr *WebSocketRouter) ServeWebSocket(conn *WebConn, r *model.WebSocketReque
 		return
 	}
 
+	if r.Action == model.WEBSOCKET_AUTHENTICATION_CHALLENGE {
+		token, ok := r.Data["token"].(string)
+		if !ok {
+			conn.WebSocket.Close()
+			return
+		}
+
+		session := GetSession(token)
+
+		if session == nil || session.IsExpired() {
+			conn.WebSocket.Close()
+		} else {
+			conn.SessionToken = session.Token
+			conn.UserId = session.UserId
+
+			resp := model.NewWebSocketResponse(model.STATUS_OK, r.Seq, nil)
+			resp.DoPreComputeJson()
+			conn.Send <- resp
+
+			HubRegister(conn)
+		}
+
+		return
+	}
+
+	if conn.SessionToken == "" {
+		err := model.NewLocAppError("ServeWebSocket", "api.web_socket_router.not_authenticated.app_error", nil, "")
+		wr.ReturnWebSocketError(conn, r, err)
+		return
+	}
+
 	var handler *webSocketHandler
 	if h, ok := wr.handlers[r.Action]; !ok {
 		err := model.NewLocAppError("ServeWebSocket", "api.web_socket_router.bad_action.app_error", nil, "")

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -26,6 +26,7 @@ const (
 	WEBSOCKET_EVENT_STATUS_CHANGE      = "status_change"
 	WEBSOCKET_EVENT_HELLO              = "hello"
 	WEBSOCKET_EVENT_WEBRTC             = "webrtc"
+	WEBSOCKET_AUTHENTICATION_CHALLENGE = "authentication_challenge"
 )
 
 type WebSocketMessage interface {

--- a/webapp/client/websocket_client.jsx
+++ b/webapp/client/websocket_client.jsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import WebSocket from 'ws';
+
 const MAX_WEBSOCKET_FAILS = 7;
 const MIN_WEBSOCKET_RETRY_TIME = 3000; // 3 sec
 const MAX_WEBSOCKET_RETRY_TIME = 300000; // 5 mins
@@ -18,7 +20,7 @@ export default class WebSocketClient {
         this.closeCallback = null;
     }
 
-    initialize(connectionUrl) {
+    initialize(connectionUrl, token) {
         if (this.conn) {
             return;
         }
@@ -30,6 +32,10 @@ export default class WebSocketClient {
         this.conn = new WebSocket(connectionUrl);
 
         this.conn.onopen = () => {
+            if (token) {
+                this.sendMessage('authentication_challenge', {token});
+            }
+
             if (this.connectFailCount > 0) {
                 console.log('websocket re-established connection'); //eslint-disable-line no-console
                 if (this.reconnectCallback) {
@@ -68,7 +74,7 @@ export default class WebSocketClient {
 
             setTimeout(
                 () => {
-                    this.initialize(connectionUrl);
+                    this.initialize(connectionUrl, token);
                 },
                 retryTime
             );
@@ -152,12 +158,12 @@ export default class WebSocketClient {
         }
     }
 
-    userTyping(channelId, parentId) {
+    userTyping(channelId, parentId, callback) {
         const data = {};
         data.channel_id = channelId;
         data.parent_id = parentId;
 
-        this.sendMessage('user_typing', data);
+        this.sendMessage('user_typing', data, callback);
     }
 
     getStatuses(callback) {

--- a/webapp/client/websocket_client.jsx
+++ b/webapp/client/websocket_client.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import WebSocket from 'ws';
-
 const MAX_WEBSOCKET_FAILS = 7;
 const MIN_WEBSOCKET_RETRY_TIME = 3000; // 3 sec
 const MAX_WEBSOCKET_RETRY_TIME = 300000; // 5 mins

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -35,7 +35,6 @@
     "twemoji": "2.2.0",
     "velocity-animate": "1.2.3",
     "webrtc-adapter": "2.0.3",
-    "ws": "^1.1.1",
     "xregexp": "3.1.1"
   },
   "devDependencies": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -35,6 +35,7 @@
     "twemoji": "2.2.0",
     "velocity-animate": "1.2.3",
     "webrtc-adapter": "2.0.3",
+    "ws": "^1.1.1",
     "xregexp": "3.1.1"
   },
   "devDependencies": {

--- a/webapp/tests/client_websocket.test.jsx
+++ b/webapp/tests/client_websocket.test.jsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
-
+/*
 var assert = require('assert');
 import TestHelper from './test_helper.jsx';
 
@@ -45,5 +45,5 @@ describe('Client.WebSocket', function() {
             );
         }, true);
     });
-});
+});*/
 

--- a/webapp/tests/client_websocket.test.jsx
+++ b/webapp/tests/client_websocket.test.jsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+var assert = require('assert');
+import TestHelper from './test_helper.jsx';
+
+describe('Client.WebSocket', function() {
+    this.timeout(10000);
+
+    it('WebSocket.getStatusesByIds', function(done) {
+        TestHelper.initBasic(() => {
+            TestHelper.basicWebSocketClient().getStatusesByIds(
+                [TestHelper.basicUser().id],
+                function(resp) {
+                    TestHelper.basicWebSocketClient().close();
+                    assert.equal(resp.data[TestHelper.basicUser().id], 'online');
+                    done();
+                }
+            );
+        }, true);
+    });
+
+    it('WebSocket.getStatuses', function(done) {
+        TestHelper.initBasic(() => {
+            TestHelper.basicWebSocketClient().getStatuses(
+                function(resp) {
+                    TestHelper.basicWebSocketClient().close();
+                    assert.equal(resp.data != null, true);
+                    done();
+                }
+            );
+        }, true);
+    });
+
+    it('WebSocket.userTyping', function(done) {
+        TestHelper.initBasic(() => {
+            TestHelper.basicWebSocketClient().userTyping(
+                TestHelper.basicChannel().id,
+                '',
+                function(resp) {
+                    TestHelper.basicWebSocketClient().close();
+                    assert.equal(resp.status, 'OK');
+                    done();
+                }
+            );
+        }, true);
+    });
+});
+

--- a/webapp/tests/test_helper.jsx
+++ b/webapp/tests/test_helper.jsx
@@ -2,11 +2,18 @@
 // See License.txt for license information.
 
 import Client from 'client/client.jsx';
+import WebSocketClient from 'client/websocket_client.jsx';
 import jqd from 'jquery-deferred';
+
+var HEADER_TOKEN = 'token';
 
 class TestHelperClass {
     basicClient = () => {
         return this.basicc;
+    }
+
+    basicWebSocketClient = () => {
+        return this.basicwsc;
     }
 
     basicTeam = () => {
@@ -53,6 +60,12 @@ class TestHelperClass {
         return c;
     }
 
+    createWebSocketClient(token) {
+        var ws = new WebSocketClient();
+        ws.initialize('http://localhost:8065/api/v3/users/websocket', token);
+        return ws;
+    }
+
     fakeEmail = () => {
         return 'success' + this.generateId() + '@simulator.amazonses.com';
     }
@@ -90,7 +103,7 @@ class TestHelperClass {
         return post;
     }
 
-    initBasic = (callback) => {
+    initBasic = (callback, connectWS) => {
         this.basicc = this.createClient();
 
         var d1 = jqd.Deferred();
@@ -122,7 +135,10 @@ class TestHelperClass {
                             rteamSignup.user.email,
                             password,
                             null,
-                            function() {
+                            function(data, res) {
+                                if (connectWS) {
+                                    outer.basicwsc = outer.createWebSocketClient(res.header[HEADER_TOKEN]);
+                                }
                                 outer.basicClient().useHeaderToken();
                                 var channel = outer.fakeChannel();
                                 channel.team_id = outer.basicTeam().id;


### PR DESCRIPTION
#### Summary
- Allow connection to the WebSocket without a session, but if a token is not provided by the client within 5 seconds, the connection is closed
- Added unit tests that worked when I included a library implementation of WebSocket but it had webpack issues and I wasn't able to figure out how to conditionally enable the library for tests vs. use the native library for dev/prod. Tests are commented out until I can figure this out
#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-3562
#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
