### PR TITLE
PLT-4665 Fix Max Channels limit wrong count

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -77,7 +77,7 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	if channel.TeamId == c.TeamId {
 
 		// Get total number of channels on current team
-		if result := <-Srv.Store.Channel().GetChannels(channel.TeamId, c.Session.UserId); result.Err != nil {
+		if result := <-Srv.Store.Channel().GetTeamChannels(channel.TeamId); result.Err != nil {
 			c.Err = model.NewLocAppError("createChannel", "api.channel.get_channels.error", nil, result.Err.Message)
 			return
 		} else {

--- a/store/store.go
+++ b/store/store.go
@@ -92,6 +92,7 @@ type ChannelStore interface {
 	GetChannels(teamId string, userId string) StoreChannel
 	GetMoreChannels(teamId string, userId string) StoreChannel
 	GetChannelCounts(teamId string, userId string) StoreChannel
+	GetTeamChannels(teamId string) StoreChannel
 	GetAll(teamId string) StoreChannel
 	GetForPost(postId string) StoreChannel
 	SaveMember(member *model.ChannelMember) StoreChannel


### PR DESCRIPTION
#### Summary
The channel count for creating a new channel for the team was wrong it returned the number of active channels including DM's and the help text in the system console says: `Maximum total number of channels per team, including both active and deleted channels.` this PR fixes that

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4665


