### PR TITLE
PLT-4595 Fixed post drafts and renamed some fields to be consistent

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -53,7 +53,7 @@ export default class CreateComment extends React.Component {
 
         const draft = PostStore.getCommentDraft(this.props.rootId);
         this.state = {
-            messageText: draft.messageText,
+            message: draft.message,
             uploadsInProgress: draft.uploadsInProgress,
             fileInfos: draft.fileInfos,
             submitting: false,
@@ -100,7 +100,7 @@ export default class CreateComment extends React.Component {
 
         const post = {};
         post.file_ids = [];
-        post.message = this.state.messageText;
+        post.message = this.state.message;
 
         if (post.message.trim().length === 0 && this.state.fileInfos.length === 0) {
             return;
@@ -119,7 +119,7 @@ export default class CreateComment extends React.Component {
             return;
         }
 
-        MessageHistoryStore.storeMessageInHistory(this.state.messageText);
+        MessageHistoryStore.storeMessageInHistory(this.state.message);
 
         const userId = UserStore.getCurrentId();
 
@@ -160,7 +160,7 @@ export default class CreateComment extends React.Component {
         );
 
         this.setState({
-            messageText: '',
+            message: '',
             submitting: false,
             postError: null,
             fileInfos: [],
@@ -181,15 +181,15 @@ export default class CreateComment extends React.Component {
     }
 
     handleChange(e) {
-        const messageText = e.target.value;
+        const message = e.target.value;
 
         const draft = PostStore.getCommentDraft(this.props.rootId);
-        draft.messageText = messageText;
+        draft.message = message;
         PostStore.storeCommentDraft(this.props.rootId, draft);
 
         $('.post-right__scroll').parent().scrollTop($('.post-right__scroll')[0].scrollHeight);
 
-        this.setState({messageText});
+        this.setState({message});
     }
 
     handleKeyDown(e) {
@@ -198,7 +198,7 @@ export default class CreateComment extends React.Component {
             return;
         }
 
-        if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && e.keyCode === KeyCodes.UP && this.state.messageText === '') {
+        if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && e.keyCode === KeyCodes.UP && this.state.message === '') {
             e.preventDefault();
 
             const lastPost = PostStore.getCurrentUsersLatestPost(this.props.channelId, this.props.rootId);
@@ -218,11 +218,11 @@ export default class CreateComment extends React.Component {
         }
 
         if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
-            const lastMessage = MessageHistoryStore.nextMessageInHistory(e.keyCode, this.state.messageText, 'comment');
+            const lastMessage = MessageHistoryStore.nextMessageInHistory(e.keyCode, this.state.message, 'comment');
             if (lastMessage !== null) {
                 e.preventDefault();
                 this.setState({
-                    messageText: lastMessage
+                    message: lastMessage
                 });
             }
         }
@@ -308,7 +308,7 @@ export default class CreateComment extends React.Component {
     componentWillReceiveProps(newProps) {
         if (newProps.rootId !== this.props.rootId) {
             const draft = PostStore.getCommentDraft(newProps.rootId);
-            this.setState({messageText: draft.messageText, uploadsInProgress: draft.uploadsInProgress, fileInfos: draft.fileInfos});
+            this.setState({message: draft.message, uploadsInProgress: draft.uploadsInProgress, fileInfos: draft.fileInfos});
         }
     }
 
@@ -396,7 +396,7 @@ export default class CreateComment extends React.Component {
                                 onChange={this.handleChange}
                                 onKeyPress={this.commentMsgKeyPress}
                                 onKeyDown={this.handleKeyDown}
-                                messageText={this.state.messageText}
+                                value={this.state.message}
                                 createMessage={Utils.localizeMessage('create_comment.addComment', 'Add a comment...')}
                                 initialText=''
                                 supportsCommands={false}

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -68,7 +68,6 @@ export default class CreatePost extends React.Component {
             uploadsInProgress: draft.uploadsInProgress,
             fileInfos: draft.fileInfos,
             submitting: false,
-            initialText: draft.message,
             ctrlSend: PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
             fullWidthTextBox: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
             showTutorialTip: false,
@@ -340,7 +339,7 @@ export default class CreatePost extends React.Component {
         if (this.state.channelId !== channelId) {
             const draft = PostStore.getCurrentDraft();
 
-            this.setState({channelId, message: draft.message, initialText: draft.message, submitting: false, serverError: null, postError: null, fileInfos: draft.fileInfos, uploadsInProgress: draft.uploadsInProgress});
+            this.setState({channelId, message: draft.message, submitting: false, serverError: null, postError: null, fileInfos: draft.fileInfos, uploadsInProgress: draft.uploadsInProgress});
         }
     }
 

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -64,11 +64,11 @@ export default class CreatePost extends React.Component {
 
         this.state = {
             channelId: ChannelStore.getCurrentId(),
-            messageText: draft.messageText,
+            message: draft.message,
             uploadsInProgress: draft.uploadsInProgress,
             fileInfos: draft.fileInfos,
             submitting: false,
-            initialText: draft.messageText,
+            initialText: draft.message,
             ctrlSend: PreferenceStore.getBool(Constants.Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter'),
             fullWidthTextBox: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_FULL_SCREEN,
             showTutorialTip: false,
@@ -85,7 +85,7 @@ export default class CreatePost extends React.Component {
 
         const post = {};
         post.file_ids = [];
-        post.message = this.state.messageText;
+        post.message = this.state.message;
 
         if (post.message.trim().length === 0 && this.state.fileInfos.length === 0) {
             return;
@@ -96,13 +96,13 @@ export default class CreatePost extends React.Component {
             return;
         }
 
-        MessageHistoryStore.storeMessageInHistory(this.state.messageText);
+        MessageHistoryStore.storeMessageInHistory(this.state.message);
 
         this.setState({submitting: true, serverError: null});
 
         if (post.message.indexOf('/') === 0) {
             PostStore.storeDraft(this.state.channelId, null);
-            this.setState({messageText: '', postError: null, fileInfos: []});
+            this.setState({message: '', postError: null, fileInfos: []});
 
             ChannelActions.executeCommand(
                 this.state.channelId,
@@ -143,7 +143,7 @@ export default class CreatePost extends React.Component {
         post.parent_id = this.state.parentId;
 
         GlobalActions.emitUserPostedEvent(post);
-        this.setState({messageText: '', submitting: false, postError: null, fileInfos: [], serverError: null});
+        this.setState({message: '', submitting: false, postError: null, fileInfos: [], serverError: null});
 
         Client.createPost(post,
             (data) => {
@@ -191,11 +191,11 @@ export default class CreatePost extends React.Component {
     }
 
     handleChange(e) {
-        const messageText = e.target.value;
-        this.setState({messageText});
+        const message = e.target.value;
+        this.setState({message});
 
         const draft = PostStore.getCurrentDraft();
-        draft.message = messageText;
+        draft.message = message;
         PostStore.storeCurrentDraft(draft);
     }
 
@@ -340,7 +340,7 @@ export default class CreatePost extends React.Component {
         if (this.state.channelId !== channelId) {
             const draft = PostStore.getCurrentDraft();
 
-            this.setState({channelId, messageText: draft.messageText, initialText: draft.messageText, submitting: false, serverError: null, postError: null, fileInfos: draft.fileInfos, uploadsInProgress: draft.uploadsInProgress});
+            this.setState({channelId, message: draft.message, initialText: draft.message, submitting: false, serverError: null, postError: null, fileInfos: draft.fileInfos, uploadsInProgress: draft.uploadsInProgress});
         }
     }
 
@@ -368,7 +368,7 @@ export default class CreatePost extends React.Component {
             return;
         }
 
-        if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && e.keyCode === KeyCodes.UP && this.state.messageText === '') {
+        if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && e.keyCode === KeyCodes.UP && this.state.message === '') {
             e.preventDefault();
 
             const channelId = ChannelStore.getCurrentId();
@@ -396,11 +396,11 @@ export default class CreatePost extends React.Component {
         }
 
         if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.keyCode === Constants.KeyCodes.UP || e.keyCode === Constants.KeyCodes.DOWN)) {
-            const lastMessage = MessageHistoryStore.nextMessageInHistory(e.keyCode, this.state.messageText, 'post');
+            const lastMessage = MessageHistoryStore.nextMessageInHistory(e.keyCode, this.state.message, 'post');
             if (lastMessage !== null) {
                 e.preventDefault();
                 this.setState({
-                    messageText: lastMessage
+                    message: lastMessage
                 });
             }
         }
@@ -495,7 +495,7 @@ export default class CreatePost extends React.Component {
                                 onChange={this.handleChange}
                                 onKeyPress={this.postMsgKeyPress}
                                 onKeyDown={this.handleKeyDown}
-                                messageText={this.state.messageText}
+                                value={this.state.message}
                                 createMessage={Utils.localizeMessage('create_post.write', 'Write a message...')}
                                 channelId={this.state.channelId}
                                 id='post_textbox'

--- a/webapp/components/edit_post_modal.jsx
+++ b/webapp/components/edit_post_modal.jsx
@@ -233,7 +233,7 @@ export default class EditPostModal extends React.Component {
                                 onChange={this.handleChange}
                                 onKeyPress={this.handleEditKeyPress}
                                 onKeyDown={this.handleKeyDown}
-                                messageText={this.state.editText}
+                                value={this.state.editText}
                                 createMessage={Utils.localizeMessage('edit_post.editPost', 'Edit the post...')}
                                 supportsCommands={false}
                                 id='edit_textbox'

--- a/webapp/components/textbox.jsx
+++ b/webapp/components/textbox.jsx
@@ -121,7 +121,7 @@ export default class Textbox extends React.Component {
     }
 
     render() {
-        const hasText = this.props.messageText && this.props.messageText.length > 0;
+        const hasText = this.props.value && this.props.value.length > 0;
 
         let previewLink = null;
         if (Utils.isFeatureEnabled(PreReleaseFeatures.MARKDOWN_PREVIEW)) {
@@ -214,14 +214,14 @@ export default class Textbox extends React.Component {
                     listComponent={SuggestionList}
                     providers={this.suggestionProviders}
                     channelId={this.props.channelId}
-                    value={this.props.messageText}
+                    value={this.props.value}
                     renderDividers={true}
                 />
                 <div
                     ref='preview'
                     className='form-control custom-textarea textbox-preview-area'
                     style={{display: this.state.preview ? 'block' : 'none'}}
-                    dangerouslySetInnerHTML={{__html: this.state.preview ? TextFormatting.formatText(this.props.messageText) : ''}}
+                    dangerouslySetInnerHTML={{__html: this.state.preview ? TextFormatting.formatText(this.props.value) : ''}}
                 />
                 <div className='help__text'>
                     {helpText}
@@ -250,7 +250,7 @@ Textbox.defaultProps = {
 Textbox.propTypes = {
     id: React.PropTypes.string.isRequired,
     channelId: React.PropTypes.string,
-    messageText: React.PropTypes.string.isRequired,
+    value: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func.isRequired,
     onKeyPress: React.PropTypes.func.isRequired,
     createMessage: React.PropTypes.string.isRequired,

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -515,7 +515,7 @@ class PostStoreClass extends EventEmitter {
 
     normalizeDraft(originalDraft) {
         let draft = {
-            messageText: '',
+            message: '',
             uploadsInProgress: [],
             fileInfos: []
         };
@@ -523,7 +523,7 @@ class PostStoreClass extends EventEmitter {
         // Make sure that the post draft is non-null and has all the required fields
         if (originalDraft) {
             draft = {
-                messageText: originalDraft.messageText || draft.messageText,
+                message: originalDraft.message || draft.message,
                 uploadsInProgress: originalDraft.uploadsInProgress || draft.uploadsInProgress,
                 fileInfos: originalDraft.fileInfos || draft.fileInfos
             };


### PR DESCRIPTION
I missed renaming some fields in a previous PR so I just went ahead and changed the message state in CreatePost, CreateComment, and the drafts to be stored in a field called `message` to stop confusing myself. I also changed the `Textbox` prop to be just value to make it more consistent with a regular text input component.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4595

#### Checklist
- Has UI changes
