### PR TITLE
Cleaned up code for ensuring post drafts are non-null

### DIFF
--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -40,7 +40,6 @@ export default class CreatePost extends React.Component {
 
         this.lastTime = 0;
 
-        this.getCurrentDraft = this.getCurrentDraft.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
         this.postMsgKeyPress = this.postMsgKeyPress.bind(this);
         this.handleChange = this.handleChange.bind(this);
@@ -61,7 +60,7 @@ export default class CreatePost extends React.Component {
 
         PostStore.clearDraftUploads();
 
-        const draft = this.getCurrentDraft();
+        const draft = PostStore.getCurrentDraft();
 
         this.state = {
             channelId: ChannelStore.getCurrentId(),
@@ -75,25 +74,6 @@ export default class CreatePost extends React.Component {
             showTutorialTip: false,
             showPostDeletedModal: false
         };
-    }
-
-    getCurrentDraft() {
-        const draft = PostStore.getCurrentDraft();
-        const safeDraft = {fileInfos: [], messageText: '', uploadsInProgress: []};
-
-        if (draft) {
-            if (draft.message) {
-                safeDraft.messageText = draft.message;
-            }
-            if (draft.fileInfos) {
-                safeDraft.fileInfos = draft.fileInfos;
-            }
-            if (draft.uploadsInProgress) {
-                safeDraft.uploadsInProgress = draft.uploadsInProgress;
-            }
-        }
-
-        return safeDraft;
     }
 
     handleSubmit(e) {
@@ -358,7 +338,7 @@ export default class CreatePost extends React.Component {
     onChange() {
         const channelId = ChannelStore.getCurrentId();
         if (this.state.channelId !== channelId) {
-            const draft = this.getCurrentDraft();
+            const draft = PostStore.getCurrentDraft();
 
             this.setState({channelId, messageText: draft.messageText, initialText: draft.messageText, submitting: false, serverError: null, postError: null, fileInfos: draft.fileInfos, uploadsInProgress: draft.uploadsInProgress});
         }

--- a/webapp/stores/browser_store.jsx
+++ b/webapp/stores/browser_store.jsx
@@ -52,7 +52,7 @@ class BrowserStoreClass {
         }
     }
 
-    getGlobalItem(name, defaultValue) {
+    getGlobalItem(name, defaultValue = null) {
         var result = null;
         try {
             if (this.isLocalStorageSupported()) {
@@ -64,7 +64,7 @@ class BrowserStoreClass {
             result = null;
         }
 
-        if (result === null && typeof defaultValue !== 'undefined') {
+        if (!result) {
             result = defaultValue;
         }
 

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -513,8 +513,23 @@ class PostStoreClass extends EventEmitter {
         return lastPost;
     }
 
-    getEmptyDraft() {
-        return {message: '', uploadsInProgress: [], fileInfos: []};
+    normalizeDraft(originalDraft) {
+        let draft = {
+            messageText: '',
+            uploadsInProgress: [],
+            fileInfos: []
+        };
+
+        // Make sure that the post draft is non-null and has all the required fields
+        if (originalDraft) {
+            draft = {
+                messageText: originalDraft.messageText || draft.messageText,
+                uploadsInProgress: originalDraft.uploadsInProgress || draft.uploadsInProgress,
+                fileInfos: originalDraft.fileInfos || draft.fileInfos
+            };
+        }
+
+        return draft;
     }
 
     storeCurrentDraft(draft) {
@@ -532,7 +547,7 @@ class PostStoreClass extends EventEmitter {
     }
 
     getDraft(channelId) {
-        return BrowserStore.getGlobalItem('draft_' + channelId, this.getEmptyDraft());
+        return this.normalizeDraft(BrowserStore.getGlobalItem('draft_' + channelId));
     }
 
     storeCommentDraft(parentPostId, draft) {
@@ -540,7 +555,7 @@ class PostStoreClass extends EventEmitter {
     }
 
     getCommentDraft(parentPostId) {
-        return BrowserStore.getGlobalItem('comment_draft_' + parentPostId, this.getEmptyDraft());
+        return this.normalizeDraft(BrowserStore.getGlobalItem('comment_draft_' + parentPostId));
     }
 
     clearDraftUploads() {


### PR DESCRIPTION
I've noticed a bug a few times where if there's been a channel that I haven't posted in since before the files changes and I upload a file, it'll throw a JS error about trying to concat to a null array. That was because some places in `CreatePost` were getting the user's draft without it going through `CreatePost.getCurrentDraft` so it was missing the `fileInfos` field. This just moves that normalization logic into the `PostStore` so that drafts returned by the store are always complete.

