### PR TITLE
Fixed error logged when joining a team from another tab

### DIFF
--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -211,6 +211,11 @@ function handleNewUserEvent(msg) {
         return;
     }
 
+    if (msg.data.user_id === UserStore.getCurrentId()) {
+        // We should already have ourselves
+        return;
+    }
+
     AsyncClient.getUser(msg.data.user_id);
     AsyncClient.getChannelStats();
     loadProfilesAndTeamMembersForDMSidebar();


### PR DESCRIPTION
The error was caused by us getting the current user through a getUser api call which overwrote some normally sanitized fields including `notify_props`