### PR TITLE
PLT-4634/PLT-4639 Don't count inactive users on statistic pages or for license

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -1029,10 +1029,11 @@ func (us SqlUserStore) AnalyticsUniqueUserCount(teamId string) StoreChannel {
 	go func() {
 		result := StoreResult{}
 
-		query := "SELECT COUNT(DISTINCT Email) FROM Users"
-
+		query := ""
 		if len(teamId) > 0 {
-			query += ", TeamMembers WHERE TeamMembers.TeamId = :TeamId AND Users.Id = TeamMembers.UserId"
+			query = "SELECT COUNT(DISTINCT Users.Email) From Users, TeamMembers WHERE TeamMembers.TeamId = :TeamId AND Users.Id = TeamMembers.UserId AND TeamMembers.DeleteAt = 0 AND Users.DeleteAt = 0"
+		} else {
+			query = "SELECT COUNT(DISTINCT Email) FROM Users WHERE DeleteAt = 0"
 		}
 
 		v, err := us.GetReplica().SelectInt(query, map[string]interface{}{"TeamId": teamId})

--- a/webapp/components/admin_console/admin_team_members_dropdown.jsx
+++ b/webapp/components/admin_console/admin_team_members_dropdown.jsx
@@ -81,6 +81,7 @@ export default class AdminTeamMembersDropdown extends React.Component {
             this.props.teamMember.team_id,
             this.props.user.id,
             () => {
+                AsyncClient.getTeamStats(this.props.teamMember.team_id);
                 UserStore.removeProfileFromTeam(this.props.teamMember.team_id, this.props.user.id);
                 UserStore.emitInTeamChange();
             },


### PR DESCRIPTION
#### Summary
Change SQL query to ignore inactive users and also fix team count not updating immediately on the team user list in the System Console.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4634
https://mattermost.atlassian.net/browse/PLT-4639