### PR TITLE
PLT-4620 fix ios safari private browsing

### DIFF
--- a/webapp/stores/browser_store.jsx
+++ b/webapp/stores/browser_store.jsx
@@ -203,7 +203,11 @@ class BrowserStoreClass {
     }
 
     hasSeenLandingPage() {
-        return JSON.parse(sessionStorage.getItem('__landingPageSeen__'));
+        if (this.isLocalStorageSupported()) {
+            return JSON.parse(sessionStorage.getItem('__landingPageSeen__'));
+        }
+
+        return true;
     }
 
     setLandingPageSeen(landingPageSeen) {


### PR DESCRIPTION
#### Summary
Private browsing error for ios safari wasn't working cause there was an attempt to get an item from the sessionStorage without verifying if the sessionStorage was supported by the browser

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4620
