### PR TITLE
GH-4658  Show profile popover when clicking on username or profile picture in DMs

### DIFF
--- a/webapp/utils/channel_intro_messages.jsx
+++ b/webapp/utils/channel_intro_messages.jsx
@@ -58,7 +58,7 @@ export function createDMIntroMessage(channel, centeredIntro) {
                     <strong>
                         <UserProfile
                             user={teammate}
-                            disablePopover={true}
+                            disablePopover={false}
                         />
                     </strong>
                 </div>

--- a/webapp/utils/channel_intro_messages.jsx
+++ b/webapp/utils/channel_intro_messages.jsx
@@ -12,6 +12,7 @@ import TeamStore from 'stores/team_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import Client from 'client/web_client.jsx';
+import ProfilePicture from 'components/profile_picture.jsx';
 
 import React from 'react';
 import {FormattedMessage, FormattedHTMLMessage, FormattedDate} from 'react-intl';
@@ -46,11 +47,11 @@ export function createDMIntroMessage(channel, centeredIntro) {
         return (
             <div className={'channel-intro ' + centeredIntro}>
                 <div className='post-profile-img__container channel-intro-img'>
-                    <img
-                        className='post-profile-img'
+                    <ProfilePicture
                         src={Client.getUsersRoute() + '/' + teammate.id + '/image?time=' + teammate.update_at}
-                        height='50'
                         width='50'
+                        height='50'
+                        user={teammate}
                     />
                 </div>
                 <div className='channel-intro-profile'>


### PR DESCRIPTION

#### Summary
Clicking a profile image or username in the top of the direct messages channel now displays the profile popover.

#### Ticket Link
https://github.com/mattermost/platform/issues/4658

#### Checklist
- [ x] Has UI changes


