### PR TITLE
Make the webapp robust to underfined user.position.

### DIFF
--- a/webapp/components/user_profile.jsx
+++ b/webapp/components/user_profile.jsx
@@ -182,8 +182,8 @@ export default class UserProfile extends React.Component {
 
         dataContent.push(webrtc);
 
-        const position = this.props.user.position.substring(0, Constants.MAX_POSITION_LENGTH);
-        if (position) {
+        if (this.props.user.position) {
+            const position = this.props.user.position.substring(0, Constants.MAX_POSITION_LENGTH);
             dataContent.push(
                 <div
                     data-toggle='tooltip'


### PR DESCRIPTION
The "Add position to User Profile" feature is causing JavaScript errors on pre-release and CI servers due to user.position being undefined.

It seems to happen when lazy loading profiles takes place, as the initial render of the UserProfile component, where most/all of the properties are not set.

This fixes the issue by ensuring that if position is undefined, it is handled without error. It the resurrection of a fix @hmhealey proposed yesterday.