### PR TITLE
PLT-4658 Fix failure to import same Slack archive to 2 teams.

### DIFF
--- a/api/slackimport.go
+++ b/api/slackimport.go
@@ -162,7 +162,11 @@ func SlackAddUsers(teamId string, slackusers []SlackUser, log *bytes.Buffer) map
 		if result := <-Srv.Store.User().GetByEmail(email); result.Err == nil {
 			existingUser := result.Data.(*model.User)
 			addedUsers[sUser.Id] = existingUser
-			log.WriteString(utils.T("api.slackimport.slack_add_users.merge_existing", map[string]interface{}{"Email": existingUser.Email, "Username": existingUser.Username}))
+			if err := JoinUserToTeam(team, addedUsers[sUser.Id]); err != nil {
+				log.WriteString(utils.T("api.slackimport.slack_add_users.merge_existing_failed", map[string]interface{}{"Email": existingUser.Email, "Username": existingUser.Username}))
+			} else {
+				log.WriteString(utils.T("api.slackimport.slack_add_users.merge_existing", map[string]interface{}{"Email": existingUser.Email, "Username": existingUser.Username}))
+			}
 			continue
 		}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1632,6 +1632,10 @@
     "translation": "Merged user with existing account: {{.Email}}, {{.Username}}\r\n"
   },
   {
+    "id": "api.slackimport.slack_add_users.merge_existing_failed",
+    "translation": "Tried to merge user with existing account: {{.Email}}, {{.Username}}, but failed to add the user to this team.\r\n"
+  },
+  {
     "id": "api.slackimport.slack_add_users.unable_import",
     "translation": "Unable to import user: {{.Username}}\r\n"
   },


### PR DESCRIPTION
#### Summary

This fixes the issue where you can't import 2 Slack exports with any
users who's emails appear in both exports onto different teams of the
same server.

#### Steps to Test

Import the same Slack export archive into two different teams on the same server. It should work fully both times.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4658
https://github.com/mattermost/platform/issues/4126

#### Checklist
- [x] Includes text changes and localization file updates
