### PR TITLE
PLT-4280 Update Slack Import help text.

### DIFF
--- a/webapp/components/team_import_tab.jsx
+++ b/webapp/components/team_import_tab.jsx
@@ -48,7 +48,7 @@ class TeamImportTab extends React.Component {
             <div>
                 <FormattedHTMLMessage
                     id='team_import_tab.importHelp'
-                    defaultMessage="<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of messages in your Slack team's public channels.</p><p>To import posts with attached files, or for more detailed information about this feature, please see the <a href='https://docs.mattermost.com/administration/migrating.html#migrating-from-slack'>Mattermost Documentation</a>.</p>"
+                    defaultMessage="<p>Slack import to Mattermost supports importing of messages in your Slack team's public channels.</p><p>To import a team from Slack, go to <strong>Slack > Team Settings > Import/Export Data > Export > Start Export</strong>.  See <a href='https://docs.mattermost.com/administration/migrating.html#migrating-from-slack'>documentation</a> to learn more.</p><p>To import posts with attached files, see <a href='https://github.com/grundleborg/slack-advanced-exporter'>Slack Advanced Exporter</a> for details.</p>"
                 />
             </div>
         );

--- a/webapp/components/team_import_tab.jsx
+++ b/webapp/components/team_import_tab.jsx
@@ -48,7 +48,7 @@ class TeamImportTab extends React.Component {
             <div>
                 <FormattedHTMLMessage
                     id='team_import_tab.importHelp'
-                    defaultMessage="<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export files, images, private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of text messages in your Slack team's public channels.</p><p>The Slack import to Mattermost is in 'Beta'. Slack bot posts do not yet import.</p>"
+                    defaultMessage="<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of messages in your Slack team's public channels.</p><p>To import posts with attached files, or for more detailed information about this feature, please see the <a href='https://docs.mattermost.com/administration/migrating.html#migrating-from-slack'>Mattermost Documentation</a>.</p>"
                 />
             </div>
         );

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1779,7 +1779,7 @@
   "team_export_tab.unable": " Unable to export: {error}",
   "team_import_tab.failure": " Import failure: ",
   "team_import_tab.import": "Import",
-  "team_import_tab.importHelp": "<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export files, images, private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of text messages in your Slack team's public channels.</p><p>The Slack import to Mattermost is in 'Beta'. Slack bot posts do not yet import.</p>",
+  "team_import_tab.importHelp": "<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of messages in your Slack team's public channels.</p><p>To import posts with attached files, or for more detailed information about this feature, please see the <a href=\"https://docs.mattermost.com/administration/migrating.html#migrating-from-slack\">Mattermost Documentation</a>.</p>",
   "team_import_tab.importSlack": "Import from Slack (Beta)",
   "team_import_tab.importing": " Importing...",
   "team_import_tab.successful": " Import successful: ",

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1779,7 +1779,7 @@
   "team_export_tab.unable": " Unable to export: {error}",
   "team_import_tab.failure": " Import failure: ",
   "team_import_tab.import": "Import",
-  "team_import_tab.importHelp": "<p>To import a team from Slack go to Slack > Team Settings > Import/Export Data > Export > Start Export. Slack does not allow you to export private groups or direct messages stored in Slack. Therefore, Slack import to Mattermost only supports importing of messages in your Slack team's public channels.</p><p>To import posts with attached files, or for more detailed information about this feature, please see the <a href=\"https://docs.mattermost.com/administration/migrating.html#migrating-from-slack\">Mattermost Documentation</a>.</p>",
+  "team_import_tab.importHelp": "<p>Slack import to Mattermost supports importing of messages in your Slack team's public channels.</p><p>To import a team from Slack, go to <strong>Slack > Team Settings > Import/Export Data > Export > Start Export</strong>.  See <a href=\"https://docs.mattermost.com/administration/migrating.html#migrating-from-slack\">documentation</a> to learn more.</p><p>To import posts with attached files, see <a href=\"https://github.com/grundleborg/slack-advanced-exporter\">Slack Advanced Exporter</a> for details.</p>",
   "team_import_tab.importSlack": "Import from Slack (Beta)",
   "team_import_tab.importing": " Importing...",
   "team_import_tab.successful": " Import successful: ",


### PR DESCRIPTION
#### Summary
This updates the Slack Import help text in the Team Settings -> Import page of the UI, as lots has changed since it was written.

Requesting a PM takes a look at my proposed new text, in particular the link to docs.mattermost.com and feeds back on any changes to that text.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4280

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
- [x] Includes text changes and localization file updates