### PR TITLE
#4695 Move Client.updateTeamMemberRoles() in components to an action

### DIFF
--- a/webapp/actions/team_actions.jsx
+++ b/webapp/actions/team_actions.jsx
@@ -75,3 +75,20 @@ export function removeUserFromTeam(teamId, userId, success, error) {
         }
     );
 }
+
+export function updateTeamMemberRoles(teamId, userId, newRoles, success, error) {
+    Client.updateTeamMemberRoles(teamId, userId, newRoles,
+        () => {
+            AsyncClient.getTeamMember(teamId, userId);
+
+            if (success) {
+                success();
+            }
+        },
+        (err) => {
+            if (error) {
+                error(err);
+            }
+        }
+    );
+}

--- a/webapp/components/admin_console/admin_team_members_dropdown.jsx
+++ b/webapp/components/admin_console/admin_team_members_dropdown.jsx
@@ -11,6 +11,7 @@ import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
 import {updateUserRoles, updateActive} from 'actions/user_actions.jsx';
+import {updateTeamMemberRoles} from 'actions/team_actions.jsx';
 
 import {FormattedMessage} from 'react-intl';
 
@@ -52,13 +53,11 @@ export default class AdminTeamMembersDropdown extends React.Component {
             }
         );
 
-        Client.updateTeamMemberRoles(
+        updateTeamMemberRoles(
             this.props.teamMember.team_id,
             this.props.user.id,
             'team_user',
-            () => {
-                AsyncClient.getTeamMember(this.props.teamMember.team_id, this.props.user.id);
-            },
+            null,
             (err) => {
                 this.setState({serverError: err.message});
             }
@@ -109,13 +108,11 @@ export default class AdminTeamMembersDropdown extends React.Component {
     }
 
     doMakeTeamAdmin() {
-        Client.updateTeamMemberRoles(
+        updateTeamMemberRoles(
             this.props.teamMember.team_id,
             this.props.user.id,
             'team_user team_admin',
-            () => {
-                AsyncClient.getTeamMember(this.props.teamMember.team_id, this.props.user.id);
-            },
+            null,
             (err) => {
                 this.setState({serverError: err.message});
             }

--- a/webapp/components/team_members_dropdown.jsx
+++ b/webapp/components/team_members_dropdown.jsx
@@ -7,10 +7,9 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 
-import {removeUserFromTeam} from 'actions/team_actions.jsx';
+import {removeUserFromTeam, updateTeamMemberRoles} from 'actions/team_actions.jsx';
 import {updateActive} from 'actions/user_actions.jsx';
 
-import Client from 'client/web_client.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -44,12 +43,11 @@ export default class TeamMembersDropdown extends React.Component {
         if (this.props.user.id === me.id && me.roles.includes('system_admin')) {
             this.handleDemote(this.props.user, 'team_user');
         } else {
-            Client.updateTeamMemberRoles(
+            updateTeamMemberRoles(
                 this.props.teamMember.team_id,
                 this.props.user.id,
                 'team_user',
                 () => {
-                    AsyncClient.getTeamMember(this.props.teamMember.team_id, this.props.user.id);
                     AsyncClient.getUser(this.props.user.id);
                 },
                 (err) => {
@@ -103,12 +101,11 @@ export default class TeamMembersDropdown extends React.Component {
         if (this.props.user.id === me.id && me.roles.includes('system_admin')) {
             this.handleDemote(this.props.user, 'team_user team_admin');
         } else {
-            Client.updateTeamMemberRoles(
+            updateTeamMemberRoles(
                 this.props.teamMember.team_id,
                 this.props.user.id,
                 'team_user team_admin',
                 () => {
-                    AsyncClient.getTeamMember(this.props.teamMember.team_id, this.props.user.id);
                     AsyncClient.getUser(this.props.user.id);
                 },
                 (err) => {
@@ -139,12 +136,11 @@ export default class TeamMembersDropdown extends React.Component {
     }
 
     handleDemoteSubmit() {
-        Client.updateTeamMemberRoles(
+        updateTeamMemberRoles(
             this.props.teamMember.team_id,
             this.props.user.id,
             this.state.newRole,
             () => {
-                AsyncClient.getTeamMember(this.props.teamMember.team_id, this.props.user.id);
                 AsyncClient.getUser(this.props.user.id);
 
                 const teamUrl = TeamStore.getCurrentTeamUrl();


### PR DESCRIPTION
#### Summary
This PR moves instances of Client.updateTeamMemberRoles() in components to a reusable action.

#### Ticket Link
https://github.com/mattermost/platform/issues/4695

#### Checklist
- [x] Touches critical sections of the codebase (update team member permission)
