### PR TITLE
PLT-4868 Fix Firefox: Javascript error when selecting a theme

### DIFF
--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -619,7 +619,9 @@ export function applyTheme(theme) {
         changeCss('.app__body .sidebar--right', 'color:' + theme.centerChannelColor);
         changeCss('.app__body .search-help-popover .search-autocomplete__item:hover, .app__body .modal .settings-modal .settings-table .settings-content .appearance-section .theme-elements__body', 'background:' + changeOpacity(theme.centerChannelColor, 0.05));
         changeCss('.app__body .search-help-popover .search-autocomplete__item.selected', 'background:' + changeOpacity(theme.centerChannelColor, 0.15));
-        changeCss('body.app__body ::-webkit-scrollbar-thumb', 'background:' + changeOpacity(theme.centerChannelColor, 0.4), 1);
+        if (!UserAgent.isFirefox() && !UserAgent.isInternetExplorer() && !UserAgent.isEdge()) {
+            changeCss('body.app__body ::-webkit-scrollbar-thumb', 'background:' + changeOpacity(theme.centerChannelColor, 0.4), 1);
+        }
         changeCss('body', 'scrollbar-arrow-color:' + theme.centerChannelColor);
         changeCss('.app__body .post-create__container .post-create-body .btn-file svg, .app__body .post.post--compact .post-image__column .post-image__details svg, .app__body .modal .about-modal .about-modal__logo svg, .app__body .post .post__img svg', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .scrollbar--horizontal, .app__body .scrollbar--vertical', 'background:' + changeOpacity(theme.centerChannelColor, 0.5));


### PR DESCRIPTION
#### Summary
Firefox was throwing an error cause the `::-webkit-scrollbar-thumb` selector is only supported by webkit browsers more info [here](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) so I just basically surrounded that in an if statement that verifies if the browser is not firefox or IE, Edge

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4868
