### PR TITLE
WIP: Update Slack Text

### DIFF
--- a/webapp/components/team_import_tab.jsx
+++ b/webapp/components/team_import_tab.jsx
@@ -48,7 +48,7 @@ class TeamImportTab extends React.Component {
             <div>
                 <FormattedHTMLMessage
                     id='team_import_tab.importHelp'
-                    defaultMessage="<p>Import users and public channel information from Slack. <a href=&quot;https://docs.mattermost.com/help/settings/team-settings.html#import&quot;>See documentation for instructions on generating a Slack export file.</a></p>"
+                    defaultMessage="<p>Import users and public channel information from Slack. <a href=&quot;https://docs.mattermost.com/help/settings/team-settings.html#import&quot;>See documentation for instructions on generating a Slack file to import.</a></p>"
                 />
             </div>
         );

--- a/webapp/components/team_import_tab.jsx
+++ b/webapp/components/team_import_tab.jsx
@@ -48,7 +48,7 @@ class TeamImportTab extends React.Component {
             <div>
                 <FormattedHTMLMessage
                     id='team_import_tab.importHelp'
-                    defaultMessage="<p>Import users and public channel information from Slack. <a href=&quot;https://docs.mattermost.com/help/settings/team-settings.html#import&quot;>See documentation for instructions</a></p>"
+                    defaultMessage="<p>Import users and public channel information from Slack. <a href=&quot;https://docs.mattermost.com/help/settings/team-settings.html#import&quot;>See documentation for instructions on generating a Slack export file.</a></p>"
                 />
             </div>
         );

--- a/webapp/components/team_import_tab.jsx
+++ b/webapp/components/team_import_tab.jsx
@@ -48,7 +48,7 @@ class TeamImportTab extends React.Component {
             <div>
                 <FormattedHTMLMessage
                     id='team_import_tab.importHelp'
-                    defaultMessage="<p>Import users and public channel information from Slack. <a href=&quot;https://docs.mattermost.com/help/settings/team-settings.html#import&quot;>See documentation for instructions on generating a Slack file to import.</a></p>"
+                    defaultMessage="<p>Import users and public channel information from Slack. See documentation for instructions on generating a Slack file to import.</p>"
                 />
             </div>
         );

--- a/webapp/components/team_import_tab.jsx
+++ b/webapp/components/team_import_tab.jsx
@@ -48,7 +48,7 @@ class TeamImportTab extends React.Component {
             <div>
                 <FormattedHTMLMessage
                     id='team_import_tab.importHelp'
-                    defaultMessage="<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export files, images, private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of text messages in your Slack team's public channels.</p><p>The Slack import to Mattermost is in 'Beta'. Slack bot posts do not yet import.</p>"
+                    defaultMessage="<p>Import users and public channel information from Slack. <a href=&quot;https://docs.mattermost.com/help/settings/team-settings.html#import&quot;>See documentation for instructions</a></p>"
                 />
             </div>
         );

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1738,7 +1738,7 @@
   "team_export_tab.unable": " Unable to export: {error}",
   "team_import_tab.failure": " Import failure: ",
   "team_import_tab.import": "Import",
-  "team_import_tab.importHelp": "<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export files, images, private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of text messages in your Slack team's public channels.</p><p>The Slack import to Mattermost is in 'Beta'. Slack bot posts do not yet import.</p>",
+  "team_import_tab.importHelp": "<p>Import users and public channel information from Slack. <a href=\"https://docs.mattermost.com/help/settings/team-settings.html#import\">See documentation for instructions</a></p>",
   "team_import_tab.importSlack": "Import from Slack (Beta)",
   "team_import_tab.importing": " Importing...",
   "team_import_tab.successful": " Import successful: ",

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1738,7 +1738,7 @@
   "team_export_tab.unable": " Unable to export: {error}",
   "team_import_tab.failure": " Import failure: ",
   "team_import_tab.import": "Import",
-  "team_import_tab.importHelp": "<p>Import users and public channel information from Slack. <a href=\"https://docs.mattermost.com/help/settings/team-settings.html#import\">See documentation for instructions</a></p>",
+  "team_import_tab.importHelp": "<p>Import users and public channel information from Slack. <a href=\"https://docs.mattermost.com/help/settings/team-settings.html#import\">See documentation for instructions on generating a Slack file to import.</a></p>",
   "team_import_tab.importSlack": "Import from Slack (Beta)",
   "team_import_tab.importing": " Importing...",
   "team_import_tab.successful": " Import successful: ",


### PR DESCRIPTION

When filling in a section please remove the help text and the above text.

#### Summary
Slack Import help text way out-of-date--from a time before we had help documentation. Replacing overly verbose instructions with link to help documentation. 

![image](https://cloud.githubusercontent.com/assets/177788/20243139/2332c3a6-a8ff-11e6-9c3b-080564124978.png)

#### Ticket Link
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

