### PR TITLE
PLT-4990 - Server: Split out channel permissions to Create/Manage/Delete

### DIFF
--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -121,8 +121,8 @@ func TestCreateChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
-	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPublicChannelCreation = model.PERMISSIONS_TEAM_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
 
 	channel2.Name = "a" + model.NewId() + "a"
@@ -146,8 +146,8 @@ func TestCreateChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
-	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPublicChannelCreation = model.PERMISSIONS_SYSTEM_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_SYSTEM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
 
 	channel2.Name = "a" + model.NewId() + "a"
@@ -167,6 +167,10 @@ func TestCreateChannel(t *testing.T) {
 	if _, err := SystemAdminClient.CreateChannel(channel3); err != nil {
 		t.Fatal(err)
 	}
+
+	*utils.Cfg.TeamSettings.RestrictPublicChannelCreation = model.PERMISSIONS_ALL
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_ALL
+	utils.SetDefaultRolesBasedOnConfig()
 }
 
 func TestCreateDirectChannel(t *testing.T) {
@@ -1161,8 +1165,8 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
-	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
 
 	th.LoginSystemAdmin()
@@ -1193,8 +1197,8 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
-	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
 
 	th.LoginSystemAdmin()
@@ -1226,6 +1230,10 @@ func TestDeleteChannel(t *testing.T) {
 	if _, err := Client.DeleteChannel(channel3.Id); err != nil {
 		t.Fatal(err)
 	}
+
+	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_ALL
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_ALL
+	utils.SetDefaultRolesBasedOnConfig()
 }
 
 func TestGetChannelStats(t *testing.T) {

--- a/config/config.json
+++ b/config/config.json
@@ -49,8 +49,12 @@
         "CustomDescriptionText": "",
         "RestrictDirectMessage": "any",
         "RestrictTeamInvite": "all",
+        "RestrictPublicChannelCreation": "all",
+        "RestrictPrivateChannelCreation": "all",
         "RestrictPublicChannelManagement": "all",
         "RestrictPrivateChannelManagement": "all",
+        "RestrictPublicChannelDeletion": "all",
+        "RestrictPrivateChannelDeletion": "all",
         "UserStatusAwayTimeout": 300,
         "MaxChannelsPerTeam": 2000,
         "MaxNotificationsPerChannel": 1000

--- a/model/config.go
+++ b/model/config.go
@@ -226,6 +226,10 @@ type TeamSettings struct {
 	RestrictTeamInvite               *string
 	RestrictPublicChannelManagement  *string
 	RestrictPrivateChannelManagement *string
+	RestrictPublicChannelCreation    *string
+	RestrictPrivateChannelCreation   *string
+	RestrictPublicChannelDeletion    *string
+	RestrictPrivateChannelDeletion   *string
 	UserStatusAwayTimeout            *int64
 	MaxChannelsPerTeam               *int64
 	MaxNotificationsPerChannel       *int64
@@ -505,6 +509,30 @@ func (o *Config) SetDefaults() {
 	if o.TeamSettings.RestrictPrivateChannelManagement == nil {
 		o.TeamSettings.RestrictPrivateChannelManagement = new(string)
 		*o.TeamSettings.RestrictPrivateChannelManagement = PERMISSIONS_ALL
+	}
+
+	if o.TeamSettings.RestrictPublicChannelCreation == nil {
+		o.TeamSettings.RestrictPublicChannelCreation = new(string)
+		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
+		*o.TeamSettings.RestrictPublicChannelCreation = *o.TeamSettings.RestrictPublicChannelManagement
+	}
+
+	if o.TeamSettings.RestrictPrivateChannelCreation == nil {
+		o.TeamSettings.RestrictPrivateChannelCreation = new(string)
+		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
+		*o.TeamSettings.RestrictPrivateChannelCreation = *o.TeamSettings.RestrictPrivateChannelManagement
+	}
+
+	if o.TeamSettings.RestrictPublicChannelDeletion == nil {
+		o.TeamSettings.RestrictPublicChannelDeletion = new(string)
+		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
+		*o.TeamSettings.RestrictPublicChannelDeletion = *o.TeamSettings.RestrictPublicChannelManagement
+	}
+
+	if o.TeamSettings.RestrictPrivateChannelDeletion == nil {
+		o.TeamSettings.RestrictPrivateChannelDeletion = new(string)
+		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
+		*o.TeamSettings.RestrictPrivateChannelDeletion = *o.TeamSettings.RestrictPrivateChannelManagement
 	}
 
 	if o.TeamSettings.UserStatusAwayTimeout == nil {

--- a/utils/authorization.go
+++ b/utils/authorization.go
@@ -9,46 +9,92 @@ func SetDefaultRolesBasedOnConfig() {
 	// Reset the roles to default to make this logic easier
 	model.InitalizeRoles()
 
-	switch *Cfg.TeamSettings.RestrictPublicChannelManagement {
+	switch *Cfg.TeamSettings.RestrictPublicChannelCreation {
 	case model.PERMISSIONS_ALL:
-		model.ROLE_CHANNEL_USER.Permissions = append(
-			model.ROLE_CHANNEL_USER.Permissions,
-			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
-		)
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
-			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 			model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
 		)
 		break
 	case model.PERMISSIONS_TEAM_ADMIN:
 		model.ROLE_TEAM_ADMIN.Permissions = append(
 			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
-			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 			model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
+		)
+		break
+	}
+
+	switch *Cfg.TeamSettings.RestrictPublicChannelManagement {
+	case model.PERMISSIONS_ALL:
+		model.ROLE_TEAM_USER.Permissions = append(
+			model.ROLE_TEAM_USER.Permissions,
+			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+		)
+		break
+	case model.PERMISSIONS_TEAM_ADMIN:
+		model.ROLE_TEAM_ADMIN.Permissions = append(
+			model.ROLE_TEAM_ADMIN.Permissions,
+			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+		)
+		break
+	}
+
+	switch *Cfg.TeamSettings.RestrictPublicChannelDeletion {
+	case model.PERMISSIONS_ALL:
+		model.ROLE_TEAM_USER.Permissions = append(
+			model.ROLE_TEAM_USER.Permissions,
+			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+		)
+		break
+	case model.PERMISSIONS_TEAM_ADMIN:
+		model.ROLE_TEAM_ADMIN.Permissions = append(
+			model.ROLE_TEAM_ADMIN.Permissions,
+			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+		)
+		break
+	}
+
+	switch *Cfg.TeamSettings.RestrictPrivateChannelCreation {
+	case model.PERMISSIONS_ALL:
+		model.ROLE_TEAM_USER.Permissions = append(
+			model.ROLE_TEAM_USER.Permissions,
+			model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
+		)
+		break
+	case model.PERMISSIONS_TEAM_ADMIN:
+		model.ROLE_TEAM_ADMIN.Permissions = append(
+			model.ROLE_TEAM_ADMIN.Permissions,
+			model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
 		)
 		break
 	}
 
 	switch *Cfg.TeamSettings.RestrictPrivateChannelManagement {
 	case model.PERMISSIONS_ALL:
-		model.ROLE_CHANNEL_USER.Permissions = append(
-			model.ROLE_CHANNEL_USER.Permissions,
-			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
-		)
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
-			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
-			model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
+			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 		)
 		break
 	case model.PERMISSIONS_TEAM_ADMIN:
 		model.ROLE_TEAM_ADMIN.Permissions = append(
 			model.ROLE_TEAM_ADMIN.Permissions,
 			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+		)
+		break
+	}
+
+	switch *Cfg.TeamSettings.RestrictPrivateChannelDeletion {
+	case model.PERMISSIONS_ALL:
+		model.ROLE_TEAM_USER.Permissions = append(
+			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
-			model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
+		)
+		break
+	case model.PERMISSIONS_TEAM_ADMIN:
+		model.ROLE_TEAM_ADMIN.Permissions = append(
+			model.ROLE_TEAM_ADMIN.Permissions,
+			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 		)
 		break
 	}

--- a/utils/config.go
+++ b/utils/config.go
@@ -238,8 +238,12 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["EnableOpenServer"] = strconv.FormatBool(*c.TeamSettings.EnableOpenServer)
 	props["RestrictDirectMessage"] = *c.TeamSettings.RestrictDirectMessage
 	props["RestrictTeamInvite"] = *c.TeamSettings.RestrictTeamInvite
+	props["RestrictPublicChannelCreation"] = *c.TeamSettings.RestrictPublicChannelCreation
+	props["RestrictPrivateChannelCreation"] = *c.TeamSettings.RestrictPrivateChannelCreation
 	props["RestrictPublicChannelManagement"] = *c.TeamSettings.RestrictPublicChannelManagement
 	props["RestrictPrivateChannelManagement"] = *c.TeamSettings.RestrictPrivateChannelManagement
+	props["RestrictPublicChannelDeletion"] = *c.TeamSettings.RestrictPublicChannelDeletion
+	props["RestrictPrivateChannelDeletion"] = *c.TeamSettings.RestrictPrivateChannelDeletion
 
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(c.ServiceSettings.EnableOAuthServiceProvider)
 	props["SegmentDeveloperKey"] = c.ServiceSettings.SegmentDeveloperKey


### PR DESCRIPTION
#### Summary
Splits out the public/private channel creation permissions to Create/Manage/Delete.

There is a corresponding PR with the UI changes for the webapp.

Doesn't add "Channel Admin" as a permissions level yet. That's coming in a separate PR later.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4990
https://mattermost.atlassian.net/browse/PLT-5054

#### Checklist
- [x] Added or updated unit tests (required for all new features)
