### PR TITLE
PLT-4618 Fix email subjects

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -842,9 +842,7 @@ func sendNotificationEmail(c *Context, post *model.Post, user *model.User, chann
 			"ChannelName": channelName, "Month": month, "Day": day, "Year": year}
 	}
 
-	subjectPage := utils.NewHTMLTemplate("post_subject", user.Locale)
-	subjectPage.Props["Subject"] = userLocale(mailTemplate, mailParameters)
-	subjectPage.Props["SiteName"] = utils.Cfg.TeamSettings.SiteName
+	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, userLocale(mailTemplate, mailParameters))
 
 	bodyPage := utils.NewHTMLTemplate("post_body", user.Locale)
 	bodyPage.Props["SiteURL"] = c.GetSiteURL()
@@ -857,7 +855,7 @@ func sendNotificationEmail(c *Context, post *model.Post, user *model.User, chann
 			"Hour": fmt.Sprintf("%02d", tm.Hour()), "Minute": fmt.Sprintf("%02d", tm.Minute()),
 			"TimeZone": zone, "Month": month, "Day": day}))
 
-	if err := utils.SendMail(user.Email, html.UnescapeString(subjectPage.Render()), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(user.Email, html.UnescapeString(subject), bodyPage.Render()); err != nil {
 		l4g.Error(utils.T("api.post.send_notifications_and_forget.send.error"), user.Email, err)
 	}
 }

