### PR TITLE
PLT-4460 Fix disappearing topbar when jumping from right sidebar

### DIFF
--- a/webapp/sass/layout/_sidebar-left.scss
+++ b/webapp/sass/layout/_sidebar-left.scss
@@ -4,7 +4,7 @@
     border-right: $border-gray;
     height: 100%;
     left: 0;
-    position: absolute;
+    position: fixed;
     width: 220px;
     z-index: 5;
 


### PR DESCRIPTION
#### Summary
In the mobile apps (or in the compact view in the browser), when the user went to recent mentions or flagged posts, and then clicked 'jump' to jump back to the channel view, the top navbar would disappear off the top of the screen, and an empty space would be left below the posts list.
This would also happen when you attached multiple files to a new post (even without sending it).
It would also be reproduced by scrolling up from the bottom of the posts list, clicking 'reply' to open the RHS, then closing the sidebar (even without sending the reply).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4460
https://mattermost.atlassian.net/browse/PLT-4484
https://mattermost.atlassian.net/browse/PLT-4511

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

