### PR TITLE
Fixed comment drafts to use the same naming convention as post drafts

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -53,7 +53,7 @@ export default class CreateComment extends React.Component {
 
         const draft = PostStore.getCommentDraft(this.props.rootId);
         this.state = {
-            messageText: draft.message,
+            messageText: draft.messageText,
             uploadsInProgress: draft.uploadsInProgress,
             fileInfos: draft.fileInfos,
             submitting: false,
@@ -184,7 +184,7 @@ export default class CreateComment extends React.Component {
         const messageText = e.target.value;
 
         const draft = PostStore.getCommentDraft(this.props.rootId);
-        draft.message = messageText;
+        draft.messageText = messageText;
         PostStore.storeCommentDraft(this.props.rootId, draft);
 
         $('.post-right__scroll').parent().scrollTop($('.post-right__scroll')[0].scrollHeight);
@@ -308,7 +308,7 @@ export default class CreateComment extends React.Component {
     componentWillReceiveProps(newProps) {
         if (newProps.rootId !== this.props.rootId) {
             const draft = PostStore.getCommentDraft(newProps.rootId);
-            this.setState({messageText: draft.message, uploadsInProgress: draft.uploadsInProgress, fileInfos: draft.fileInfos});
+            this.setState({messageText: draft.messageText, uploadsInProgress: draft.uploadsInProgress, fileInfos: draft.fileInfos});
         }
     }
 


### PR DESCRIPTION
Post drafts store their message text in the `messageText` field while comment drafts currently store them in the `message` field. I just noticed this naming inconsistency when I was working on some related stuff, and I'm amazed it didn't throw more errors.