### PR TITLE
PLT-5080 (Server): Channel-Admin level permissions

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -171,6 +171,42 @@ func UpdateUserToTeamAdmin(user *model.User, team *model.Team) {
 	utils.EnableDebugLogForTest()
 }
 
+func MakeUserChannelAdmin(user *model.User, channel *model.Channel) {
+	utils.DisableDebugLogForTest()
+
+	if cmr := <-Srv.Store.Channel().GetMember(channel.Id, user.Id); cmr.Err == nil {
+		cm := cmr.Data.(model.ChannelMember)
+		cm.Roles = "channel_admin channel_user"
+		if sr := <-Srv.Store.Channel().UpdateMember(&cm); sr.Err != nil {
+			utils.EnableDebugLogForTest()
+			panic(sr.Err)
+		}
+	} else {
+		utils.EnableDebugLogForTest()
+		panic(cmr.Err)
+	}
+
+	utils.EnableDebugLogForTest()
+}
+
+func MakeUserChannelUser(user *model.User, channel *model.Channel) {
+	utils.DisableDebugLogForTest()
+
+	if cmr := <-Srv.Store.Channel().GetMember(channel.Id, user.Id); cmr.Err == nil {
+		cm := cmr.Data.(model.ChannelMember)
+		cm.Roles = "channel_user"
+		if sr := <-Srv.Store.Channel().UpdateMember(&cm); sr.Err != nil {
+			utils.EnableDebugLogForTest()
+			panic(sr.Err)
+		}
+	} else {
+		utils.EnableDebugLogForTest()
+		panic(cmr.Err)
+	}
+
+	utils.EnableDebugLogForTest()
+}
+
 func (me *TestHelper) CreateChannel(client *model.Client, team *model.Team) *model.Channel {
 	return me.createChannel(client, team, model.CHANNEL_OPEN)
 }

