### PR TITLE
PLT-4491 Fix navbar title for dm channels on mobile

### DIFF
--- a/webapp/components/navbar.jsx
+++ b/webapp/components/navbar.jsx
@@ -653,17 +653,8 @@ export default class Navbar extends React.Component {
                 channelTitle = channel.display_name;
             } else if (channel.type === 'D') {
                 isDirect = true;
-                if (this.state.users.length > 1) {
-                    let p;
-                    if (this.state.users[0].id === currentId) {
-                        p = UserStore.getProfile(this.state.users[1].id);
-                    } else {
-                        p = UserStore.getProfile(this.state.users[0].id);
-                    }
-                    if (p != null) {
-                        channelTitle = p.username;
-                    }
-                }
+                const teammateId = Utils.getUserIdFromChannelName(channel);
+                channelTitle = Utils.displayUsername(teammateId);
             }
 
             if (channel.header.length === 0) {


### PR DESCRIPTION
#### Summary
In the desktop view we display the `ChannelHeader` component, where we use `Utils.displayUsername` for the title of direct message channels. On mobile, inside of the `Navbar` component, we were trying to get a username from `state.users`. It doesn't seem that we are setting `state.users` anymore. Now we are using `Utils.getUserIdFromChannelName` & `Utils.displayUsername` in both components.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4491

#### Checklist
- [x] Has UI changes

