### PR TITLE
Fixed websocket to properly logout when logged out from another tab

### DIFF
--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -461,21 +461,23 @@ export function emitRemoteUserTypingEvent(channelId, userId, postParentId) {
     });
 }
 
-export function emitUserLoggedOutEvent(redirectTo) {
-    const rURL = (redirectTo && typeof redirectTo === 'string') ? redirectTo : '/';
+export function emitUserLoggedOutEvent(redirectTo = '/', shouldSignalLogout = true) {
     Client.logout(
         () => {
-            BrowserStore.signalLogout();
+            if (shouldSignalLogout) {
+                BrowserStore.signalLogout();
+            }
+
             BrowserStore.clear();
             ErrorStore.clearLastError();
             PreferenceStore.clear();
             UserStore.clear();
             TeamStore.clear();
             newLocalizationSelected(global.window.mm_config.DefaultClientLocale);
-            browserHistory.push(rURL);
+            browserHistory.push(redirectTo);
         },
         () => {
-            browserHistory.push(rURL);
+            browserHistory.push(redirectTo);
         }
     );
 }

--- a/webapp/components/logged_in.jsx
+++ b/webapp/components/logged_in.jsx
@@ -14,8 +14,6 @@ import {loadEmoji} from 'actions/emoji_actions.jsx';
 import * as Utils from 'utils/utils.jsx';
 import Constants from 'utils/constants.jsx';
 
-import {browserHistory} from 'react-router/es6';
-
 const BACKSPACE_CHAR = 8;
 
 import $ from 'jquery';
@@ -41,7 +39,7 @@ export default class LoggedIn extends React.Component {
                 }
 
                 console.log('detected logout from a different tab'); //eslint-disable-line no-console
-                browserHistory.push('/');
+                GlobalActions.emitUserLoggedOutEvent('/', false);
             }
 
             if (e.originalEvent.key === '__login__' && e.originalEvent.storageArea === localStorage && e.originalEvent.newValue) {


### PR DESCRIPTION
Before, the websocket wouldn't go through the full logout procedures when another tab was closed so it would go through a weird flow like:
1. Redirect to /
2. Unmount LoggedIn component which closes websocket
3. Remount LoggedIn component for some reason (likely because it thought it should still be logged in) which reopens websocket
4. Remount SelectTeam component which causes an error and triggers the actual client logout
5. Unmount LoggedIn and fail to close websocket because [websocket wasn't fully open yet](https://github.com/mattermost/platform/blob/master/webapp/client/websocket_client.jsx#L139)
6. Actually switch to /