### PR TITLE
Default team config and UI

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -51,7 +51,8 @@
         "RestrictPublicChannelManagement": "all",
         "RestrictPrivateChannelManagement": "all",
         "UserStatusAwayTimeout": 300,
-        "MaxChannelsPerTeam": 2000
+        "MaxChannelsPerTeam": 2000,
+        "DefaultTeam": ""
     },
     "SqlSettings": {
         "DriverName": "mysql",

--- a/model/config.go
+++ b/model/config.go
@@ -221,6 +221,7 @@ type TeamSettings struct {
 	RestrictPrivateChannelManagement *string
 	UserStatusAwayTimeout            *int64
 	MaxChannelsPerTeam               *int64
+	DefaultTeam                      *string
 }
 
 type LdapSettings struct {

--- a/model/config.go
+++ b/model/config.go
@@ -221,7 +221,7 @@ type TeamSettings struct {
 	RestrictPrivateChannelManagement *string
 	UserStatusAwayTimeout            *int64
 	MaxChannelsPerTeam               *int64
-	DefaultTeam                      *string
+	DefaultTeam                      string
 }
 
 type LdapSettings struct {

--- a/utils/config.go
+++ b/utils/config.go
@@ -240,7 +240,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["RestrictTeamInvite"] = *c.TeamSettings.RestrictTeamInvite
 	props["RestrictPublicChannelManagement"] = *c.TeamSettings.RestrictPublicChannelManagement
 	props["RestrictPrivateChannelManagement"] = *c.TeamSettings.RestrictPrivateChannelManagement
-	props["DefaultTeamName"] = c.TeamSettings.DefaultTeam
+	props["DefaultTeam"] = c.TeamSettings.DefaultTeam
 
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(c.ServiceSettings.EnableOAuthServiceProvider)
 	props["SegmentDeveloperKey"] = c.ServiceSettings.SegmentDeveloperKey

--- a/utils/config.go
+++ b/utils/config.go
@@ -240,7 +240,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["RestrictTeamInvite"] = *c.TeamSettings.RestrictTeamInvite
 	props["RestrictPublicChannelManagement"] = *c.TeamSettings.RestrictPublicChannelManagement
 	props["RestrictPrivateChannelManagement"] = *c.TeamSettings.RestrictPrivateChannelManagement
-	props["DefaultTeamName"] = *c.TeamSettings.DefaultTeam
+	props["DefaultTeamName"] = c.TeamSettings.DefaultTeam
 
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(c.ServiceSettings.EnableOAuthServiceProvider)
 	props["SegmentDeveloperKey"] = c.ServiceSettings.SegmentDeveloperKey

--- a/utils/config.go
+++ b/utils/config.go
@@ -240,6 +240,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["RestrictTeamInvite"] = *c.TeamSettings.RestrictTeamInvite
 	props["RestrictPublicChannelManagement"] = *c.TeamSettings.RestrictPublicChannelManagement
 	props["RestrictPrivateChannelManagement"] = *c.TeamSettings.RestrictPrivateChannelManagement
+	props["DefaultTeamName"] = *c.TeamSettings.DefaultTeam
 
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(c.ServiceSettings.EnableOAuthServiceProvider)
 	props["SegmentDeveloperKey"] = c.ServiceSettings.SegmentDeveloperKey

--- a/webapp/components/admin_console/users_and_teams_settings.jsx
+++ b/webapp/components/admin_console/users_and_teams_settings.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import * as Utils from 'utils/utils.jsx';
 import Constants from 'utils/constants.jsx';
+import TeamStore from 'stores/team_store.jsx';
 
 import AdminSettings from './admin_settings.jsx';
 import BooleanSetting from './boolean_setting.jsx';
@@ -23,6 +24,16 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
+        this.teamValues = this.teamValues.bind(this);
+
+        this.state = this.getStateFromStores(false);
+    }
+
+    getStateFromStores() {
+        return {
+            ...this.state,
+            teams: TeamStore.getAll()
+        };
     }
 
     getConfigFromState(config) {
@@ -58,6 +69,19 @@ export default class UsersAndTeamsSettings extends AdminSettings {
                 />
             </h3>
         );
+    }
+
+    teamValues() {
+        const teamValues = [];
+        const teams = this.state.teams;
+
+        for (const id in teams) {
+            if (teams[id]) {
+                teamValues.push({value: teams[id].name, text: teams[id].display_name});
+            }
+        }
+        teamValues.unshift({value: '', text: 'No Defalut'});
+        return teamValues;
     }
 
     renderSettings() {
@@ -172,8 +196,9 @@ export default class UsersAndTeamsSettings extends AdminSettings {
                     value={this.state.restrictDirectMessage}
                     onChange={this.handleChange}
                 />
-                <TextSetting
+                <DropdownSetting
                     id='defaultTeam'
+                    values={this.teamValues()}
                     label={
                         <FormattedMessage
                             id='admin.team.defaultTeam'

--- a/webapp/components/admin_console/users_and_teams_settings.jsx
+++ b/webapp/components/admin_console/users_and_teams_settings.jsx
@@ -32,6 +32,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         config.TeamSettings.RestrictCreationToDomains = this.state.restrictCreationToDomains;
         config.TeamSettings.RestrictDirectMessage = this.state.restrictDirectMessage;
         config.TeamSettings.MaxChannelsPerTeam = this.parseIntNonZero(this.state.maxChannelsPerTeam, Constants.DEFAULT_MAX_CHANNELS_PER_TEAM);
+        config.TeamSettings.DefaultTeam = this.state.defaultTeam;
 
         return config;
     }
@@ -43,7 +44,8 @@ export default class UsersAndTeamsSettings extends AdminSettings {
             maxUsersPerTeam: config.TeamSettings.MaxUsersPerTeam,
             restrictCreationToDomains: config.TeamSettings.RestrictCreationToDomains,
             restrictDirectMessage: config.TeamSettings.RestrictDirectMessage,
-            maxChannelsPerTeam: config.TeamSettings.MaxChannelsPerTeam
+            maxChannelsPerTeam: config.TeamSettings.MaxChannelsPerTeam,
+            defaultTeam: config.TeamSettings.DefaultTeam
         };
     }
 
@@ -168,6 +170,24 @@ export default class UsersAndTeamsSettings extends AdminSettings {
                         />
                     }
                     value={this.state.restrictDirectMessage}
+                    onChange={this.handleChange}
+                />
+                <TextSetting
+                    id='defaultTeam'
+                    label={
+                        <FormattedMessage
+                            id='admin.team.defaultTeam'
+                            defaultMessage='Set a default team:'
+                        />
+                    }
+                    placeholder={Utils.localizeMessage('admin.team.defaultTeam', 'Ex "example-team"')}
+                    helpText={
+                        <FormattedMessage
+                            id='admin.team.defaultTeam'
+                            defaultMessage='When set, users will be automatically redirected to this team page skipping the team selection page.'
+                        />
+                    }
+                    value={this.state.defaultTeam}
                     onChange={this.handleChange}
                 />
             </SettingsGroup>

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -21,7 +21,7 @@ import {browserHistory, Link} from 'react-router/es6';
 import React from 'react';
 import logoImage from 'images/logo.png';
 
-const DefaultTeamName = global.window.mm_config.DefaultTeamName;
+const DefaultTeam = global.window.mm_config.DefaultTeam;
 
 export default class LoginController extends React.Component {
     static get propTypes() {
@@ -59,8 +59,8 @@ export default class LoginController extends React.Component {
             browserHistory.push('/select_team');
         }
 
-        if (UserStore.getCurrentUser() && DefaultTeamName) {
-            browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
+        if (UserStore.getCurrentUser() && DefaultTeam) {
+            browserHistory.push(`/${DefaultTeam}/channels/town-square`);
         }
 
         AsyncClient.checkVersion();
@@ -209,8 +209,8 @@ export default class LoginController extends React.Component {
                 GlobalActions.loadDefaultLocale();
                 if (query.redirect_to) {
                     browserHistory.push(query.redirect_to);
-                } else if (DefaultTeamName) {
-                    browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
+                } else if (DefaultTeam) {
+                    browserHistory.push(`/${DefaultTeam}/channels/town-square`);
                 } else {
                     browserHistory.push('/select_team');
                 }

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -21,7 +21,7 @@ import {browserHistory, Link} from 'react-router/es6';
 import React from 'react';
 import logoImage from 'images/logo.png';
 
-const DefaultTeam = global.window.mm_config.DefaultTeam;
+const config = global.window.mm_config;
 
 export default class LoginController extends React.Component {
     static get propTypes() {
@@ -42,10 +42,10 @@ export default class LoginController extends React.Component {
         this.handlePasswordChange = this.handlePasswordChange.bind(this);
 
         this.state = {
-            ldapEnabled: global.window.mm_license.IsLicensed === 'true' && global.window.mm_config.EnableLdap === 'true',
-            usernameSigninEnabled: global.window.mm_config.EnableSignInWithUsername === 'true',
-            emailSigninEnabled: global.window.mm_config.EnableSignInWithEmail === 'true',
-            samlEnabled: global.window.mm_license.IsLicensed === 'true' && global.window.mm_config.EnableSaml === 'true',
+            ldapEnabled: global.window.mm_license.IsLicensed === 'true' && config.EnableLdap === 'true',
+            usernameSigninEnabled: config.EnableSignInWithUsername === 'true',
+            emailSigninEnabled: config.EnableSignInWithEmail === 'true',
+            samlEnabled: global.window.mm_license.IsLicensed === 'true' && config.EnableSaml === 'true',
             loginId: '', // the browser will set a default for this
             password: '',
             showMfa: false
@@ -53,14 +53,14 @@ export default class LoginController extends React.Component {
     }
 
     componentDidMount() {
-        document.title = global.window.mm_config.SiteName;
+        document.title = config.SiteName;
 
         if (UserStore.getCurrentUser()) {
             browserHistory.push('/select_team');
         }
 
-        if (UserStore.getCurrentUser() && DefaultTeam) {
-            browserHistory.push(`/${DefaultTeam}/channels/town-square`);
+        if (UserStore.getCurrentUser() && config.DefaultTeam) {
+            browserHistory.push(`/${config.DefaultTeam}/channels/town-square`);
         }
 
         AsyncClient.checkVersion();
@@ -102,7 +102,7 @@ export default class LoginController extends React.Component {
                     <FormattedMessage
                         id={msgId}
                         values={{
-                            ldapUsername: global.window.mm_config.LdapLoginFieldName || Utils.localizeMessage('login.ldapUsernameLower', 'AD/LDAP username')
+                            ldapUsername: config.LdapLoginFieldName || Utils.localizeMessage('login.ldapUsernameLower', 'AD/LDAP username')
                         }}
                     />
                 )
@@ -122,7 +122,7 @@ export default class LoginController extends React.Component {
             return;
         }
 
-        if (global.window.mm_config.EnableMultifactorAuthentication === 'true') {
+        if (config.EnableMultifactorAuthentication === 'true') {
             Client.checkMfa(
                 loginId,
                 (data) => {
@@ -209,8 +209,8 @@ export default class LoginController extends React.Component {
                 GlobalActions.loadDefaultLocale();
                 if (query.redirect_to) {
                     browserHistory.push(query.redirect_to);
-                } else if (DefaultTeam) {
-                    browserHistory.push(`/${DefaultTeam}/channels/town-square`);
+                } else if (config.DefaultTeam) {
+                    browserHistory.push(`/${config.DefaultTeam}/channels/town-square`);
                 } else {
                     browserHistory.push('/select_team');
                 }
@@ -233,8 +233,8 @@ export default class LoginController extends React.Component {
     createCustomLogin() {
         if (global.window.mm_license.IsLicensed === 'true' &&
                 global.window.mm_license.CustomBrand === 'true' &&
-                global.window.mm_config.EnableCustomBrand === 'true') {
-            const text = global.window.mm_config.CustomBrandText || '';
+                config.EnableCustomBrand === 'true') {
+            const text = config.CustomBrandText || '';
 
             return (
                 <div>
@@ -264,8 +264,8 @@ export default class LoginController extends React.Component {
         }
 
         if (ldapEnabled) {
-            if (global.window.mm_config.LdapLoginFieldName) {
-                loginPlaceholders.push(global.window.mm_config.LdapLoginFieldName);
+            if (config.LdapLoginFieldName) {
+                loginPlaceholders.push(config.LdapLoginFieldName);
             } else {
                 loginPlaceholders.push(Utils.localizeMessage('login.ldapUsername', 'AD/LDAP Username'));
             }
@@ -283,12 +283,12 @@ export default class LoginController extends React.Component {
     }
 
     checkSignUpEnabled() {
-        return global.window.mm_config.EnableSignUpWithEmail === 'true' ||
-            global.window.mm_config.EnableSignUpWithGitLab === 'true' ||
-            global.window.mm_config.EnableSignUpWithOffice365 === 'true' ||
-            global.window.mm_config.EnableSignUpWithGoogle === 'true' ||
-            global.window.mm_config.EnableLdap === 'true' ||
-            global.window.mm_config.EnableSaml === 'true';
+        return config.EnableSignUpWithEmail === 'true' ||
+            config.EnableSignUpWithGitLab === 'true' ||
+            config.EnableSignUpWithOffice365 === 'true' ||
+            config.EnableSignUpWithGoogle === 'true' ||
+            config.EnableLdap === 'true' ||
+            config.EnableSaml === 'true';
     }
 
     createLoginOptions() {
@@ -341,9 +341,9 @@ export default class LoginController extends React.Component {
         const loginControls = [];
 
         const ldapEnabled = this.state.ldapEnabled;
-        const gitlabSigninEnabled = global.window.mm_config.EnableSignUpWithGitLab === 'true';
-        const googleSigninEnabled = global.window.mm_config.EnableSignUpWithGoogle === 'true';
-        const office365SigninEnabled = global.window.mm_config.EnableSignUpWithOffice365 === 'true';
+        const gitlabSigninEnabled = config.EnableSignUpWithGitLab === 'true';
+        const googleSigninEnabled = config.EnableSignUpWithGoogle === 'true';
+        const office365SigninEnabled = config.EnableSignUpWithOffice365 === 'true';
         const samlSigninEnabled = this.state.samlEnabled;
         const usernameSigninEnabled = this.state.usernameSigninEnabled;
         const emailSigninEnabled = this.state.emailSigninEnabled;
@@ -404,7 +404,7 @@ export default class LoginController extends React.Component {
             );
         }
 
-        if (global.window.mm_config.EnableOpenServer === 'true' && this.checkSignUpEnabled()) {
+        if (config.EnableOpenServer === 'true' && this.checkSignUpEnabled()) {
             loginControls.push(
                 <div
                     className='form-group'
@@ -591,8 +591,8 @@ export default class LoginController extends React.Component {
         }
 
         let description = null;
-        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && global.window.mm_config.EnableCustomBrand === 'true') {
-            description = global.window.mm_config.CustomDescriptionText;
+        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && config.EnableCustomBrand === 'true') {
+            description = config.CustomDescriptionText;
         } else {
             description = (
                 <FormattedMessage
@@ -615,7 +615,7 @@ export default class LoginController extends React.Component {
                             src={logoImage}
                         />
                         <div className='signup__content'>
-                            <h1>{global.window.mm_config.SiteName}</h1>
+                            <h1>{config.SiteName}</h1>
                             <h4 className='color--light'>
                                 {description}
                             </h4>

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -21,6 +21,8 @@ import {browserHistory, Link} from 'react-router/es6';
 import React from 'react';
 import logoImage from 'images/logo.png';
 
+const DefaultTeamName = global.window.mm_config.DefaultTeamName;
+
 export default class LoginController extends React.Component {
     static get propTypes() {
         return {
@@ -55,6 +57,10 @@ export default class LoginController extends React.Component {
 
         if (UserStore.getCurrentUser()) {
             browserHistory.push('/select_team');
+        }
+
+        if (UserStore.getCurrentUser() && DefaultTeamName) {
+            browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
         }
 
         AsyncClient.checkVersion();
@@ -203,6 +209,8 @@ export default class LoginController extends React.Component {
                 GlobalActions.loadDefaultLocale();
                 if (query.redirect_to) {
                     browserHistory.push(query.redirect_to);
+                } else if (DefaultTeamName) {
+                    browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
                 } else {
                     browserHistory.push('/select_team');
                 }

--- a/webapp/components/root.jsx
+++ b/webapp/components/root.jsx
@@ -46,12 +46,12 @@ export default class Root extends React.Component {
     }
 
     redirectIfNecessary(props) {
-        const DefaultTeamName = global.window.mm_config.DefaultTeamName;
+        const DefaultTeam = global.window.mm_config.DefaultTeam;
         if (props.location.pathname === '/') {
             if (UserStore.getNoAccounts()) {
                 browserHistory.push('/signup_user_complete');
-            } else if (UserStore.getCurrentUser() && DefaultTeamName) {
-                browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
+            } else if (UserStore.getCurrentUser() && DefaultTeam) {
+                browserHistory.push(`/${DefaultTeam}/channels/town-square`);
             } else if (UserStore.getCurrentUser()) {
                 browserHistory.push('/select_team');
             } else {

--- a/webapp/components/root.jsx
+++ b/webapp/components/root.jsx
@@ -46,9 +46,12 @@ export default class Root extends React.Component {
     }
 
     redirectIfNecessary(props) {
+        const DefaultTeamName = global.window.mm_config.DefaultTeamName;
         if (props.location.pathname === '/') {
             if (UserStore.getNoAccounts()) {
                 browserHistory.push('/signup_user_complete');
+            } else if (UserStore.getCurrentUser() && DefaultTeamName) {
+                browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
             } else if (UserStore.getCurrentUser()) {
                 browserHistory.push('/select_team');
             } else {


### PR DESCRIPTION
#### Summary
This PR adds the ability for an admin to set a default team.  When set, users will skip the team selection page and be redirected directly to the teams town square channel.

#### Ticket Link
PLT-2977

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

![screen shot 2016-11-01 at 5 22 02 pm](https://cloud.githubusercontent.com/assets/3249825/19912453/c974d55c-a057-11e6-940e-fd563fd7c61b.png)
