### PR TITLE
Fix `Cannot read property "window" of undefined`

### DIFF
--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -524,7 +524,7 @@ export default class LoginController extends React.Component {
                 >
                     <span className='icon fa fa-lock fa--margin-top'/>
                     <span>
-                        {window.mm_config.SamlLoginButtonText}
+                        {global.window.mm_config.SamlLoginButtonText}
                     </span>
                 </a>
             );


### PR DESCRIPTION
I have no good way of testing this without enterprise code to build, but with SAML enabled on our build we get an error on line 1 of a js bundle.

```
Cannot read property 'window' of undefined
```

Looking through the bundles that are being loaded, I noticed that this controller looked interesting. There was one call to window that did not reference `global` and it was only when SAML was enabled. So it seems to match like a good puzzle piece. 

Happy to get some help debugging this if I'm totally wrong in this.


#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [x] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
