### PR TITLE
PLT-4670 DM channel creation via webhook fails

### DIFF
--- a/api/webhook.go
+++ b/api/webhook.go
@@ -443,6 +443,8 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		} else {
 			channel = newChanResult.Data.(*model.Channel)
+			InvalidateCacheForUser(directUserId)
+			InvalidateCacheForUser(hook.UserId)
 		}
 	} else if result.Err != nil {
 		c.Err = model.NewLocAppError("incomingWebhook", "web.incoming_webhook.channel.app_error", nil, "err="+result.Err.Message)


### PR DESCRIPTION
#### Summary
Newly implemented caches lead to this bug, it's required to clear cache after channel creation.

#### Ticket Link
[PLT-4670](https://mattermost.atlassian.net/browse/PLT-4670)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

