### PR TITLE
PLT-4205 Fixed pending posts always being considered as part of a thread

### DIFF
--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -272,11 +272,13 @@ export default class PostList extends React.Component {
                 commentRootId = post.id;
             }
 
-            for (const postId in posts) {
-                if (posts[postId].root_id === commentRootId) {
-                    commentCount += 1;
-                    if (posts[postId].user_id === userId) {
-                        shouldHighlightThreads = true;
+            if (commentRootId) {
+                for (const postId in posts) {
+                    if (posts[postId].root_id === commentRootId) {
+                        commentCount += 1;
+                        if (posts[postId].user_id === userId) {
+                            shouldHighlightThreads = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The reason that pending posts were always showing with a username and profile picture visible were because the code was treating it as if it was a comment on a thread with an undefined rootId so new posts would be briefly rendered as if they were a comment before they were saved to the server and rendered correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4205

#### Checklist
- Has UI changes