### PR TITLE
PLT-4697 Update channel switcher to autocomplete all users on the system

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -59,6 +59,7 @@ func InitUser() {
 	BaseRoutes.NeedChannel.Handle("/users/not_in_channel/{offset:[0-9]+}/{limit:[0-9]+}", ApiUserRequired(getProfilesNotInChannel)).Methods("GET")
 	BaseRoutes.Users.Handle("/search", ApiUserRequired(searchUsers)).Methods("POST")
 	BaseRoutes.Users.Handle("/ids", ApiUserRequired(getProfilesByIds)).Methods("POST")
+	BaseRoutes.Users.Handle("/autocomplete", ApiUserRequired(autocompleteUsers)).Methods("GET")
 
 	BaseRoutes.NeedTeam.Handle("/users/autocomplete", ApiUserRequired(autocompleteUsersInTeam)).Methods("GET")
 	BaseRoutes.NeedChannel.Handle("/users/autocomplete", ApiUserRequired(autocompleteUsersInChannel)).Methods("GET")
@@ -2745,4 +2746,25 @@ func autocompleteUsersInTeam(c *Context, w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Write([]byte(autocomplete.ToJson()))
+}
+
+func autocompleteUsers(c *Context, w http.ResponseWriter, r *http.Request) {
+	term := r.URL.Query().Get("term")
+
+	uchan := Srv.Store.User().Search("", term, map[string]bool{})
+
+	var profiles []*model.User
+
+	if result := <-uchan; result.Err != nil {
+		c.Err = result.Err
+		return
+	} else {
+		profiles = result.Data.([]*model.User)
+
+		for _, p := range profiles {
+			sanitizeProfile(c, p)
+		}
+	}
+
+	w.Write([]byte(model.UserListToJson(profiles)))
 }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -2275,6 +2275,44 @@ func TestAutocompleteUsers(t *testing.T) {
 	th := Setup().InitBasic()
 	Client := th.BasicClient
 
+	if result, err := Client.AutocompleteUsers(th.BasicUser.Username); err != nil {
+		t.Fatal(err)
+	} else {
+		users := result.Data.([]*model.User)
+		if len(users) != 1 {
+			t.Fatal("should have returned 1 user in")
+		}
+	}
+
+	if result, err := Client.AutocompleteUsers(""); err != nil {
+		t.Fatal(err)
+	} else {
+		users := result.Data.([]*model.User)
+		if len(users) == 0 {
+			t.Fatal("should have many users")
+		}
+	}
+
+	notInTeamUser := th.CreateUser(Client)
+
+	if result, err := Client.AutocompleteUsers(notInTeamUser.Username); err != nil {
+		t.Fatal(err)
+	} else {
+		users := result.Data.([]*model.User)
+		if len(users) != 1 {
+			t.Fatal("should have returned 1 user in")
+		}
+	}
+
+	if result, err := Client.AutocompleteUsersInTeam(notInTeamUser.Username); err != nil {
+		t.Fatal(err)
+	} else {
+		autocomplete := result.Data.(*model.UserAutocompleteInTeam)
+		if len(autocomplete.InTeam) != 0 {
+			t.Fatal("should have returned 0 users")
+		}
+	}
+
 	if result, err := Client.AutocompleteUsersInTeam(th.BasicUser.Username); err != nil {
 		t.Fatal(err)
 	} else {

--- a/model/client.go
+++ b/model/client.go
@@ -610,6 +610,19 @@ func (c *Client) AutocompleteUsersInTeam(term string) (*Result, *AppError) {
 	}
 }
 
+// AutocompleteUsers returns a list for autocompletion of users on the system that match the provided term,
+// matching against username, full name and nickname. Must be authenticated.
+func (c *Client) AutocompleteUsers(term string) (*Result, *AppError) {
+	url := fmt.Sprintf("/users/autocomplete?term=%s", url.QueryEscape(term))
+	if r, err := c.DoApiGet(url, "", ""); err != nil {
+		return nil, err
+	} else {
+		defer closeBody(r)
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), UserListFromJson(r.Body)}, nil
+	}
+}
+
 // LoginById authenticates a user by user id and password.
 func (c *Client) LoginById(id string, password string) (*Result, *AppError) {
 	m := make(map[string]string)

--- a/webapp/actions/user_actions.jsx
+++ b/webapp/actions/user_actions.jsx
@@ -317,6 +317,24 @@ export function autocompleteUsersInTeam(username, success, error) {
     );
 }
 
+export function autocompleteUsers(username, success, error) {
+    Client.autocompleteUsers(
+        username,
+        (data) => {
+            if (success) {
+                success(data);
+            }
+        },
+        (err) => {
+            AsyncClient.dispatchError(err, 'autocompleteUsers');
+
+            if (error) {
+                error(err);
+            }
+        }
+    );
+}
+
 export function updateUser(username, success, error) {
     Client.updateUser(
         username,

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -1103,12 +1103,21 @@ export default class Client {
             set(this.defaultHeaders).
             type('application/json').
             accept('application/json').
-            end(this.handleResponse.bind(this, 'autocompleteUsers', success, error));
+            end(this.handleResponse.bind(this, 'autocompleteUsersInChannel', success, error));
     }
 
     autocompleteUsersInTeam(term, success, error) {
         request.
             get(`${this.getTeamNeededRoute()}/users/autocomplete?term=${encodeURIComponent(term)}`).
+            set(this.defaultHeaders).
+            type('application/json').
+            accept('application/json').
+            end(this.handleResponse.bind(this, 'autocompleteUsersInTeam', success, error));
+    }
+
+    autocompleteUsers(term, success, error) {
+        request.
+            get(`${this.getUsersRoute()}/autocomplete?term=${encodeURIComponent(term)}`).
             set(this.defaultHeaders).
             type('application/json').
             accept('application/json').

--- a/webapp/components/suggestion/switch_channel_provider.jsx
+++ b/webapp/components/suggestion/switch_channel_provider.jsx
@@ -6,7 +6,7 @@ import Suggestion from './suggestion.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
-import {autocompleteUsersInTeam} from 'actions/user_actions.jsx';
+import {autocompleteUsers} from 'actions/user_actions.jsx';
 
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import {Constants, ActionTypes} from 'utils/constants.jsx';
@@ -64,10 +64,9 @@ export default class SwitchChannelProvider {
             const channels = [];
 
             function autocomplete() {
-                autocompleteUsersInTeam(
+                autocompleteUsers(
                     channelPrefix,
-                    (data) => {
-                        const users = data.in_team;
+                    (users) => {
                         const currentId = UserStore.getCurrentId();
 
                         for (const id of Object.keys(allChannels)) {

--- a/webapp/tests/client_user.test.jsx
+++ b/webapp/tests/client_user.test.jsx
@@ -587,6 +587,21 @@ describe('Client.User', function() {
         });
     });
 
+    it('autocompleteUsers', function(done) {
+        TestHelper.initBasic(() => {
+            TestHelper.basicClient().autocompleteUsers(
+                'uid',
+                function(data) {
+                    assert.equal(data != null, true);
+                    done();
+                },
+                function(err) {
+                    done(new Error(err.message));
+                }
+            );
+        });
+    });
+
     it('getStatusesByIds', function(done) {
         TestHelper.initBasic(() => {
             var ids = [];


### PR DESCRIPTION
#### Summary
Adds an API `/users/autocomplete` to allow auto-completing for all users on the system and not just on the team.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4697

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#35)
- [x] All new/modified APIs include changes to the drivers