### PR TITLE
add missing messages

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1300,6 +1300,8 @@
   "get_link.copy": "Copy Link",
   "get_post_link_modal.help": "The link below allows authorized users to see your post.",
   "get_post_link_modal.title": "Copy Permalink",
+  "get_public_link_modal.title": "Copy Public Link",
+  "get_public_link_modal.help": "The link below allows anyone to see this file without being registered on this server.",
   "get_team_invite_link_modal.help": "Send teammates the link below for them to sign-up to this team site. The Team Invite Link can be shared with multiple teammates as it does not change unless it's regenerated in Team Settings by a Team Admin.",
   "get_team_invite_link_modal.helpDisabled": "User creation has been disabled for your team. Please ask your Team Administrator for details.",
   "get_team_invite_link_modal.title": "Team Invite Link",


### PR DESCRIPTION
#### Summary
Some messages aren't translated in Copy Public Link modal.
That messages added to `en.json`.
![mm-untranslated](https://cloud.githubusercontent.com/assets/1310661/21164754/76c4d250-c1de-11e6-9fa2-7481b3fdce12.png)

#### Ticket Link
n/a

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
