### PR TITLE
PLT-4546 Welcome/tutorial screens have messed up layout at a width of…

### DIFF
--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -83,9 +83,10 @@
     .tutorial-steps__container {
         .tutorial__content {
             .tutorial__steps {
-                margin-bottom: 0;
-                min-height: auto;
-                padding-bottom: 8em;
+                margin-top: 15%;
+                margin-bottom: 15%;
+                max-height: 70%;
+                padding-bottom: 0;
             }
         }
     }
@@ -1397,6 +1398,25 @@
             .tutorial__steps {
                 padding: 0 20px;
                 width: 100%;
+                h1 {
+                    font-size: 35px;
+                    margin: -5px 0 20px;
+                }
+                h3 {
+                    margin-bottom: 10px;
+                }
+                .tutorial__app-icons {
+                    margin: 10px 0;
+                }
+                .tutorial__circles {
+                    margin: 0 0 15px;
+                    bottom: 60px;
+                    position: absolute;
+                }
+                .tutorial__footer {
+                    bottom: 30px;
+                    position: absolute;
+                }
             }
         }
     }


### PR DESCRIPTION
#### Summary
On an iPhone 5/5s (or smaller) and Android small screen size:
When a new user signs in and selects a team, in all 3 welcome/tutorial screens, the buttons ('next', 'skip', & carousel controls) are jumbled/overlapping with the text.
This is true on web, desktop, & mobile.

The changes are on styles specific for small devices:
![tutorial1](https://cloud.githubusercontent.com/assets/160621/20023407/d16b54b8-a2ad-11e6-8635-070c208787b2.png)
![tutorial2](https://cloud.githubusercontent.com/assets/160621/20023408/d2443260-a2ad-11e6-81ce-0f877fbed3fc.png)
![tutorial3](https://cloud.githubusercontent.com/assets/160621/20023409/d4a14d22-a2ad-11e6-9edc-674fb15b8851.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4546

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
