### PR TITLE
PLT-4275 Add `exitToDirectChannel` to more_direct_channels

### DIFF
--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -26,6 +26,7 @@ export default class MoreDirectChannels extends React.Component {
         super(props);
 
         this.handleHide = this.handleHide.bind(this);
+        this.handleExit = this.handleExit.bind(this);
         this.handleShowDirectChannel = this.handleShowDirectChannel.bind(this);
         this.onChange = this.onChange.bind(this);
         this.createJoinDirectChannelButton = this.createJoinDirectChannelButton.bind(this);
@@ -70,6 +71,12 @@ export default class MoreDirectChannels extends React.Component {
         }
     }
 
+    handleExit() {
+        if (this.exitToDirectChannel) {
+            browserHistory.push(this.exitToDirectChannel);
+        }
+    }
+
     handleShowDirectChannel(teammate, e) {
         e.preventDefault();
 
@@ -81,7 +88,10 @@ export default class MoreDirectChannels extends React.Component {
         openDirectChannelToUser(
             teammate,
             (channel) => {
-                browserHistory.push(TeamStore.getCurrentTeamUrl() + '/channels/' + channel.name);
+                // Due to how react-overlays Modal handles focus, we delay pushing
+                // the new channel information until the modal is fully exited.
+                // The channel information will be pushed in `handleExit`
+                this.exitToDirectChannel = TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name;
                 this.setState({loadingDMChannel: -1});
                 this.handleHide();
             },
@@ -228,6 +238,7 @@ export default class MoreDirectChannels extends React.Component {
                 dialogClassName='more-modal more-direct-channels'
                 show={this.props.show}
                 onHide={this.handleHide}
+                onExited={this.handleExit}
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>


### PR DESCRIPTION
#### Summary

Ensures focus is returned to center textarea by waiting for modal to exit before updating the url with the newly selected DM channel resolving #4304.
#### Ticket Link

JIRA: [PLT-4275](https://mattermost.atlassian.net/browse/PLT-4275)
Github: [4304](https://github.com/mattermost/platform/issues/4304)
#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

When a new channel is selected, we set `exitToDirectChannel` to the
newly selected channel. In `handleExit` if `exitToDirectChannel` exists,
the new channel information is pushed. This fixes an issue where the
create_post textarea gains and then loses focus due to the way that
react-overlays (react-bootstrap dependency) handles previous focus which
in this particular case is the `More...` link.
