### PR TITLE
PLT-4376 iOS and Android: Keep the keyboard open after sending a message

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -317,7 +317,7 @@ export default class CreateComment extends React.Component {
         return this.state.fileInfos.length + this.state.uploadsInProgress.length;
     }
 
-    focusTextbox(keepFocus=false) {
+    focusTextbox(keepFocus = false) {
         if (keepFocus || !Utils.isMobile()) {
             this.refs.textbox.focus();
         }

--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -166,6 +166,7 @@ export default class CreateComment extends React.Component {
             fileInfos: [],
             serverError: null
         });
+        this.focusTextbox(true);
     }
 
     commentMsgKeyPress(e) {
@@ -316,8 +317,8 @@ export default class CreateComment extends React.Component {
         return this.state.fileInfos.length + this.state.uploadsInProgress.length;
     }
 
-    focusTextbox() {
-        if (!Utils.isMobile()) {
+    focusTextbox(keepFocus=false) {
+        if (keepFocus || !Utils.isMobile()) {
             this.refs.textbox.focus();
         }
     }

--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -37,6 +37,7 @@ export default class CreateComment extends React.Component {
         this.commentMsgKeyPress = this.commentMsgKeyPress.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.handleBlur = this.handleBlur.bind(this);
         this.handleUploadClick = this.handleUploadClick.bind(this);
         this.handleUploadStart = this.handleUploadStart.bind(this);
         this.handleFileUploadComplete = this.handleFileUploadComplete.bind(this);
@@ -58,7 +59,8 @@ export default class CreateComment extends React.Component {
             fileInfos: draft.fileInfos,
             submitting: false,
             ctrlSend: PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
-            showPostDeletedModal: false
+            showPostDeletedModal: false,
+            lastBlurAt: 0
         };
     }
 
@@ -166,7 +168,10 @@ export default class CreateComment extends React.Component {
             fileInfos: [],
             serverError: null
         });
-        this.focusTextbox(true);
+
+        const fasterThanHumanWillClick = 150;
+        const forceFocus = (Date.now() - this.state.lastBlurAt < fasterThanHumanWillClick);
+        this.focusTextbox(forceFocus);
     }
 
     commentMsgKeyPress(e) {
@@ -335,6 +340,10 @@ export default class CreateComment extends React.Component {
         });
     }
 
