### PR TITLE
PLT-4430 improve slow channel switching

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -21,7 +21,7 @@ func InitChannel() {
 	BaseRoutes.Channels.Handle("/", ApiUserRequired(getChannels)).Methods("GET")
 	BaseRoutes.Channels.Handle("/more", ApiUserRequired(getMoreChannels)).Methods("GET")
 	BaseRoutes.Channels.Handle("/counts", ApiUserRequired(getChannelCounts)).Methods("GET")
-	BaseRoutes.Channels.Handle("/unread", ApiUserRequired(getChannelsUnread)).Methods("GET")
+	BaseRoutes.Channels.Handle("/members", ApiUserRequired(getMyChannelMembers)).Methods("GET")
 	BaseRoutes.Channels.Handle("/create", ApiUserRequired(createChannel)).Methods("POST")
 	BaseRoutes.Channels.Handle("/create_direct", ApiUserRequired(createDirectChannel)).Methods("POST")
 	BaseRoutes.Channels.Handle("/update", ApiUserRequired(updateChannel)).Methods("POST")
@@ -447,25 +447,6 @@ func getChannelCounts(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		data := result.Data.(*model.ChannelCounts)
 		w.Header().Set(model.HEADER_ETAG_SERVER, data.Etag())
-		w.Write([]byte(data.ToJson()))
-	}
-}
-
-func getChannelsUnread(c *Context, w http.ResponseWriter, r *http.Request) {
-	if result := <-Srv.Store.Channel().GetChannelsUnread(c.TeamId, c.Session.UserId); result.Err != nil {
-		if result.Err.Id == "store.sql_channel.get_channels.not_found.app_error" {
-			// lets make sure the user is valid
-			if result := <-Srv.Store.User().Get(c.Session.UserId); result.Err != nil {
-				c.Err = result.Err
-				c.RemoveSessionCookie(w, r)
-				l4g.Error(utils.T("api.channel.get_channels.error"), c.Session.UserId)
-				return
-			}
-		}
-		c.Err = result.Err
-		return
-	} else {
-		data := result.Data.(*model.ChannelMembers)
 		w.Write([]byte(data.ToJson()))
 	}
 }
@@ -1004,6 +985,16 @@ func getChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		member := result.Data.(model.ChannelMember)
 		w.Write([]byte(member.ToJson()))
+	}
+}
+
+func getMyChannelMembers(c *Context, w http.ResponseWriter, r *http.Request) {
+	if result := <-Srv.Store.Channel().GetMembersForUser(c.TeamId, c.Session.UserId); result.Err != nil {
+		c.Err = result.Err
+		return
+	} else {
+		data := result.Data.(*model.ChannelMembers)
+		w.Write([]byte(data.ToJson()))
 	}
 }
 

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -240,8 +240,8 @@ func TestUpdateChannel(t *testing.T) {
 	}
 
 	rget := Client.Must(Client.GetChannels(""))
