### PR TITLE
PLT-4521 Fixing permissions issue when deleting slash commands

### DIFF
--- a/api/command.go
+++ b/api/command.go
@@ -415,7 +415,7 @@ func deleteCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = result.Err
 		return
 	} else {
-		if c.TeamId != result.Data.(*model.Command).TeamId || (c.Session.UserId != result.Data.(*model.Command).CreatorId && HasPermissionToCurrentTeamContext(c, model.PERMISSION_MANAGE_OTHERS_SLASH_COMMANDS)) {
+		if c.TeamId != result.Data.(*model.Command).TeamId || (c.Session.UserId != result.Data.(*model.Command).CreatorId && !HasPermissionToCurrentTeamContext(c, model.PERMISSION_MANAGE_OTHERS_SLASH_COMMANDS)) {
 			c.LogAudit("fail - inappropriate permissions")
 			c.Err = model.NewLocAppError("deleteCommand", "api.command.delete.app_error", nil, "user_id="+c.Session.UserId)
 			return


### PR DESCRIPTION
#### Summary
Fixing problem where any user could delete another's slash command. 
Didn't remove the delete button because users receive an appropriate error and it would be hard to tell if they have permissions without adding a route to check permissions. 

#### Checklist
- [x] Added or updated unit tests (required for all new features)


