### PR TITLE
fix message text

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1509,7 +1509,7 @@
   },
   {
     "id": "api.reaction.delete_reaction.mismatched_channel_id.app_error",
-    "translation": "Failed to save reaction when channel id in URL doesn't match post id in URL"
+    "translation": "Failed to delete reaction when channel id in URL doesn't match post id in URL"
   },
   {
     "id": "api.reaction.list_reactions.mismatched_channel_id.app_error",


### PR DESCRIPTION
#### Summary
FIx incorrect message.
The message ID has the text of `delete_reaction`, but that message says `Failed to save reaction~`.

#### Ticket Link
N/A

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates

