### PR TITLE
PLT-4242 Deauthenticate websockets and set status to offline when user account deactivated 

### DIFF
--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1088,8 +1088,9 @@ func TestUserUpdateDeviceId(t *testing.T) {
 }
 
 func TestUserUpdateActive(t *testing.T) {
-	th := Setup()
+	th := Setup().InitSystemAdmin()
 	Client := th.CreateClient()
+	SystemAdminClient := th.SystemAdminClient
 
 	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
@@ -1141,6 +1142,18 @@ func TestUserUpdateActive(t *testing.T) {
 
 	if _, err := Client.UpdateActive("12345678901234567890123456", false); err == nil {
 		t.Fatal("Should have errored, bad id")
+	}
+
+	SetStatusOnline(user3.Id, "", false)
+
+	if _, err := SystemAdminClient.UpdateActive(user3.Id, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if status, err := GetStatus(user3.Id); err != nil {
+		t.Fatal(err)
+	} else if status.Status != model.STATUS_OFFLINE {
+		t.Fatal("status should have been set to offline")
 	}
 }
 

--- a/api/web_conn.go
+++ b/api/web_conn.go
@@ -139,7 +139,16 @@ func (webCon *WebConn) InvalidateCache() {
 }
 
 func (webCon *WebConn) isAuthenticated() bool {
-	return webCon.SessionToken != ""
+	if webCon.SessionToken == "" {
+		return false
+	}
+
+	session := GetSession(webCon.SessionToken)
+	if session == nil || session.IsExpired() {
+		return false
+	}
+
+	return true
 }
 
 func (webCon *WebConn) ShouldSendEvent(msg *model.WebSocketEvent) bool {

--- a/api/websocket_router.go
+++ b/api/websocket_router.go
@@ -62,7 +62,7 @@ func (wr *WebSocketRouter) ServeWebSocket(conn *WebConn, r *model.WebSocketReque
 		return
 	}
 
-	if conn.SessionToken == "" {
+	if !conn.isAuthenticated() {
 		err := model.NewLocAppError("ServeWebSocket", "api.web_socket_router.not_authenticated.app_error", nil, "")
 		wr.ReturnWebSocketError(conn, r, err)
 		return


### PR DESCRIPTION
#### Summary
* Propagate session cache invalidation on session revoke
* Move websockets to check for a valid session on all actions
* Set status offline immediately when deactivating a user

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4242