### PR TITLE
Fix webclient this.setTeamId

### DIFF
--- a/webapp/client/web_client.jsx
+++ b/webapp/client/web_client.jsx
@@ -14,7 +14,7 @@ class WebClientClass extends Client {
     constructor() {
         super();
         this.enableLogErrorsToConsole(true);
-        TeamStore.addChangeListener(this.onTeamStoreChanged);
+        TeamStore.addChangeListener(this.onTeamStoreChanged.bind(this));
     }
 
     onTeamStoreChanged() {


### PR DESCRIPTION
#### Summary
Currently in master the TeamStore event listener in `web_client.jsx` throws an error this `bind` fixes the issue
