### PR TITLE
PLT-4635 Fix Cannot read property 'body' of undefined

### DIFF
--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -201,8 +201,8 @@ export default class Client {
 
             if (errorCallback) {
                 errorCallback(e, err, res);
-                return;
             }
+            return;
         }
 
         if (successCallback) {

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -206,7 +206,7 @@ export default class Client {
         }
 
         if (successCallback) {
-            if (res.body) {
+            if (res && res.body) {
                 successCallback(res.body, res);
             } else {
                 console.error('Missing response body for ' + methodName); // eslint-disable-line no-console


### PR DESCRIPTION
#### Summary
For some reason when the network goes offline and there is a request being made Chrome ends the request but somehow does not throw an error, so in this case before firing the `success callback` we validate that it actually has a response

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4635