### PR TITLE
PLT-4486 Don't apply sidebar bg color to settings modals w/o tabs

### DIFF
--- a/webapp/components/channel_notifications_modal.jsx
+++ b/webapp/components/channel_notifications_modal.jsx
@@ -381,7 +381,7 @@ export default class ChannelNotificationsModal extends React.Component {
         return (
             <Modal
                 show={this.props.show}
-                dialogClassName='settings-modal'
+                dialogClassName='settings-modal settings-modal__tabless'
                 onHide={this.props.onHide}
             >
                 <Modal.Header closeButton={true}>

--- a/webapp/components/channel_notifications_modal.jsx
+++ b/webapp/components/channel_notifications_modal.jsx
@@ -381,7 +381,7 @@ export default class ChannelNotificationsModal extends React.Component {
         return (
             <Modal
                 show={this.props.show}
-                dialogClassName='settings-modal settings-modal__tabless'
+                dialogClassName='settings-modal settings-modal--tabless'
                 onHide={this.props.onHide}
             >
                 <Modal.Header closeButton={true}>

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -465,7 +465,7 @@ export function applyTheme(theme) {
     if (theme.sidebarBg) {
         changeCss('.sidebar--left, .sidebar--left .sidebar__divider .sidebar__divider__text, .app__body .modal .settings-modal .settings-table .settings-links, .app__body .sidebar--menu', 'background:' + theme.sidebarBg, 1);
         changeCss('body.app__body', 'scrollbar-face-color:' + theme.sidebarBg, 3);
-        changeCss('@media(max-width: 768px){.app__body .modal .settings-modal:not(.settings-modal__tabless):not(.display--content) .modal-content', 'background:' + theme.sidebarBg, 1);
+        changeCss('@media(max-width: 768px){.app__body .modal .settings-modal:not(.settings-modal--tabless):not(.display--content) .modal-content', 'background:' + theme.sidebarBg, 1);
     }
 
     if (theme.sidebarText) {

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -465,7 +465,7 @@ export function applyTheme(theme) {
     if (theme.sidebarBg) {
         changeCss('.sidebar--left, .sidebar--left .sidebar__divider .sidebar__divider__text, .app__body .modal .settings-modal .settings-table .settings-links, .app__body .sidebar--menu', 'background:' + theme.sidebarBg, 1);
         changeCss('body.app__body', 'scrollbar-face-color:' + theme.sidebarBg, 3);
-        changeCss('@media(max-width: 768px){.app__body .modal .settings-modal:not(.display--content) .modal-content', 'background:' + theme.sidebarBg, 1);
+        changeCss('@media(max-width: 768px){.app__body .modal .settings-modal:not(.settings-modal__tabless):not(.display--content) .modal-content', 'background:' + theme.sidebarBg, 1);
     }
 
     if (theme.sidebarText) {


### PR DESCRIPTION
#### Summary
We assume that modals with a class of `.settings-modal` (on the outer `.modal-dialog` `div`) contain collapsible tabs. We therefore apply the theme's sidebar background color to the modal body (when no tabs are open). The `ChannelNotificationsModal` is the exception to this; it doesn't contain any tabs. So it shouldn't have the sidebar bg color applied to it.

This issue is only observable when using a theme with a sidebar color other than the default (e.g. the "organization" theme). This is because the other three built-in themes have a sidebar color that matches the bg color of an expanded tab in a settings modal.

Note: It would be better to only apply the collapsible tab styles/behavior to modals with an explicit class (like `.modal--tabbed` or `.modal--collapsible`) but those modals are being referenced by `.settings-modal` in numerous places already. This was the quicker, safer fix.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4486

#### Checklist
- [x] Has UI changes

