### PR TITLE
Hotfix: Lower autocomplete timeout to 100ms

### DIFF
--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -849,7 +849,7 @@ export const Constants = {
     MENTION_SPECIAL: 'mention.special',
     DEFAULT_NOTIFICATION_DURATION: 5000,
     STATUS_INTERVAL: 60000,
-    AUTOCOMPLETE_TIMEOUT: 200
+    AUTOCOMPLETE_TIMEOUT: 100
 };
 
 export default Constants;


### PR DESCRIPTION
#### Summary
Lower autocomplete timeout to make autocomplete more responsive.


**NOT CONFIRMED, DO NOT MERGE**