### PR TITLE
Fix SystemAdmin use of CreateAt in CreatePost API (#4349)

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -132,7 +132,9 @@ func CreatePost(c *Context, post *model.Post, triggerWebhooks bool) (*model.Post
 		}
 	}
 
-	post.CreateAt = 0
+	if post.CreateAt != 0 && !HasPermissionToContext(c, model.PERMISSION_MANAGE_SYSTEM) {
+		post.CreateAt = 0
+	}
 
 	post.Hashtags, _ = model.ParseHashtags(post.Message)
 

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -138,6 +138,37 @@ func TestCreatePost(t *testing.T) {
 	}
 }
 
+func TestCreatePostWithCreateAt(t *testing.T) {
+
+	// An ordinary user cannot use CreateAt
+
+	th := Setup().InitBasic()
+	Client := th.BasicClient
+	channel1 := th.BasicChannel
+
+	post := &model.Post{
+		ChannelId: channel1.Id,
+		Message:   "PLT-4349",
+		CreateAt:  1234,
+	}
+	if resp, err := Client.CreatePost(post); err != nil {
+		t.Fatal(err)
+	} else if rpost := resp.Data.(*model.Post); rpost.CreateAt == post.CreateAt {
+		t.Fatal("post should be created with default CreateAt timestamp for ordinary user")
+	}
+
+	// But a System Admin user can
+
+	th2 := Setup().InitSystemAdmin()
+	SysClient := th2.SystemAdminClient
+
+	if resp, err := SysClient.CreatePost(post); err != nil {
+		t.Fatal(err)
+	} else if rpost := resp.Data.(*model.Post); rpost.CreateAt != post.CreateAt {
+		t.Fatal("post should be created with provided CreateAt timestamp for System Admin user")
+	}
+}
+
 func testCreatePostWithOutgoingHook(
 	t *testing.T,
 	hookContentType string,


### PR DESCRIPTION
#### Summary
Currently the CreatePost API ignores the CreateAt param if the user has provided it.
This is for security reasons, to stop a malevolent user rewriting history.
This fix allows a System Admin user to use the CreateAt param.

#### Ticket Link
https://github.com/mattermost/platform/issues/4349

#### Checklist
- [X] Added or updated unit tests (required for all new features)
- [X] All new/modified APIs include changes to the drivers
