### PR TITLE
PLT-4442 Generate preview images sequentially in Slack importer

### DIFF
--- a/api/import.go
+++ b/api/import.go
@@ -62,22 +62,16 @@ func ImportFile(file io.Reader, teamId string, channelId string, userId string, 
 	io.Copy(buf, file)
 	data := buf.Bytes()
 
-	previewPathList := []string{}
-	thumbnailPathList := []string{}
-	imageDataList := [][]byte{}
-
 	fileInfo, err := doUploadFile(teamId, channelId, userId, fileName, data)
 	if err != nil {
 		return nil, err
 	}
 
-	if fileInfo.PreviewPath != "" || fileInfo.ThumbnailPath != "" {
-		previewPathList = append(previewPathList, fileInfo.PreviewPath)
-		thumbnailPathList = append(thumbnailPathList, fileInfo.ThumbnailPath)
-		imageDataList = append(imageDataList, data)
+	preparedImage := prepareImage(data)
+	if preparedImage != nil {
+		generateThumbnailImage(preparedImage.Img, fileInfo.ThumbnailPath, preparedImage.Width, preparedImage.Height)
+		generatePreviewImage(preparedImage.Img, fileInfo.PreviewPath, preparedImage.Width)
 	}
-
-	go handleImages(previewPathList, thumbnailPathList, imageDataList)
 
 	return fileInfo, nil
 }

--- a/api/import.go
+++ b/api/import.go
@@ -67,10 +67,10 @@ func ImportFile(file io.Reader, teamId string, channelId string, userId string, 
 		return nil, err
 	}
 
-	preparedImage := prepareImage(data)
-	if preparedImage != nil {
-		generateThumbnailImage(preparedImage.Img, fileInfo.ThumbnailPath, preparedImage.Width, preparedImage.Height)
-		generatePreviewImage(preparedImage.Img, fileInfo.PreviewPath, preparedImage.Width)
+	img, width, height := prepareImage(data)
+	if img != nil {
+		generateThumbnailImage(*img, fileInfo.ThumbnailPath, width, height)
+		generatePreviewImage(*img, fileInfo.PreviewPath, width)
 	}
 
 	return fileInfo, nil


### PR DESCRIPTION
#### Summary
Run preview image generation sequentially in Slack importer to avoid a race condition between it and the CLI exiting when using the CLI to import a Slack archive with attachments.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4442
