### PR TITLE
PLT-4787 Fixed not being able to join a channel through a public link in a new tab

### DIFF
--- a/webapp/components/post_view/post_view_cache.jsx
+++ b/webapp/components/post_view/post_view_cache.jsx
@@ -17,11 +17,12 @@ export default class PostViewCache extends React.Component {
 
         this.onChannelChange = this.onChannelChange.bind(this);
 
+        const currentChannelId = ChannelStore.getCurrentId();
         const channel = ChannelStore.getCurrent();
 
         this.state = {
-            currentChannelId: channel.id,
-            channels: [channel]
+            currentChannelId,
+            channels: channel ? [channel] : []
         };
     }
 
@@ -40,7 +41,7 @@ export default class PostViewCache extends React.Component {
         const channels = Object.assign([], this.state.channels);
         const currentChannel = ChannelStore.getCurrent();
 
-        if (currentChannel == null) {
+        if (!currentChannel) {
             return;
         }
 

--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -29,13 +29,16 @@ function doChannelChange(state, replace, callback) {
         channel = JSON.parse(state.location.query.fakechannel);
     } else {
         channel = ChannelStore.getByName(state.params.channel);
-        if (!channel) {
-            channel = ChannelStore.getMoreByName(state.params.channel);
-        }
+
         if (!channel) {
             Client.joinChannelByName(
                 state.params.channel,
                 (data) => {
+                    AppDispatcher.handleServerAction({
+                        type: ActionTypes.RECEIVED_CHANNEL,
+                        channel: data
+                    });
+
                     GlobalActions.emitChannelClickEvent(data);
                     callback();
                 },


### PR DESCRIPTION
Potential fix for 3.5.1

This also fixes an edge case where you're not able to join a public channel from a link within Mattermost after opening the More Channels modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4787