### PR TITLE
PLT-4535/PLT-4503 Fix inactive users in searches and add option functionality to DB user search

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -6,7 +6,6 @@ package api
 import (
 	"bytes"
 	b64 "encoding/base64"
-	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"html/template"
@@ -2593,19 +2592,10 @@ func sanitizeProfile(c *Context, user *model.User) *model.User {
 }
 
 func searchUsers(c *Context, w http.ResponseWriter, r *http.Request) {
-	var props struct {
-		Term           string `json:"term"`
-		TeamId         string `json:"team_id"`
-		InChannelId    string `json:"in_channel_id"`
-		NotInChannelId string `json:"not_in_channel_id"`
-		AllowInactive  bool   `json:"allow_inactive"`
-	}
-
-	if propBytes, err := ioutil.ReadAll(r.Body); err != nil {
+	props := model.UserSearchFromJson(r.Body)
+	if props == nil {
 		c.SetInvalidParam("searchUsers", "")
 		return
-	} else {
-		json.Unmarshal(propBytes, &props)
 	}
 
 	if len(props.Term) == 0 {

--- a/api/user.go
+++ b/api/user.go
@@ -2612,13 +2612,16 @@ func searchUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	searchOptions := map[string]bool{}
+	searchOptions[store.USER_SEARCH_OPTION_USERNAME_ONLY] = true
+
 	var uchan store.StoreChannel
 	if inChannelId != "" {
-		uchan = Srv.Store.User().SearchInChannel(inChannelId, term, store.USER_SEARCH_TYPE_USERNAME)
+		uchan = Srv.Store.User().SearchInChannel(inChannelId, term, searchOptions)
 	} else if notInChannelId != "" {
-		uchan = Srv.Store.User().SearchNotInChannel(teamId, notInChannelId, term, store.USER_SEARCH_TYPE_USERNAME)
+		uchan = Srv.Store.User().SearchNotInChannel(teamId, notInChannelId, term, searchOptions)
 	} else {
-		uchan = Srv.Store.User().Search(teamId, term, store.USER_SEARCH_TYPE_USERNAME)
+		uchan = Srv.Store.User().Search(teamId, term, searchOptions)
 	}
 
 	if result := <-uchan; result.Err != nil {
@@ -2674,8 +2677,8 @@ func autocompleteUsersInChannel(c *Context, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	uchan := Srv.Store.User().SearchInChannel(channelId, term, store.USER_SEARCH_TYPE_ALL)
-	nuchan := Srv.Store.User().SearchNotInChannel(teamId, channelId, term, store.USER_SEARCH_TYPE_ALL)
+	uchan := Srv.Store.User().SearchInChannel(channelId, term, map[string]bool{})
+	nuchan := Srv.Store.User().SearchNotInChannel(teamId, channelId, term, map[string]bool{})
 
 	autocomplete := &model.UserAutocompleteInChannel{}
 
@@ -2720,7 +2723,7 @@ func autocompleteUsersInTeam(c *Context, w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	uchan := Srv.Store.User().Search(teamId, term, store.USER_SEARCH_TYPE_ALL)
+	uchan := Srv.Store.User().Search(teamId, term, map[string]bool{})
 
 	autocomplete := &model.UserAutocompleteInTeam{}
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -2037,7 +2037,7 @@ func TestSearchUsers(t *testing.T) {
 	LinkUserToTeam(inactiveUser, th.BasicTeam)
 	th.SystemAdminClient.Must(th.SystemAdminClient.UpdateActive(inactiveUser.Id, false))
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{}); err != nil {
+	if result, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser.Username}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2054,7 +2054,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(inactiveUser.Username, th.BasicTeam.Id, map[string]interface{}{}); err != nil {
+	if result, err := Client.SearchUsers(model.UserSearch{Term: inactiveUser.Username, TeamId: th.BasicTeam.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2071,7 +2071,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(inactiveUser.Username, th.BasicTeam.Id, map[string]interface{}{"allow_inactive": true}); err != nil {
+	if result, err := Client.SearchUsers(model.UserSearch{Term: inactiveUser.Username, TeamId: th.BasicTeam.Id, AllowInactive: true}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2088,7 +2088,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"in_channel_id": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser.Username, InChannelId: th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2109,7 +2109,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser2.Username, "", map[string]interface{}{"not_in_channel_id": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser2.Username, NotInChannelId: th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2136,7 +2136,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser2.Username, th.BasicTeam.Id, map[string]interface{}{"not_in_channel_id": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser2.Username, TeamId: th.BasicTeam.Id, NotInChannelId: th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2163,7 +2163,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "junk", map[string]interface{}{"not_in_channel_id": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser.Username, TeamId: "junk", NotInChannelId: th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2175,7 +2175,7 @@ func TestSearchUsers(t *testing.T) {
 
 	th.LoginBasic2()
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{}); err != nil {
+	if result, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser.Username}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2192,15 +2192,15 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if _, err := Client.SearchUsers("", "", map[string]interface{}{}); err == nil {
+	if _, err := Client.SearchUsers(model.UserSearch{}); err == nil {
 		t.Fatal("should have errored - blank term")
 	}
 
-	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"in_channel_id": th.BasicChannel.Id}); err == nil {
+	if _, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser.Username, InChannelId: th.BasicChannel.Id}); err == nil {
 		t.Fatal("should not have access")
 	}
 
-	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"not_in_channel_id": th.BasicChannel.Id}); err == nil {
+	if _, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser.Username, NotInChannelId: th.BasicChannel.Id}); err == nil {
 		t.Fatal("should not have access")
 	}
 }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -2030,10 +2030,14 @@ func TestGetProfilesNotInChannel(t *testing.T) {
 }
 
 func TestSearchUsers(t *testing.T) {
-	th := Setup().InitBasic()
+	th := Setup().InitBasic().InitSystemAdmin()
 	Client := th.BasicClient
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]string{}); err != nil {
+	inactiveUser := th.CreateUser(Client)
+	LinkUserToTeam(inactiveUser, th.BasicTeam)
+	th.SystemAdminClient.Must(th.SystemAdminClient.UpdateActive(inactiveUser.Id, false))
+
+	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2050,7 +2054,41 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]string{"in_channel": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(inactiveUser.Username, th.BasicTeam.Id, map[string]interface{}{}); err != nil {
+		t.Fatal(err)
+	} else {
+		users := result.Data.([]*model.User)
+
+		found := false
+		for _, user := range users {
+			if user.Id == inactiveUser.Id {
+				found = true
+			}
+		}
+
+		if found {
+			t.Fatal("should not have found inactive user")
+		}
+	}
+
+	if result, err := Client.SearchUsers(inactiveUser.Username, th.BasicTeam.Id, map[string]interface{}{"allow_inactive": true}); err != nil {
+		t.Fatal(err)
+	} else {
+		users := result.Data.([]*model.User)
+
+		found := false
+		for _, user := range users {
+			if user.Id == inactiveUser.Id {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Fatal("should have found inactive user")
+		}
+	}
+
+	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"in_channel": th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2071,7 +2109,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser2.Username, "", map[string]string{"not_in_channel": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(th.BasicUser2.Username, "", map[string]interface{}{"not_in_channel": th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2098,7 +2136,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser2.Username, th.BasicTeam.Id, map[string]string{"not_in_channel": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(th.BasicUser2.Username, th.BasicTeam.Id, map[string]interface{}{"not_in_channel": th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2125,7 +2163,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "junk", map[string]string{"not_in_channel": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(th.BasicUser.Username, "junk", map[string]interface{}{"not_in_channel": th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2137,7 +2175,7 @@ func TestSearchUsers(t *testing.T) {
 
 	th.LoginBasic2()
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]string{}); err != nil {
+	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2154,15 +2192,15 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if _, err := Client.SearchUsers("", "", map[string]string{}); err == nil {
+	if _, err := Client.SearchUsers("", "", map[string]interface{}{}); err == nil {
 		t.Fatal("should have errored - blank term")
 	}
 
-	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]string{"in_channel": th.BasicChannel.Id}); err == nil {
+	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"in_channel": th.BasicChannel.Id}); err == nil {
 		t.Fatal("should not have access")
 	}
 
-	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]string{"not_in_channel": th.BasicChannel.Id}); err == nil {
+	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"not_in_channel": th.BasicChannel.Id}); err == nil {
 		t.Fatal("should not have access")
 	}
 }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -2088,7 +2088,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"in_channel": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"in_channel_id": th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2109,7 +2109,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser2.Username, "", map[string]interface{}{"not_in_channel": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(th.BasicUser2.Username, "", map[string]interface{}{"not_in_channel_id": th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2136,7 +2136,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser2.Username, th.BasicTeam.Id, map[string]interface{}{"not_in_channel": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(th.BasicUser2.Username, th.BasicTeam.Id, map[string]interface{}{"not_in_channel_id": th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2163,7 +2163,7 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	if result, err := Client.SearchUsers(th.BasicUser.Username, "junk", map[string]interface{}{"not_in_channel": th.BasicChannel.Id}); err != nil {
+	if result, err := Client.SearchUsers(th.BasicUser.Username, "junk", map[string]interface{}{"not_in_channel_id": th.BasicChannel.Id}); err != nil {
 		t.Fatal(err)
 	} else {
 		users := result.Data.([]*model.User)
@@ -2196,11 +2196,11 @@ func TestSearchUsers(t *testing.T) {
 		t.Fatal("should have errored - blank term")
 	}
 
-	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"in_channel": th.BasicChannel.Id}); err == nil {
+	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"in_channel_id": th.BasicChannel.Id}); err == nil {
 		t.Fatal("should not have access")
 	}
 
-	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"not_in_channel": th.BasicChannel.Id}); err == nil {
+	if _, err := Client.SearchUsers(th.BasicUser.Username, "", map[string]interface{}{"not_in_channel_id": th.BasicChannel.Id}); err == nil {
 		t.Fatal("should not have access")
 	}
 }

--- a/model/client.go
+++ b/model/client.go
@@ -572,10 +572,10 @@ func (c *Client) GetProfilesByIds(userIds []string) (*Result, *AppError) {
 
 // SearchUsers returns a list of users that have a username matching or similar to the search term. Must
 // be authenticated.
-func (c *Client) SearchUsers(term string, teamId string, options map[string]string) (*Result, *AppError) {
+func (c *Client) SearchUsers(term string, teamId string, options map[string]interface{}) (*Result, *AppError) {
 	options["term"] = term
 	options["team_id"] = teamId
-	if r, err := c.DoApiPost("/users/search", MapToJson(options)); err != nil {
+	if r, err := c.DoApiPost("/users/search", StringInterfaceToJson(options)); err != nil {
 		return nil, err
 	} else {
 		defer closeBody(r)

--- a/model/client.go
+++ b/model/client.go
@@ -572,10 +572,8 @@ func (c *Client) GetProfilesByIds(userIds []string) (*Result, *AppError) {
 
 // SearchUsers returns a list of users that have a username matching or similar to the search term. Must
 // be authenticated.
-func (c *Client) SearchUsers(term string, teamId string, options map[string]interface{}) (*Result, *AppError) {
-	options["term"] = term
-	options["team_id"] = teamId
-	if r, err := c.DoApiPost("/users/search", StringInterfaceToJson(options)); err != nil {
+func (c *Client) SearchUsers(params UserSearch) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/users/search", params.ToJson()); err != nil {
 		return nil, err
 	} else {
 		defer closeBody(r)

--- a/model/user_search.go
+++ b/model/user_search.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type UserSearch struct {
+	Term           string `json:"term"`
+	TeamId         string `json:"team_id"`
+	InChannelId    string `json:"in_channel_id"`
+	NotInChannelId string `json:"not_in_channel_id"`
+	AllowInactive  bool   `json:"allow_inactive"`
+}
+
+// ToJson convert a User to a json string
+func (u *UserSearch) ToJson() string {
+	b, err := json.Marshal(u)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+// UserSearchFromJson will decode the input and return a User
+func UserSearchFromJson(data io.Reader) *UserSearch {
+	decoder := json.NewDecoder(data)
+	var us UserSearch
+	err := decoder.Decode(&us)
+	if err == nil {
+		return &us
+	} else {
+		return nil
+	}
+}

--- a/model/user_search_test.go
+++ b/model/user_search_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUserSearchJson(t *testing.T) {
+	userSearch := UserSearch{Term: NewId(), TeamId: NewId()}
+	json := userSearch.ToJson()
+	ruserSearch := UserSearchFromJson(strings.NewReader(json))
+
+	if userSearch.Term != ruserSearch.Term {
+		t.Fatal("Terms do not match")
+	}
+}

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -1092,7 +1092,10 @@ func (us SqlUserStore) Search(teamId string, term string, options map[string]boo
 
 	go func() {
 		searchQuery := ""
+
 		if teamId == "" {
+
+			// Id != '' is added because both SEARCH_CLAUSE and INACTIVE_CLAUSE start with an AND
 			searchQuery = `
 			SELECT
 				*

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -15,12 +15,14 @@ import (
 )
 
 const (
-	MISSING_ACCOUNT_ERROR          = "store.sql_user.missing_account.const"
-	MISSING_AUTH_ACCOUNT_ERROR     = "store.sql_user.get_by_auth.missing_account.app_error"
-	PROFILES_IN_CHANNEL_CACHE_SIZE = 5000
-	PROFILES_IN_CHANNEL_CACHE_SEC  = 900 // 15 mins
-	USER_SEARCH_TYPE_ALL           = "Username, FirstName, LastName, Nickname"
-	USER_SEARCH_TYPE_USERNAME      = "Username"
+	MISSING_ACCOUNT_ERROR             = "store.sql_user.missing_account.const"
+	MISSING_AUTH_ACCOUNT_ERROR        = "store.sql_user.get_by_auth.missing_account.app_error"
+	PROFILES_IN_CHANNEL_CACHE_SIZE    = 5000
+	PROFILES_IN_CHANNEL_CACHE_SEC     = 900 // 15 mins
+	USER_SEARCH_OPTION_USERNAME_ONLY  = "username_only"
+	USER_SEARCH_OPTION_ALLOW_INACTIVE = "allow_inactive"
+	USER_SEARCH_TYPE_ALL              = "Username, FirstName, LastName, Nickname"
+	USER_SEARCH_TYPE_USERNAME         = "Username"
 )
 
 type SqlUserStore struct {
@@ -1085,7 +1087,7 @@ func (us SqlUserStore) GetUnreadCountForChannel(userId string, channelId string)
 	return storeChannel
 }
 
-func (us SqlUserStore) Search(teamId string, term string, searchType string) StoreChannel {
+func (us SqlUserStore) Search(teamId string, term string, options map[string]bool) StoreChannel {
 	storeChannel := make(StoreChannel, 1)
 
 	go func() {
@@ -1097,8 +1099,9 @@ func (us SqlUserStore) Search(teamId string, term string, searchType string) Sto
 			FROM
 				Users
 			WHERE
-				DeleteAt = 0
+				Id != ''
 				SEARCH_CLAUSE
+				INACTIVE_CLAUSE
 				ORDER BY Username ASC
 			LIMIT 50`
 		} else {
@@ -1110,14 +1113,14 @@ func (us SqlUserStore) Search(teamId string, term string, searchType string) Sto
 			WHERE
 				TeamMembers.TeamId = :TeamId
 				AND Users.Id = TeamMembers.UserId
-				AND Users.DeleteAt = 0
 				AND TeamMembers.DeleteAt = 0
 				SEARCH_CLAUSE
+				INACTIVE_CLAUSE
 				ORDER BY Users.Username ASC
 			LIMIT 100`
 		}
 
-		storeChannel <- us.performSearch(searchQuery, term, searchType, map[string]interface{}{"TeamId": teamId})
+		storeChannel <- us.performSearch(searchQuery, term, options, map[string]interface{}{"TeamId": teamId})
 		close(storeChannel)
 
 	}()
@@ -1125,7 +1128,7 @@ func (us SqlUserStore) Search(teamId string, term string, searchType string) Sto
 	return storeChannel
 }
 
-func (us SqlUserStore) SearchNotInChannel(teamId string, channelId string, term string, searchType string) StoreChannel {
+func (us SqlUserStore) SearchNotInChannel(teamId string, channelId string, term string, options map[string]bool) StoreChannel {
 	storeChannel := make(StoreChannel, 1)
 
 	go func() {
@@ -1133,34 +1136,38 @@ func (us SqlUserStore) SearchNotInChannel(teamId string, channelId string, term 
 		if teamId == "" {
 			searchQuery = `
 			SELECT
-				u.*
-			FROM Users u
+				Users.*
+			FROM Users
 			LEFT JOIN ChannelMembers cm
-				ON cm.UserId = u.Id
+				ON cm.UserId = Users.Id
 				AND cm.ChannelId = :ChannelId
-			WHERE cm.UserId IS NULL
-			SEARCH_CLAUSE
-			ORDER BY u.Username ASC
+			WHERE
+				cm.UserId IS NULL
+				SEARCH_CLAUSE
+				INACTIVE_CLAUSE
+			ORDER BY Users.Username ASC
 			LIMIT 100`
 		} else {
 			searchQuery = `
 			SELECT
-				u.*
-			FROM Users u
+				Users.*
+			FROM Users
 			INNER JOIN TeamMembers tm
-				ON tm.UserId = u.Id
+				ON tm.UserId = Users.Id
 				AND tm.TeamId = :TeamId
 				AND tm.DeleteAt = 0
 			LEFT JOIN ChannelMembers cm
-				ON cm.UserId = u.Id
+				ON cm.UserId = Users.Id
 				AND cm.ChannelId = :ChannelId
-			WHERE cm.UserId IS NULL
-			SEARCH_CLAUSE
-			ORDER BY u.Username ASC
+			WHERE
+				cm.UserId IS NULL
+				SEARCH_CLAUSE
+				INACTIVE_CLAUSE
+			ORDER BY Users.Username ASC
 			LIMIT 100`
 		}
 
-		storeChannel <- us.performSearch(searchQuery, term, searchType, map[string]interface{}{"TeamId": teamId, "ChannelId": channelId})
+		storeChannel <- us.performSearch(searchQuery, term, options, map[string]interface{}{"TeamId": teamId, "ChannelId": channelId})
 		close(storeChannel)
 
 	}()
@@ -1168,7 +1175,7 @@ func (us SqlUserStore) SearchNotInChannel(teamId string, channelId string, term 
 	return storeChannel
 }
 
-func (us SqlUserStore) SearchInChannel(channelId string, term string, searchType string) StoreChannel {
+func (us SqlUserStore) SearchInChannel(channelId string, term string, options map[string]bool) StoreChannel {
 	storeChannel := make(StoreChannel, 1)
 
 	go func() {
@@ -1180,12 +1187,12 @@ func (us SqlUserStore) SearchInChannel(channelId string, term string, searchType
         WHERE
             ChannelMembers.ChannelId = :ChannelId
             AND ChannelMembers.UserId = Users.Id
-            AND Users.DeleteAt = 0
             SEARCH_CLAUSE
+            INACTIVE_CLAUSE
             ORDER BY Users.Username ASC
         LIMIT 100`
 
-		storeChannel <- us.performSearch(searchQuery, term, searchType, map[string]interface{}{"ChannelId": channelId})
+		storeChannel <- us.performSearch(searchQuery, term, options, map[string]interface{}{"ChannelId": channelId})
 		close(storeChannel)
 
 	}()
@@ -1193,12 +1200,23 @@ func (us SqlUserStore) SearchInChannel(channelId string, term string, searchType
 	return storeChannel
 }
 
-func (us SqlUserStore) performSearch(searchQuery string, term string, searchType string, parameters map[string]interface{}) StoreResult {
+func (us SqlUserStore) performSearch(searchQuery string, term string, options map[string]bool, parameters map[string]interface{}) StoreResult {
 	result := StoreResult{}
 
 	// these chars have special meaning and can be treated as spaces
 	for _, c := range specialSearchChar {
 		term = strings.Replace(term, c, " ", -1)
+	}
+
+	searchType := USER_SEARCH_TYPE_ALL
+	if ok := options[USER_SEARCH_OPTION_USERNAME_ONLY]; ok {
+		searchType = USER_SEARCH_TYPE_USERNAME
+	}
+
+	if ok := options[USER_SEARCH_OPTION_ALLOW_INACTIVE]; ok {
+		searchQuery = strings.Replace(searchQuery, "INACTIVE_CLAUSE", "", 1)
+	} else {
+		searchQuery = strings.Replace(searchQuery, "INACTIVE_CLAUSE", "AND Users.DeleteAt = 0", 1)
 	}
 
 	if term == "" {

--- a/store/store.go
+++ b/store/store.go
@@ -164,9 +164,9 @@ type UserStore interface {
 	GetUnreadCount(userId string) StoreChannel
 	GetUnreadCountForChannel(userId string, channelId string) StoreChannel
 	GetRecentlyActiveUsersForTeam(teamId string) StoreChannel
-	Search(teamId string, term string, searchType string) StoreChannel
-	SearchInChannel(channelId string, term string, searchType string) StoreChannel
-	SearchNotInChannel(teamId string, channelId string, term string, searchType string) StoreChannel
+	Search(teamId string, term string, options map[string]bool) StoreChannel
+	SearchInChannel(channelId string, term string, options map[string]bool) StoreChannel
+	SearchNotInChannel(teamId string, channelId string, term string, options map[string]bool) StoreChannel
 }
 
 type SessionStore interface {

--- a/webapp/components/admin_console/team_users.jsx
+++ b/webapp/components/admin_console/team_users.jsx
@@ -13,7 +13,7 @@ import UserStore from 'stores/user_store.jsx';
 import {searchUsers, loadProfilesAndTeamMembers, loadTeamMembersForProfilesList} from 'actions/user_actions.jsx';
 import {getTeamStats, getUser} from 'utils/async_client.jsx';
 
-import Constants from 'utils/constants.jsx';
+import {Constants, UserSearchOptions} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import React from 'react';
@@ -145,10 +145,13 @@ export default class UserList extends React.Component {
             return;
         }
 
+        const options = {};
+        options[UserSearchOptions.ALLOW_INACTIVE] = true;
+
         searchUsers(
             term,
             this.props.params.team,
-            {},
+            options,
             (users) => {
                 this.setState({loading: true, search: true, users});
                 loadTeamMembersForProfilesList(users, this.props.params.team, this.loadComplete);

--- a/webapp/components/channel_invite_modal.jsx
+++ b/webapp/components/channel_invite_modal.jsx
@@ -105,7 +105,7 @@ export default class ChannelInviteModal extends React.Component {
         searchUsers(
             term,
             TeamStore.getCurrentId(),
-            {not_in_channel: this.props.channel.id},
+            {not_in_channel_id: this.props.channel.id},
             (users) => {
                 this.setState({search: true, users});
             }

--- a/webapp/components/channel_members_modal.jsx
+++ b/webapp/components/channel_members_modal.jsx
@@ -117,7 +117,7 @@ export default class ChannelMembersModal extends React.Component {
         searchUsers(
             term,
             TeamStore.getCurrentId(),
-            {in_channel: this.props.channel.id},
+            {in_channel_id: this.props.channel.id},
             (users) => {
                 this.setState({search: true, users});
             }

--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -37,7 +37,7 @@ export default class MoreDirectChannels extends React.Component {
         this.loadComplete = this.loadComplete.bind(this);
 
         this.state = {
-            users: UserStore.getProfileListInTeam(TeamStore.getCurrentId(), true),
+            users: UserStore.getProfileListInTeam(TeamStore.getCurrentId(), true, true),
             loadingDMChannel: -1,
             listType: 'team',
             loading: false,
@@ -111,7 +111,7 @@ export default class MoreDirectChannels extends React.Component {
         if (this.state.listType === 'any') {
             users = UserStore.getProfileList();
         } else {
-            users = UserStore.getProfileListInTeam(TeamStore.getCurrentId(), true);
+            users = UserStore.getProfileListInTeam(TeamStore.getCurrentId(), true, true);
         }
 
         this.setState({
@@ -125,7 +125,7 @@ export default class MoreDirectChannels extends React.Component {
         if (listType === 'any') {
             users = UserStore.getProfileList();
         } else {
-            users = UserStore.getProfileListInTeam(TeamStore.getCurrentId(), true);
+            users = UserStore.getProfileListInTeam(TeamStore.getCurrentId(), true, true);
         }
 
         this.setState({

--- a/webapp/stores/user_store.jsx
+++ b/webapp/stores/user_store.jsx
@@ -312,7 +312,7 @@ class UserStoreClass extends EventEmitter {
         this.saveProfiles(profiles);
     }
 
-    getProfileListInTeam(teamId = TeamStore.getCurrentId(), skipCurrent) {
+    getProfileListInTeam(teamId = TeamStore.getCurrentId(), skipCurrent = false, skipInactive = false) {
         const userIds = this.profiles_in_team[teamId] || [];
         const profiles = [];
         const currentId = this.getCurrentId();
@@ -321,6 +321,10 @@ class UserStoreClass extends EventEmitter {
             const profile = this.getProfile(userIds[i]);
 
             if (skipCurrent && profile.id === currentId) {
+                continue;
+            }
+
+            if (skipInactive && profile.delete_at > 0) {
                 continue;
             }
 

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -182,6 +182,10 @@ export const UserStatuses = {
     ONLINE: 'online'
 };
 
+export const UserSearchOptions = {
+    ALLOW_INACTIVE: 'allow_inactive'
+};
+
 export const SocketEvents = {
     POSTED: 'posted',
     POST_EDITED: 'post_edited',
@@ -215,6 +219,7 @@ export const Constants = {
     ActionTypes,
     WebrtcActionTypes,
     UserStatuses,
+    UserSearchOptions,
     TutorialSteps,
 
     PayloadSources: keyMirror({


### PR DESCRIPTION
#### Summary
Does two things:
1. Add the infrastructure for passing options to the user DB search function
2. Adds an option for allowing inactive users to show up in the search results

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4535
https://mattermost.atlassian.net/browse/PLT-4503

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers