### PR TITLE
Adding session cache directly to web-conn

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -566,6 +566,8 @@ func RemoveAllSessionsForUserIdSkipClusterSend(userId string) {
 		}
 	}
 
+	InvalidateWebConnSessionCacheForUser(userId)
+
 }
 
 func AddSessionToCache(session *model.Session) {

--- a/api/post.go
+++ b/api/post.go
@@ -705,7 +705,7 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 			}
 
 			if userAllowsEmails && status.Status != model.STATUS_ONLINE {
-				go sendNotificationEmail(c, post, profileMap[id], channel, team, senderName[id], sender)
+				sendNotificationEmail(c, post, profileMap[id], channel, team, senderName[id], sender)
 			}
 		}
 	}
@@ -801,7 +801,7 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 			}
 
 			if DoesStatusAllowPushNotification(profileMap[id], status, post.ChannelId) {
-				go sendPushNotification(post, profileMap[id], channel, senderName[id], true)
+				sendPushNotification(post, profileMap[id], channel, senderName[id], true)
 			}
 		}
 
@@ -814,7 +814,7 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 				}
 
 				if DoesStatusAllowPushNotification(profileMap[id], status, post.ChannelId) {
-					go sendPushNotification(post, profileMap[id], channel, senderName[id], false)
+					sendPushNotification(post, profileMap[id], channel, senderName[id], false)
 				}
 			}
 		}

--- a/api/web_hub.go
+++ b/api/web_hub.go
@@ -145,6 +145,12 @@ func InvalidateCacheForUserSkipClusterSend(userId string) {
 	}
 }
 
+func InvalidateWebConnSessionCacheForUser(userId string) {
+	if len(hubs) != 0 {
+		GetHubForUserId(userId).InvalidateUser(userId)
+	}
+}
+
 func (h *Hub) Register(webConn *WebConn) {
 	h.register <- webConn
 


### PR DESCRIPTION
#### Summary
Adds a session cache directly on the web conn so it does not have to go to the session cache. 
Also removes some unneeded `go`s 
