### PR TITLE
Fix API Get channels for a user returns users' dm channels with blank teamid

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -398,10 +398,13 @@ func updateChannelPurpose(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getChannels(c *Context, w http.ResponseWriter, r *http.Request) {
-
+	if c.TeamId == "" {
+		c.Err = model.NewLocAppError("", "api.context.teamid.app_error", nil, "TeamIdRequired")
+		c.Err.StatusCode = http.StatusBadRequest
+		return
+	}
 	// user is already in the team
 	// Get's all channels the user is a member of
-
 	if result := <-Srv.Store.Channel().GetChannels(c.TeamId, c.Session.UserId); result.Err != nil {
 		if result.Err.Id == "store.sql_channel.get_channels.not_found.app_error" {
 			// lets make sure the user is valid

--- a/api/channel.go
+++ b/api/channel.go
@@ -399,7 +399,7 @@ func updateChannelPurpose(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func getChannels(c *Context, w http.ResponseWriter, r *http.Request) {
 	if c.TeamId == "" {
-		c.Err = model.NewLocAppError("", "api.context.teamid.app_error", nil, "TeamIdRequired")
+		c.Err = model.NewLocAppError("", "api.context.missing_teamid.app_error", nil, "TeamIdRequired")
 		c.Err.StatusCode = http.StatusBadRequest
 		return
 	}

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -719,10 +719,21 @@ func TestGetChannel(t *testing.T) {
 		t.Fatal("should have failed - bad channel id")
 	}
 
-	Client.SetTeamId(team2.Id)
+	th.BasicClient.SetTeamId(team2.Id)
 	if _, err := Client.GetChannel(channel2.Id, ""); err == nil {
 		t.Fatal("should have failed - wrong team")
 	}
+
+	//Test if a wrong team id is supplied should return error
+	if _, err := Client.CreateDirectChannel(th.BasicUser2.Id); err != nil {
+		t.Fatal(err)
+	}
+
+	th.BasicClient.SetTeamId("nonexitingteamid")
+	if _, err := Client.GetChannels(""); err == nil {
+		t.Fatal("should have failed - wrong team id")
+	}
+
 }
 
 func TestGetMoreChannelsPage(t *testing.T) {

--- a/api/context.go
+++ b/api/context.go
@@ -221,7 +221,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		SetStatusOnline(c.Session.UserId, c.Session.Id, false)
 	}
 
-	if c.Err == nil {
+	if c.Err == nil && (h.requireUser || h.requireSystemAdmin) {
 		//check if teamId exist
 		c.CheckTeamId()
 	}

--- a/api/context.go
+++ b/api/context.go
@@ -581,8 +581,7 @@ func (c *Context) CheckTeamId() {
 				return
 			}
 		} else {
-			c.Err = model.NewLocAppError("", "api.context.teamid.app_error", nil, "TeamIdRequired")
-			c.Err.StatusCode = http.StatusBadRequest
+			// just return because it fail on the HasPermissionToContext and the error is already on the Context c.Err
 			return
 		}
 	}

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -175,7 +175,7 @@ func TestRemoveUserFromTeam(t *testing.T) {
 	if _, err := th.BasicClient.RemoveUserFromTeam(th.SystemAdminTeam.Id, th.SystemAdminUser.Id); err == nil {
 		t.Fatal("should fail not enough permissions")
 	} else {
-		if err.Id != "api.context.permissions.app_error" {
+		if err.Id != "api.context.teamid.app_error" {
 			t.Fatal("wrong error. Got: " + err.Id)
 		}
 	}
@@ -731,15 +731,11 @@ func TestGetTeamStats(t *testing.T) {
 		}
 	}
 
-	if result, err := th.SystemAdminClient.GetTeamStats("junk"); err != nil {
-		t.Fatal(err)
+	if _, err := th.SystemAdminClient.GetTeamStats("junk"); err == nil {
+		t.Fatal("should fail invalid teamid")
 	} else {
-		if result.Data.(*model.TeamStats).TotalMemberCount != 0 {
-			t.Fatal("wrong count")
-		}
-
-		if result.Data.(*model.TeamStats).ActiveMemberCount != 0 {
-			t.Fatal("wrong count")
+		if err.Id != "store.sql_team.get.find.app_error" {
+			t.Fatal("wrong error. Got: " + err.Id)
 		}
 	}
 

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -175,7 +175,7 @@ func TestRemoveUserFromTeam(t *testing.T) {
 	if _, err := th.BasicClient.RemoveUserFromTeam(th.SystemAdminTeam.Id, th.SystemAdminUser.Id); err == nil {
 		t.Fatal("should fail not enough permissions")
 	} else {
-		if err.Id != "api.context.teamid.app_error" {
+		if err.Id != "api.context.permissions.app_error" {
 			t.Fatal("wrong error. Got: " + err.Id)
 		}
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -708,7 +708,7 @@
     "translation": "You do not have the appropriate permissions"
   },
   {
-    "id": "api.context.teamid.app_error",
+    "id": "api.context.missing_teamid.app_error",
     "translation": "Missing Team Id"
   },
   {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -708,6 +708,10 @@
     "translation": "You do not have the appropriate permissions"
   },
   {
+    "id": "api.context.teamid.app_error",
+    "translation": "Missing Team Id"
+  },
+  {
     "id": "api.context.session_expired.app_error",
     "translation": "Invalid or expired session, please login again."
   },


### PR DESCRIPTION
#### Summary
API Get channels for a user returns users' dm channels on 3.5 with blank team ID 
This fix also fix issue: https://github.com/mattermost/platform/issues/4398
#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/PLT-4873 and https://mattermost.atlassian.net/browse/PLT-4302
GitHub: https://github.com/mattermost/platform/issues/4583 and https://github.com/mattermost/platform/issues/4398

#### Checklist
- [X] Added or updated unit tests (required for all new features)
- [X] Includes text changes and localization file ([.../i18n/en.json]