### PR TITLE
PLT-4600 Properly clear autocomplete suggestions when suggestions are out of date

### DIFF
--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -37,6 +37,13 @@ export default class SuggestionBox extends React.Component {
         SuggestionStore.addPretextChangedListener(this.suggestionId, this.handlePretextChanged);
     }
 
+    componentWillReceiveProps(nextProps) {
+        // Clear any suggestions when the SuggestionBox is cleared
+        if (nextProps.value === '' && this.props.value !== nextProps.value) {
+            GlobalActions.emitClearSuggestions(this.suggestionId);
+        }
+    }
+
     componentWillUnmount() {
         SuggestionStore.removeCompleteWordListener(this.suggestionId, this.handleCompleteWord);
         SuggestionStore.removePretextChangedListener(this.suggestionId, this.handlePretextChanged);

--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -2,7 +2,6 @@
 // See License.txt for license information.
 
 import $ from 'jquery';
-import ReactDOM from 'react-dom';
 
 import Constants from 'utils/constants.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
@@ -71,7 +70,7 @@ export default class SuggestionBox extends React.Component {
             return;
         }
 
-        const container = $(ReactDOM.findDOMNode(this));
+        const container = $(this.refs.container);
 
         if (!(container.is(e.target) || container.has(e.target).length > 0)) {
             // We can't just use blur for this because it fires and hides the children before
@@ -205,7 +204,7 @@ export default class SuggestionBox extends React.Component {
         const SuggestionListComponent = listComponent;
 
         return (
-            <div>
+            <div ref='container'>
                 {textbox}
                 <SuggestionListComponent
                     suggestionId={this.suggestionId}
@@ -246,6 +245,5 @@ SuggestionBox.propTypes = {
 
     // explicitly name any input event handlers we override and need to manually call
     onChange: React.PropTypes.func,
-    onBlur: React.PropTypes.func,
     onKeyDown: React.PropTypes.func
 };

--- a/webapp/stores/suggestion_store.jsx
+++ b/webapp/stores/suggestion_store.jsx
@@ -223,7 +223,7 @@ class SuggestionStore extends EventEmitter {
     }
 
     handleEventPayload(payload) {
-        const {type, id, ...other} = payload.action; // eslint-disable-line no-use-before-define
+        const {type, id, ...other} = payload.action;
 
         switch (type) {
         case ActionTypes.SUGGESTION_PRETEXT_CHANGED:

--- a/webapp/stores/suggestion_store.jsx
+++ b/webapp/stores/suggestion_store.jsx
@@ -121,6 +121,11 @@ class SuggestionStore extends EventEmitter {
     }
 
     addSuggestions(id, terms, items, component, matchedPretext) {
+        if (this.getPretext(id) !== matchedPretext) {
+            // These suggestions are out of date since the pretext has changed
+            return;
+        }
+
         const suggestion = this.suggestions.get(id);
 
         suggestion.terms.push(...terms);
@@ -243,6 +248,7 @@ class SuggestionStore extends EventEmitter {
             this.emitSuggestionsChanged(id);
             break;
         case ActionTypes.SUGGESTION_CLEAR_SUGGESTIONS:
+            this.setPretext(id, '');
             this.clearSuggestions(id);
             this.clearSelection(id);
             this.emitSuggestionsChanged(id);


### PR DESCRIPTION
Any unused autocomplete suggestions should now be cleared after the user sends their message and asynchronously received results should only be displayed if the user hasn't typed anything since then.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4600

#### Checklist
- Has UI changes