-	data := rget.Data.(*model.ChannelList)
-	for _, c := range *data {
+	channels := rget.Data.(*model.ChannelList)
+	for _, c := range *channels {
 		if c.Name == model.DEFAULT_CHANNEL {
 			c.Header = "new header"
 			c.Name = "pseudo-square"
@@ -654,13 +654,13 @@ func TestGetChannel(t *testing.T) {
 	channel2 = Client.Must(Client.CreateChannel(channel2)).Data.(*model.Channel)
 
 	rget := Client.Must(Client.GetChannels(""))
-	data := rget.Data.(*model.ChannelList)
+	channels := rget.Data.(*model.ChannelList)
 
-	if (*data)[0].DisplayName != channel1.DisplayName {
+	if (*channels)[0].DisplayName != channel1.DisplayName {
 		t.Fatal("full name didn't match")
 	}
 
-	if (*data)[1].DisplayName != channel2.DisplayName {
+	if (*channels)[1].DisplayName != channel2.DisplayName {
 		t.Fatal("full name didn't match")
 	}
 
@@ -717,13 +717,13 @@ func TestGetMoreChannel(t *testing.T) {
 	th.LoginBasic2()
 
 	rget := Client.Must(Client.GetMoreChannels(""))
-	data := rget.Data.(*model.ChannelList)
+	channels := rget.Data.(*model.ChannelList)
 
-	if (*data)[0].DisplayName != channel1.DisplayName {
+	if (*channels)[0].DisplayName != channel1.DisplayName {
 		t.Fatal("full name didn't match")
 	}
 
-	if (*data)[1].DisplayName != channel2.DisplayName {
+	if (*channels)[1].DisplayName != channel2.DisplayName {
 		t.Fatal("full name didn't match")
 	}
 
@@ -770,7 +770,7 @@ func TestGetChannelCounts(t *testing.T) {
 
 }
 
-func TestGetChannelsUnread(t *testing.T) {
+func TestGetMyChannelMembers(t *testing.T) {
 	th := Setup().InitBasic()
 	Client := th.BasicClient
 	team := th.BasicTeam
@@ -781,43 +781,14 @@ func TestGetChannelsUnread(t *testing.T) {
 	channel2 := &model.Channel{DisplayName: "B Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel2 = Client.Must(Client.CreateChannel(channel2)).Data.(*model.Channel)
 
-	Client.Must(Client.Logout())
-	th.LoginBasic2()
-	th.BasicClient.SetTeamId(th.BasicTeam.Id)
-
-	Client.Must(Client.JoinChannel(channel1.Id))
-	Client.Must(Client.JoinChannel(channel2.Id))
-
-	post1 := &model.Post{ChannelId: channel1.Id, Message: "a new message without mention"}
-	Client.Must(Client.CreatePost(post1))
-
-	post2 := &model.Post{ChannelId: channel2.Id, Message: "a new message with mention for @" + th.BasicUser.Username}
-	Client.Must(Client.CreatePost(post2))
-
-	Client.Must(Client.Logout())
-	th.LoginBasic()
-	th.BasicClient.SetTeamId(th.BasicTeam.Id)
-
-	if result, err := Client.GetChannelsUnread(); err != nil {
+	if result, err := Client.GetMyChannelMembers(); err != nil {
 		t.Fatal(err)
 	} else {
 		members := result.Data.(*model.ChannelMembers)
 
-		if len(*members) != 2 {
+		// town-square, off-topic, basic test channel, channel1, channel2
+		if len(*members) != 5 {
 			t.Fatal("wrong number of members", len(*members))
-		}
-
-		for i := range *members {
-			m := (*members)[i]
-			if m.ChannelId == channel1.Id {
-				if m.MsgCount != 1 {
-					t.Fatal("Member should have 1 unread message")
-				}
-			} else if m.ChannelId == channel2.Id {
-				if m.MentionCount != 1 {
-					t.Fatal("Member should have 1 unread mention")
-				}
-			}
 		}
 	}
 
@@ -1313,14 +1284,6 @@ func TestUpdateNotifyProps(t *testing.T) {
 	} else if notifyProps["mark_unread"] != model.CHANNEL_MARK_UNREAD_ALL {
 		t.Fatalf("NotifyProps[\"mark_unread\"] changed to %v", notifyProps["mark_unread"])
 	}
-
-	//rget := Client.Must(Client.GetChannels(""))
-	//rdata := rget.Data.(*model.ChannelList)
-	//if len(rdata.Members) == 0 || rdata.Members[channel1.Id].NotifyProps["desktop"] != data["desktop"] {
-	//	t.Fatal("NotifyProps[\"desktop\"] did not update properly")
-	//} else if rdata.Members[channel1.Id].LastUpdateAt <= timeBeforeUpdate {
-	//	t.Fatal("LastUpdateAt did not update")
-	//}
 
 	// test an empty update
 	delete(data, "desktop")

--- a/api/command_join.go
+++ b/api/command_join.go
@@ -38,7 +38,7 @@ func (me *JoinProvider) DoCommand(c *Context, channelId string, message string) 
 	} else {
 		channels := result.Data.(*model.ChannelList)
 
-		for _, v := range channels.Channels {
+		for _, v := range *channels {
 
 			if v.Name == message {
 

--- a/api/command_join_test.go
+++ b/api/command_join_test.go
@@ -42,7 +42,7 @@ func TestJoinCommands(t *testing.T) {
 	c1 := Client.Must(Client.GetChannels("")).Data.(*model.ChannelList)
 
 	found := false
-	for _, c := range c1.Channels {
+	for _, c := range *c1 {
 		if c.Id == channel2.Id {
 			found = true
 		}

--- a/api/team.go
+++ b/api/team.go
@@ -325,20 +325,20 @@ func LeaveTeam(team *model.Team, user *model.User) *model.AppError {
 		teamMember = result.Data.(model.TeamMember)
 	}
 
-	var channelMembers *model.ChannelList
+	var channelList *model.ChannelList
 
 	if result := <-Srv.Store.Channel().GetChannels(team.Id, user.Id); result.Err != nil {
 		if result.Err.Id == "store.sql_channel.get_channels.not_found.app_error" {
-			channelMembers = &model.ChannelList{make([]*model.Channel, 0), make(map[string]*model.ChannelMember)}
+			channelList = &model.ChannelList{}
 		} else {
 			return result.Err
 		}
 
 	} else {
-		channelMembers = result.Data.(*model.ChannelList)
+		channelList = result.Data.(*model.ChannelList)
 	}
 
-	for _, channel := range channelMembers.Channels {
+	for _, channel := range *channelList {
 		if channel.Type != model.CHANNEL_DIRECT {
 			Srv.Store.User().InvalidateProfilesInChannelCache(channel.Id)
 			if result := <-Srv.Store.Channel().RemoveMember(channel.Id, user.Id); result.Err != nil {

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -63,7 +63,7 @@ func TestCreateFromSignupTeam(t *testing.T) {
 	}
 
 	c1 := Client.Must(Client.GetChannels("")).Data.(*model.ChannelList)
-	if len(c1.Channels) != 2 {
+	if len(*c1) != 2 {
 		t.Fatal("default channels not created")
 	}
 
@@ -94,7 +94,7 @@ func TestCreateTeam(t *testing.T) {
 	Client.SetTeamId(rteam.Data.(*model.Team).Id)
 
 	c1 := Client.Must(Client.GetChannels("")).Data.(*model.ChannelList)
-	if len(c1.Channels) != 2 {
+	if len(*c1) != 2 {
 		t.Fatal("default channels not created")
 	}
 

--- a/manualtesting/manual_testing.go
+++ b/manualtesting/manual_testing.go
@@ -159,13 +159,13 @@ func getChannelID(channelname string, teamid string, userid string) (id string, 
 		return "", false
 	}
 
-	data := result.Data.(*model.ChannelList)
+	data := result.Data.(model.ChannelList)
 
-	for _, channel := range data.Channels {
+	for _, channel := range data {
 		if channel.Name == channelname {
 			return channel.Id, true
 		}
 	}
-	l4g.Debug(utils.T("manaultesting.get_channel_id.no_found.debug"), channelname, strconv.Itoa(len(data.Channels)))
+	l4g.Debug(utils.T("manaultesting.get_channel_id.no_found.debug"), channelname, strconv.Itoa(len(data)))
 	return "", false
 }

--- a/model/channel_list.go
+++ b/model/channel_list.go
@@ -8,15 +8,11 @@ import (
 	"io"
 )
 
-type ChannelList struct {
-	Channels []*Channel                `json:"channels"`
-	Members  map[string]*ChannelMember `json:"members"`
-}
+type ChannelList []*Channel
 
 func (o *ChannelList) ToJson() string {
-	b, err := json.Marshal(o)
-	if err != nil {
-		return ""
+	if b, err := json.Marshal(o); err != nil {
+		return "[]"
 	} else {
 		return string(b)
 	}
@@ -28,7 +24,7 @@ func (o *ChannelList) Etag() string {
 	var t int64 = 0
 	var delta int64 = 0
 
-	for _, v := range o.Channels {
+	for _, v := range *o {
 		if v.LastPostAt > t {
 			t = v.LastPostAt
 			id = v.Id
@@ -39,30 +35,9 @@ func (o *ChannelList) Etag() string {
 			id = v.Id
 		}
 
-		member := o.Members[v.Id]
-
-		if member != nil {
-			max := v.LastPostAt
-			if v.UpdateAt > max {
-				max = v.UpdateAt
-			}
-
-			delta += max - member.LastViewedAt
-
-			if member.LastViewedAt > t {
-				t = member.LastViewedAt
-				id = v.Id
-			}
-
-			if member.LastUpdateAt > t {
-				t = member.LastUpdateAt
-				id = v.Id
-			}
-
-		}
 	}
 
-	return Etag(id, t, delta, len(o.Channels))
+	return Etag(id, t, delta, len(*o))
 }
 
 func ChannelListFromJson(data io.Reader) *ChannelList {

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -29,6 +29,27 @@ type ChannelMember struct {
 	LastUpdateAt int64     `json:"last_update_at"`
 }
 
+type ChannelMembers []ChannelMember
+
+func (o *ChannelMembers) ToJson() string {
+	if b, err := json.Marshal(o); err != nil {
+		return "[]"
+	} else {
+		return string(b)
+	}
+}
+
+func ChannelMembersFromJson(data io.Reader) *ChannelMembers {
+	decoder := json.NewDecoder(data)
+	var o ChannelMembers
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
+	} else {
+		return nil
+	}
+}
+
 func (o *ChannelMember) ToJson() string {
 	b, err := json.Marshal(o)
 	if err != nil {

--- a/model/client.go
+++ b/model/client.go
@@ -1124,13 +1124,13 @@ func (c *Client) UpdateNotifyProps(data map[string]string) (*Result, *AppError) 
 	}
 }
 
-func (c *Client) GetChannels(etag string) (*Result, *AppError) {
-	if r, err := c.DoApiGet(c.GetTeamRoute()+"/channels/", "", etag); err != nil {
+func (c *Client) GetChannelsUnread() (*Result, *AppError) {
+	if r, err := c.DoApiGet(c.GetTeamRoute()+"/channels/unread", "", ""); err != nil {
 		return nil, err
 	} else {
 		defer closeBody(r)
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),
-			r.Header.Get(HEADER_ETAG_SERVER), ChannelListFromJson(r.Body)}, nil
+			r.Header.Get(HEADER_ETAG_SERVER), ChannelMembersFromJson(r.Body)}, nil
 	}
 }
 
@@ -1161,6 +1161,16 @@ func (c *Client) GetChannelCounts(etag string) (*Result, *AppError) {
 		defer closeBody(r)
 		return &Result{r.Header.Get(HEADER_REQUEST_ID),
 			r.Header.Get(HEADER_ETAG_SERVER), ChannelCountsFromJson(r.Body)}, nil
+	}
+}
+
+func (c *Client) GetChannels(etag string) (*Result, *AppError) {
+	if r, err := c.DoApiGet(c.GetTeamRoute()+"/channels/", "", etag); err != nil {
+		return nil, err
+	} else {
+		defer closeBody(r)
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), ChannelListFromJson(r.Body)}, nil
 	}
 }
 

--- a/model/client.go
+++ b/model/client.go
@@ -1124,8 +1124,8 @@ func (c *Client) UpdateNotifyProps(data map[string]string) (*Result, *AppError) 
 	}
 }
 
-func (c *Client) GetChannelsUnread() (*Result, *AppError) {
-	if r, err := c.DoApiGet(c.GetTeamRoute()+"/channels/unread", "", ""); err != nil {
+func (c *Client) GetMyChannelMembers() (*Result, *AppError) {
+	if r, err := c.DoApiGet(c.GetTeamRoute()+"/channels/members", "", ""); err != nil {
 		return nil, err
 	} else {
 		defer closeBody(r)

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -367,23 +367,16 @@ func (s SqlChannelStore) GetChannels(teamId string, userId string) StoreChannel 
 	go func() {
 		result := StoreResult{}
 
-		var data []channelWithMember
-		_, err := s.GetReplica().Select(&data, "SELECT * FROM Channels, ChannelMembers WHERE Id = ChannelId AND UserId = :UserId AND DeleteAt = 0 AND (TeamId = :TeamId OR TeamId = '') ORDER BY DisplayName", map[string]interface{}{"TeamId": teamId, "UserId": userId})
+		data := &model.ChannelList{}
+		_, err := s.GetReplica().Select(data, "SELECT Channels.* FROM Channels, ChannelMembers WHERE Id = ChannelId AND UserId = :UserId AND DeleteAt = 0 AND (TeamId = :TeamId OR TeamId = '') ORDER BY DisplayName", map[string]interface{}{"TeamId": teamId, "UserId": userId})
 
 		if err != nil {
 			result.Err = model.NewLocAppError("SqlChannelStore.GetChannels", "store.sql_channel.get_channels.get.app_error", nil, "teamId="+teamId+", userId="+userId+", err="+err.Error())
 		} else {
-			channels := &model.ChannelList{make([]*model.Channel, len(data)), make(map[string]*model.ChannelMember)}
-			for i := range data {
-				v := data[i]
-				channels.Channels[i] = &v.Channel
-				channels.Members[v.Channel.Id] = &v.ChannelMember
-			}
-
-			if len(channels.Channels) == 0 {
+			if len(*data) == 0 {
 				result.Err = model.NewLocAppError("SqlChannelStore.GetChannels", "store.sql_channel.get_channels.not_found.app_error", nil, "teamId="+teamId+", userId="+userId)
 			} else {
-				result.Data = channels
+				result.Data = data
 			}
 		}
 
@@ -400,8 +393,8 @@ func (s SqlChannelStore) GetMoreChannels(teamId string, userId string) StoreChan
 	go func() {
 		result := StoreResult{}
 
-		var data []*model.Channel
-		_, err := s.GetReplica().Select(&data,
+		data := &model.ChannelList{}
+		_, err := s.GetReplica().Select(data,
 			`SELECT 
 			    *
 			FROM
@@ -426,7 +419,7 @@ func (s SqlChannelStore) GetMoreChannels(teamId string, userId string) StoreChan
 		if err != nil {
 			result.Err = model.NewLocAppError("SqlChannelStore.GetMoreChannels", "store.sql_channel.get_more_channels.get.app_error", nil, "teamId="+teamId+", userId="+userId+", err="+err.Error())
 		} else {
-			result.Data = &model.ChannelList{data, make(map[string]*model.ChannelMember)}
+			result.Data = data
 		}
 
 		storeChannel <- result
@@ -918,11 +911,12 @@ func (s SqlChannelStore) IncrementMentionCount(channelId string, userId string) 
 			`UPDATE
 				ChannelMembers
 			SET
-				MentionCount = MentionCount + 1
+				MentionCount = MentionCount + 1,
+				LastUpdateAt = :LastUpdateAt
 			WHERE
 				UserId = :UserId
 					AND ChannelId = :ChannelId`,
-			map[string]interface{}{"ChannelId": channelId, "UserId": userId})
+			map[string]interface{}{"ChannelId": channelId, "UserId": userId, "LastUpdateAt": model.GetMillis()})
 		if err != nil {
 			result.Err = model.NewLocAppError("SqlChannelStore.IncrementMentionCount", "store.sql_channel.increment_mention_count.app_error", nil, "channel_id="+channelId+", user_id="+userId+", "+err.Error())
 		}
@@ -1024,6 +1018,32 @@ func (s SqlChannelStore) ExtraUpdateByUser(userId string, time int64) StoreChann
 
 		if err != nil {
 			result.Err = model.NewLocAppError("SqlChannelStore.extraUpdated", "store.sql_channel.extra_updated.app_error", nil, "user_id="+userId+", "+err.Error())
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlChannelStore) GetChannelsUnread(teamId string, userId string) StoreChannel {
+	storeChannel := make(StoreChannel, 1)
+
+	go func() {
+		result := StoreResult{}
+
+		members := &model.ChannelMembers{}
+		_, err := s.GetReplica().Select(members, `SELECT ChannelId, UserId, Roles, LastViewedAt, (TotalMsgCount -  MsgCount) as MsgCount, MentionCount, NotifyProps, LastUpdateAt
+		FROM Channels, ChannelMembers
+		WHERE Id = ChannelId AND UserId = :UserId AND DeleteAt = 0 AND TeamId = :TeamId
+		AND (TotalMsgCount -  MsgCount) > 0
+		`, map[string]interface{}{"TeamId": teamId, "UserId": userId})
+
+		if err != nil {
+			result.Err = model.NewLocAppError("SqlChannelStore.GetChannelsUnread", "store.sql_channel.get_channels.get.app_error", nil, "teamId="+teamId+", userId="+userId+", err="+err.Error())
+		} else {
+			result.Data = members
 		}
 
 		storeChannel <- result

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -305,14 +305,14 @@ func TestChannelStoreDelete(t *testing.T) {
 	cresult := <-store.Channel().GetChannels(o1.TeamId, m1.UserId)
 	list := cresult.Data.(*model.ChannelList)
 
-	if len(list.Channels) != 1 {
+	if len(*list) != 1 {
 		t.Fatal("invalid number of channels")
 	}
 
 	cresult = <-store.Channel().GetMoreChannels(o1.TeamId, m1.UserId)
 	list = cresult.Data.(*model.ChannelList)
 
-	if len(list.Channels) != 1 {
+	if len(*list) != 1 {
 		t.Fatal("invalid number of channels")
 	}
 }
@@ -514,7 +514,7 @@ func TestChannelStoreGetChannels(t *testing.T) {
 	cresult := <-store.Channel().GetChannels(o1.TeamId, m1.UserId)
 	list := cresult.Data.(*model.ChannelList)
 
-	if list.Channels[0].Id != o1.Id {
+	if (*list)[0].Id != o1.Id {
 		t.Fatal("missing channel")
 	}
 
@@ -614,11 +614,11 @@ func TestChannelStoreGetMoreChannels(t *testing.T) {
 	cresult := <-store.Channel().GetMoreChannels(o1.TeamId, m1.UserId)
 	list := cresult.Data.(*model.ChannelList)
 
-	if len(list.Channels) != 1 {
+	if len(*list) != 1 {
 		t.Fatal("wrong list")
 	}
 
-	if list.Channels[0].Name != o3.Name {
+	if (*list)[0].Name != o3.Name {
 		t.Fatal("missing channel")
 	}
 
@@ -685,6 +685,51 @@ func TestChannelStoreGetChannelCounts(t *testing.T) {
 
 	if len(counts.UpdateTimes) != 1 {
 		t.Fatal("wrong number of update times")
+	}
+}
+
+func TestChannelStoreGetChannelsUnread(t *testing.T) {
+	Setup()
+
+	t1 := model.Team{}
+	t1.DisplayName = "Name"
+	t1.Name = model.NewId()
+	t1.Email = model.NewId() + "@nowhere.com"
+	t1.Type = model.TEAM_OPEN
+	Must(store.Team().Save(&t1))
+
+	o1 := model.Channel{}
+	o1.TeamId = t1.Id
+	o1.DisplayName = "Channel1"
+	o1.Name = "a" + model.NewId() + "b"
+	o1.Type = model.CHANNEL_OPEN
+	Must(store.Channel().Save(&o1))
+
+	o2 := model.Channel{}
+	o2.TeamId = o1.TeamId
+	o2.DisplayName = "Channel2"
+	o2.Name = "a" + model.NewId() + "b"
+	o2.Type = model.CHANNEL_OPEN
+	Must(store.Channel().Save(&o2))
+
+	m1 := model.ChannelMember{}
+	m1.ChannelId = o1.Id
+	m1.UserId = model.NewId()
+	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
+	Must(store.Channel().SaveMember(&m1))
+
+	m2 := model.ChannelMember{}
+	m2.ChannelId = o2.Id
+	m2.UserId = m1.UserId
+	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
+	Must(store.Channel().SaveMember(&m2))
+
+	cresult := <-store.Channel().GetChannelsUnread(o1.TeamId, m1.UserId)
+	members := cresult.Data.(*model.ChannelMembers)
+
+	// no unread messages
+	if len(*members) != 0 {
+		t.Fatal("wrong number of members")
 	}
 }
 

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -688,7 +688,7 @@ func TestChannelStoreGetChannelCounts(t *testing.T) {
 	}
 }
 
-func TestChannelStoreGetChannelsUnread(t *testing.T) {
+func TestChannelStoreGetMembersForUser(t *testing.T) {
 	Setup()
 
 	t1 := model.Team{}
@@ -724,11 +724,11 @@ func TestChannelStoreGetChannelsUnread(t *testing.T) {
 	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m2))
 
-	cresult := <-store.Channel().GetChannelsUnread(o1.TeamId, m1.UserId)
+	cresult := <-store.Channel().GetMembersForUser(o1.TeamId, m1.UserId)
 	members := cresult.Data.(*model.ChannelMembers)
 
 	// no unread messages
-	if len(*members) != 0 {
+	if len(*members) != 2 {
 		t.Fatal("wrong number of members")
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -109,7 +109,7 @@ type ChannelStore interface {
 	IncrementMentionCount(channelId string, userId string) StoreChannel
 	AnalyticsTypeCount(teamId string, channelType string) StoreChannel
 	ExtraUpdateByUser(userId string, time int64) StoreChannel
-	GetChannelsUnread(teamId string, userId string) StoreChannel
+	GetMembersForUser(teamId string, userId string) StoreChannel
 }
 
 type PostStore interface {

--- a/store/store.go
+++ b/store/store.go
@@ -109,6 +109,7 @@ type ChannelStore interface {
 	IncrementMentionCount(channelId string, userId string) StoreChannel
 	AnalyticsTypeCount(teamId string, channelType string) StoreChannel
 	ExtraUpdateByUser(userId string, time int64) StoreChannel
+	GetChannelsUnread(teamId string, userId string) StoreChannel
 }
 
 type PostStore interface {

--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -42,8 +42,7 @@ export function emitChannelClickEvent(channel) {
         );
     }
     function switchToChannel(chan) {
-        AsyncClient.getChannels(true);
-        AsyncClient.getMoreChannels(true);
+        AsyncClient.getChannelsUnread(true);
         AsyncClient.getChannelStats(chan.id);
         AsyncClient.updateLastViewedAt(chan.id);
         loadPosts(chan.id);
@@ -436,10 +435,6 @@ export function loadDefaultLocale() {
 }
 
 export function viewLoggedIn() {
-    AsyncClient.getChannels();
-    AsyncClient.getMoreChannels();
-    AsyncClient.getChannelStats();
-
     // Clear pending posts (shouldn't have pending posts if we are loading)
     PostStore.clearPendingPosts();
 }

--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -42,7 +42,6 @@ export function emitChannelClickEvent(channel) {
         );
     }
     function switchToChannel(chan) {
-        AsyncClient.getChannelsUnread(true);
         AsyncClient.getChannelStats(chan.id);
         AsyncClient.updateLastViewedAt(chan.id);
         loadPosts(chan.id);

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -120,7 +120,7 @@ export function setUnreadPost(channelId, postId) {
         member.msg_count = channel.total_msg_count - unreadPosts;
         member.mention_count = 0;
         ChannelStore.storeMyChannelMember(member);
-        ChannelStore.setUnreadCount(channelId);
+        ChannelStore.setUnreadCountByChannel(channelId);
         AsyncClient.setLastViewedAt(lastViewed, channelId);
     }
 

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -76,6 +76,7 @@ function handleFirstConnect() {
 function handleReconnect() {
     if (Client.teamId) {
         AsyncClient.getChannels();
+        AsyncClient.getMyChannelMembers();
         loadPosts(ChannelStore.getCurrentId());
     }
 

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -1357,6 +1357,15 @@ export default class Client {
             end(this.handleResponse.bind(this, 'getChannelCounts', success, error));
     }
 
+    getChannelsUnread(success, error) {
+        request.
+        get(`${this.getChannelsRoute()}/unread`).
+        set(this.defaultHeaders).
+        type('application/json').
+        accept('application/json').
+        end(this.handleResponse.bind(this, 'getChannelsUnread', success, error));
+    }
+
     getChannelStats(channelId, success, error) {
         request.
             get(`${this.getChannelNeededRoute(channelId)}/stats`).

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -1357,13 +1357,13 @@ export default class Client {
             end(this.handleResponse.bind(this, 'getChannelCounts', success, error));
     }
 
-    getChannelsUnread(success, error) {
+    getMyChannelMembers(success, error) {
         request.
-        get(`${this.getChannelsRoute()}/unread`).
+        get(`${this.getChannelsRoute()}/members`).
         set(this.defaultHeaders).
         type('application/json').
         accept('application/json').
-        end(this.handleResponse.bind(this, 'getChannelsUnread', success, error));
+        end(this.handleResponse.bind(this, 'getMyChannelMembers', success, error));
     }
 
     getChannelStats(channelId, success, error) {

--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -75,8 +75,7 @@ function preNeedsTeam(nextState, replace, callback) {
         (data) => {
             AppDispatcher.handleServerAction({
                 type: ActionTypes.RECEIVED_CHANNELS,
-                channels: data.channels,
-                members: data.members
+                channels: data
             });
 
             d1.resolve();

--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -78,6 +78,8 @@ function preNeedsTeam(nextState, replace, callback) {
                 channels: data
             });
 
+            AsyncClient.getMyChannelMembers();
+
             d1.resolve();
         },
         (err) => {

--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -250,7 +250,7 @@ class ChannelStoreClass extends EventEmitter {
         this.myChannelMembers = channelMembers;
     }
 
-    storeMyChannelMembersNew(channelMembers) {
+    storeMyChannelMembersList(channelMembers) {
         channelMembers.forEach((m) => {
             this.myChannelMembers[m.channel_id] = m;
         });
@@ -286,15 +286,7 @@ class ChannelStoreClass extends EventEmitter {
 
     setUnreadCountsByMembers(members) {
         members.forEach((m) => {
-            const id = m.channel_id;
-            const chMentionCount = m.mention_count;
-            let chUnreadCount = m.msg_count;
-
-            if (m.notify_props && m.notify_props.mark_unread === NotificationPrefs.MENTION) {
-                chUnreadCount = 0;
-            }
-
-            this.unreadCounts[id] = {msgs: chUnreadCount, mentions: chMentionCount};
+            this.setUnreadCountByChannel(m.channel_id);
         });
     }
 
@@ -391,8 +383,8 @@ ChannelStore.dispatchToken = AppDispatcher.register((payload) => {
         ChannelStore.emitChange();
         break;
 
-    case ActionTypes.RECEIVED_CHANNELS_UNREAD:
-        ChannelStore.storeMyChannelMembersNew(action.members);
+    case ActionTypes.RECEIVED_MY_CHANNEL_MEMBERS:
+        ChannelStore.storeMyChannelMembersList(action.members);
         currentId = ChannelStore.getCurrentId();
         if (currentId && window.isActive) {
             ChannelStore.resetCounts(currentId);

--- a/webapp/tests/client_channel.test.jsx
+++ b/webapp/tests/client_channel.test.jsx
@@ -285,11 +285,11 @@ describe('Client.Channels', function() {
         });
     });
 
-    it('getChannelsUnread', function(done) {
+    it('getMyChannelMembers', function(done) {
         TestHelper.initBasic(() => {
-            TestHelper.basicClient().getChannelsUnread(
+            TestHelper.basicClient().getMyChannelMembers(
                 function(data) {
-                    assert.equal(data.length, 0);
+                    assert.equal(data.length > 0, true);
                     done();
                 },
                 function(err) {

--- a/webapp/tests/client_channel.test.jsx
+++ b/webapp/tests/client_channel.test.jsx
@@ -232,7 +232,7 @@ describe('Client.Channels', function() {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().getChannels(
                 function(data) {
-                    assert.equal(data.channels.length, 3);
+                    assert.equal(data.length, 3);
                     done();
                 },
                 function(err) {
@@ -261,7 +261,7 @@ describe('Client.Channels', function() {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().getMoreChannels(
                 function(data) {
-                    assert.equal(data.channels.length, 0);
+                    assert.equal(data.length, 0);
                     done();
                 },
                 function(err) {
@@ -276,6 +276,20 @@ describe('Client.Channels', function() {
             TestHelper.basicClient().getChannelCounts(
                 function(data) {
                     assert.equal(data.counts[TestHelper.basicChannel().id], 1);
+                    done();
+                },
+                function(err) {
+                    done(new Error(err.message));
+                }
+            );
+        });
+    });
+
+    it('getChannelsUnread', function(done) {
+        TestHelper.initBasic(() => {
+            TestHelper.basicClient().getChannelsUnread(
+                function(data) {
+                    assert.equal(data.length, 0);
                     done();
                 },
                 function(err) {

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -114,29 +114,29 @@ export function getChannel(id) {
     );
 }
 
-export function getChannelsUnread(doVersionCheck) {
-    if (isCallInProgress('getChannels')) {
-        return null;
+export function getMyChannelMembers(doVersionCheck) {
+    if (isCallInProgress('getMyChannelMembers')) {
+        return;
     }
 
-    callTracker.getChannelsUnread = utils.getTimestamp();
+    callTracker.getMyChannelMembers = utils.getTimestamp();
 
-    return Client.getChannelsUnread(
+    Client.getMyChannelMembers(
         (data) => {
-            callTracker.getChannelsUnread = 0;
+            callTracker.getMyChannelMembers = 0;
 
             if (doVersionCheck) {
                 checkVersion();
             }
 
             AppDispatcher.handleServerAction({
-                type: ActionTypes.RECEIVED_CHANNELS_UNREAD,
+                type: ActionTypes.RECEIVED_MY_CHANNEL_MEMBERS,
                 members: data
             });
         },
         (err) => {
             callTracker.getChannelsUnread = 0;
-            dispatchError(err, 'getChannelsUnread');
+            dispatchError(err, 'getMyChannelMembers');
         }
     );
 }

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -80,8 +80,7 @@ export function getChannels(doVersionCheck) {
 
             AppDispatcher.handleServerAction({
                 type: ActionTypes.RECEIVED_CHANNELS,
-                channels: data.channels,
-                members: data.members
+                channels: data
             });
         },
         (err) => {
@@ -111,6 +110,33 @@ export function getChannel(id) {
         (err) => {
             callTracker['getChannel' + id] = 0;
             dispatchError(err, 'getChannel');
+        }
+    );
+}
+
+export function getChannelsUnread(doVersionCheck) {
+    if (isCallInProgress('getChannels')) {
+        return null;
+    }
+
+    callTracker.getChannelsUnread = utils.getTimestamp();
+
+    return Client.getChannelsUnread(
+        (data) => {
+            callTracker.getChannelsUnread = 0;
+
+            if (doVersionCheck) {
+                checkVersion();
+            }
+
+            AppDispatcher.handleServerAction({
+                type: ActionTypes.RECEIVED_CHANNELS_UNREAD,
+                members: data
+            });
+        },
+        (err) => {
+            callTracker.getChannelsUnread = 0;
+            dispatchError(err, 'getChannelsUnread');
         }
     );
 }
@@ -205,8 +231,7 @@ export function getMoreChannels(force) {
 
                 AppDispatcher.handleServerAction({
                     type: ActionTypes.RECEIVED_MORE_CHANNELS,
-                    channels: data.channels,
-                    members: data.members
+                    channels: data
                 });
             },
             (err) => {

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -72,7 +72,7 @@ export const ActionTypes = keyMirror({
     RECEIVED_CHANNEL: null,
     RECEIVED_MORE_CHANNELS: null,
     RECEIVED_CHANNEL_STATS: null,
-    RECEIVED_CHANNELS_UNREAD: null,
+    RECEIVED_MY_CHANNEL_MEMBERS: null,
 
     FOCUS_POST: null,
     RECEIVED_POSTS: null,

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -72,6 +72,7 @@ export const ActionTypes = keyMirror({
     RECEIVED_CHANNEL: null,
     RECEIVED_MORE_CHANNELS: null,
     RECEIVED_CHANNEL_STATS: null,
+    RECEIVED_CHANNELS_UNREAD: null,
 
     FOCUS_POST: null,
     RECEIVED_POSTS: null,


### PR DESCRIPTION
#### Summary
Remove the getChannels and getMoreChannels requests on channel switch and add a new API for getting the current user's channel members.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4430

API proposal: https://github.com/mattermost/mattermost-api-reference/pull/12

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

