### PR TITLE
PLT-4098 Don't show @mention suggestions if word chars immediately precede at sign

### DIFF
--- a/webapp/components/suggestion/at_mention_provider.jsx
+++ b/webapp/components/suggestion/at_mention_provider.jsx
@@ -112,10 +112,9 @@ export default class AtMentionProvider {
     handlePretextChanged(suggestionId, pretext) {
         clearTimeout(this.timeoutId);
 
-        const captured = (/(\w*)@([a-z0-9\-\._]*)$/i).exec(pretext.toLowerCase());
-        const wordCharsBeforeAtSign = captured ? captured[1] : null;
-        if (captured && !wordCharsBeforeAtSign) {
-            const prefix = captured[2];
+        const captured = (/(?:^|\W)@([a-z0-9\-\._]*)$/i).exec(pretext.toLowerCase());
+        if (captured) {
+            const prefix = captured[1];
 
             function autocomplete() {
                 autocompleteUsersInChannel(
@@ -147,7 +146,7 @@ export default class AtMentionProvider {
                         AppDispatcher.handleServerAction({
                             type: ActionTypes.SUGGESTION_RECEIVED_SUGGESTIONS,
                             id: suggestionId,
-                            matchedPretext: captured[0],
+                            matchedPretext: `@${captured[1]}`,
                             terms: mentions,
                             items: users,
                             component: AtMentionSuggestion

--- a/webapp/components/suggestion/at_mention_provider.jsx
+++ b/webapp/components/suggestion/at_mention_provider.jsx
@@ -112,9 +112,10 @@ export default class AtMentionProvider {
     handlePretextChanged(suggestionId, pretext) {
         clearTimeout(this.timeoutId);
 
-        const captured = (/@([a-z0-9\-\._]*)$/i).exec(pretext.toLowerCase());
-        if (captured) {
-            const prefix = captured[1];
+        const captured = (/(\w*)@([a-z0-9\-\._]*)$/i).exec(pretext.toLowerCase());
+        const wordCharsBeforeAtSign = captured ? captured[1] : null;
+        if (captured && !wordCharsBeforeAtSign) {
+            const prefix = captured[2];
 
             function autocomplete() {
                 autocompleteUsersInChannel(


### PR DESCRIPTION
#### Summary
If an at sign is immediately preceded by one or more word characters in the text input for a post, the user is most likely typing an email address and it doesn't make sense to show the at-mention suggestion box.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4098

#### Checklist
- [x] Has UI changes