### PR TITLE
PLT-4378 Slack import when channel name is deleted

### DIFF
--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -470,18 +470,28 @@ func SlackAddChannels(teamId string, slackchannels []SlackChannel, posts map[str
 			Header:      sChannel.Topic["value"],
 		}
 		newChannel = SlackSanitiseChannelProperties(newChannel)
-		mChannel := ImportChannel(&newChannel)
+
+		var mChannel *model.Channel
+		if result := <-Srv.Store.Channel().GetByName(teamId, sChannel.Name); result.Err == nil {
+			// The channel already exists as an active channel. Merge with the existing one.
+			mChannel = result.Data.(*model.Channel)
+			log.WriteString(utils.T("api.slackimport.slack_add_channels.merge", map[string]interface{}{"DisplayName": newChannel.DisplayName}))
+		} else if result := <-Srv.Store.Channel().GetDeletedByName(teamId, sChannel.Name); result.Err == nil {
+			// The channel already exists but has been deleted. Generate a random string for the handle instead.
+			newChannel.Name = model.NewId()
+			newChannel = SlackSanitiseChannelProperties(newChannel)
+		}
+
 		if mChannel == nil {
-			// Maybe it already exists?
-			if result := <-Srv.Store.Channel().GetByName(teamId, sChannel.Name); result.Err != nil {
+			// Haven't found an existing channel to merge with. Try importing it as a new one.
+			mChannel = ImportChannel(&newChannel)
+			if mChannel == nil {
 				l4g.Warn(utils.T("api.slackimport.slack_add_channels.import_failed.warn"), newChannel.DisplayName)
 				log.WriteString(utils.T("api.slackimport.slack_add_channels.import_failed", map[string]interface{}{"DisplayName": newChannel.DisplayName}))
 				continue
-			} else {
-				mChannel = result.Data.(*model.Channel)
-				log.WriteString(utils.T("api.slackimport.slack_add_channels.merge", map[string]interface{}{"DisplayName": newChannel.DisplayName}))
 			}
 		}
+
 		addSlackUsersToChannel(sChannel.Members, users, mChannel, log)
 		log.WriteString(newChannel.DisplayName + "\r\n")
 		addedChannels[sChannel.Id] = mChannel

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4316,6 +4316,14 @@
     "translation": "No channels were found"
   },
   {
+    "id": "store.sql_channel.get_deleted_by_name.existing.app_error",
+    "translation": "We couldn't find the existing deleted channel"
+  },
+  {
+    "id": "store.sql_channel.get_deleted_by_name.missing.app_error",
+    "translation": "No deleted channel exists with that name"
+  },
+  {
     "id": "store.sql_channel.get_extra_members.app_error",
     "translation": "We couldn't get the extra info for channel members"
   },

--- a/store/store.go
+++ b/store/store.go
@@ -93,6 +93,7 @@ type ChannelStore interface {
 	PermanentDeleteByTeam(teamId string) StoreChannel
 	GetByName(team_id string, name string) StoreChannel
 	GetByNameIncludeDeleted(team_id string, name string) StoreChannel
+	GetDeletedByName(team_id string, name string) StoreChannel
 	GetChannels(teamId string, userId string) StoreChannel
 	GetMoreChannels(teamId string, userId string, offset int, limit int) StoreChannel
 	GetChannelCounts(teamId string, userId string) StoreChannel


### PR DESCRIPTION
#### Summary
This fixes a bug where importing channels from Slack failed when the channel name was the same as one that had already been deleted on the Mattermost server.

I've implemented this exactly as per the proposed solution in JIRA ticket. However, I'm not actually so sure now whether that's the right fix. I can see a number of edge cases when this would still fail or do unexpected things:
- there is a deleted channel called `stuff` and another deleted channel called `stuff-slack`. In this case the import would fail.
- there is a deleted channel called `stuff` and an existing channel called `stuff-slack` - in this case `stuff` from the Slack export would be merged into `stuff-slack`.
- the channel name being imported is longer than the maximum length permitted by Mattermost, so is truncated to that maximum length. The truncated channel name already exists in Mattermost but is deleted. The import will then fail.

I guess the question really is, how far down the rabbit hole do we want to go? @yangchen1 any thoughts?

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4378

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates