### PR TITLE
Tweaked new message indicator calculation:

### DIFF
--- a/webapp/components/post_view/components/new_message_indicator.jsx
+++ b/webapp/components/post_view/components/new_message_indicator.jsx
@@ -40,7 +40,7 @@ export default class NewMessageIndicator extends React.Component {
                     />
                     <FormattedMessage
                         id='posts_view.newMsgBelow'
-                        defaultMessage='{count} new {count, plural, one {message} other {messages}} below'
+                        defaultMessage='New {count, plural, one {message} other {messages}} below'
                         values={{count: this.props.newMessages}}
                     />
                 </div>

--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import _ from 'lodash';
 import $ from 'jquery';
 
 import Post from './post.jsx';
@@ -84,13 +85,14 @@ export default class PostList extends React.Component {
         // Only count if we're  not at the bottom, not in highlight view,
         // or anything else
         if (nextProps.scrollType === Constants.ScrollTypes.FREE) {
-            for (let i = order.length - 1; i >= 0; i--) {
-                const post = posts[order[i]];
+            unViewedCount = _.reduce(order, (count, orderId) => {
+                const post = posts[orderId];
                 if (post.create_at > nextProps.lastViewedBottom &&
                     post.user_id !== nextProps.currentUser.id) {
-                    unViewedCount++;
+                    return count + 1;
                 }
-            }
+                return count;
+            }, 0);
         }
         this.setState({unViewedCount});
     }

--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -1,7 +1,5 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
-
-import _ from 'lodash';
 import $ from 'jquery';
 
 import Post from './post.jsx';
@@ -85,7 +83,7 @@ export default class PostList extends React.Component {
         // Only count if we're  not at the bottom, not in highlight view,
         // or anything else
         if (nextProps.scrollType === Constants.ScrollTypes.FREE) {
-            unViewedCount = _.reduce(order, (count, orderId) => {
+            unViewedCount = order.reduce((count, orderId) => {
                 const post = posts[orderId];
                 if (post.create_at > nextProps.lastViewedBottom &&
                     post.user_id !== nextProps.currentUser.id &&

--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -88,7 +88,8 @@ export default class PostList extends React.Component {
             unViewedCount = _.reduce(order, (count, orderId) => {
                 const post = posts[orderId];
                 if (post.create_at > nextProps.lastViewedBottom &&
-                    post.user_id !== nextProps.currentUser.id) {
+                    post.user_id !== nextProps.currentUser.id &&
+                    post.state !== Constants.POST_DELETED) {
                     return count + 1;
                 }
                 return count;

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1655,7 +1655,7 @@
   "post_info.reply": "Reply",
   "posts_view.loadMore": "Load more messages",
   "posts_view.newMsg": "New Messages",
-  "posts_view.newMsgBelow": "{count} new {count, plural, one {message} other {messages}} below",
+  "posts_view.newMsgBelow": "New {count, plural, one {message} other {messages}} below",
   "reaction.clickToAdd": "(click to add)",
   "reaction.clickToRemove": "(click to remove)",
   "reaction.othersReacted": "{otherUsers, number} {otherUsers, plural, one {user} other {users}}",


### PR DESCRIPTION
#### Summary
Fixed issues mentioned in the Mattermost channel while reviewing the new message indicator #4299 

#### Ticket Link
#4299 

#### Checklist
_none_

Summary
 - Don't show the indicator when switching from one channel to another, only when receiving new messages in a channel you've already joined.
 - Don't show the indicator when the number of messages doesn't make any sense, for example when all messages in your channel are _new_ messages
    (# new posts >= # visible posts)