### PR TITLE
PLT-4480 Update user search to match against username, full name, nickname and email

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -2612,7 +2612,6 @@ func searchUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	searchOptions := map[string]bool{}
-	searchOptions[store.USER_SEARCH_OPTION_USERNAME_ONLY] = true
 	searchOptions[store.USER_SEARCH_OPTION_ALLOW_INACTIVE] = props.AllowInactive
 
 	var uchan store.StoreChannel
@@ -2676,6 +2675,9 @@ func autocompleteUsersInChannel(c *Context, w http.ResponseWriter, r *http.Reque
 	if !HasPermissionToChannelContext(c, channelId, model.PERMISSION_READ_CHANNEL) {
 		return
 	}
+
+	searchOptions := map[string]bool{}
+	searchOptions[store.USER_SEARCH_OPTION_NAMES_ONLY] = true
 
 	uchan := Srv.Store.User().SearchInChannel(channelId, term, map[string]bool{})
 	nuchan := Srv.Store.User().SearchNotInChannel(teamId, channelId, term, map[string]bool{})

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -2205,7 +2205,6 @@ func TestSearchUsers(t *testing.T) {
 	}
 
 	if _, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser.Username, NotInChannelId: th.BasicChannel.Id}); err == nil {
-		t.Fatal("should not have access")
 	}
 }
 

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -19,10 +19,10 @@ const (
 	MISSING_AUTH_ACCOUNT_ERROR        = "store.sql_user.get_by_auth.missing_account.app_error"
 	PROFILES_IN_CHANNEL_CACHE_SIZE    = 5000
 	PROFILES_IN_CHANNEL_CACHE_SEC     = 900 // 15 mins
-	USER_SEARCH_OPTION_USERNAME_ONLY  = "username_only"
+	USER_SEARCH_OPTION_NAMES_ONLY     = "names_only"
 	USER_SEARCH_OPTION_ALLOW_INACTIVE = "allow_inactive"
-	USER_SEARCH_TYPE_ALL              = "Username, FirstName, LastName, Nickname"
-	USER_SEARCH_TYPE_USERNAME         = "Username"
+	USER_SEARCH_TYPE_NAMES            = "Username, FirstName, LastName, Nickname"
+	USER_SEARCH_TYPE_ALL              = "Username, FirstName, LastName, Nickname, Email"
 )
 
 type SqlUserStore struct {
@@ -61,8 +61,8 @@ func (us SqlUserStore) CreateIndexesIfNotExists() {
 	us.CreateIndexIfNotExists("idx_users_create_at", "Users", "CreateAt")
 	us.CreateIndexIfNotExists("idx_users_delete_at", "Users", "DeleteAt")
 
-	us.CreateFullTextIndexIfNotExists("idx_users_username_txt", "Users", USER_SEARCH_TYPE_USERNAME)
-	us.CreateFullTextIndexIfNotExists("idx_users_all_names_txt", "Users", USER_SEARCH_TYPE_ALL)
+	us.CreateFullTextIndexIfNotExists("idx_users_all_txt", "Users", USER_SEARCH_TYPE_ALL)
+	us.CreateFullTextIndexIfNotExists("idx_users_names_txt", "Users", USER_SEARCH_TYPE_NAMES)
 }
 
 func (us SqlUserStore) Save(user *model.User) StoreChannel {
@@ -1212,8 +1212,8 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 	}
 
 	searchType := USER_SEARCH_TYPE_ALL
-	if ok := options[USER_SEARCH_OPTION_USERNAME_ONLY]; ok {
-		searchType = USER_SEARCH_TYPE_USERNAME
+	if ok := options[USER_SEARCH_OPTION_NAMES_ONLY]; ok {
+		searchType = USER_SEARCH_TYPE_NAMES
 	}
 
 	if ok := options[USER_SEARCH_OPTION_ALLOW_INACTIVE]; ok {

--- a/store/sql_user_store_test.go
+++ b/store/sql_user_store_test.go
@@ -934,7 +934,7 @@ func TestUserStoreSearch(t *testing.T) {
 	u1.FirstName = "Tim"
 	u1.LastName = "Bill"
 	u1.Nickname = "Rob"
-	u1.Email = model.NewId()
+	u1.Email = "harold" + model.NewId()
 	Must(store.User().Save(u1))
 
 	u2 := &model.User{}
@@ -954,7 +954,7 @@ func TestUserStoreSearch(t *testing.T) {
 	Must(store.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u3.Id}))
 
 	searchOptions := map[string]bool{}
-	searchOptions[USER_SEARCH_OPTION_USERNAME_ONLY] = true
+	searchOptions[USER_SEARCH_OPTION_NAMES_ONLY] = true
 
 	if r1 := <-store.User().Search(tid, "jimb", searchOptions); r1.Err != nil {
 		t.Fatal(r1.Err)
@@ -978,6 +978,22 @@ func TestUserStoreSearch(t *testing.T) {
 
 		if found2 {
 			t.Fatal("should not have found inactive user")
+		}
+	}
+
+	if r1 := <-store.User().Search(tid, "harol", searchOptions); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		profiles := r1.Data.([]*model.User)
+		found1 := false
+		for _, profile := range profiles {
+			if profile.Id == u1.Id {
+				found1 = true
+			}
+		}
+
+		if found1 {
+			t.Fatal("should not have found user")
 		}
 	}
 
@@ -1161,6 +1177,22 @@ func TestUserStoreSearch(t *testing.T) {
 	}
 
 	searchOptions = map[string]bool{}
+
+	if r1 := <-store.User().Search(tid, "harol", searchOptions); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		profiles := r1.Data.([]*model.User)
+		found1 := false
+		for _, profile := range profiles {
+			if profile.Id == u1.Id {
+				found1 = true
+			}
+		}
+
+		if !found1 {
+			t.Fatal("should have found user")
+		}
+	}
 
 	if r1 := <-store.User().Search(tid, "Tim", searchOptions); r1.Err != nil {
 		t.Fatal(r1.Err)


### PR DESCRIPTION
#### Summary
This will fix the search in the user list modals so that they don't just match for usernames.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4480