### PR TITLE
Fix URL parsing when URL has been encoded with escape() (fixes #4322)

### DIFF
--- a/webapp/tests/formatting_links.test.jsx
+++ b/webapp/tests/formatting_links.test.jsx
@@ -501,4 +501,18 @@ describe('Markdown.Links', function() {
 
         done();
     });
+
+    it('Links containing %', function(done) {
+        assert.equal(
+            Markdown.format('https://en.wikipedia.org/wiki/%C3%89').trim(),
+            '<p><a class="theme markdown__link" href="https://en.wikipedia.org/wiki/%C3%89" rel="noreferrer" target="_blank">https://en.wikipedia.org/wiki/%C3%89</a></p>'
+        );
+
+        assert.equal(
+            Markdown.format('https://en.wikipedia.org/wiki/%E9').trim(),
+            '<p><a class="theme markdown__link" href="https://en.wikipedia.org/wiki/%E9" rel="noreferrer" target="_blank">https://en.wikipedia.org/wiki/%E9</a></p>'
+        );
+
+        done();
+    });
 });

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -135,7 +135,13 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         let outHref = href;
 
         try {
-            const unescaped = decodeURIComponent(unescape(href)).replace(/[^\w:]/g, '').toLowerCase();
+            let unescaped = unescape(href);
+            try {
+                unescaped = decodeURIComponent(unescaped);
+            } catch (e) {
+                unescaped = global.unescape(unescaped);
+            }
+            unescaped = unescaped.replace(/[^\w:]/g, '').toLowerCase();
 
             if (unescaped.indexOf('javascript:') === 0 || unescaped.indexOf('vbscript:') === 0 || unescaped.indexOf('data:') === 0) { // eslint-disable-line no-script-url
                 return text;


### PR DESCRIPTION
#### Summary
Some URLs like [this one](http://www.associationmodeemploi.fr/PAR_TPL_IDENTIFIANT/25062/TPL_CODE/TPL_REVUE_ART_FICHE/PAG_TITLE/Pourquoi+les+%E9tudiants+s%27engagent+dans+les+associations/2605-fiche-article.htm) where not parsed correctly because they were encoded with the old `escape()` function (instead of `encodeURI()`).
This patch fixes this issue by testing both `decodeURIComponent()` and `unescape()`.

#### Ticket Link
https://github.com/mattermost/platform/issues/4322

#### Checklist
- [x] Added or updated unit tests (required for all new features)

