### PR TITLE
PLT-4859 Email notifications sent when email notifications set to never

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -487,5 +487,5 @@ export default class CreateComment extends React.Component {
 CreateComment.propTypes = {
     channelId: React.PropTypes.string.isRequired,
     rootId: React.PropTypes.string.isRequired,
-    latestPostId: React.PropTypes.string.isRequired
+    latestPostId: React.PropTypes.string
 };

--- a/webapp/components/user_settings/email_notification_setting.jsx
+++ b/webapp/components/user_settings/email_notification_setting.jsx
@@ -64,7 +64,7 @@ export default class EmailNotificationSetting extends React.Component {
         if (this.props.activeSection !== 'email') {
             let description;
 
-            if (this.props.enableEmail === 'true') {
+            if (this.props.enableEmail) {
                 switch (this.state.emailInterval) {
                 case INTERVAL_IMMEDIATE:
                     description = (
@@ -119,7 +119,7 @@ export default class EmailNotificationSetting extends React.Component {
                             <input
                                 type='radio'
                                 name='emailNotifications'
-                                checked={this.props.enableEmail === 'true' && this.state.emailInterval === INTERVAL_FIFTEEN_MINUTES}
+                                checked={this.props.enableEmail && this.state.emailInterval === INTERVAL_FIFTEEN_MINUTES}
                                 onChange={this.handleChange.bind(this, 'true', INTERVAL_FIFTEEN_MINUTES)}
                             />
                             <FormattedMessage
@@ -134,7 +134,7 @@ export default class EmailNotificationSetting extends React.Component {
                             <input
                                 type='radio'
                                 name='emailNotifications'
-                                checked={this.props.enableEmail === 'true' && this.state.emailInterval === INTERVAL_HOUR}
+                                checked={this.props.enableEmail && this.state.emailInterval === INTERVAL_HOUR}
                                 onChange={this.handleChange.bind(this, 'true', INTERVAL_HOUR)}
                             />
                             <FormattedMessage
@@ -170,7 +170,7 @@ export default class EmailNotificationSetting extends React.Component {
                                 <input
                                     type='radio'
                                     name='emailNotifications'
-                                    checked={this.props.enableEmail === 'true' && this.state.emailInterval === INTERVAL_IMMEDIATE}
+                                    checked={this.props.enableEmail && this.state.emailInterval === INTERVAL_IMMEDIATE}
                                     onChange={this.handleChange.bind(this, 'true', INTERVAL_IMMEDIATE)}
                                 />
                                 <FormattedMessage
@@ -185,7 +185,7 @@ export default class EmailNotificationSetting extends React.Component {
                                 <input
                                     type='radio'
                                     name='emailNotifications'
-                                    checked={this.props.enableEmail === 'false'}
+                                    checked={!this.props.enableEmail}
                                     onChange={this.handleChange.bind(this, 'false', INTERVAL_IMMEDIATE)}
                                 />
                                 <FormattedMessage


### PR DESCRIPTION
#### Summary
The initial report was that the notifications for replies wasn't taking into account the setting for email notifications, but in the end it was because the setting was shown being set as **Never** regardless the real value

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4859