### PR TITLE
Fix some react warning messages

### DIFF
--- a/webapp/components/autosize_textarea.jsx
+++ b/webapp/components/autosize_textarea.jsx
@@ -53,11 +53,17 @@ export default class AutosizeTextarea extends React.Component {
     }
 
     render() {
+        const props = {...this.props};
+
+        Reflect.deleteProperty(props, 'onHeightChange');
+        Reflect.deleteProperty(props, 'providers');
+        Reflect.deleteProperty(props, 'channelId');
+
         const {
             value,
             placeholder,
             ...otherProps
-        } = this.props;
+        } = props;
 
         const heightProps = {};
         if (this.height <= 0) {
@@ -72,7 +78,7 @@ export default class AutosizeTextarea extends React.Component {
                 <textarea
                     ref='textarea'
                     {...heightProps}
-                    {...this.props}
+                    {...props}
                 />
                 <div style={{height: 0, overflow: 'hidden'}}>
                     <textarea

--- a/webapp/components/change_url_modal.jsx
+++ b/webapp/components/change_url_modal.jsx
@@ -227,6 +227,6 @@ ChangeUrlModal.propTypes = {
     currentURL: React.PropTypes.string,
     serverError: React.PropTypes.node,
     onModalSubmit: React.PropTypes.func.isRequired,
-    onModalExited: React.PropTypes.func.optional,
+    onModalExited: React.PropTypes.func,
     onModalDismissed: React.PropTypes.func.isRequired
 };

--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -448,7 +448,10 @@ export default class ChannelHeader extends React.Component {
             );
 
             dropdownContents.push(
-                <li className='divider'/>
+                <li
+                    key='divider-1'
+                    className='divider'
+                />
             );
 
             if (!ChannelStore.isDefault(channel)) {
@@ -511,7 +514,10 @@ export default class ChannelHeader extends React.Component {
             }
 
             dropdownContents.push(
-                <li className='divider'/>
+                <li
+                    key='divider-2'
+                    className='divider'
+                />
             );
 
             const deleteOption = (
@@ -607,7 +613,10 @@ export default class ChannelHeader extends React.Component {
             }
 
             dropdownContents.push(
-                <li className='divider'/>
+                <li
+                    key='divider-3'
+                    className='divider'
+                />
             );
 
             const canLeave = channel.type === Constants.PRIVATE_CHANNEL ? this.state.userCount > 1 : true;

--- a/webapp/components/new_channel_modal.jsx
+++ b/webapp/components/new_channel_modal.jsx
@@ -12,20 +12,13 @@ import UserStore from 'stores/user_store.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 
-import {intlShape, injectIntl, defineMessages, FormattedMessage} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {Modal} from 'react-bootstrap';
 
-const holders = defineMessages({
-    nameEx: {
-        id: 'channel_modal.nameEx',
-        defaultMessage: 'E.g.: "Bugs", "Marketing", "客户支持"'
-    }
-});
-
 import React from 'react';
 
-class NewChannelModal extends React.Component {
+export default class NewChannelModal extends React.Component {
     constructor(props) {
         super(props);
 
@@ -242,7 +235,7 @@ class NewChannelModal extends React.Component {
                                         type='text'
                                         ref='display_name'
                                         className='form-control'
-                                        placeholder={this.props.intl.formatMessage(holders.nameEx)}
+                                        placeholder={Utils.localizeMessage('channel_modal.nameEx', 'E.g.: "Bugs", "Marketing", "客户支持"')}
                                         maxLength='22'
                                         value={this.props.channelData.displayName}
                                         autoFocus={true}
@@ -284,7 +277,7 @@ class NewChannelModal extends React.Component {
                                         className='form-control no-resize'
                                         ref='channel_purpose'
                                         rows='4'
-                                        placeholder={this.props.intl.formatMessage({id: 'channel_modal.purpose'})}
+                                        placeholder={Utils.localizeMessage('channel_modal.purpose', 'Purpose')}
                                         maxLength='250'
                                         value={this.props.channelData.purpose}
                                         onChange={this.handleChange}
@@ -321,7 +314,7 @@ class NewChannelModal extends React.Component {
                                         className='form-control no-resize'
                                         ref='channel_header'
                                         rows='4'
-                                        placeholder={this.props.intl.formatMessage({id: 'channel_modal.header'})}
+                                        placeholder={Utils.localizeMessage('channel_modal.header', 'Header')}
                                         maxLength='128'
                                         value={this.props.channelData.header}
                                         onChange={this.handleChange}
@@ -377,17 +370,15 @@ NewChannelModal.defaultProps = {
     serverError: null
 };
 NewChannelModal.propTypes = {
-    intl: intlShape.isRequired,
     show: React.PropTypes.bool.isRequired,
     channelType: React.PropTypes.string.isRequired,
     channelData: React.PropTypes.object.isRequired,
     serverError: React.PropTypes.node,
     onSubmitChannel: React.PropTypes.func.isRequired,
     onModalDismissed: React.PropTypes.func.isRequired,
-    onModalExited: React.PropTypes.func.optional,
+    onModalExited: React.PropTypes.func,
     onTypeSwitched: React.PropTypes.func.isRequired,
     onChangeURLPressed: React.PropTypes.func.isRequired,
     onDataChanged: React.PropTypes.func.isRequired
 };
 
-export default injectIntl(NewChannelModal);

--- a/webapp/components/post_view/components/post_body.jsx
+++ b/webapp/components/post_view/components/post_body.jsx
@@ -211,7 +211,7 @@ export default class PostBody extends React.Component {
 PostBody.propTypes = {
     post: React.PropTypes.object.isRequired,
     parentPost: React.PropTypes.object,
-    retryPost: React.PropTypes.func.isRequired,
+    retryPost: React.PropTypes.func,
     handleCommentClick: React.PropTypes.func.isRequired,
     compactDisplay: React.PropTypes.bool,
     previewCollapsed: React.PropTypes.string,

--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -456,7 +456,8 @@ export default class SidebarHeaderDropdown extends React.Component {
 
         return (
             <Dropdown
-                open={this.state.showDropdown}
+                id='sidebar-header-dropdown'
+                defaultOpen={this.state.showDropdown}
                 onClose={this.toggleDropdown}
                 className='sidebar-header-dropdown'
                 pullRight={true}

--- a/webapp/components/status_icon.jsx
+++ b/webapp/components/status_icon.jsx
@@ -33,5 +33,5 @@ export default class StatusIcon extends React.Component {
 }
 
 StatusIcon.propTypes = {
-    status: React.PropTypes.string.isRequired
+    status: React.PropTypes.string
 };

--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -180,11 +180,13 @@ export default class SuggestionBox extends React.Component {
                 />
             );
         } else if (type === 'search') {
+            const newProps = {...props};
+            Reflect.deleteProperty(newProps, 'providers');
             textbox = (
                 <input
                     ref='textbox'
                     type='search'
-                    {...props}
+                    {...newProps}
                     onInput={this.handleChange}
                     onKeyDown={this.handleKeyDown}
                 />

--- a/webapp/components/user_settings/user_settings_general.jsx
+++ b/webapp/components/user_settings/user_settings_general.jsx
@@ -96,7 +96,6 @@ class UserSettingsGeneralTab extends React.Component {
         this.updateSection = this.updateSection.bind(this);
 
         this.state = this.setupInitialState(props);
-        this.setState({maxFileSize: global.window.mm_config.MaxFileSize});
     }
 
     submitUsername(e) {
@@ -307,7 +306,8 @@ class UserSettingsGeneralTab extends React.Component {
             confirmEmail: '',
             picture: null,
             loadingPicture: false,
-            emailChangeInProgress: false
+            emailChangeInProgress: false,
+            maxFileSize: global.window.mm_config.MaxFileSize
         };
     }
 


### PR DESCRIPTION
This fixes a few react warnings that were shown in the system console although I cannot find a way to get rid of this one

```
warning.js?4077:40Warning: Unknown props `bsRole`, `bsClass` on <a> tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop
    in a (created by Dropdown)
    in div (created by ButtonGroup)
    in ButtonGroup (created by Dropdown)
    in Dropdown (created by Uncontrolled(Dropdown))
    in Uncontrolled(Dropdown) (created by SidebarHeaderDropdown)
    in SidebarHeaderDropdown (created by SidebarHeader)
    in div (created by SidebarHeader)
    in SidebarHeader (created by Sidebar)
    in div (created by Sidebar)
    in Sidebar (created by RouterContext)
    in div (created by NeedsTeam)
    in div (created by NeedsTeam)
    in NeedsTeam (created by RouterContext)
    in LoggedIn (created by RouterContext)
    in IntlProvider (created by Root)
    in Root (created by RouterContext)
    in RouterContext (created by Router)
    in Router
```