### PR TITLE
#4697 Move Client.createChannel() in components to an action

### DIFF
--- a/webapp/actions/channel_actions.jsx
+++ b/webapp/actions/channel_actions.jsx
@@ -275,3 +275,39 @@ export function updateChannelNotifyProps(data, success, error) {
         }
     );
 }
+
+export function createChannel(channel, success, error) {
+    Client.createChannel(
+        channel,
+        (data) => {
+            Client.getChannel(
+                data.id,
+                (data2) => {
+                    AppDispatcher.handleServerAction({
+                        type: ActionTypes.RECEIVED_CHANNEL,
+                        channel: data2.channel,
+                        member: data2.channel
+                    });
+
+                    if (success) {
+                        success(data2);
+                    }
+                },
+                (err) => {
+                    AsyncClient.dispatchError(err, 'getChannel');
+
+                    if (error) {
+                        error(err);
+                    }
+                }
+            )
+        },
+        (err) => {
+            AsyncClient.dispatchError(err, 'createChannel');
+
+            if (error) {
+                error(err);
+            }
+        }
+    );
+}

--- a/webapp/actions/channel_actions.jsx
+++ b/webapp/actions/channel_actions.jsx
@@ -300,7 +300,7 @@ export function createChannel(channel, success, error) {
                         error(err);
                     }
                 }
-            )
+            );
         },
         (err) => {
             AsyncClient.dispatchError(err, 'createChannel');

--- a/webapp/components/new_channel_flow.jsx
+++ b/webapp/components/new_channel_flow.jsx
@@ -12,8 +12,6 @@ import {intlShape, injectIntl, defineMessages, FormattedMessage} from 'react-int
 import {createChannel} from 'actions/channel_actions.jsx';
 import {browserHistory} from 'react-router/es6';
 
-import Constants from 'utils/constants.jsx';
-
 const SHOW_NEW_CHANNEL = 1;
 const SHOW_EDIT_URL = 2;
 const SHOW_EDIT_URL_THEN_COMPLETE = 3;

--- a/webapp/components/new_channel_flow.jsx
+++ b/webapp/components/new_channel_flow.jsx
@@ -10,6 +10,7 @@ import NewChannelModal from './new_channel_modal.jsx';
 import ChangeURLModal from './change_url_modal.jsx';
 
 import {intlShape, injectIntl, defineMessages, FormattedMessage} from 'react-intl';
+import {createChannel} from 'actions/channel_actions.jsx'
 import {browserHistory} from 'react-router/es6';
 
 import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
@@ -106,25 +107,15 @@ class NewChannelFlow extends React.Component {
             header: this.state.channelHeader,
             type: this.state.channelType
         };
-        Client.createChannel(
+
+        createChannel(
             channel,
             (data) => {
-                Client.getChannel(
-                    data.id,
-                    (data2) => {
-                        AppDispatcher.handleServerAction({
-                            type: ActionTypes.RECEIVED_CHANNEL,
-                            channel: data2.channel,
-                            member: data2.member
-                        });
+                this.doOnModalExited = () => {
+                    browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + data.channel.name);
+                };
 
-                        this.doOnModalExited = () => {
-                            browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + data2.channel.name);
-                        };
-
-                        this.props.onModalDismissed();
-                    }
-                );
+                this.props.onModalDismissed();
             },
             (err) => {
                 if (err.id === 'model.channel.is_valid.2_or_more.app_error') {

--- a/webapp/components/new_channel_flow.jsx
+++ b/webapp/components/new_channel_flow.jsx
@@ -2,7 +2,6 @@
 // See License.txt for license information.
 
 import * as Utils from 'utils/utils.jsx';
-import Client from 'client/web_client.jsx';
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 
@@ -10,12 +9,10 @@ import NewChannelModal from './new_channel_modal.jsx';
 import ChangeURLModal from './change_url_modal.jsx';
 
 import {intlShape, injectIntl, defineMessages, FormattedMessage} from 'react-intl';
-import {createChannel} from 'actions/channel_actions.jsx'
+import {createChannel} from 'actions/channel_actions.jsx';
 import {browserHistory} from 'react-router/es6';
 
-import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import Constants from 'utils/constants.jsx';
-const ActionTypes = Constants.ActionTypes;
 
 const SHOW_NEW_CHANNEL = 1;
 const SHOW_EDIT_URL = 2;


### PR DESCRIPTION
#### Summary
This PR moves instances of Client.createChannel() in components to a reusable action. 

#### Ticket Link
https://github.com/mattermost/platform/issues/4697

#### Checklist
- [x] Touches critical sections of the codebase (channel creation)