+    handleBlur() {
+        this.setState({lastBlurAt: Date.now()});
+    }
+
     render() {
         let serverError = null;
         if (this.state.serverError) {
@@ -398,6 +407,7 @@ export default class CreateComment extends React.Component {
                                 onKeyPress={this.commentMsgKeyPress}
                                 onKeyDown={this.handleKeyDown}
                                 value={this.state.message}
+                                onBlur={this.handleBlur}
                                 createMessage={Utils.localizeMessage('create_comment.addComment', 'Add a comment...')}
                                 initialText=''
                                 supportsCommands={false}

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -128,6 +128,7 @@ export default class CreatePost extends React.Component {
         } else {
             this.sendMessage(post);
         }
+        this.focusTextbox(true);
     }
 
     sendMessage(post) {
@@ -171,8 +172,8 @@ export default class CreatePost extends React.Component {
         );
     }
 
-    focusTextbox() {
-        if (!Utils.isMobile()) {
+    focusTextbox(keepFocus=false) {
+        if (keepFocus || !Utils.isMobile()) {
             this.refs.textbox.focus();
         }
     }

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -172,7 +172,7 @@ export default class CreatePost extends React.Component {
         );
     }
 
-    focusTextbox(keepFocus=false) {
+    focusTextbox(keepFocus = false) {
         if (keepFocus || !Utils.isMobile()) {
             this.refs.textbox.focus();
         }

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -131,7 +131,8 @@ export default class CreatePost extends React.Component {
             this.sendMessage(post);
         }
 
-        const forceFocus = (Date.now() - this.state.lastBlurAt < 25);
+        const fasterThanHumanWillClick = 150;
+        const forceFocus = (Date.now() - this.state.lastBlurAt < fasterThanHumanWillClick);
         this.focusTextbox(forceFocus);
     }
 

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -52,6 +52,7 @@ export default class CreatePost extends React.Component {
         this.onPreferenceChange = this.onPreferenceChange.bind(this);
         this.getFileCount = this.getFileCount.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.handleBlur = this.handleBlur.bind(this);
         this.sendMessage = this.sendMessage.bind(this);
         this.focusTextbox = this.focusTextbox.bind(this);
         this.showPostDeletedModal = this.showPostDeletedModal.bind(this);
@@ -71,7 +72,8 @@ export default class CreatePost extends React.Component {
             ctrlSend: PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
             fullWidthTextBox: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
             showTutorialTip: false,
-            showPostDeletedModal: false
+            showPostDeletedModal: false,
+            lastBlurAt: 0
         };
     }
 
@@ -128,7 +130,9 @@ export default class CreatePost extends React.Component {
         } else {
             this.sendMessage(post);
         }
-        this.focusTextbox(true);
+
+        const forceFocus = (Date.now() - this.state.lastBlurAt < 25);
+        this.focusTextbox(forceFocus);
     }
 
     sendMessage(post) {
@@ -406,6 +410,10 @@ export default class CreatePost extends React.Component {
         }
     }
 
+    handleBlur() {
+        this.setState({lastBlurAt: Date.now()});
+    }
+
     showPostDeletedModal() {
         this.setState({
             showPostDeletedModal: true
@@ -496,6 +504,7 @@ export default class CreatePost extends React.Component {
                                 onKeyPress={this.postMsgKeyPress}
                                 onKeyDown={this.handleKeyDown}
                                 value={this.state.message}
+                                onBlur={this.handleBlur}
                                 createMessage={Utils.localizeMessage('create_post.write', 'Write a message...')}
                                 channelId={this.state.channelId}
                                 id='post_textbox'

--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -24,6 +24,7 @@ export default class SuggestionBox extends React.Component {
         this.handleCompleteWord = this.handleCompleteWord.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.handleBlur = this.handleBlur.bind(this);
         this.handlePretextChanged = this.handlePretextChanged.bind(this);
 
         this.suggestionId = Utils.generateId();
@@ -79,6 +80,12 @@ export default class SuggestionBox extends React.Component {
 
         if (this.props.onChange) {
             this.props.onChange(e);
+        }
+    }
+
+    handleBlur(e) {
+        if (this.props.onBlur) {
+            this.props.onBlur(e);
         }
     }
 
@@ -159,6 +166,7 @@ export default class SuggestionBox extends React.Component {
                     {...this.props}
                     onChange={this.handleChange}
                     onKeyDown={this.handleKeyDown}
+                    onBlur={this.handleBlur}
                 />
             );
         } else if (this.props.type === 'search') {
@@ -169,6 +177,7 @@ export default class SuggestionBox extends React.Component {
                     {...this.props}
                     onChange={this.handleChange}
                     onKeyDown={this.handleKeyDown}
+                    onBlur={this.handleBlur}
                 />
             );
         } else if (this.props.type === 'textarea') {
@@ -179,6 +188,7 @@ export default class SuggestionBox extends React.Component {
                     {...this.props}
                     onChange={this.handleChange}
                     onKeyDown={this.handleKeyDown}
+                    onBlur={this.handleBlur}
                 />
             );
         }
@@ -227,5 +237,6 @@ SuggestionBox.propTypes = {
 
     // explicitly name any input event handlers we override and need to manually call
     onChange: React.PropTypes.func,
+    onBlur: React.PropTypes.func,
     onKeyDown: React.PropTypes.func
 };

--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -24,7 +24,6 @@ export default class SuggestionBox extends React.Component {
         this.handleCompleteWord = this.handleCompleteWord.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
-        this.handleBlur = this.handleBlur.bind(this);
         this.handlePretextChanged = this.handlePretextChanged.bind(this);
 
         this.suggestionId = Utils.generateId();
@@ -80,12 +79,6 @@ export default class SuggestionBox extends React.Component {
 
         if (this.props.onChange) {
             this.props.onChange(e);
-        }
-    }
-
-    handleBlur(e) {
-        if (this.props.onBlur) {
-            this.props.onBlur(e);
         }
     }
 
@@ -166,7 +159,6 @@ export default class SuggestionBox extends React.Component {
                     {...this.props}
                     onChange={this.handleChange}
                     onKeyDown={this.handleKeyDown}
-                    onBlur={this.handleBlur}
                 />
             );
         } else if (this.props.type === 'search') {
@@ -177,7 +169,6 @@ export default class SuggestionBox extends React.Component {
                     {...this.props}
                     onChange={this.handleChange}
                     onKeyDown={this.handleKeyDown}
-                    onBlur={this.handleBlur}
                 />
             );
         } else if (this.props.type === 'textarea') {
@@ -188,7 +179,6 @@ export default class SuggestionBox extends React.Component {
                     {...this.props}
                     onChange={this.handleChange}
                     onKeyDown={this.handleKeyDown}
-                    onBlur={this.handleBlur}
                 />
             );
         }

--- a/webapp/components/textbox.jsx
+++ b/webapp/components/textbox.jsx
@@ -29,6 +29,7 @@ export default class Textbox extends React.Component {
         this.onRecievedError = this.onRecievedError.bind(this);
         this.handleKeyPress = this.handleKeyPress.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.handleBlur = this.handleBlur.bind(this);
         this.handleHeightChange = this.handleHeightChange.bind(this);
         this.showPreview = this.showPreview.bind(this);
 
@@ -81,6 +82,12 @@ export default class Textbox extends React.Component {
     handleKeyDown(e) {
         if (this.props.onKeyDown) {
             this.props.onKeyDown(e);
+        }
+    }
+
+    handleBlur(e) {
+        if (this.props.onBlur) {
+            this.props.onBlur(e);
         }
     }
 
@@ -209,6 +216,7 @@ export default class Textbox extends React.Component {
                     onChange={this.props.onChange}
                     onKeyPress={this.handleKeyPress}
                     onKeyDown={this.handleKeyDown}
+                    onBlur={this.handleBlur}
                     onHeightChange={this.handleHeightChange}
                     style={{visibility: this.state.preview ? 'hidden' : 'visible'}}
                     listComponent={SuggestionList}
@@ -255,5 +263,6 @@ Textbox.propTypes = {
     onKeyPress: React.PropTypes.func.isRequired,
     createMessage: React.PropTypes.string.isRequired,
     onKeyDown: React.PropTypes.func,
+    onBlur: React.PropTypes.func,
     supportsCommands: React.PropTypes.bool.isRequired
 };


### PR DESCRIPTION
#### Summary

This PR ensures that the keyboard stays open after submitting a post and comment on mobile.

Tested on IOS 10.0 and MotoX Android 6
#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-4376
#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features) ?
- [x] Has UI changes
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.) ?
