### PR TITLE
PLT-4277 Custom Emojis: Allow custom emojis larger than 64kb, and scale them down to the appropriate size

### DIFF
--- a/api/emoji.go
+++ b/api/emoji.go
@@ -6,23 +6,26 @@ package api
 import (
 	"bytes"
 	"image"
-	_ "image/gif"
+	"image/draw"
+	"image/gif"
 	_ "image/jpeg"
-	_ "image/png"
+	"image/png"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"strings"
 
 	l4g "github.com/alecthomas/log4go"
+	"github.com/disintegration/imaging"
 	"github.com/gorilla/mux"
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
+	"image/color/palette"
 )
 
 const (
-	MaxEmojiFileSize = 64 * 1024 // 64 KB
+	MaxEmojiFileSize = 1000 * 1024 // 1 MB
 	MaxEmojiWidth    = 128
 	MaxEmojiHeight   = 128
 )
@@ -147,11 +150,39 @@ func uploadEmojiImage(id string, imageData *multipart.FileHeader) *model.AppErro
 	if config, _, err := image.DecodeConfig(bytes.NewReader(buf.Bytes())); err != nil {
 		return model.NewLocAppError("uploadEmojiImage", "api.emoji.upload.image.app_error", nil, err.Error())
 	} else if config.Width > MaxEmojiWidth || config.Height > MaxEmojiHeight {
-		return model.NewLocAppError("uploadEmojiImage", "api.emoji.upload.large_image.app_error", nil, "")
-	}
-
-	if err := WriteFile(buf.Bytes(), getEmojiImagePath(id)); err != nil {
-		return err
+		data := buf.Bytes()
+		newbuf := bytes.NewBuffer(nil)
+		if info, err := model.GetInfoForBytes(imageData.Filename, data); err != nil {
+			return err
+		} else if info.MimeType == "image/gif" {
+			if gif_data, err := gif.DecodeAll(bytes.NewReader(data)); err != nil {
+				return model.NewLocAppError("uploadEmojiImage", "api.emoji.upload.large_image.gif_decode_error", nil, "")
+			} else {
+				resized_gif := resizeEmojiGif(gif_data)
+				if err := gif.EncodeAll(newbuf, resized_gif); err != nil {
+					return model.NewLocAppError("uploadEmojiImage", "api.emoji.upload.large_image.gif_encode_error", nil, "")
+				}
+				if err := WriteFile(newbuf.Bytes(), getEmojiImagePath(id)); err != nil {
+					return err
+				}
+			}
+		} else {
+			if img, _, err := image.Decode(bytes.NewReader(data)); err != nil {
+				return model.NewLocAppError("uploadEmojiImage", "api.emoji.upload.large_image.decode_error", nil, "")
+			} else {
+				resized_image := resizeEmoji(img, config.Width, config.Height)
+				if err := png.Encode(newbuf, resized_image); err != nil {
+					return model.NewLocAppError("uploadEmojiImage", "api.emoji.upload.large_image.encode_error", nil, "")
+				}
+				if err := WriteFile(newbuf.Bytes(), getEmojiImagePath(id)); err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		if err := WriteFile(buf.Bytes(), getEmojiImagePath(id)); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -251,4 +282,44 @@ func getEmojiImage(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func getEmojiImagePath(id string) string {
 	return "emoji/" + id + "/image"
+}
+
+func resizeEmoji(img image.Image, width int, height int) image.Image {
+	emojiWidth := float64(width)
+	emojiHeight := float64(height)
+
+	var emoji image.Image
+	if emojiHeight <= MaxEmojiHeight && emojiWidth <= MaxEmojiWidth {
+		emoji = img
+	} else {
+		emoji = imaging.Fit(img, MaxEmojiWidth, MaxEmojiHeight, imaging.Lanczos)
+	}
+	return emoji
+}
+
+func resizeEmojiGif(gifImg *gif.GIF) *gif.GIF {
+	// Create a new RGBA image to hold the incremental frames.
+	firstFrame := gifImg.Image[0].Bounds()
+	b := image.Rect(0, 0, firstFrame.Dx(), firstFrame.Dy())
+	img := image.NewRGBA(b)
+
+	resizedImage := image.Image(nil)
+	// Resize each frame.
+	for index, frame := range gifImg.Image {
+		bounds := frame.Bounds()
+		draw.Draw(img, bounds, frame, bounds.Min, draw.Over)
+		resizedImage = resizeEmoji(img, firstFrame.Dx(), firstFrame.Dy())
+		gifImg.Image[index] = imageToPaletted(resizedImage)
+	}
+	// Set new gif width and height
+	gifImg.Config.Width = resizedImage.Bounds().Dx()
+	gifImg.Config.Height = resizedImage.Bounds().Dy()
+	return gifImg
+}
+
+func imageToPaletted(img image.Image) *image.Paletted {
+	b := img.Bounds()
+	pm := image.NewPaletted(b, palette.Plan9)
+	draw.FloydSteinberg.Draw(pm, b, img, image.ZP)
+	return pm
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -783,7 +783,7 @@
   },
   {
     "id": "api.emoji.create.too_large.app_error",
-    "translation": "Unable to create emoji. Image must be less than 64 KB in size."
+    "translation": "Unable to create emoji. Image must be less than 1 MB in size."
   },
   {
     "id": "api.emoji.delete.permissions.app_error",
@@ -814,8 +814,20 @@
     "translation": "Unable to create emoji. File must be a PNG, JPEG, or GIF."
   },
   {
-    "id": "api.emoji.upload.large_image.app_error",
-    "translation": "Unable to create emoji. Image must be at most 128 by 128 pixels."
+    "id": "api.emoji.upload.large_image.decode_error",
+    "translation": "Unable to create emoji. An error occurred when trying to decode the image."
+  },
+  {
+    "id": "api.emoji.upload.large_image.encode_error",
+    "translation": "Unable to create emoji. An error occurred when trying to encode the image."
+  },
+  {
+    "id": "api.emoji.upload.large_image.gif_decode_error",
+    "translation": "Unable to create emoji. An error occurred when trying to decode the GIF image."
+  },
+  {
+    "id": "api.emoji.upload.large_image.gif_encode_error",
+    "translation": "Unable to create emoji. An error occurred when trying to encode the GIF image."
   },
   {
     "id": "api.file.get_file.public_disabled.app_error",

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -73,7 +73,7 @@
   "add_emoji.header": "Add",
   "add_emoji.image": "Image",
   "add_emoji.image.button": "Select",
-  "add_emoji.image.help": "Choose the image for your emoji. The image can be a gif, png, or jpeg file with a max size of 64 KB and dimensions up to 128 by 128 pixels.",
+  "add_emoji.image.help": "Choose the image for your emoji. The image can be a gif, png, or jpeg file with a max size of 1 MB. Dimensions will automatically resize to fit 128 by 128 pixels but keeping aspect ratio.",
   "add_emoji.imageRequired": "An image is required for the emoji",
   "add_emoji.name": "Name",
   "add_emoji.name.help": "Choose a name for your emoji made of up to 64 characters consisting of lowercase letters, numbers, and the symbols '-' and '_'.",


### PR DESCRIPTION
#### Summary
This PR resizes an emoji image (jpeg or png) or gif frames if it is higher than `MaxEmojiWidth` or `MaxEmojiHeight`. Also increases `MaxEmojiFileSize`. The image and gif resize uses [nfnt/resize](https://godoc.org/github.com/nfnt/resize#Thumbnail), also uses function to convert image.Image to image.Paletted from [here](https://github.com/dpup/go-scratch/blob/master/gif-resize/gif-resize.go).

#### Ticket Link
[Jira PLT-4277](https://mattermost.atlassian.net/browse/PLT-4277)
[Github 4235](https://github.com/mattermost/platform/issues/4235)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)