### PR TITLE
PLT-4839 Split too-long Slack messages on import.

### DIFF
--- a/api/import.go
+++ b/api/import.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"io"
 	"regexp"
+	"unicode/utf8"
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/platform/model"
@@ -19,10 +20,24 @@ import (
 //
 
 func ImportPost(post *model.Post) {
-	post.Hashtags, _ = model.ParseHashtags(post.Message)
+	for utf8.RuneCountInString(post.Message) > 0 {
+		var remainder string
+		if utf8.RuneCountInString(post.Message) > model.POST_MESSAGE_MAX_RUNES {
+			remainder = string(([]rune(post.Message))[model.POST_MESSAGE_MAX_RUNES:])
+			post.Message = truncateRunes(post.Message, model.POST_MESSAGE_MAX_RUNES)
+		} else {
+			remainder = ""
+		}
 
-	if result := <-Srv.Store.Post().Save(post); result.Err != nil {
-		l4g.Debug(utils.T("api.import.import_post.saving.debug"), post.UserId, post.Message)
+		post.Hashtags, _ = model.ParseHashtags(post.Message)
+
+		if result := <-Srv.Store.Post().Save(post); result.Err != nil {
+			l4g.Debug(utils.T("api.import.import_post.saving.debug"), post.UserId, post.Message)
+		}
+
+		post.Id = ""
+		post.CreateAt++
+		post.Message = remainder
 	}
 }
 

--- a/api/import.go
+++ b/api/import.go
@@ -20,9 +20,9 @@ import (
 //
 
 func ImportPost(post *model.Post) {
-	for utf8.RuneCountInString(post.Message) > 0 {
+	for messageRuneCount := utf8.RuneCountInString(post.Message); messageRuneCount > 0; messageRuneCount = utf8.RuneCountInString(post.Message) {
 		var remainder string
-		if utf8.RuneCountInString(post.Message) > model.POST_MESSAGE_MAX_RUNES {
+		if messageRuneCount > model.POST_MESSAGE_MAX_RUNES {
 			remainder = string(([]rune(post.Message))[model.POST_MESSAGE_MAX_RUNES:])
 			post.Message = truncateRunes(post.Message, model.POST_MESSAGE_MAX_RUNES)
 		} else {

--- a/model/post.go
+++ b/model/post.go
@@ -19,6 +19,11 @@ const (
 	POST_HEADER_CHANGE         = "system_header_change"
 	POST_CHANNEL_DELETED       = "system_channel_deleted"
 	POST_EPHEMERAL             = "system_ephemeral"
+	POST_FILEIDS_MAX_RUNES     = 150
+	POST_FILENAMES_MAX_RUNES   = 4000
+	POST_HASHTAGS_MAX_RUNES    = 1000
+	POST_MESSAGE_MAX_RUNES     = 4000
+	POST_PROPS_MAX_RUNES       = 8000
 )
 
 type Post struct {
@@ -102,11 +107,11 @@ func (o *Post) IsValid() *AppError {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.original_id.app_error", nil, "")
 	}
 
-	if utf8.RuneCountInString(o.Message) > 4000 {
+	if utf8.RuneCountInString(o.Message) > POST_MESSAGE_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.msg.app_error", nil, "id="+o.Id)
 	}
 
-	if utf8.RuneCountInString(o.Hashtags) > 1000 {
+	if utf8.RuneCountInString(o.Hashtags) > POST_HASHTAGS_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.hashtags.app_error", nil, "id="+o.Id)
 	}
 
@@ -115,15 +120,15 @@ func (o *Post) IsValid() *AppError {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.type.app_error", nil, "id="+o.Type)
 	}
 
-	if utf8.RuneCountInString(ArrayToJson(o.Filenames)) > 4000 {
+	if utf8.RuneCountInString(ArrayToJson(o.Filenames)) > POST_FILENAMES_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.filenames.app_error", nil, "id="+o.Id)
 	}
 
-	if utf8.RuneCountInString(ArrayToJson(o.FileIds)) > 150 {
+	if utf8.RuneCountInString(ArrayToJson(o.FileIds)) > POST_FILEIDS_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.file_ids.app_error", nil, "id="+o.Id)
 	}
 
-	if utf8.RuneCountInString(StringInterfaceToJson(o.Props)) > 8000 {
+	if utf8.RuneCountInString(StringInterfaceToJson(o.Props)) > POST_PROPS_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.props.app_error", nil, "id="+o.Id)
 	}
 


### PR DESCRIPTION
#### Summary
Split too-long Slack messages on import.

This PR also takes the opportunity to make the max values for Post
properties into constants for easier use elsewhere, as has previously
been done for Channel properties.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4839