### PR TITLE
Hotfix: Fix user search when using an asterisk

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -1217,11 +1217,24 @@ func (us SqlUserStore) SearchInChannel(channelId string, term string, options ma
 	return storeChannel
 }
 
+var specialUserSearchChar = []string{
+	"<",
+	">",
+	"+",
+	"-",
+	"(",
+	")",
+	"~",
+	"@",
+	":",
+	"*",
+}
+
 func (us SqlUserStore) performSearch(searchQuery string, term string, options map[string]bool, parameters map[string]interface{}) StoreResult {
 	result := StoreResult{}
 
 	// these chars have special meaning and can be treated as spaces
-	for _, c := range specialSearchChar {
+	for _, c := range specialUserSearchChar {
 		term = strings.Replace(term, c, " ", -1)
 	}
 

--- a/store/sql_user_store_test.go
+++ b/store/sql_user_store_test.go
@@ -981,6 +981,32 @@ func TestUserStoreSearch(t *testing.T) {
 		}
 	}
 
+	// * should be treated as a space
+	if r1 := <-store.User().Search(tid, "jimb*", searchOptions); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		profiles := r1.Data.([]*model.User)
+		found1 := false
+		found2 := false
+		for _, profile := range profiles {
+			if profile.Id == u1.Id {
+				found1 = true
+			}
+
+			if profile.Id == u3.Id {
+				found2 = true
+			}
+		}
+
+		if !found1 {
+			t.Fatal("should have found user")
+		}
+
+		if found2 {
+			t.Fatal("should not have found inactive user")
+		}
+	}
+
 	if r1 := <-store.User().Search(tid, "harol", searchOptions); r1.Err != nil {
 		t.Fatal(r1.Err)
 	} else {


### PR DESCRIPTION
#### Summary
User search was broken when using `*` in the search.

**NOT CONFIRMED, DO NOT MERGE**