### PR TITLE
PLT-5011 Remove new user event handling on client

### DIFF
--- a/api/team.go
+++ b/api/team.go
@@ -303,11 +303,6 @@ func JoinUserToTeam(team *model.Team, user *model.User) *model.AppError {
 	RemoveAllSessionsForUserId(user.Id)
 	InvalidateCacheForUser(user.Id)
 
-	// This message goes to everyone, so the teamId, channelId and userId are irrelevant
-	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_NEW_USER, "", "", "", nil)
-	message.Add("user_id", user.Id)
-	go Publish(message)
-
 	return nil
 }
 

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -115,10 +115,6 @@ function handleEvent(msg) {
         handlePostDeleteEvent(msg);
         break;
 
-    case SocketEvents.NEW_USER:
-        handleNewUserEvent(msg);
-        break;
-
     case SocketEvents.LEAVE_TEAM:
         handleLeaveTeamEvent(msg);
         break;
@@ -217,26 +213,6 @@ function handlePostDeleteEvent(msg) {
     const selectedPostId = PostStore.getSelectedPostId();
     if (selectedPostId === post.id) {
         GlobalActions.emitCloseRightHandSide();
-    }
-}
-
-function handleNewUserEvent(msg) {
-    if (TeamStore.getCurrentId() === '') {
-        // Any new users will be loaded when we switch into a context with a team
-        return;
-    }
-
-    if (msg.data.user_id === UserStore.getCurrentId()) {
-        // We should already have ourselves
-        return;
-    }
-
-    AsyncClient.getUser(msg.data.user_id);
-    AsyncClient.getChannelStats();
-    loadProfilesAndTeamMembersForDMSidebar();
-
-    if (msg.data.user_id === UserStore.getCurrentId()) {
-        AsyncClient.getMyTeamMembers();
     }
 }
 


### PR DESCRIPTION
#### Summary
* Remove a duplicate send of the new user event
* Remove handling on the client for the new user event since it's no longer needed as the on-the-fly loading handles loading new users as needed
* Left the WebSocket event on the server to handle backwards compatibility for integrations using it

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5011