### PR TITLE
PLT-4300 Switched emoji to use a background-image

### DIFF
--- a/webapp/sass/components/_emoticons.scss
+++ b/webapp/sass/components/_emoticons.scss
@@ -1,11 +1,14 @@
 @charset 'UTF-8';
 
 .emoticon {
+    background-repeat: no-repeat;
+    background-position: 50% 50%;
     background-size: contain;
     display: inline-block;
-    height: 1.5em;
-    margin-bottom: .25em;
-    width: 1.5em;
+    font-size: 19px;
+    height: 1em;
+    vertical-align: text-top;
+    width: 1em;
 }
 
 .emoticon-suggestion {

--- a/webapp/utils/emoticons.jsx
+++ b/webapp/utils/emoticons.jsx
@@ -38,7 +38,7 @@ export function handleEmoticons(text, tokens, emojis) {
 
             // we have an image path so we found a matching emoticon
             tokens.set(alias, {
-                value: `<img align="absmiddle" alt="${matchText}" class="emoticon" src="${path}" title="${matchText}" />`,
+                value: `<span alt="${matchText}" class="emoticon" title="${matchText}" style="background-image:url(${path})"></span>`,
                 originalText: fullMatch
             });
 


### PR DESCRIPTION
This switches emoji to use a span with a background-image so that they'll maintain their aspect ratio, but still take up the same amount of space. It may also make them slightly smaller than they were previously, but now they'll be the same size as the line of text that they're in.

Oddly enough, the CSS didn't need to be changed for unicode emojis which still use an image tag.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4300

#### Checklist
- Has UI changes