--- a/api/channel.go
+++ b/api/channel.go
@@ -803,11 +803,11 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		// Allow delete if user is the only member left in channel
 		if memberCount > 1 {
-			if channel.Type == model.CHANNEL_OPEN && !HasPermissionToTeamContext(c, channel.TeamId, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
+			if channel.Type == model.CHANNEL_OPEN && !HasPermissionToChannelContext(c, channel.Id, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
 				return
 			}
 
-			if channel.Type == model.CHANNEL_PRIVATE && !HasPermissionToTeamContext(c, channel.TeamId, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
+			if channel.Type == model.CHANNEL_PRIVATE && !HasPermissionToChannelContext(c, channel.Id, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
 				return
 			}
 		}

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -330,6 +330,31 @@ func TestUpdateChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
+	utils.SetDefaultRolesBasedOnConfig()
+	MakeUserChannelUser(th.BasicUser, channel2)
+	MakeUserChannelUser(th.BasicUser, channel3)
+	store.ClearChannelCaches()
+
+	if _, err := Client.UpdateChannel(channel2); err == nil {
+		t.Fatal("should have errored not team admin")
+	}
+	if _, err := Client.UpdateChannel(channel3); err == nil {
+		t.Fatal("should have errored not team admin")
+	}
+
+	MakeUserChannelAdmin(th.BasicUser, channel2)
+	MakeUserChannelAdmin(th.BasicUser, channel3)
+	store.ClearChannelCaches()
+
+	if _, err := Client.UpdateChannel(channel2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.UpdateChannel(channel3); err != nil {
+		t.Fatal(err)
+	}
+
 	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
@@ -512,6 +537,31 @@ func TestUpdateChannelHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
+	utils.SetDefaultRolesBasedOnConfig()
+	MakeUserChannelUser(th.BasicUser, channel2)
+	MakeUserChannelUser(th.BasicUser, channel3)
+	store.ClearChannelCaches()
+
+	if _, err := Client.UpdateChannelHeader(data2); err == nil {
+		t.Fatal("should have errored not channel admin")
+	}
+	if _, err := Client.UpdateChannelHeader(data3); err == nil {
+		t.Fatal("should have errored not channel admin")
+	}
+
+	MakeUserChannelAdmin(th.BasicUser, channel2)
+	MakeUserChannelAdmin(th.BasicUser, channel3)
+	store.ClearChannelCaches()
+
+	if _, err := Client.UpdateChannelHeader(data2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.UpdateChannelHeader(data3); err != nil {
+		t.Fatal(err)
+	}
+
 	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
@@ -638,6 +688,31 @@ func TestUpdateChannelPurpose(t *testing.T) {
 	data3["channel_purpose"] = "new purpose"
 
 	Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+
+	if _, err := Client.UpdateChannelPurpose(data2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.UpdateChannelPurpose(data3); err != nil {
+		t.Fatal(err)
+	}
+
+	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
+	utils.SetDefaultRolesBasedOnConfig()
+	MakeUserChannelUser(th.BasicUser, channel2)
+	MakeUserChannelUser(th.BasicUser, channel3)
+	store.ClearChannelCaches()
+
+	if _, err := Client.UpdateChannelPurpose(data2); err == nil {
+		t.Fatal("should have errored not channel admin")
+	}
+	if _, err := Client.UpdateChannelPurpose(data3); err == nil {
+		t.Fatal("should have errored not channel admin")
+	}
+
+	MakeUserChannelAdmin(th.BasicUser, channel2)
+	MakeUserChannelAdmin(th.BasicUser, channel3)
+	store.ClearChannelCaches()
 
 	if _, err := Client.UpdateChannelPurpose(data2); err != nil {
 		t.Fatal(err)
@@ -1158,6 +1233,37 @@ func TestDeleteChannel(t *testing.T) {
 	Client.Must(Client.LeaveChannel(channel4.Id))
 
 	Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+
+	if _, err := Client.DeleteChannel(channel2.Id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.DeleteChannel(channel3.Id); err != nil {
+		t.Fatal(err)
+	}
+
+	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
+	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
+	utils.SetDefaultRolesBasedOnConfig()
+
+	th.LoginSystemAdmin()
+
+	channel2 = th.CreateChannel(Client, team)
+	channel3 = th.CreatePrivateChannel(Client, team)
+	Client.Must(Client.AddChannelMember(channel2.Id, th.BasicUser.Id))
+	Client.Must(Client.AddChannelMember(channel3.Id, th.BasicUser.Id))
+
+	Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+
+	if _, err := Client.DeleteChannel(channel2.Id); err == nil {
+		t.Fatal("should have errored not channel admin")
+	}
+	if _, err := Client.DeleteChannel(channel3.Id); err == nil {
+		t.Fatal("should have errored not channel admin")
+	}
+
+	MakeUserChannelAdmin(th.BasicUser, channel2)
+	MakeUserChannelAdmin(th.BasicUser, channel3)
+	store.ClearChannelCaches()
 
 	if _, err := Client.DeleteChannel(channel2.Id); err != nil {
 		t.Fatal(err)

--- a/model/config.go
+++ b/model/config.go
@@ -38,9 +38,10 @@ const (
 	DIRECT_MESSAGE_ANY  = "any"
 	DIRECT_MESSAGE_TEAM = "team"
 
-	PERMISSIONS_ALL          = "all"
-	PERMISSIONS_TEAM_ADMIN   = "team_admin"
-	PERMISSIONS_SYSTEM_ADMIN = "system_admin"
+	PERMISSIONS_ALL           = "all"
+	PERMISSIONS_CHANNEL_ADMIN = "channel_admin"
+	PERMISSIONS_TEAM_ADMIN    = "team_admin"
+	PERMISSIONS_SYSTEM_ADMIN  = "system_admin"
 
 	FAKE_SETTING = "********************************"
 

--- a/utils/authorization.go
+++ b/utils/authorization.go
@@ -31,6 +31,12 @@ func SetDefaultRolesBasedOnConfig() {
 			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 		)
 		break
+	case model.PERMISSIONS_CHANNEL_ADMIN:
+		model.ROLE_CHANNEL_ADMIN.Permissions = append(
+			model.ROLE_CHANNEL_ADMIN.Permissions,
+			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+		)
+		break
 	case model.PERMISSIONS_TEAM_ADMIN:
 		model.ROLE_TEAM_ADMIN.Permissions = append(
 			model.ROLE_TEAM_ADMIN.Permissions,
@@ -43,6 +49,12 @@ func SetDefaultRolesBasedOnConfig() {
 	case model.PERMISSIONS_ALL:
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
+			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+		)
+		break
+	case model.PERMISSIONS_CHANNEL_ADMIN:
+		model.ROLE_CHANNEL_ADMIN.Permissions = append(
+			model.ROLE_CHANNEL_ADMIN.Permissions,
 			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 		)
 		break
@@ -76,6 +88,12 @@ func SetDefaultRolesBasedOnConfig() {
 			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 		)
 		break
+	case model.PERMISSIONS_CHANNEL_ADMIN:
+		model.ROLE_CHANNEL_ADMIN.Permissions = append(
+			model.ROLE_CHANNEL_ADMIN.Permissions,
+			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+		)
+		break
 	case model.PERMISSIONS_TEAM_ADMIN:
 		model.ROLE_TEAM_ADMIN.Permissions = append(
 			model.ROLE_TEAM_ADMIN.Permissions,
@@ -88,6 +106,12 @@ func SetDefaultRolesBasedOnConfig() {
 	case model.PERMISSIONS_ALL:
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
+			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
+		)
+		break
+	case model.PERMISSIONS_CHANNEL_ADMIN:
+		model.ROLE_CHANNEL_ADMIN.Permissions = append(
+			model.ROLE_CHANNEL_ADMIN.Permissions,
 			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 		)
 		break


### PR DESCRIPTION
#### Summary
Adds permissions for manage/delete public/private channels at the Channel Admin level.

This is the server side changes only. Webapp changes will come in a separate PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5080

#### Checklist
- [x] Added or updated unit tests (required for all new features)
