### PR TITLE
Update .editorconfig to end files with newlines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 
 [*]
 end_of_line = lf
-insert_final_newline = false
+insert_final_newline = true
 charset = utf-8
 
 [*.go]


### PR DESCRIPTION
This file was added a while ago by Florian, but I think I'm the only one using it so everyone else's text editors are adding newlines to the end of files and mine is removing them causing some unnecessary diffs to appear (as you can see in this one).