### PR TITLE
Made it so that getPostsSince api call won't return deleted posts and fixed its name in the Javascript client 

### DIFF
--- a/api/post_test.go
+++ b/api/post_test.go
@@ -477,7 +477,7 @@ func TestGetPostsSince(t *testing.T) {
 
 	r3 := Client.Must(Client.GetPostsSince(channel1.Id, now)).Data.(*model.PostList)
 
-	if len(r3.Order) != 2 { // 2 because deleted post is returned as well
+	if len(r3.Order) != 1 {
 		t.Fatal("missing post update")
 	}
 }

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -117,7 +117,7 @@ export function loadPosts(channelId = ChannelStore.getCurrentId()) {
         return;
     }
 
-    Client.getPosts(
+    Client.getPostsSince(
         channelId,
         latestPostTime,
         (data) => {

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -1666,7 +1666,12 @@ export default class Client {
             end(this.handleResponse.bind(this, 'getPostsPage', success, error));
     }
 
+    // SCHEDULED FOR DEPRECATION IN 3.7 - use getPostsSince instead
     getPosts(channelId, since, success, error) {
+        return this.getPostsSince(channelId, since, success, error);
+    }
+
+    getPostsSince(channelId, since, success, error) {
         request.
             get(`${this.getPostsRoute(channelId)}/since/${since}`).
             set(this.defaultHeaders).


### PR DESCRIPTION
There's handling in post_store.jsx for receiving deleted posts that made me look into if any of the server calls were returning deleted posts. This is the only place that I could find, but I didn't want to risk breaking other things on the client by touching the PostStore.

I also renamed `Client.getPosts`  in the Javascript client to `Client.getPostsSince` so that it'll match what the function is named on the server.