### PR TITLE
PLT-4126 Fixed EmailAuthenticationSettings mutating the stored config

### DIFF
--- a/webapp/components/admin_console/email_connection_test.jsx
+++ b/webapp/components/admin_console/email_connection_test.jsx
@@ -12,6 +12,7 @@ export default class EmailConnectionTestButton extends React.Component {
     static get propTypes() {
         return {
             config: React.PropTypes.object.isRequired,
+            getConfigFromState: React.PropTypes.func.isRequired,
             disabled: React.PropTypes.bool.isRequired
         };
     }
@@ -37,8 +38,11 @@ export default class EmailConnectionTestButton extends React.Component {
             fail: null
         });
 
+        const config = JSON.parse(JSON.stringify(this.props.config));
+        this.props.getConfigFromState(config);
+
         Client.testEmail(
-            this.props.config,
+            config,
             () => {
                 this.setState({
                     testing: false,

--- a/webapp/components/admin_console/email_settings.jsx
+++ b/webapp/components/admin_console/email_settings.jsx
@@ -272,7 +272,8 @@ export default class EmailSettings extends AdminSettings {
                     disabled={!this.state.sendEmailNotifications}
                 />
                 <EmailConnectionTest
-                    config={this.getConfigFromState(this.props.config)}
+                    config={this.props.config}
+                    getConfigFromState={this.getConfigFromState}
                     disabled={!this.state.sendEmailNotifications}
                 />
                 <BooleanSetting


### PR DESCRIPTION
`getConfigFromState` mutates the argument passed into it so it was modifying `this.props.config` only on that one page of the system console

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4126