### PR TITLE
PLT-2610 Allow Slash Command to set username/icon from the reply payload

### DIFF
--- a/api/command.go
+++ b/api/command.go
@@ -230,6 +230,8 @@ func handleResponse(c *Context, w http.ResponseWriter, response *model.CommandRe
 	if utils.Cfg.ServiceSettings.EnablePostUsernameOverride {
 		if len(cmd.Username) != 0 {
 			post.AddProp("override_username", cmd.Username)
+		} else if len(response.Username) != 0 {
+			post.AddProp("override_username", response.Username)
 		} else {
 			post.AddProp("override_username", model.DEFAULT_WEBHOOK_USERNAME)
 		}
@@ -238,6 +240,8 @@ func handleResponse(c *Context, w http.ResponseWriter, response *model.CommandRe
 	if utils.Cfg.ServiceSettings.EnablePostIconOverride {
 		if len(cmd.IconURL) != 0 {
 			post.AddProp("override_icon_url", cmd.IconURL)
+		} else if len(response.IconURL) != 0 {
+			post.AddProp("override_icon_url", response.IconURL)
 		} else {
 			post.AddProp("override_icon_url", "")
 		}

--- a/model/command_response.go
+++ b/model/command_response.go
@@ -16,6 +16,8 @@ const (
 type CommandResponse struct {
 	ResponseType string      `json:"response_type"`
 	Text         string      `json:"text"`
+	Username     string      `json:"username"`
+	IconURL      string      `json:"icon_url"`
 	GotoLocation string      `json:"goto_location"`
 	Attachments  interface{} `json:"attachments"`
 }


### PR DESCRIPTION
#### Summary

Allow slash command to overwrite username/icon from the reply payload.
#### Ticket Link

JIRA: [PLT-2610](https://mattermost.atlassian.net/browse/PLT-2610)
Github: [#4248](https://github.com/mattermost/platform/issues/4248)
#### Checklist

N/A
