### PR TITLE
Fixing panic of incoming webhook with float64 values (#4444)

### DIFF
--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -6,6 +6,7 @@ package model
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
@@ -233,7 +234,7 @@ func expandAnnouncements(i *IncomingWebhookRequest) {
 				for _, field := range fields {
 					f := field.(map[string]interface{})
 					if f["value"] != nil {
-						f["value"] = expandAnnouncement(f["value"].(string))
+						f["value"] = expandAnnouncement(fmt.Sprintf("%v", f["value"]))
 					}
 				}
 			}


### PR DESCRIPTION
#### Summary
Fixes the incoming webhook value parsing of json with float64 values

#### Ticket Link
https://github.com/mattermost/platform/issues/4444

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

