### PR TITLE
Support explicit image sizes in markdown

### DIFF
--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -117,20 +117,21 @@ class MattermostMarkdownRenderer extends marked.Renderer {
     }
 
     image(href, title, text) {
+        let src = href;
         let dimensions = [];
-        let parts = href.split(' ');
+        const parts = href.split(' ');
         if (parts.length > 1) {
-            let lastPart = parts.pop();
-            href = parts.join(' ');
-            if (lastPart[0] == '=') {
+            const lastPart = parts.pop();
+            src = parts.join(' ');
+            if (lastPart[0] === '=') {
                 dimensions = lastPart.substr(1).split('x');
             }
         }
-        let out = '<img src="' + href + '" alt="' + text + '"';
+        let out = '<img src="' + src + '" alt="' + text + '"';
         if (title) {
             out += ' title="' + title + '"';
         }
-        if (dimensions.length == 2) {
+        if (dimensions.length === 2) {
             out += ' width="' + dimensions[0] + '" height="' + dimensions[1] + '"';
         }
         out += ' onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"';

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -8,7 +8,7 @@ import marked from 'marked';
 import katex from 'katex';
 
 function markdownImageLoaded(image) {
-    if (image.hasAttribute('height')) {
+    if (image.hasAttribute('height') && image.attributes.height.value !== 'auto') {
         image.style.height = image.attributes.height.value + 'px';
     } else {
         image.style.height = 'auto';

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -9,7 +9,14 @@ import katex from 'katex';
 
 function markdownImageLoaded(image) {
     if (image.hasAttribute('height') && image.attributes.height.value !== 'auto') {
-        image.style.height = image.attributes.height.value + 'px';
+        const maxHeight = parseInt(global.getComputedStyle(image).maxHeight);
+
+        if (image.attributes.height.value > maxHeight) {
+            image.style.height = maxHeight + 'px';
+            image.style.width = (maxHeight * image.attributes.width.value / image.attributes.height.value) + 'px';
+        } else {
+            image.style.height = image.attributes.height.value + 'px';
+        }
     } else {
         image.style.height = 'auto';
     }

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -117,9 +117,21 @@ class MattermostMarkdownRenderer extends marked.Renderer {
     }
 
     image(href, title, text) {
+        let dimensions = [];
+        let parts = href.split(' ');
+        if (parts.length > 1) {
+            let lastPart = parts.pop();
+            href = parts.join(' ');
+            if (lastPart[0] == '=') {
+                dimensions = lastPart.substr(1).split('x');
+            }
+        }
         let out = '<img src="' + href + '" alt="' + text + '"';
         if (title) {
             out += ' title="' + title + '"';
+        }
+        if (dimensions.length == 2) {
+            out += ' width="' + dimensions[0] + '" height="' + dimensions[1] + '"';
         }
         out += ' onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"';
         out += this.options.xhtml ? '/>' : '>';

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -8,8 +8,8 @@ import marked from 'marked';
 import katex from 'katex';
 
 function markdownImageLoaded(image) {
-    if (image.hasOwnProperty('height')) {
-        image.style.height = image.height;
+    if (image.hasAttribute('height')) {
+        image.style.height = image.attributes.height.value + 'px';
     } else {
         image.style.height = 'auto';
     }

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -9,11 +9,11 @@ import katex from 'katex';
 
 function markdownImageLoaded(image) {
     if (image.hasAttribute('height') && image.attributes.height.value !== 'auto') {
-        const maxHeight = parseInt(global.getComputedStyle(image).maxHeight);
+        const maxHeight = parseInt(global.getComputedStyle(image).maxHeight, 10);
 
         if (image.attributes.height.value > maxHeight) {
             image.style.height = maxHeight + 'px';
-            image.style.width = (maxHeight * image.attributes.width.value / image.attributes.height.value) + 'px';
+            image.style.width = ((maxHeight * image.attributes.width.value) / image.attributes.height.value) + 'px';
         } else {
             image.style.height = image.attributes.height.value + 'px';
         }

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -8,7 +8,11 @@ import marked from 'marked';
 import katex from 'katex';
 
 function markdownImageLoaded(image) {
-    image.style.height = 'auto';
+    if (image.hasOwnProperty('height')) {
+        image.style.height = image.height;
+    } else {
+        image.style.height = 'auto';
+    }
 }
 global.markdownImageLoaded = markdownImageLoaded;
 

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -125,14 +125,20 @@ class MattermostMarkdownRenderer extends marked.Renderer {
             src = parts.join(' ');
             if (lastPart[0] === '=') {
                 dimensions = lastPart.substr(1).split('x');
+                if (dimensions.length === 2 && dimensions[1] === '') {
+                    dimensions[1] = 'auto';
+                }
             }
         }
         let out = '<img src="' + src + '" alt="' + text + '"';
         if (title) {
             out += ' title="' + title + '"';
         }
-        if (dimensions.length === 2) {
-            out += ' width="' + dimensions[0] + '" height="' + dimensions[1] + '"';
+        if (dimensions.length > 0) {
+            out += ' width="' + dimensions[0] + '"';
+        }
+        if (dimensions.length > 1) {
+            out += ' height="' + dimensions[1] + '"';
         }
         out += ' onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"';
         out += this.options.xhtml ? '/>' : '>';


### PR DESCRIPTION
#### Summary
Sometimes images have a size that's not suitable, like e.g. avatars when posting notifications from some tracking systems like github.com through bots. This PR allows to use image size defintion in markdown like this:

`![avatar](https://example.com/avatar/user.png =50x50)`

and converts that into width and height attributes in HTML output.

#### Ticket Link
http://forum.mattermost.org/t/how-to-define-size-of-images/2574
