### PR TITLE
Matterbot as internal API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -112,6 +112,7 @@ func InitApi() {
 	utils.InitHTML()
 
 	InitEmailBatching()
+	InitMatterbot()
 }
 
 func HandleEtag(etag string, w http.ResponseWriter, r *http.Request) bool {

--- a/api/command_statuses_test.go
+++ b/api/command_statuses_test.go
@@ -22,6 +22,7 @@ func commandAndTest(t *testing.T, th *TestHelper, status string) {
 	channel := th.BasicChannel
 	user := th.BasicUser
 
+	Client.Login(user.Username, user.Password)
 	r1 := Client.Must(Client.Command(channel.Id, "/"+status, false)).Data.(*model.CommandResponse)
 	if r1 == nil {
 		t.Fatal("Command failed to execute")

--- a/api/matterbot.go
+++ b/api/matterbot.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api
+
+import (
+	"fmt"
+	"regexp"
+
+	"strings"
+
+	l4g "github.com/alecthomas/log4go"
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+var matterbotUser *model.User
+
+const (
+	matterbotName  = "Matterbot"
+	matterbotEmail = "matterbot@mattermost.com"
+)
+
+func InitMatterbot() {
+	// Find an existing matterbot or create a new matterbot user
+	if matterbotUser == nil {
+		matterbotUser = makeMatterbotUserIfNeeded()
+	}
+}
+
+func makeMatterbotUserIfNeeded() *model.User {
+	// Try to find an existing matterbot user
+	if result := <-Srv.Store.User().GetByUsername(matterbotName); result.Err == nil {
+		existingUser := result.Data.(*model.User)
+		if existingUser.Email != matterbotEmail || !existingUser.EmailVerified {
+			l4g.Error(utils.T("api.matterbot.init_matterbot.create_user.error"))
+			return nil
+		}
+		return existingUser
+	}
+	// Create a new matterbot user
+	newUser := &model.User{
+		Email:         matterbotEmail,
+		Username:      matterbotName,
+		Nickname:      matterbotName,
+		Password:      model.NewRandomString(16),
+		EmailVerified: true,
+	}
+
+	// matterbot is always online
+	SetStatusOnline(newUser.Id, "", true)
+
+	if u, err := CreateUser(newUser); err != nil {
+		l4g.Error(utils.T("api.matterbot.init_matterbot.create_user.error"), err)
+		return nil
+	} else {
+		return u
+	}
+}
+
+func SendMatterbotMessage(c *Context, userId string, message string) {
+	if matterbotUser == nil || userId == matterbotUser.Id {
+		return
+	}
+
+	// Try to get an existing direct channel
+	var botchannel *model.Channel
+	if result := <-Srv.Store.Channel().GetByName("", model.GetDMNameFromIds(userId, matterbotUser.Id)); result.Err != nil {
+		// Create a direct channel
+		if sc, err := CreateDirectChannel(matterbotUser.Id, userId); err != nil {
+			l4g.Error(utils.T("api.matterbot.send_message.create_direct_channel.error"), err)
+			return
+		} else {
+			botchannel = sc
+		}
+	} else {
+		botchannel = result.Data.(*model.Channel)
+	}
+
+	// Create the post
+	if botchannel != nil {
+		post := &model.Post{
+			ChannelId: botchannel.Id,
+			Message:   message,
+			Type:      model.POST_DEFAULT,
+			UserId:    matterbotUser.Id,
+		}
+
+		if _, err := CreatePost(c, post, false); err != nil {
+			l4g.Error(utils.T("api.matterbot.send_message.create_post.error"), err)
+			return
+		}
+	}
+}
+
+func MatterbotPostUserRemovedMessage(c *Context, removedUserId string, otherUserId string, channel *model.Channel) {
+	if matterbotUser == nil {
+		return
+	}
+
+	// Get the user that removed the removed user
+	if oresult := <-Srv.Store.User().Get(otherUserId); oresult.Err != nil {
+		l4g.Error(utils.T("api.matterbot.channel.remove_member.error"), oresult.Err)
+		return
+	} else {
+		otherUser := oresult.Data.(*model.User)
+		message := fmt.Sprintf(utils.T("api.matterbot.channel.remove_member.removed"), channel.DisplayName, otherUser.Username)
+
+		go SendMatterbotMessage(c, removedUserId, message)
+	}
+}
+
+func MatterbotPostChannelDeletedMessage(c *Context, channel *model.Channel, user *model.User) {
+	var members []model.ChannelMember
+
+	if result := <-Srv.Store.Channel().GetMembers(channel.Id); result.Err != nil {
+		l4g.Error(utils.T("api.matterbot.channel.retrieve_members.error"), result.Err)
+		return
+	} else {
+		members = result.Data.([]model.ChannelMember)
+
+		for _, channelMember := range members {
+			if channelMember.UserId != user.Id {
+				message := fmt.Sprintf(utils.T("api.matterbot.channel.delete_channel.archived"), user.Username, channel.DisplayName)
+				go SendMatterbotMessage(c, channelMember.UserId, message)
+			}
+		}
+	}
+}
+
+func MatterbotProcessPost(c *Context, post *model.Post) {
+	if matterbotUser == nil || matterbotUser.Id == post.UserId {
+		return
+	}
+
+	// Check if the post was sent to matterbot
+	if cresult := <-Srv.Store.Channel().GetByName("", model.GetDMNameFromIds(post.UserId, matterbotUser.Id)); cresult.Err != nil {
+		// No direct message channel between sender and matterbot
+		return
+	} else if cresult.Data.(*model.Channel).Id != post.ChannelId {
+		// The message is not meant for matterbot
+		return
+	}
+
+	// Get the sending user to retrieve personal information
+	var sender *model.User
+	if uresult := <-Srv.Store.User().Get(post.UserId); uresult.Err != nil {
+		// No user for the post
+		return
+	} else {
+		sender = uresult.Data.(*model.User)
+	}
+
+	msg := strings.ToLower(post.Message)
+
+	// Respond to a greeting
+	if matched, _ := regexp.MatchString(`(?:^|\W)(?:hi|hello|hey)(?: matterbot)?!*(?:$|\W)`, msg); matched {
+		SendMatterbotMessage(c, sender.Id, "Hey "+sender.GetDisplayName()+"!")
+	}
+
+	// Respond to gratitude
+	if matched, _ := regexp.MatchString(`(?:^|\W)(?:thanks|thank you)(?: matterbot)?!*(?:$|\W)`, msg); matched {
+		SendMatterbotMessage(c, sender.Id, "No problem "+sender.GetDisplayName()+"!")
+	}
+}

--- a/api/matterbot_test.go
+++ b/api/matterbot_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+func messageCountFromMatterbot(t *testing.T, c *model.Client, u *model.User, expectValid bool) int {
+	const (
+		MESSAGES_LIMIT = 10
+	)
+
+	// matterbot must exist by now?
+	if mresult := <-Srv.Store.User().GetByUsername(matterbotName); mresult.Err == nil {
+		c.Login(u.Username, u.Password)
+		matterbot := mresult.Data.(*model.User)
+
+		// direct channel with matterbot must exist by now?
+		if cresult := <-Srv.Store.Channel().GetByName("", model.GetDMNameFromIds(matterbot.Id, u.Id)); cresult.Err == nil {
+			botchannel := cresult.Data.(*model.Channel)
+
+			if presult, err := c.GetPosts(botchannel.Id, 0, MESSAGES_LIMIT, ""); err == nil {
+				postList := presult.Data.(*model.PostList)
+				return len(postList.Posts)
+
+			} else if expectValid {
+				t.Fatal(fmt.Sprintf("Could not retrieve Matterbot messages %v", expectValid))
+			}
+
+		} else if expectValid {
+			t.Fatal(fmt.Sprintf("Matterbot direct channel was not created %v", expectValid))
+		}
+
+	} else if expectValid {
+		t.Fatal(fmt.Sprintf("Matterbot was not created %v", expectValid))
+	}
+
+	return 0
+}
+
+func getMockContext(u *model.User, t *model.Team) *Context {
+	mockSession := model.Session{
+		UserId:      u.Id,
+		TeamMembers: []*model.TeamMember{{TeamId: t.Id, UserId: u.Id}},
+		IsOAuth:     false,
+	}
+
+	newContext := &Context{
+		Session:   mockSession,
+		RequestId: model.NewId(),
+		IpAddress: "",
+		Path:      "fake",
+		Err:       nil,
+		siteURL:   *utils.Cfg.ServiceSettings.SiteURL,
+		TeamId:    t.Id,
+	}
+
+	return newContext
+}
+
+func TestMatterbotMessageOnUserRemoved(t *testing.T) {
+	th := Setup().InitBasic()
+	c := th.BasicClient
+	team := th.BasicTeam
+
+	basic := th.BasicUser
+	UpdateUserToTeamAdmin(basic, team)
+
+	basic2 := th.BasicUser2
+	LinkUserToTeam(basic2, team)
+
+	// create channel and add the other user
+	th.LoginBasic()
+	channel := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel = c.Must(c.CreateChannel(channel)).Data.(*model.Channel)
+	c.Must(c.AddChannelMember(channel.Id, basic2.Id))
+
+	starting_count := messageCountFromMatterbot(t, c, basic2, false)
+
+	MatterbotPostUserRemovedMessage(getMockContext(basic, team), basic2.Id, basic.Id, channel)
+
+	ending_count := messageCountFromMatterbot(t, c, basic2, true)
+
+	if ending_count != starting_count+1 {
+		t.Fatal("Matterbot did not create message")
+	}
+}
+
+func TestMatterbotMessagesOnChannelArchived(t *testing.T) {
+	th := Setup().InitBasic()
+	c := th.BasicClient
+	team := th.BasicTeam
+
+	basic := th.BasicUser
+	UpdateUserToTeamAdmin(basic, team)
+
+	user1 := th.CreateUser(c)
+	user2 := th.CreateUser(c)
+	LinkUserToTeam(user1, team)
+	LinkUserToTeam(user2, team)
+
+	// create channel and add the other users
+	th.LoginBasic()
+	channel := &model.Channel{DisplayName: "A Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel = c.Must(c.CreateChannel(channel)).Data.(*model.Channel)
+	c.Must(c.AddChannelMember(channel.Id, user1.Id))
+	c.Must(c.AddChannelMember(channel.Id, user2.Id))
+
+	starting_count1 := messageCountFromMatterbot(t, c, user1, false)
+	starting_count2 := messageCountFromMatterbot(t, c, user2, false)
+
+	MatterbotPostChannelDeletedMessage(getMockContext(basic, team), channel, basic)
+
+	ending_count1 := messageCountFromMatterbot(t, c, user1, true)
+	ending_count2 := messageCountFromMatterbot(t, c, user2, true)
+
+	if ending_count1 != starting_count1+1 || ending_count2 != starting_count2+1 {
+		t.Fatal("Matterbot did not create message")
+	}
+}

--- a/api/post.go
+++ b/api/post.go
@@ -279,6 +279,10 @@ func handlePostEvents(c *Context, post *model.Post, triggerWebhooks bool) {
 	if channel.Type == model.CHANNEL_DIRECT {
 		go makeDirectChannelVisible(post.ChannelId)
 	}
+
+	if triggerWebhooks && channel.Type == model.CHANNEL_DIRECT {
+		go MatterbotProcessPost(c, post)
+	}
 }
 
 func makeDirectChannelVisible(channelId string) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1102,6 +1102,34 @@
     "translation": "License did not remove properly."
   },
   {
+    "id": "api.matterbot.channel.retrieve_members.error",
+    "translation": "Could not retrieve list of members belonging to channel, err=%v"
+  },
+  {
+    "id": "api.matterbot.channel.delete_channel.archived",
+    "translation": "%v archived the private group/public channel %v"
+  },
+  {
+    "id": "api.matterbot.channel.remove_member.error",
+    "translation": "Could not retrieve the removing user, err=%v"
+  },
+  {
+    "id": "api.matterbot.channel.remove_member.removed",
+    "translation": "You have been removed from the channel %v by %v."
+  },
+  {
+    "id": "api.matterbot.init_matterbot.create_user.error",
+    "translation": "Error creating a user for matterbot, err=%v"
+  },
+  {
+    "id": "api.matterbot.send_message.create_direct_channel.error",
+    "translation": "Error creating a direct channel for matterbot, err=%v"
+  },
+  {
+    "id": "api.matterbot.send_message.create_post.error",
+    "translation": "Error creating a matterbot message, err=%v"
+  },
+  {
     "id": "api.oauth.allow_oauth.bad_client.app_error",
     "translation": "invalid_request: Bad client_id"
   },

--- a/model/user.go
+++ b/model/user.go
@@ -463,7 +463,6 @@ var validUsernameChars = regexp.MustCompile(`^[a-z0-9\.\-_]+$`)
 var restrictedUsernames = []string{
 	"all",
 	"channel",
-	"matterbot",
 }
 
 func IsValidUsername(s string) bool {

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -205,6 +205,7 @@ func (s SqlChannelStore) saveChannelT(transaction *gorp.Transaction, channel *mo
 	if err := transaction.Insert(channel); err != nil {
 		if IsUniqueConstraintError(err.Error(), []string{"Name", "channels_name_teamid_key"}) {
 			dupChannel := model.Channel{}
+			// this DeleteAt > 0 query condition could be a bug
 			s.GetMaster().SelectOne(&dupChannel, "SELECT * FROM Channels WHERE TeamId = :TeamId AND Name = :Name AND DeleteAt > 0", map[string]interface{}{"TeamId": channel.TeamId, "Name": channel.Name})
 			if dupChannel.DeleteAt > 0 {
 				result.Err = model.NewLocAppError("SqlChannelStore.Save", "store.sql_channel.save_channel.previously.app_error", nil, "id="+channel.Id+", "+err.Error())


### PR DESCRIPTION
#### Summary
Adds basic Matterbot functionality. Matterbot reports certain events as direct messages to users.

**Incomplete**: requires more functionality feedback.
1. Should Matterbot be a system level toggle? (and where should this appear)
2. Should Matterbot be a team level toggle? (and where should this appear)
3. Should Matterbot be treated exactly as a regular user, or should there be special handling. (eg not showing up in a channel invite) If so, what cases should be handled?
4. When Matterbot is toggled, what should the migration behavior look like? If a previous "Matterbot" exists, do we wipe them out?

#### Ticket Link
https://github.com/mattermost/platform/issues/4333

We are aiming only to accomplish (1) and (2) for "Matterbot" functionality from the issue link.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates

#### Team
@michael-ahn
@rjoleary
