### PR TITLE
PLT-4498 Prevent post flag button from overlapping post action button on mobile

### DIFF
--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -1276,14 +1276,6 @@
                     height: auto;
                 }
             }
-
-            .post__header {
-                .col__name {
-                    .user-popover {
-                        max-width: 100%;
-                    }
-                }
-            }
         }
     }
 

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -209,11 +209,12 @@
 
         .post__header {
             margin-bottom: 0;
+            padding-right: 50px;
 
             .col__reply {
                 top: -3px;
-                width: 65px;
                 z-index: auto;
+                text-align: center;
             }
 
             .col__name {

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -1276,6 +1276,24 @@
                     height: auto;
                 }
             }
+            .post__header {
+                .col__name {
+                    .user-popover {
+                        max-width: 80px;
+                    }
+                }
+            }
+        }
+        .search-items-container {
+            .post {
+                .post__header {
+                    .col__name {
+                        .user-popover {
+                            max-width: 120px;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/webapp/sass/styles.scss
+++ b/webapp/sass/styles.scss
@@ -3,7 +3,7 @@
 @import 'compass/utilities';
 @import 'compass/css3';
 
-// Dependancies
+// Dependencies
 @import '~bootstrap/dist/css/bootstrap.css';
 @import '~jasny-bootstrap/dist/css/jasny-bootstrap.css';
 @import '~perfect-scrollbar/dist/css/perfect-scrollbar.css';


### PR DESCRIPTION
#### Summary
Line 212 Prevents `.post__header .col__reply` and `.col__controls` from overlaying `.post__header` on mobile. This magic number causes `.col__name`, `.post__time` and `.flag-icon__container` to line break just-in-time. At some point, `.post__header` should use flexbox to allow for a more flexible layout.

Line 215 Removes a gratuitous declaration

Line 217 Centers the reply button (aka menu button) within the tappable area. This results in better visual alignment and usability.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4498

#### Checklist
- [x] Has UI changes
