### PR TITLE
PLT-4713 If email accounts are disabled, allow email users to switch account type to one of the available types

### DIFF
--- a/webapp/components/user_settings/user_settings_security.jsx
+++ b/webapp/components/user_settings/user_settings_security.jsx
@@ -928,8 +928,9 @@ export default class SecurityTab extends React.Component {
         numMethods = config.EnableLdap === 'true' ? numMethods + 1 : numMethods;
         numMethods = config.EnableSaml === 'true' ? numMethods + 1 : numMethods;
 
+        // If there are other sign-in methods and either email is enabled or the user's account is email, then allow switching
         let signInSection;
-        if (config.EnableSignUpWithEmail === 'true' && numMethods > 0) {
+        if ((config.EnableSignUpWithEmail === 'true' || user.auth_service === '') && numMethods > 0) {
             signInSection = this.createSignInSection();
         }
 


### PR DESCRIPTION
#### Summary
If the admin has disabled email account creation, any users still on email accounts will be allowed to switch to the account type (but not back to email).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4713