### PR TITLE
PLT-4835 Ignore double quotes in user search

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -1234,6 +1234,7 @@ var specialUserSearchChar = []string{
 	"@",
 	":",
 	"*",
+	"\"",
 }
 
 func (us SqlUserStore) performSearch(searchQuery string, term string, options map[string]bool, parameters map[string]interface{}) StoreResult {


### PR DESCRIPTION
#### Summary
Fixes a bug where searching with `"` caused errors.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4835