### PR TITLE
GH-4759 add system message feedbak for expand/collapse command

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -468,6 +468,10 @@
     "translation": "collapse"
   },
   {
+    "id": "api.command_collapse.success",
+    "translation": "Image links now collapse by default"
+  },
+  {
     "id": "api.command_echo.create.app_error",
     "translation": "Unable to create /echo post, err=%v"
   },
@@ -498,6 +502,10 @@
   {
     "id": "api.command_expand.name",
     "translation": "expand"
+  },
+  {
+    "id": "api.command_expand.success",
+    "translation": "Image links now expand by default"
   },
   {
     "id": "api.command_expand_collapse.fail.app_error",


### PR DESCRIPTION
#### Summary
When typing `/expand` and `/collapse`, system retur `Image links now expand by default` and `Image links now collapse by default` respectively.

#### Ticket Link
#4759

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
