### PR TITLE
Adding caching layer to some posts calls

### DIFF
--- a/api/command_statuses_test.go
+++ b/api/command_statuses_test.go
@@ -27,7 +27,7 @@ func commandAndTest(t *testing.T, th *TestHelper, status string) {
 		t.Fatal("Command failed to execute")
 	}
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 
 	statuses := Client.Must(Client.GetStatuses()).Data.(map[string]string)
 

--- a/api/context.go
+++ b/api/context.go
@@ -564,4 +564,5 @@ func InvalidateAllCaches() {
 	ClearStatusCache()
 	store.ClearChannelCaches()
 	store.ClearUserCaches()
+	store.ClearPostCaches()
 }

--- a/api/slackimport.go
+++ b/api/slackimport.go
@@ -560,6 +560,8 @@ func SlackImport(fileData multipart.File, fileSize int64, teamID string) (*model
 		deactivateSlackBotUser(botUser)
 	}
 
+	InvalidateAllCaches()
+
 	log.WriteString(utils.T("api.slackimport.slack_import.notes"))
 	log.WriteString("=======\r\n\r\n")
 

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -103,8 +103,28 @@ func PublishSkipClusterSend(message *model.WebSocketEvent) {
 }
 
 func InvalidateCacheForChannel(channelId string) {
+	InvalidateCacheForChannelSkipClusterSend(channelId)
+
+	if cluster := einterfaces.GetClusterInterface(); cluster != nil {
+		cluster.InvalidateCacheForChannel(channelId)
+	}
+}
+
+func InvalidateCacheForChannelSkipClusterSend(channelId string) {
 	Srv.Store.User().InvalidateProfilesInChannelCache(channelId)
 	Srv.Store.Channel().InvalidateMemberCount(channelId)
+}
+
+func InvalidateCacheForChannelPosts(channelId string) {
+	InvalidateCacheForChannelPostsSkipClusterSend(channelId)
+
+	if cluster := einterfaces.GetClusterInterface(); cluster != nil {
+		cluster.InvalidateCacheForChannelPosts(channelId)
+	}
+}
+
+func InvalidateCacheForChannelPostsSkipClusterSend(channelId string) {
+	Srv.Store.Post().InvalidatePostEtagCache(channelId)
 }
 
 func InvalidateCacheForUser(userId string) {

--- a/einterfaces/cluster.go
+++ b/einterfaces/cluster.go
@@ -14,6 +14,8 @@ type ClusterInterface interface {
 	GetClusterStats() ([]*model.ClusterStats, *model.AppError)
 	RemoveAllSessionsForUserId(userId string)
 	InvalidateCacheForUser(userId string)
+	InvalidateCacheForChannel(channelId string)
+	InvalidateCacheForChannelPosts(channelId string)
 	Publish(event *model.WebSocketEvent)
 	UpdateStatus(status *model.Status)
 	GetLogs() ([]string, *model.AppError)

--- a/store/store.go
+++ b/store/store.go
@@ -130,11 +130,12 @@ type PostStore interface {
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsSince(channelId string, time int64) StoreChannel
-	GetEtag(channelId string) StoreChannel
+	GetEtag(channelId string, allowFromCache bool) StoreChannel
 	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	AnalyticsUserCountsWithPostsByDay(teamId string) StoreChannel
 	AnalyticsPostCountsByDay(teamId string) StoreChannel
 	AnalyticsPostCount(teamId string, mustHaveFile bool, mustHaveHashtag bool) StoreChannel
+	InvalidatePostEtagCache(channelId string)
 }
 
 type UserStore interface {


### PR DESCRIPTION
EE PR: https://github.com/mattermost/enterprise/pull/77

#### Summary
- Added caching to the etag call of GetPosts
- Fixed channel cache not sending to cluster
- This is a first stage PR. Future PRs will expand this cache to multiple post calls. 

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes (please link)