--- a/api/team.go
+++ b/api/team.go
@@ -69,8 +69,7 @@ func signupTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	subjectPage := utils.NewHTMLTemplate("signup_team_subject", c.Locale)
-	subjectPage.Props["Subject"] = c.T("api.templates.signup_team_subject",
+	subject := c.T("api.templates.signup_team_subject",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
 	bodyPage := utils.NewHTMLTemplate("signup_team_body", c.Locale)
@@ -89,7 +88,7 @@ func signupTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	bodyPage.Props["Link"] = fmt.Sprintf("%s/signup_team_complete/?d=%s&h=%s", c.GetSiteURL(), url.QueryEscape(data), url.QueryEscape(hash))
 
-	if err := utils.SendMail(email, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(email, subject, bodyPage.Render()); err != nil {
 		c.Err = err
 		return
 	}
@@ -717,8 +716,7 @@ func InviteMembers(c *Context, team *model.Team, user *model.User, invites []str
 
 			senderRole := c.T("api.team.invite_members.member")
 
-			subjectPage := utils.NewHTMLTemplate("invite_subject", c.Locale)
-			subjectPage.Props["Subject"] = c.T("api.templates.invite_subject",
+			subject := c.T("api.templates.invite_subject",
 				map[string]interface{}{"SenderName": sender, "TeamDisplayName": team.DisplayName, "SiteName": utils.ClientCfg["SiteName"]})
 
 			bodyPage := utils.NewHTMLTemplate("invite_body", c.Locale)
@@ -744,7 +742,7 @@ func InviteMembers(c *Context, team *model.Team, user *model.User, invites []str
 				l4g.Info(utils.T("api.team.invite_members.sending.info"), invite, bodyPage.Props["Link"])
 			}
 
-			if err := utils.SendMail(invite, subjectPage.Render(), bodyPage.Render()); err != nil {
+			if err := utils.SendMail(invite, subject, bodyPage.Render()); err != nil {
 				l4g.Error(utils.T("api.team.invite_members.send.error"), err)
 			}
 		}

--- a/api/user.go
+++ b/api/user.go
@@ -358,8 +358,7 @@ func CreateOAuthUser(c *Context, w http.ResponseWriter, r *http.Request, service
 func sendWelcomeEmail(c *Context, userId string, email string, siteURL string, verified bool) {
 	rawUrl, _ := url.Parse(siteURL)
 
-	subjectPage := utils.NewHTMLTemplate("welcome_subject", c.Locale)
-	subjectPage.Props["Subject"] = c.T("api.templates.welcome_subject", map[string]interface{}{"ServerURL": rawUrl.Host})
+	subject := c.T("api.templates.welcome_subject", map[string]interface{}{"ServerURL": rawUrl.Host})
 
 	bodyPage := utils.NewHTMLTemplate("welcome_body", c.Locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -380,7 +379,7 @@ func sendWelcomeEmail(c *Context, userId string, email string, siteURL string, v
 		bodyPage.Props["VerifyUrl"] = link
 	}
 
-	if err := utils.SendMail(email, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(email, subject, bodyPage.Render()); err != nil {
 		l4g.Error(utils.T("api.user.send_welcome_email_and_forget.failed.error"), err)
 	}
 }
@@ -427,8 +426,7 @@ func SendVerifyEmail(c *Context, userId, userEmail, siteURL string) {
 
 	url, _ := url.Parse(siteURL)
 
-	subjectPage := utils.NewHTMLTemplate("verify_subject", c.Locale)
-	subjectPage.Props["Subject"] = c.T("api.templates.verify_subject",
+	subject := c.T("api.templates.verify_subject",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
 	bodyPage := utils.NewHTMLTemplate("verify_body", c.Locale)
@@ -438,7 +436,7 @@ func SendVerifyEmail(c *Context, userId, userEmail, siteURL string) {
 	bodyPage.Props["VerifyUrl"] = link
 	bodyPage.Props["Button"] = c.T("api.templates.verify_body.button")
 
-	if err := utils.SendMail(userEmail, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(userEmail, subject, bodyPage.Render()); err != nil {
 		l4g.Error(utils.T("api.user.send_verify_email_and_forget.failed.error"), err)
 	}
 }
@@ -1732,8 +1730,7 @@ func sendPasswordReset(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	link := fmt.Sprintf("%s/reset_password_complete?code=%s", c.GetSiteURL(), url.QueryEscape(recovery.Code))
 
-	subjectPage := utils.NewHTMLTemplate("reset_subject", c.Locale)
-	subjectPage.Props["Subject"] = c.T("api.templates.reset_subject")
+	subject := c.T("api.templates.reset_subject")
 
 	bodyPage := utils.NewHTMLTemplate("reset_body", c.Locale)
 	bodyPage.Props["SiteURL"] = c.GetSiteURL()
@@ -1742,7 +1739,7 @@ func sendPasswordReset(c *Context, w http.ResponseWriter, r *http.Request) {
 	bodyPage.Props["ResetUrl"] = link
 	bodyPage.Props["Button"] = c.T("api.templates.reset_body.button")
 
-	if err := utils.SendMail(email, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(email, subject, bodyPage.Render()); err != nil {
 		c.Err = model.NewLocAppError("sendPasswordReset", "api.user.send_password_reset.send.app_error", nil, "err="+err.Message)
 		return
 	}
@@ -1828,8 +1825,7 @@ func ResetPassword(c *Context, userId, newPassword string) *model.AppError {
 }
 
 func sendPasswordChangeEmail(c *Context, email, siteURL, method string) {
-	subjectPage := utils.NewHTMLTemplate("password_change_subject", c.Locale)
-	subjectPage.Props["Subject"] = c.T("api.templates.password_change_subject",
+	subject := c.T("api.templates.password_change_subject",
 		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName, "SiteName": utils.Cfg.TeamSettings.SiteName})
 
 	bodyPage := utils.NewHTMLTemplate("password_change_body", c.Locale)
@@ -1838,16 +1834,14 @@ func sendPasswordChangeEmail(c *Context, email, siteURL, method string) {
 	bodyPage.Html["Info"] = template.HTML(c.T("api.templates.password_change_body.info",
 		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName, "TeamURL": siteURL, "Method": method}))
 
-	if err := utils.SendMail(email, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(email, subject, bodyPage.Render()); err != nil {
 		l4g.Error(utils.T("api.user.send_password_change_email_and_forget.error"), err)
 	}
 }
 
 func sendEmailChangeEmail(c *Context, oldEmail, newEmail, siteURL string) {
-	subjectPage := utils.NewHTMLTemplate("email_change_subject", c.Locale)
-	subjectPage.Props["Subject"] = c.T("api.templates.email_change_subject",
-		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName})
-	subjectPage.Props["SiteName"] = utils.Cfg.TeamSettings.SiteName
+	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, c.T("api.templates.email_change_subject",
+		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName}))
 
 	bodyPage := utils.NewHTMLTemplate("email_change_body", c.Locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -1855,7 +1849,7 @@ func sendEmailChangeEmail(c *Context, oldEmail, newEmail, siteURL string) {
 	bodyPage.Html["Info"] = template.HTML(c.T("api.templates.email_change_body.info",
 		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName, "NewEmail": newEmail}))
 
-	if err := utils.SendMail(oldEmail, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(oldEmail, subject, bodyPage.Render()); err != nil {
 		l4g.Error(utils.T("api.user.send_email_change_email_and_forget.error"), err)
 	}
 }
@@ -1863,10 +1857,8 @@ func sendEmailChangeEmail(c *Context, oldEmail, newEmail, siteURL string) {
 func SendEmailChangeVerifyEmail(c *Context, userId, newUserEmail, siteURL string) {
 	link := fmt.Sprintf("%s/do_verify_email?uid=%s&hid=%s&email=%s", siteURL, userId, model.HashPassword(userId), url.QueryEscape(newUserEmail))
 
-	subjectPage := utils.NewHTMLTemplate("email_change_verify_subject", c.Locale)
-	subjectPage.Props["Subject"] = c.T("api.templates.email_change_verify_subject",
-		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName})
-	subjectPage.Props["SiteName"] = utils.Cfg.TeamSettings.SiteName
+	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, c.T("api.templates.email_change_verify_subject",
+		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName}))
 
 	bodyPage := utils.NewHTMLTemplate("email_change_verify_body", c.Locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -1876,16 +1868,14 @@ func SendEmailChangeVerifyEmail(c *Context, userId, newUserEmail, siteURL string
 	bodyPage.Props["VerifyUrl"] = link
 	bodyPage.Props["VerifyButton"] = c.T("api.templates.email_change_verify_body.button")
 
-	if err := utils.SendMail(newUserEmail, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(newUserEmail, subject, bodyPage.Render()); err != nil {
 		l4g.Error(utils.T("api.user.send_email_change_verify_email_and_forget.error"), err)
 	}
 }
 
 func sendEmailChangeUsername(c *Context, oldUsername, newUsername, email, siteURL string) {
-	subjectPage := utils.NewHTMLTemplate("username_change_subject", c.Locale)
-	subjectPage.Props["Subject"] = c.T("api.templates.username_change_subject",
-		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName})
-	subjectPage.Props["SiteName"] = utils.Cfg.TeamSettings.SiteName
+	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, c.T("api.templates.username_change_subject",
+		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName}))
 
 	bodyPage := utils.NewHTMLTemplate("email_change_body", c.Locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -1893,7 +1883,7 @@ func sendEmailChangeUsername(c *Context, oldUsername, newUsername, email, siteUR
 	bodyPage.Html["Info"] = template.HTML(c.T("api.templates.username_change_body.info",
 		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName, "NewUsername": newUsername}))
 
-	if err := utils.SendMail(email, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(email, subject, bodyPage.Render()); err != nil {
 		l4g.Error(utils.T("api.user.send_email_change_username_and_forget.error"), err)
 	}
 
@@ -2236,8 +2226,7 @@ func ldapToEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func sendSignInChangeEmail(c *Context, email, siteURL, method string) {
-	subjectPage := utils.NewHTMLTemplate("signin_change_subject", c.Locale)
-	subjectPage.Props["Subject"] = c.T("api.templates.singin_change_email.subject",
+	subject := c.T("api.templates.singin_change_email.subject",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
 	bodyPage := utils.NewHTMLTemplate("signin_change_body", c.Locale)
@@ -2246,7 +2235,7 @@ func sendSignInChangeEmail(c *Context, email, siteURL, method string) {
 	bodyPage.Html["Info"] = template.HTML(c.T("api.templates.singin_change_email.body.info",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"], "Method": method}))
 
-	if err := utils.SendMail(email, subjectPage.Render(), bodyPage.Render()); err != nil {
+	if err := utils.SendMail(email, subject, bodyPage.Render()); err != nil {
 		l4g.Error(utils.T("api.user.send_sign_in_change_email_and_forget.error"), err)
 	}
 }

--- a/templates/email_change_subject.html
+++ b/templates/email_change_subject.html
@@ -1,1 +1,0 @@
-{{define "email_change_subject"}}[{{.Props.SiteName}}] {{.Props.Subject}}{{end}}

--- a/templates/email_change_verify_subject.html
+++ b/templates/email_change_verify_subject.html
@@ -1,1 +1,0 @@
-{{define "email_change_verify_subject"}}[{{.Props.SiteName}}] {{.Props.Subject}}{{end}}

--- a/templates/invite_subject.html
+++ b/templates/invite_subject.html
@@ -1,1 +1,0 @@
-{{define "invite_subject"}}{{.Props.Subject}}{{end}}

--- a/templates/password_change_subject.html
+++ b/templates/password_change_subject.html
@@ -1,1 +1,0 @@
-{{define "password_change_subject"}}{{.Props.Subject}}{{end}}

--- a/templates/post_subject.html
+++ b/templates/post_subject.html
@@ -1,1 +1,0 @@
-{{define "post_subject"}}[{{.Props.SiteName}}] {{.Props.Subject}}{{end}}

--- a/templates/reset_subject.html
+++ b/templates/reset_subject.html
@@ -1,1 +1,0 @@
-{{define "reset_subject"}}{{.Props.Subject}}{{end}}

--- a/templates/signin_change_subject.html
+++ b/templates/signin_change_subject.html
@@ -1,1 +1,0 @@
-{{define "signin_change_subject"}}{{.Props.Subject}}{{end}}

--- a/templates/signup_team_subject.html
+++ b/templates/signup_team_subject.html
@@ -1,1 +1,0 @@
-{{define "signup_team_subject"}}{{.Props.Subject}}{{end}}

--- a/templates/username_change_subject.html
+++ b/templates/username_change_subject.html
@@ -1,1 +1,0 @@
-{{define "username_change_subject"}}[{{.Props.SiteName}}] {{.Props.Subject}}{{end}}

--- a/templates/verify_subject.html
+++ b/templates/verify_subject.html
@@ -1,1 +1,0 @@
-{{define "verify_subject"}}{{.Props.Subject}}{{end}}

--- a/templates/welcome_subject.html
+++ b/templates/welcome_subject.html
@@ -1,1 +1,0 @@
-{{define "welcome_subject"}}{{.Props.Subject}}{{end}}

--- a/utils/mail.go
+++ b/utils/mail.go
@@ -5,10 +5,10 @@ package utils
 
 import (
 	"crypto/tls"
-	"encoding/base64"
 	"fmt"
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/platform/model"
+	"mime"
 	"net"
 	"net/mail"
 	"net/smtp"
@@ -16,10 +16,7 @@ import (
 )
 
 func encodeRFC2047Word(s string) string {
-	// TODO: use `mime.BEncoding.Encode` instead when `go` >= 1.5
-	// return mime.BEncoding.Encode("utf-8", s)
-	dst := base64.StdEncoding.EncodeToString([]byte(s))
-	return "=?utf-8?b?" + dst + "?="
+	return mime.BEncoding.Encode("utf-8", s)
 }
 
 func connectToSMTPServer(config *model.Config) (net.Conn, *model.AppError) {


### PR DESCRIPTION
#### Summary
Email subjects didn't rendered UTF-8 characters cause there wasn't a charset in the template, this PR remove templates for building the subject line for emails allowing the correct parse of UTF-8 characters

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4618
