### PR TITLE
PLT4750 Invalidate user channel members cache when creating a new channel

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -120,6 +120,8 @@ func CreateChannel(c *Context, channel *model.Channel, addMember bool) (*model.C
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				return nil, cmresult.Err
 			}
+
+			InvalidateCacheForUser(c.Session.UserId)
 		}
 
 		c.LogAudit("name=" + channel.Name)


### PR DESCRIPTION
#### Summary
This was causing slash commands and other messages to seem not to work in newly created channels for ~15 minutes until the cache expired.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4750