### PR TITLE
PLT-4783 Fix autofocus for "Add/Manage Members" and "More public channels" modals

### DIFF
--- a/webapp/components/channel_invite_modal.jsx
+++ b/webapp/components/channel_invite_modal.jsx
@@ -12,6 +12,7 @@ import TeamStore from 'stores/team_store.jsx';
 import {searchUsers} from 'actions/user_actions.jsx';
 
 import * as AsyncClient from 'utils/async_client.jsx';
+import * as UserAgent from 'utils/user_agent.jsx';
 
 import React from 'react';
 import {Modal} from 'react-bootstrap';
@@ -140,6 +141,7 @@ export default class ChannelInviteModal extends React.Component {
                     nextPage={this.nextPage}
                     search={this.search}
                     actions={[ChannelInviteButton]}
+                    focusOnMount={!UserAgent.isMobile()}
                     actionProps={{
                         channel: this.props.channel,
                         onInviteError: this.handleInviteError

--- a/webapp/components/member_list_team.jsx
+++ b/webapp/components/member_list_team.jsx
@@ -12,6 +12,8 @@ import {getTeamStats} from 'utils/async_client.jsx';
 
 import Constants from 'utils/constants.jsx';
 
+import * as UserAgent from 'utils/user_agent.jsx';
+
 import React from 'react';
 
 const USERS_PER_PAGE = 50;
@@ -132,6 +134,7 @@ export default class MemberListTeam extends React.Component {
                 search={this.search}
                 actions={teamMembersDropdown}
                 actionUserProps={actionUserProps}
+                focusOnMount={!UserAgent.isMobile()}
             />
         );
     }

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -19,6 +19,7 @@ import * as AsyncClient from 'utils/async_client.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as ChannelUtils from 'utils/channel_utils.jsx';
 import * as ChannelActions from 'actions/channel_actions.jsx';
+import * as UserAgent from 'utils/user_agent.jsx';
 
 import Constants from 'utils/constants.jsx';
 
@@ -341,6 +342,11 @@ export default class Sidebar extends React.Component {
     showMoreChannelsModal() {
         // manually show the modal because using data-toggle messes with keyboard focus when the modal is dismissed
         $('#more_channels').modal({'data-channeltype': 'O'}).modal('show');
+        $('#more_channels').on('shown.bs.modal', () => {
+            if (!UserAgent.isMobile()) {
+                $('#more_channels input').focus();
+            }
+        });
     }
 
     showNewChannelModal(type) {

--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -121,7 +121,6 @@ export default class SidebarHeaderDropdown extends React.Component {
         e.preventDefault();
 
         this.setState({
-            // showDropdown: false,
             showTeamMembersModal: true
         });
     }

--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -121,7 +121,7 @@ export default class SidebarHeaderDropdown extends React.Component {
         e.preventDefault();
 
         this.setState({
-            showDropdown: false,
+            // showDropdown: false,
             showTeamMembersModal: true
         });
     }

--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -447,6 +447,7 @@ export default class SidebarHeaderDropdown extends React.Component {
         if (this.state.showTeamMembersModal) {
             teamMembersModal = (
                 <TeamMembersModal
+                    onLoad={this.toggleDropdown}
                     onHide={this.hideTeamMembersModal}
                     isAdmin={isAdmin}
                 />

--- a/webapp/components/team_members_modal.jsx
+++ b/webapp/components/team_members_modal.jsx
@@ -25,6 +25,9 @@ export default class TeamMembersModal extends React.Component {
 
     componentDidMount() {
         TeamStore.addChangeListener(this.teamChanged);
+        if (this.props.onLoad) {
+            this.props.onLoad();
+        }
     }
 
     componentWillUnmount() {
@@ -75,5 +78,6 @@ export default class TeamMembersModal extends React.Component {
 
 TeamMembersModal.propTypes = {
     onHide: React.PropTypes.func.isRequired,
-    isAdmin: React.PropTypes.bool.isRequired
+    isAdmin: React.PropTypes.bool.isRequired,
+    onLoad: React.PropTypes.func
 };


### PR DESCRIPTION
This is a draft PR, as I think more conversation is necessary here. There are a couple of changes here I'm pretty sure about: 

 - `web_client.jsx`: this is just changed in anticipation of #4603 being merged, because otherwise my local repo crashes;
 - `channel_invite_modal.jsx, member_list_team.jsx`: I think these need to pass the prop `focusOnMount` to their `SearchableUserList` components so that autofocus works properly;

***The change I'm not sure about is in `sidebar_header_dropdown.jsx`:***

This is intended to fix the focus issue when you select "Manage Members" from the sidebar dropdown. Selecting this seems to do 2 things synchronously, (1) hide the dropdown, and (2) show the modal. The problem seems to be that both actions want to grab focus, at the same time.

The react-bootstrap Dropdown component will check focus whenever it updates. When it toggles off, if the menu has focus still, the toggle button tries to retain focus. If it doesn't it doesn't. Here, with both the modal and the dropdown getting toggled at the same time, the most likely chain of events is:

 1. modal appears;
 1. menu still has focus when the modal appears, so `Dropdown` calls `focus()` on the toggle button;
 1. the modal calls `focus()` on its search bar;
 1. the toggle button finally takes focus.

My proposed solution (after trying a couple of things) is to pass an "onLoad" function prop to the `TeamMembersModal` that gets run when the modal is mounted. This function is just the dropdown's `toggleDropdown` method. So in effect, the modal is mounted, *then* the dropdown is hidden, and the dropdown doesn't try to take focus because it detects that something else besides itself has focus.

#### Ticket Link
See issue #4599

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Has UI changes

