### PR TITLE
PLT-4493 Fixed copy button in Get Link Modal on Safari 10

### DIFF
--- a/webapp/components/get_link_modal.jsx
+++ b/webapp/components/get_link_modal.jsx
@@ -87,7 +87,7 @@ export default class GetLinkModal extends React.Component {
                     <i className='fa fa-check'/>
                     <FormattedMessage
                         id='get_link.clipboard'
-                        defaultMessage=' Link copied to clipboard.'
+                        defaultMessage=' Link copied'
                     />
                 </p>
             );

--- a/webapp/components/get_link_modal.jsx
+++ b/webapp/components/get_link_modal.jsx
@@ -1,13 +1,10 @@
 // Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import $ from 'jquery';
-import ReactDOM from 'react-dom';
-import {FormattedMessage} from 'react-intl';
-
-import {Modal} from 'react-bootstrap';
-
 import React from 'react';
+
+import {FormattedMessage} from 'react-intl';
+import {Modal} from 'react-bootstrap';
 
 export default class GetLinkModal extends React.Component {
     constructor(props) {
@@ -16,15 +13,10 @@ export default class GetLinkModal extends React.Component {
         this.onHide = this.onHide.bind(this);
 
         this.copyLink = this.copyLink.bind(this);
-        this.selectLinkOnClick = this.selectLinkOnClick.bind(this);
 
         this.state = {
             copiedLink: false
         };
-    }
-
-    componntWillUnmount() {
-        $(this.refs.textarea).off('click');
     }
 
     onHide() {
@@ -33,20 +25,13 @@ export default class GetLinkModal extends React.Component {
         this.props.onHide();
     }
 
-    selectLinkOnClick() {
-        $(this.refs.textarea).on('click', function selectLinkOnClick() {
-            $(this).select();
-            this.setSelectionRange(0, this.value.length);
-        });
-    }
-
     copyLink() {
-        var copyTextarea = $(ReactDOM.findDOMNode(this.refs.textarea));
-        copyTextarea.select();
+        const textarea = this.refs.textarea;
+        textarea.focus();
+        textarea.setSelectionRange(0, this.props.link.length);
 
         try {
-            var successful = document.execCommand('copy');
-            if (successful) {
+            if (document.execCommand('copy')) {
                 this.setState({copiedLink: true});
             } else {
                 this.setState({copiedLink: false});
@@ -90,6 +75,7 @@ export default class GetLinkModal extends React.Component {
                 className='form-control no-resize min-height'
                 ref='textarea'
                 value={this.props.link}
+                onClick={this.copyLink}
                 readOnly={true}
             />
         );
@@ -111,7 +97,6 @@ export default class GetLinkModal extends React.Component {
             <Modal
                 show={this.props.show}
                 onHide={this.onHide}
-                onEntered={this.selectLinkOnClick}
             >
                 <Modal.Header closeButton={true}>
                     <h4 className='modal-title'>{this.props.title}</h4>

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1295,7 +1295,7 @@
   "get_app.iosHeader": "Mattermost works best if you switch to our iPhone app",
   "get_app.mattermostInc": "Mattermost, Inc",
   "get_app.openMattermost": "Open Mattermost",
-  "get_link.clipboard": " Link copied to clipboard.",
+  "get_link.clipboard": " Link copied",
   "get_link.close": "Close",
   "get_link.copy": "Copy Link",
   "get_post_link_modal.help": "The link below allows authorized users to see your post.",


### PR DESCRIPTION
Safari on both Mac and iOS finally match the other browsers with this!

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4493

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- Has UI changes
- Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates