### PR TITLE
PLT-4150 Added pre-emptive check for no matches found in channel switcher

### DIFF
--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -26,6 +26,11 @@ export default class SuggestionBox extends React.Component {
         this.handlePretextChanged = this.handlePretextChanged.bind(this);
 
         this.suggestionId = Utils.generateId();
+
+        if (this.props.suggestionId !== null) {
+            this.suggestionId = this.props.suggestionId;
+        }
+
         SuggestionStore.registerSuggestionBox(this.suggestionId);
     }
 
@@ -243,6 +248,7 @@ SuggestionBox.propTypes = {
     providers: React.PropTypes.arrayOf(React.PropTypes.object),
     listStyle: React.PropTypes.string,
     renderDividers: React.PropTypes.bool,
+    suggestionId: React.PropTypes.string,
 
     // explicitly name any input event handlers we override and need to manually call
     onChange: React.PropTypes.func,

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -854,7 +854,8 @@ export const Constants = {
     MENTION_SPECIAL: 'mention.special',
     DEFAULT_NOTIFICATION_DURATION: 5000,
     STATUS_INTERVAL: 60000,
-    AUTOCOMPLETE_TIMEOUT: 100
+    AUTOCOMPLETE_TIMEOUT: 100,
+    CHANNEL_SWITCH_ID: 'channelSwitch'
 };
 
 export default Constants;


### PR DESCRIPTION
#### Summary
Users no longer need to press enter or click Switch on the channel switcher to see "No matches found".

Done by pre-emptively checking the suggestions upon a change. Note: will be 1 character behind.

Also refactored channel switcher logic slightly.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4150

#### Checklist
- [x] Has UI changes

