### PR TITLE
PLT-4516 Mobile: Sometimes when posts list reloads, it is completely empty until it is scrolled

### DIFF
--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -412,16 +412,15 @@ export default class PostList extends React.Component {
         } else if (this.props.scrollType === ScrollTypes.SIDEBAR_OPEN) {
             // If we are at the bottom then stay there
             if (this.wasAtBottom) {
-                this.refs.postlist.scrollTop = this.refs.postlist.scrollHeight;
+                // this.refs.postlist.scrollTop = this.refs.postlist.scrollHeight;
+                this.scrollToBottom();
             } else {
-                window.requestAnimationFrame(() => {
-                    this.jumpToPostNode.scrollIntoView();
-                    if (this.refs.postlist.scrollTop === this.jumpToPostNode.offsetTop) {
-                        this.refs.postlist.scrollTop -= (this.refs.postlist.offsetHeight / Constants.SCROLL_PAGE_FRACTION);
-                    } else {
-                        this.refs.postlist.scrollTop -= (this.refs.postlist.offsetHeight / Constants.SCROLL_PAGE_FRACTION) + (this.refs.postlist.scrollTop - this.jumpToPostNode.offsetTop);
-                    }
-                });
+                this.jumpToPostNode.scrollIntoView();
+                let scrollTo = this.refs.postlist.scrollTop - (this.refs.postlist.offsetHeight / Constants.SCROLL_PAGE_FRACTION);
+                if (this.refs.postlist.scrollTop !== this.jumpToPostNode.offsetTop) {
+                    scrollTo += (this.refs.postlist.scrollTop - this.jumpToPostNode.offsetTop);
+                }
+                this.animateScrollTo(scrollTo, '200');
             }
         } else if (this.refs.postlist.scrollHeight !== this.prevScrollHeight) {
             window.requestAnimationFrame(() => {
@@ -437,20 +436,17 @@ export default class PostList extends React.Component {
     }
 
     scrollToBottom() {
-        /*
-        this.animationFrameId = window.requestAnimationFrame(() => {
-            if (this.refs.postlist) {
-                this.refs.postlist.scrollTop = this.refs.postlistcontent.scrollHeight;
-            }
-        });
-        */
-        var postList = $(this.refs.postlist);
-        postList.animate({scrollTop: this.refs.postlist.scrollHeight}, '200');
+        this.animateScrollTo(this.refs.postlist.scrollHeight, '200');
     }
 
     scrollToBottomAnimated() {
         var postList = $(this.refs.postlist);
         postList.animate({scrollTop: this.refs.postlist.scrollHeight}, '500');
+    }
+
+    animateScrollTo(scrollValue, duration) {
+        var postList = $(this.refs.postlist);
+        postList.animate({scrollTop: (scrollValue - postList.height())}, duration);
     }
 
     getArchivesIntroMessage() {

--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -437,11 +437,15 @@ export default class PostList extends React.Component {
     }
 
     scrollToBottom() {
+        /*
         this.animationFrameId = window.requestAnimationFrame(() => {
             if (this.refs.postlist) {
-                this.refs.postlist.scrollTop = this.refs.postlist.scrollHeight;
+                this.refs.postlist.scrollTop = this.refs.postlistcontent.scrollHeight;
             }
         });
+        */
+        var postList = $(this.refs.postlist);
+        postList.animate({scrollTop: this.refs.postlist.scrollHeight}, '200');
     }
 
     scrollToBottomAnimated() {


### PR DESCRIPTION
#### Summary
Mobile: On IOs native application when posts list reloads and has a lot of posts, it is completely empty (white screen) until the screen is touched. Also this happens when you select a channel, from the left menu, that has a good amount of posts.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4516
https://mattermost.atlassian.net/browse/PLT-3017
https://github.com/mattermost/platform/pull/3586

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
