### PR TITLE
PLT-4467 Remove message button from more direct channels

### DIFF
--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -2,7 +2,6 @@
 // See License.txt for license information.
 
 import SearchableUserList from 'components/searchable_user_list.jsx';
-import SpinnerButton from 'components/spinner_button.jsx';
 
 import {searchUsers} from 'actions/user_actions.jsx';
 import {openDirectChannelToUser} from 'actions/channel_actions.jsx';
@@ -68,13 +67,13 @@ export default class MoreDirectChannels extends React.Component {
 
     handleExit() {
         if (this.exitToDirectChannel) {
-            browserHistory.push(this.exitToDirectChannel);
+            setTimeout(() => {
+                browserHistory.push(this.exitToDirectChannel);
+            }, 500);
         }
     }
 
-    handleShowDirectChannel(teammate, e) {
-        e.preventDefault();
-
+    handleShowDirectChannel(teammate) {
         if (this.state.loadingDMChannel !== -1) {
             return;
         }
@@ -89,6 +88,7 @@ export default class MoreDirectChannels extends React.Component {
                 this.exitToDirectChannel = TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name;
                 this.setState({loadingDMChannel: -1});
                 this.handleHide();
+                this.handleExit();
             },
             () => {
                 this.setState({loadingDMChannel: -1});
@@ -128,19 +128,8 @@ export default class MoreDirectChannels extends React.Component {
         });
     }
 
-    createJoinDirectChannelButton({user}) {
-        return (
-            <SpinnerButton
-                className='btn btm-sm btn-primary'
-                spinning={this.state.loadingDMChannel === user.id}
-                onClick={this.handleShowDirectChannel.bind(this, user)}
-            >
-                <FormattedMessage
-                    id='more_direct_channels.message'
-                    defaultMessage='Message'
-                />
-            </SpinnerButton>
-        );
+    createJoinDirectChannelButton(user) {
+        return Reflect.apply(this.handleShowDirectChannel, this, [user]);
     }
 
     nextPage(page) {
@@ -228,7 +217,6 @@ export default class MoreDirectChannels extends React.Component {
                 dialogClassName='more-modal more-direct-channels'
                 show={this.props.show}
                 onHide={this.handleHide}
-                onExited={this.handleExit}
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>
@@ -247,7 +235,7 @@ export default class MoreDirectChannels extends React.Component {
                         usersPerPage={USERS_PER_PAGE}
                         nextPage={this.nextPage}
                         search={this.search}
-                        actions={[this.createJoinDirectChannelButton]}
+                        rowAction={this.createJoinDirectChannelButton}
                         focusOnMount={!UserAgent.isMobile()}
                     />
                 </Modal.Body>

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -195,6 +195,7 @@ export default class SearchableUserList extends React.Component {
                         users={usersToDisplay}
                         extraInfo={this.props.extraInfo}
                         actions={this.props.actions}
+                        rowAction={this.props.rowAction}
                         actionProps={this.props.actionProps}
                         actionUserProps={this.props.actionUserProps}
                     />
@@ -213,6 +214,7 @@ SearchableUserList.defaultProps = {
     usersPerPage: 50, //eslint-disable-line no-magic-numbers
     extraInfo: {},
     actions: [],
+    rowAction: null,
     actionProps: {},
     actionUserProps: {},
     showTeamToggle: false,
@@ -227,6 +229,7 @@ SearchableUserList.propTypes = {
     nextPage: React.PropTypes.func.isRequired,
     search: React.PropTypes.func.isRequired,
     actions: React.PropTypes.arrayOf(React.PropTypes.func),
+    rowAction: React.PropTypes.func,
     actionProps: React.PropTypes.object,
     actionUserProps: React.PropTypes.object,
     style: React.PropTypes.object,

--- a/webapp/components/user_list.jsx
+++ b/webapp/components/user_list.jsx
@@ -22,6 +22,7 @@ export default class UserList extends React.Component {
                         user={user}
                         extraInfo={this.props.extraInfo[user.id]}
                         actions={this.props.actions}
+                        rowAction={this.props.rowAction}
                         actionProps={this.props.actionProps}
                         actionUserProps={this.props.actionUserProps[user.id]}
                     />
@@ -55,6 +56,7 @@ UserList.defaultProps = {
     users: [],
     extraInfo: {},
     actions: [],
+    rowAction: null,
     actionProps: {}
 };
 
@@ -62,6 +64,7 @@ UserList.propTypes = {
     users: React.PropTypes.arrayOf(React.PropTypes.object),
     extraInfo: React.PropTypes.object,
     actions: React.PropTypes.arrayOf(React.PropTypes.func),
+    rowAction: React.PropTypes.func,
     actionProps: React.PropTypes.object,
     actionUserProps: React.PropTypes.object
 };

--- a/webapp/components/user_list_row.jsx
+++ b/webapp/components/user_list_row.jsx
@@ -13,7 +13,7 @@ import Client from 'client/web_client.jsx';
 import React from 'react';
 import {FormattedHTMLMessage} from 'react-intl';
 
-export default function UserListRow({user, extraInfo, actions, actionProps, actionUserProps}) {
+export default function UserListRow({user, extraInfo, actions, rowAction, actionProps, actionUserProps}) {
     const nameFormat = PreferenceStore.get(Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, 'name_format', '');
 
     let name = user.username;
@@ -58,10 +58,17 @@ export default function UserListRow({user, extraInfo, actions, actionProps, acti
         status = UserStore.getStatus(user.id);
     }
 
+    let rowStyle;
+    if (rowAction) {
+        rowStyle = {cursor: 'pointer'};
+    }
+
     return (
         <div
             key={user.id}
+            onClick={rowAction.bind(null, user)}
             className='more-modal__row'
+            style={rowStyle}
         >
             <ProfilePicture
                 src={`${Client.getUsersRoute()}/${user.id}/image?time=${user.update_at}`}
@@ -92,6 +99,7 @@ export default function UserListRow({user, extraInfo, actions, actionProps, acti
 UserListRow.defaultProps = {
     extraInfo: [],
     actions: [],
+    rowAction: null,
     actionProps: {},
     actionUserProps: {}
 };
@@ -100,6 +108,7 @@ UserListRow.propTypes = {
     user: React.PropTypes.object.isRequired,
     extraInfo: React.PropTypes.arrayOf(React.PropTypes.object),
     actions: React.PropTypes.arrayOf(React.PropTypes.func),
+    rowAction: React.PropTypes.func,
     actionProps: React.PropTypes.object,
     actionUserProps: React.PropTypes.object
 };

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1505,7 +1505,6 @@
   "more_channels.noMore": "No more channels to join",
   "more_channels.title": "More Channels",
   "more_direct_channels.close": "Close",
-  "more_direct_channels.message": "Message",
   "more_direct_channels.title": "Direct Messages",
   "msg_typing.areTyping": "{users} and {last} are typing...",
   "msg_typing.isTyping": "{user} is typing...",


### PR DESCRIPTION
#### Summary
When opening the more direct channels modal now you can add or switch to a dm channel by just clicking the row and the *Message* button was removed

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4467

#### Checklist
- [x] Has UI changes
