### PR TITLE
PLT-4651 Off screen edited posts no longer show up as new posts

### DIFF
--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -177,7 +177,7 @@ function handleNewPostEvent(msg) {
 function handlePostEditEvent(msg) {
     // Store post
     const post = JSON.parse(msg.data.post);
-    PostStore.storePost(post);
+    PostStore.storePost(post, false);
     PostStore.emitChange();
 
     // Update channel state

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -245,7 +245,7 @@ class PostStoreClass extends EventEmitter {
         this.postsInfo[id].postList = combinedPosts;
     }
 
-    storePost(post) {
+    storePost(post, isNewPost = false) {
         const postList = makePostListNonNull(this.getAllPosts(post.channel_id));
 
         if (post.pending_post_id !== '') {
@@ -255,7 +255,7 @@ class PostStoreClass extends EventEmitter {
         post.pending_post_id = '';
 
         postList.posts[post.id] = post;
-        if (postList.order.indexOf(post.id) === -1) {
+        if (isNewPost && postList.order.indexOf(post.id) === -1) {
             postList.order.unshift(post.id);
         }
 
@@ -629,7 +629,7 @@ PostStore.dispatchToken = AppDispatcher.register((payload) => {
         PostStore.emitChange();
         break;
     case ActionTypes.RECEIVED_POST:
-        PostStore.storePost(action.post);
+        PostStore.storePost(action.post, true);
         PostStore.emitChange();
         break;
     case ActionTypes.RECEIVED_EDIT_POST:


### PR DESCRIPTION
#### Summary
Previously if a user edited an old post that was not loaded into your post view then it would show up at the bottom of the post list. This fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4651