### PR TITLE
Fix team switch

### DIFF
--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -70,40 +70,39 @@ function preNeedsTeam(nextState, replace, callback) {
         browserHistory.push('/');
         return;
     }
-    if (nextState.location.pathname.indexOf('/channels/') > -1) {
-        GlobalActions.emitCloseRightHandSide();
 
-        TeamStore.saveMyTeam(team);
-        TeamStore.emitChange();
+    TeamStore.saveMyTeam(team);
+    TeamStore.emitChange();
+    GlobalActions.emitCloseRightHandSide();
+
+    if (nextState.location.pathname.indexOf('/channels/') > -1) {
         loadProfilesAndTeamMembersForDMSidebar();
         AsyncClient.getMyTeamsUnread();
         AsyncClient.getMyChannelMembers();
-
-        const d1 = $.Deferred(); //eslint-disable-line new-cap
-
-        Client.getChannels(
-            (data) => {
-                AppDispatcher.handleServerAction({
-                    type: ActionTypes.RECEIVED_CHANNELS,
-                    channels: data
-                });
-
-                loadStatusesForChannelAndSidebar();
-
-                d1.resolve();
-            },
-            (err) => {
-                AsyncClient.dispatchError(err, 'getChannels');
-                d1.resolve();
-            }
-        );
-
-        $.when(d1).done(() => {
-            callback();
-        });
-    } else {
-        callback();
     }
+
+    const d1 = $.Deferred(); //eslint-disable-line new-cap
+
+    Client.getChannels(
+        (data) => {
+            AppDispatcher.handleServerAction({
+                type: ActionTypes.RECEIVED_CHANNELS,
+                channels: data
+            });
+
+            loadStatusesForChannelAndSidebar();
+
+            d1.resolve();
+        },
+        (err) => {
+            AsyncClient.dispatchError(err, 'getChannels');
+            d1.resolve();
+        }
+    );
+
+    $.when(d1).done(() => {
+        callback();
+    });
 }
 
 function selectLastChannel(nextState, replace, callback) {


### PR DESCRIPTION
#### Summary
Previously we changed the `preNeedsTeam` function in the router to only made the requests to the server when a channel was specified, but then that prevented the switch to the last channel viewed on the team, this PR is to revert that