### PR TITLE
API for getting channel members by IDs.

### DIFF
--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -1777,3 +1777,40 @@ func TestViewChannel(t *testing.T) {
 		t.Fatal("message counts don't match")
 	}
 }
+
+func TestGetChannelMembersByIds(t *testing.T) {
+	th := Setup().InitBasic()
+
+	if _, err := AddUserToChannel(th.BasicUser2, th.BasicChannel); err != nil {
+		t.Fatal("Could not add second user to channel")
+	}
+
+	if result, err := th.BasicClient.GetChannelMembersByIds(th.BasicChannel.Id, []string{th.BasicUser.Id}); err != nil {
+		t.Fatal(err)
+	} else {
+		member := (*result.Data.(*model.ChannelMembers))[0]
+		if member.UserId != th.BasicUser.Id {
+			t.Fatal("user id did not match")
+		}
+		if member.ChannelId != th.BasicChannel.Id {
+			t.Fatal("team id did not match")
+		}
+	}
+
+	if result, err := th.BasicClient.GetChannelMembersByIds(th.BasicChannel.Id, []string{th.BasicUser.Id, th.BasicUser2.Id, model.NewId()}); err != nil {
+		t.Fatal(err)
+	} else {
+		members := result.Data.(*model.ChannelMembers)
+		if len(*members) != 2 {
+			t.Fatal("length should have been 2, got ", len(*members))
+		}
+	}
+
+	if _, err := th.BasicClient.GetChannelMembersByIds("junk", []string{th.BasicUser.Id}); err == nil {
+		t.Fatal("should have errored - bad team id")
+	}
+
+	if _, err := th.BasicClient.GetChannelMembersByIds(th.BasicChannel.Id, []string{}); err == nil {
+		t.Fatal("should have errored - empty user ids")
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4176,6 +4176,10 @@
     "translation": "We encountered an error finding the channel"
   },
   {
+    "id": "store.sql_channel.get_members_by_ids.app_error",
+    "translation": "We couldn't get the channel members"
+  },
+  {
     "id": "store.sql_channel.get_all.app_error",
     "translation": "We couldn't get all the channels"
   },

--- a/model/client.go
+++ b/model/client.go
@@ -1387,6 +1387,18 @@ func (c *Client) GetChannelMember(channelId string, userId string) (*Result, *Ap
 	}
 }
 
+// GetChannelMembersByIds will return channel member objects as an array based on the
+// channel id and a list of user ids provided. Must be authenticated.
+func (c *Client) GetChannelMembersByIds(channelId string, userIds []string) (*Result, *AppError) {
+	if r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/members/ids", ArrayToJson(userIds)); err != nil {
+		return nil, err
+	} else {
+		defer closeBody(r)
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), ChannelMembersFromJson(r.Body)}, nil
+	}
+}
+
 func (c *Client) CreatePost(post *Post) (*Result, *AppError) {
 	if r, err := c.DoApiPost(c.GetChannelRoute(post.ChannelId)+"/posts/create", post.ToJson()); err != nil {
 		return nil, err

--- a/store/store.go
+++ b/store/store.go
@@ -118,6 +118,7 @@ type ChannelStore interface {
 	GetMembersForUser(teamId string, userId string) StoreChannel
 	SearchInTeam(teamId string, term string) StoreChannel
 	SearchMore(userId string, teamId string, term string) StoreChannel
+	GetMembersByIds(channelId string, userIds []string) StoreChannel
 }
 
 type PostStore interface {


### PR DESCRIPTION
#### Summary

Add a new API for getting channel members by IDs. This will be used to show different actions in the Manage Channel Members modal for users who are Channel Admins vs those who are Channel Users.

New method will be added to the Javascript driver in the PR for using this in the webapp.

API Proposal: https://github.com/mattermost/mattermost-api-reference/pull/58

#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-5049

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file updates
