### PR TITLE
Plt-4483 Removed unnecessary events from ChannelStore

### DIFF
--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -23,7 +23,6 @@ import SearchStore from 'stores/search_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 import WebrtcStore from 'stores/webrtc_store.jsx';
 
-import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import * as WebrtcActions from 'actions/webrtc_actions.jsx';
 import * as ChannelActions from 'actions/channel_actions.jsx';
@@ -34,7 +33,7 @@ import Client from 'client/web_client.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
 import {getFlaggedPosts} from 'actions/post_actions.jsx';
 
-import {ActionTypes, Constants, Preferences, UserStatuses} from 'utils/constants.jsx';
+import {Constants, Preferences, UserStatuses} from 'utils/constants.jsx';
 
 import React from 'react';
 import {FormattedMessage} from 'react-intl';
@@ -129,11 +128,6 @@ export default class ChannelHeader extends React.Component {
         Client.leaveChannel(this.state.channel.id,
             () => {
                 const channelId = this.state.channel.id;
-
-                AppDispatcher.handleViewAction({
-                    type: ActionTypes.LEAVE_CHANNEL,
-                    id: channelId
-                });
 
                 if (this.state.isFavorite) {
                     ChannelActions.unmarkFavorite(channelId);

--- a/webapp/components/more_channels.jsx
+++ b/webapp/components/more_channels.jsx
@@ -41,7 +41,7 @@ export default class MoreChannels extends React.Component {
 
     componentDidMount() {
         const self = this;
-        ChannelStore.addMoreChangeListener(this.onListenerChange);
+        ChannelStore.addChangeListener(this.onListenerChange);
 
         $(this.refs.modal).on('shown.bs.modal', () => {
             AsyncClient.getMoreChannels(true);
@@ -54,7 +54,7 @@ export default class MoreChannels extends React.Component {
     }
 
     componentWillUnmount() {
-        ChannelStore.removeMoreChangeListener(this.onListenerChange);
+        ChannelStore.removeChangeListener(this.onListenerChange);
     }
 
     getStateFromStores() {

--- a/webapp/components/post_view/components/post_message_container.jsx
+++ b/webapp/components/post_view/components/post_message_container.jsx
@@ -48,7 +48,6 @@ export default class PostMessageContainer extends React.Component {
         PreferenceStore.addChangeListener(this.onPreferenceChange);
         UserStore.addChangeListener(this.onUserChange);
         ChannelStore.addChangeListener(this.onChannelChange);
-        ChannelStore.addMoreChangeListener(this.onChannelChange);
     }
 
     componentWillUnmount() {
@@ -56,7 +55,6 @@ export default class PostMessageContainer extends React.Component {
         PreferenceStore.removeChangeListener(this.onPreferenceChange);
         UserStore.removeChangeListener(this.onUserChange);
         ChannelStore.removeChangeListener(this.onChannelChange);
-        ChannelStore.removeMoreChangeListener(this.onChannelChange);
     }
 
     onEmojiChange() {

--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -5,12 +5,10 @@ import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import EventEmitter from 'events';
 
 var Utils;
-import Constants from 'utils/constants.jsx';
-const ActionTypes = Constants.ActionTypes;
+import {ActionTypes, Constants} from 'utils/constants.jsx';
 const NotificationPrefs = Constants.NotificationPrefs;
 
 const CHANGE_EVENT = 'change';
-const LEAVE_EVENT = 'leave';
 const STATS_EVENT = 'stats';
 const LAST_VIEVED_EVENT = 'last_viewed';
 
@@ -59,17 +57,6 @@ class ChannelStoreClass extends EventEmitter {
 
     removeStatsChangeListener(callback) {
         this.removeListener(STATS_EVENT, callback);
-    }
-    emitLeave(id) {
-        this.emit(LEAVE_EVENT, id);
-    }
-
-    addLeaveListener(callback) {
-        this.on(LEAVE_EVENT, callback);
-    }
-
-    removeLeaveListener(callback) {
-        this.removeListener(LEAVE_EVENT, callback);
     }
 
     emitLastViewed(lastViewed, ownNewMessage) {
@@ -308,14 +295,6 @@ class ChannelStoreClass extends EventEmitter {
         return this.unreadCounts;
     }
 
-    leaveChannel(id) {
-        Reflect.deleteProperty(this.myChannelMembers, id);
-        const element = this.channels.indexOf(id);
-        if (element > -1) {
-            this.channels.splice(element, 1);
-        }
-    }
-
     getChannelNamesMap() {
         var channelNamesMap = {};
 
@@ -399,11 +378,6 @@ ChannelStore.dispatchToken = AppDispatcher.register((payload) => {
         stats[action.stats.channel_id] = action.stats;
         ChannelStore.storeStats(stats);
         ChannelStore.emitStatsChange();
-        break;
-
-    case ActionTypes.LEAVE_CHANNEL:
-        ChannelStore.leaveChannel(action.id);
-        ChannelStore.emitLeave(action.id);
         break;
 
     default:

--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -11,7 +11,6 @@ const NotificationPrefs = Constants.NotificationPrefs;
 
 const CHANGE_EVENT = 'change';
 const LEAVE_EVENT = 'leave';
-const MORE_CHANGE_EVENT = 'change';
 const STATS_EVENT = 'stats';
 const LAST_VIEVED_EVENT = 'last_viewed';
 
@@ -48,18 +47,6 @@ class ChannelStoreClass extends EventEmitter {
 
     removeChangeListener(callback) {
         this.removeListener(CHANGE_EVENT, callback);
-    }
-
-    emitMoreChange() {
-        this.emit(MORE_CHANGE_EVENT);
-    }
-
-    addMoreChangeListener(callback) {
-        this.on(MORE_CHANGE_EVENT, callback);
-    }
-
-    removeMoreChangeListener(callback) {
-        this.removeListener(MORE_CHANGE_EVENT, callback);
     }
 
     emitStatsChange() {
@@ -404,7 +391,7 @@ ChannelStore.dispatchToken = AppDispatcher.register((payload) => {
         break;
     case ActionTypes.RECEIVED_MORE_CHANNELS:
         ChannelStore.storeMoreChannels(action.channels);
-        ChannelStore.emitMoreChange();
+        ChannelStore.emitChange();
         break;
 
     case ActionTypes.RECEIVED_CHANNEL_STATS:

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -63,7 +63,6 @@ export const ActionTypes = keyMirror({
 
     CLICK_CHANNEL: null,
     CREATE_CHANNEL: null,
-    LEAVE_CHANNEL: null,
     CREATE_POST: null,
     CREATE_COMMENT: null,
     POST_DELETED: null,


### PR DESCRIPTION
- I removed the MoreChange event from the ChannelStore because it's been called at exactly the same time as the Change listener since [as long as this project has been on GitHub](https://github.com/mattermost/platform/blob/56e74239d6b34df8f30ef046f0b0ff4ff0866a71/web/react/stores/channel_store.jsx#L12) so we were listening to the same event twice in a couple places (which caused the warnings).
- The LeaveChannel event wasn't actually listened by anything and the code that fired it was redundant because we get all of the channels again when the user leaves the channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4483
