### PR TITLE
PLT-4723 Cleared at mention suggestions when something invalid is typed

### DIFF
--- a/webapp/components/suggestion/at_mention_provider.jsx
+++ b/webapp/components/suggestion/at_mention_provider.jsx
@@ -4,6 +4,7 @@
 import Suggestion from './suggestion.jsx';
 
 import ChannelStore from 'stores/channel_store.jsx';
+import SuggestionStore from 'stores/suggestion_store.jsx';
 
 import {autocompleteUsersInChannel} from 'actions/user_actions.jsx';
 
@@ -106,11 +107,22 @@ export default class AtMentionProvider {
     }
 
     componentWillUnmount() {
-        clearTimeout(this.timeoutId);
+        this.clearTimeout(this.timeoutId);
+    }
+
+    clearTimeout() {
+        if (this.timeoutId) {
+            clearTimeout(this.timeoutId);
+            this.timeoutId = '';
+
+            return true;
+        }
+
+        return false;
     }
 
     handlePretextChanged(suggestionId, pretext) {
-        clearTimeout(this.timeoutId);
+        const hadSuggestions = this.clearTimeout(this.timeoutId);
 
         const captured = (/(?:^|\W)@([a-z0-9\-._]*)$/i).exec(pretext.toLowerCase());
         if (captured) {
@@ -159,6 +171,11 @@ export default class AtMentionProvider {
                 autocomplete.bind(this),
                 Constants.AUTOCOMPLETE_TIMEOUT
             );
+        }
+
+        if (hadSuggestions) {
+            // Clear the suggestions since the user has now typed something invalid
+            SuggestionStore.clearSuggestions(suggestionId);
         }
     }
 }


### PR DESCRIPTION
This changes the AtMentionProvider to automatically clear suggestions when something invalid gets typed. Right now, if you type anything that is no longer a hashtag like `@abc,`, it'll still show the autocomplete suggestions and attempt to fill them in when you hit enter.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4723

#### Checklist
- Has UI changes
