### PR TITLE
PLT-4664 Fix CLI join team site url

### DIFF
--- a/mattermost.go
+++ b/mattermost.go
@@ -1499,6 +1499,11 @@ func getMockContext() *api.Context {
 	c.IpAddress = "cmd_line"
 	c.T = utils.TfuncWithFallback(model.DEFAULT_LOCALE)
 	c.Locale = model.DEFAULT_LOCALE
+
+	if *utils.Cfg.ServiceSettings.SiteURL != "" {
+		c.SetSiteURL(*utils.Cfg.ServiceSettings.SiteURL)
+	}
+
 	return c
 }
 


### PR DESCRIPTION
#### Summary
By calling `SetSiteURL` in the `getMockContext` function this and every other call that uses that function will set the correct site url

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4661