### PR TITLE
Prevent channel creation if TeamId invalid

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -52,7 +52,7 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(channel.TeamID) > 0 && channel.TeamId != c.TeamId {
+	if len(channel.TeamId) > 0 && channel.TeamId != c.TeamId {
 		c.SetInvalidParam("createChannel", "channel.TeamId")
 		return
 	}

--- a/api/channel.go
+++ b/api/channel.go
@@ -52,6 +52,11 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(channel.TeamID) > 0 && channel.TeamId != c.TeamId {
+		c.SetInvalidParam("createChannel", "channel.TeamId")
+		return
+	}
+
 	if len(channel.TeamId) == 0 {
 		channel.TeamId = c.TeamId
 	}

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -71,8 +71,8 @@ func TestCreateChannel(t *testing.T) {
 
 	channel = model.Channel{DisplayName: "Channel on Different Team", Name: "aaaa" + model.NewId() + "abbb", Type: model.CHANNEL_OPEN, TeamId: team2.Id}
 
-	if _, err := Client.CreateChannel(&channel); err.StatusCode != http.StatusForbidden {
-		t.Fatal(err)
+	if _, err == nil(&channel); err.StatusCode != http.StatusForbidden {
+		t.Fatal("should have failed - team ID didn't match client team ID")
 	}
 
 	channel = model.Channel{DisplayName: "Channel With No TeamId", Name: "aaaa" + model.NewId() + "abbb", Type: model.CHANNEL_OPEN, TeamId: ""}


### PR DESCRIPTION
#### Summary
Now when a user tries to create a channel, the TeamId they associate with it must be relevant and cannot be random or non-existent.  If the TeamId is no good, it's treated as an invalid param.

#### Ticket Link
Resolves #4398 

#### Checklist

- [ ] Added or updated unit tests (required for all new features)

