### PR TITLE
Fixing etag issue with load tests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -117,6 +117,7 @@ func InitApi() {
 func HandleEtag(etag string, w http.ResponseWriter, r *http.Request) bool {
 	if et := r.Header.Get(model.HEADER_ETAG_CLIENT); len(etag) > 0 {
 		if et == etag {
+			w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 			w.WriteHeader(http.StatusNotModified)
 			return true
 		}


### PR DESCRIPTION
Looks like it should be there as part of the HTTP1.1 spec.