### PR TITLE
PLT-5004 (server) Skip intensive stat DB queries when more than a set number of users on the system

### DIFF
--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -192,6 +192,12 @@ func TestGetTeamAnalyticsStandard(t *testing.T) {
 		t.Fatal("Shouldn't have permissions")
 	}
 
+	maxUsersForStats := *utils.Cfg.AnalyticsSettings.MaxUsersForStatistics
+	defer func() {
+		*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = maxUsersForStats
+	}()
+	*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = 1000000
+
 	if result, err := th.SystemAdminClient.GetTeamAnalytics(th.BasicTeam.Id, "standard"); err != nil {
 		t.Fatal(err)
 	} else {
@@ -303,6 +309,24 @@ func TestGetTeamAnalyticsStandard(t *testing.T) {
 			t.Fatal()
 		}
 	}
+
+	*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = 1
+
+	if result, err := th.SystemAdminClient.GetSystemAnalytics("standard"); err != nil {
+		t.Fatal(err)
+	} else {
+		rows := result.Data.(model.AnalyticsRows)
+
+		if rows[2].Name != "post_count" {
+			t.Log(rows.ToJson())
+			t.Fatal()
+		}
+
+		if rows[2].Value != -1 {
+			t.Log(rows.ToJson())
+			t.Fatal()
+		}
+	}
 }
 
 func TestGetPostCount(t *testing.T) {
@@ -316,12 +340,31 @@ func TestGetPostCount(t *testing.T) {
 		t.Fatal("Shouldn't have permissions")
 	}
 
+	maxUsersForStats := *utils.Cfg.AnalyticsSettings.MaxUsersForStatistics
+	defer func() {
+		*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = maxUsersForStats
+	}()
+	*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = 1000000
+
 	if result, err := th.SystemAdminClient.GetTeamAnalytics(th.BasicTeam.Id, "post_counts_day"); err != nil {
 		t.Fatal(err)
 	} else {
 		rows := result.Data.(model.AnalyticsRows)
 
 		if rows[0].Value != 1 {
+			t.Log(rows.ToJson())
+			t.Fatal()
+		}
+	}
+
+	*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = 1
+
+	if result, err := th.SystemAdminClient.GetTeamAnalytics(th.BasicTeam.Id, "post_counts_day"); err != nil {
+		t.Fatal(err)
+	} else {
+		rows := result.Data.(model.AnalyticsRows)
+
+		if rows[0].Value != -1 {
 			t.Log(rows.ToJson())
 			t.Fatal()
 		}
@@ -339,12 +382,31 @@ func TestUserCountsWithPostsByDay(t *testing.T) {
 		t.Fatal("Shouldn't have permissions")
 	}
 
+	maxUsersForStats := *utils.Cfg.AnalyticsSettings.MaxUsersForStatistics
+	defer func() {
+		*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = maxUsersForStats
+	}()
+	*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = 1000000
+
 	if result, err := th.SystemAdminClient.GetTeamAnalytics(th.BasicTeam.Id, "user_counts_with_posts_day"); err != nil {
 		t.Fatal(err)
 	} else {
 		rows := result.Data.(model.AnalyticsRows)
 
 		if rows[0].Value != 1 {
+			t.Log(rows.ToJson())
+			t.Fatal()
+		}
+	}
+
+	*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = 1
+
+	if result, err := th.SystemAdminClient.GetTeamAnalytics(th.BasicTeam.Id, "user_counts_with_posts_day"); err != nil {
+		t.Fatal(err)
+	} else {
+		rows := result.Data.(model.AnalyticsRows)
+
+		if rows[0].Value != -1 {
 			t.Log(rows.ToJson())
 			t.Fatal()
 		}
@@ -359,6 +421,12 @@ func TestGetTeamAnalyticsExtra(t *testing.T) {
 	if _, err := th.BasicClient.GetTeamAnalytics("", "extra_counts"); err == nil {
 		t.Fatal("Shouldn't have permissions")
 	}
+
+	maxUsersForStats := *utils.Cfg.AnalyticsSettings.MaxUsersForStatistics
+	defer func() {
+		*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = maxUsersForStats
+	}()
+	*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = 1000000
 
 	if result, err := th.SystemAdminClient.GetTeamAnalytics(th.BasicTeam.Id, "extra_counts"); err != nil {
 		t.Fatal(err)
@@ -457,6 +525,24 @@ func TestGetTeamAnalyticsExtra(t *testing.T) {
 		}
 
 		if rows[5].Name != "session_count" {
+			t.Log(rows.ToJson())
+			t.Fatal()
+		}
+	}
+
+	*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics = 1
+
+	if result, err := th.SystemAdminClient.GetSystemAnalytics("extra_counts"); err != nil {
+		t.Fatal(err)
+	} else {
+		rows := result.Data.(model.AnalyticsRows)
+
+		if rows[0].Value != -1 {
+			t.Log(rows.ToJson())
+			t.Fatal()
+		}
+
+		if rows[1].Value != -1 {
 			t.Log(rows.ToJson())
 			t.Fatal()
 		}

--- a/config/config.json
+++ b/config/config.json
@@ -237,6 +237,9 @@
         "BlockProfileRate": 0,
         "ListenAddress": ":8067"
     },
+    "AnalyticsSettings": {
+        "MaxUsersForStatistics": 2500
+    },
     "WebrtcSettings": {
         "Enable": false,
         "GatewayWebsocketUrl": "",

--- a/model/config.go
+++ b/model/config.go
@@ -105,6 +105,10 @@ type MetricsSettings struct {
 	ListenAddress    *string
 }
 
+type AnalyticsSettings struct {
+	MaxUsersForStatistics *int
+}
+
 type SSOSettings struct {
 	Enable          bool
 	Secret          string
@@ -341,6 +345,7 @@ type Config struct {
 	NativeAppSettings    NativeAppSettings
 	ClusterSettings      ClusterSettings
 	MetricsSettings      MetricsSettings
+	AnalyticsSettings    AnalyticsSettings
 	WebrtcSettings       WebrtcSettings
 }
 
@@ -806,6 +811,11 @@ func (o *Config) SetDefaults() {
 	if o.MetricsSettings.Enable == nil {
 		o.MetricsSettings.Enable = new(bool)
 		*o.MetricsSettings.Enable = false
+	}
+
+	if o.AnalyticsSettings.MaxUsersForStatistics == nil {
+		o.AnalyticsSettings.MaxUsersForStatistics = new(int)
+		*o.AnalyticsSettings.MaxUsersForStatistics = 2500
 	}
 
 	if o.ComplianceSettings.Enable == nil {


### PR DESCRIPTION
#### Summary
* Add a configurable field `MaxUsersForStatistics` in new `AnalyticsSettings` config section for controlling when to turn off intensive statistic DB queries
* Skip all post-related DB queries when above user threshold and return -1 instead

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5004

#### Checklist
- [x] Added or updated unit tests (required for all new features)