### PR TITLE
PLT-4596 Stopped trying to get new users when not in a context with a team

### DIFF
--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -199,6 +199,11 @@ function handlePostDeleteEvent(msg) {
 }
 
 function handleNewUserEvent(msg) {
+    if (TeamStore.getCurrentId() === '') {
+        // Any new users will be loaded when we switch into a context with a team
+        return;
+    }
+
     AsyncClient.getUser(msg.data.user_id);
     AsyncClient.getChannelStats();
     loadProfilesAndTeamMembersForDMSidebar();


### PR DESCRIPTION
When you create a team, you receive a NEW_USER event for yourself before you have a team loaded which causes a 404 error. This also fixes errors which occur for the same reason when you're not on a page with a team (eg. the system console or select_team page)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4596
