### PR TITLE
PLT-4467 Remove message button from more direct channels

### DIFF
--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -156,7 +156,10 @@ export default class SearchableUserList extends React.Component {
         }
 
         return (
-            <div className='filtered-user-list'>
+            <div
+                className='filtered-user-list'
+                style={this.props.style}
+            >
                 <div className='filter-row'>
                     <div className='col-xs-9 col-sm-5'>
                         <input
@@ -192,6 +195,7 @@ export default class SearchableUserList extends React.Component {
                         users={usersToDisplay}
                         extraInfo={this.props.extraInfo}
                         actions={this.props.actions}
+                        rowAction={this.props.rowAction}
                         actionProps={this.props.actionProps}
                         actionUserProps={this.props.actionUserProps}
                     />
@@ -210,6 +214,7 @@ SearchableUserList.defaultProps = {
     usersPerPage: 50, //eslint-disable-line no-magic-numbers
     extraInfo: {},
     actions: [],
+    rowAction: null,
     actionProps: {},
     actionUserProps: {},
     showTeamToggle: false,
@@ -224,7 +229,9 @@ SearchableUserList.propTypes = {
     nextPage: React.PropTypes.func.isRequired,
     search: React.PropTypes.func.isRequired,
     actions: React.PropTypes.arrayOf(React.PropTypes.func),
+    rowAction: React.PropTypes.func,
     actionProps: React.PropTypes.object,
     actionUserProps: React.PropTypes.object,
+    style: React.PropTypes.object,
     focusOnMount: React.PropTypes.bool.isRequired
 };

--- a/webapp/components/user_list.jsx
+++ b/webapp/components/user_list.jsx
@@ -22,6 +22,7 @@ export default class UserList extends React.Component {
                         user={user}
                         extraInfo={this.props.extraInfo[user.id]}
                         actions={this.props.actions}
+                        rowAction={this.props.rowAction}
                         actionProps={this.props.actionProps}
                         actionUserProps={this.props.actionUserProps[user.id]}
                     />
@@ -55,6 +56,7 @@ UserList.defaultProps = {
     users: [],
     extraInfo: {},
     actions: [],
+    rowAction: null,
     actionProps: {}
 };
 
@@ -62,6 +64,7 @@ UserList.propTypes = {
     users: React.PropTypes.arrayOf(React.PropTypes.object),
     extraInfo: React.PropTypes.object,
     actions: React.PropTypes.arrayOf(React.PropTypes.func),
+    rowAction: React.PropTypes.func,
     actionProps: React.PropTypes.object,
     actionUserProps: React.PropTypes.object
 };

--- a/webapp/components/user_list_row.jsx
+++ b/webapp/components/user_list_row.jsx
@@ -13,7 +13,7 @@ import Client from 'client/web_client.jsx';
 import React from 'react';
 import {FormattedHTMLMessage} from 'react-intl';
 
-export default function UserListRow({user, extraInfo, actions, actionProps, actionUserProps}) {
+export default function UserListRow({user, extraInfo, actions, rowAction, actionProps, actionUserProps}) {
     const nameFormat = PreferenceStore.get(Constants.Preferences.CATEGORY_DISPLAY_SETTINGS, 'name_format', '');
 
     let name = user.username;
@@ -58,10 +58,17 @@ export default function UserListRow({user, extraInfo, actions, actionProps, acti
         status = UserStore.getStatus(user.id);
     }
 
+    let rowStyle;
+    if (rowAction) {
+        rowStyle = {cursor: 'pointer'};
+    }
+
     return (
         <div
             key={user.id}
+            onClick={rowAction.bind(null, user)}
             className='more-modal__row'
+            style={rowStyle}
         >
             <ProfilePicture
                 src={`${Client.getUsersRoute()}/${user.id}/image?time=${user.update_at}`}
@@ -92,6 +99,7 @@ export default function UserListRow({user, extraInfo, actions, actionProps, acti
 UserListRow.defaultProps = {
     extraInfo: [],
     actions: [],
+    rowAction: null,
     actionProps: {},
     actionUserProps: {}
 };
@@ -100,6 +108,7 @@ UserListRow.propTypes = {
     user: React.PropTypes.object.isRequired,
     extraInfo: React.PropTypes.arrayOf(React.PropTypes.object),
     actions: React.PropTypes.arrayOf(React.PropTypes.func),
+    rowAction: React.PropTypes.func,
     actionProps: React.PropTypes.object,
     actionUserProps: React.PropTypes.object
 };

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1505,7 +1505,6 @@
   "more_channels.noMore": "No more channels to join",
   "more_channels.title": "More Channels",
   "more_direct_channels.close": "Close",
-  "more_direct_channels.message": "Message",
   "more_direct_channels.title": "Direct Messages",
   "msg_typing.areTyping": "{users} and {last} are typing...",
   "msg_typing.isTyping": "{user} is typing...",


### PR DESCRIPTION
#### Summary
When opening the more direct channels modal now you can add or switch to a dm channel by just clicking the row and the *Message* button was removed

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4467

#### Checklist
- [x] Has UI changes
