### PR TITLE
PLT-5073 Improve performance of /channels/view endpoint

### DIFF
--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -1862,14 +1862,12 @@ func TestViewChannel(t *testing.T) {
 	}
 
 	view.PrevChannelId = ""
-	view.Time = 1234567890
 
 	if _, resp := Client.ViewChannel(view); resp.Error != nil {
 		t.Fatal(resp.Error)
 	}
 
 	view.PrevChannelId = "junk"
-	view.Time = 0
 
 	if _, resp := Client.ViewChannel(view); resp.Error != nil {
 		t.Fatal(resp.Error)
@@ -1878,6 +1876,8 @@ func TestViewChannel(t *testing.T) {
 	rdata := Client.Must(Client.GetChannel(th.BasicChannel.Id, "")).Data.(*model.ChannelData)
 
 	if rdata.Channel.TotalMsgCount != rdata.Member.MsgCount {
+		t.Log(rdata.Channel.Id)
+		t.Log(rdata.Member.UserId)
 		t.Log(rdata.Channel.TotalMsgCount)
 		t.Log(rdata.Member.MsgCount)
 		t.Fatal("message counts don't match")

--- a/api/deprecated.go
+++ b/api/deprecated.go
@@ -76,7 +76,7 @@ func updateLastViewedAt(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	Srv.Store.Channel().UpdateLastViewedAt(id, c.Session.UserId)
+	Srv.Store.Channel().UpdateLastViewedAt([]string{id}, c.Session.UserId)
 
 	// Must be after update so that unread count is correct
 	if doClearPush {

--- a/api/post.go
+++ b/api/post.go
@@ -95,7 +95,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		// Update the LastViewAt only if the post does not have from_webhook prop set (eg. Zapier app)
 		if _, ok := post.Props["from_webhook"]; !ok {
-			if result := <-Srv.Store.Channel().UpdateLastViewedAt(post.ChannelId, c.Session.UserId); result.Err != nil {
+			if result := <-Srv.Store.Channel().UpdateLastViewedAt([]string{post.ChannelId}, c.Session.UserId); result.Err != nil {
 				l4g.Error(utils.T("api.post.create_post.last_viewed.error"), post.ChannelId, c.Session.UserId, result.Err)
 			}
 		}

--- a/model/channel_view.go
+++ b/model/channel_view.go
@@ -11,7 +11,6 @@ import (
 type ChannelView struct {
 	ChannelId     string `json:"channel_id"`
 	PrevChannelId string `json:"prev_channel_id"`
-	Time          int64  `json:"time"`
 }
 
 func (o *ChannelView) ToJson() string {

--- a/model/client.go
+++ b/model/client.go
@@ -1350,10 +1350,9 @@ func (c *Client) UpdateLastViewedAt(channelId string, active bool) (*Result, *Ap
 }
 
 // ViewChannel performs all the actions related to viewing a channel. This includes marking
-// the channel and the previous one as read, marking the channel as being actively viewed.
+// the channel and the previous one as read, and marking the channel as being actively viewed.
 // ChannelId is required but may be blank to indicate no channel is being viewed.
-// PrevChannelId is optional, populate to indicate a channel switch occurred. Optionally
-// provide a non-zero Time, in Unix milliseconds, to manually set the viewing time.
+// PrevChannelId is optional, populate to indicate a channel switch occurred.
 func (c *Client) ViewChannel(params ChannelView) (bool, *ResponseMetadata) {
 	if r, err := c.DoApiPost(c.GetTeamRoute()+"/channels/view", params.ToJson()); err != nil {
 		return false, &ResponseMetadata{StatusCode: r.StatusCode, Error: err}

--- a/model/status.go
+++ b/model/status.go
@@ -22,7 +22,7 @@ type Status struct {
 	Status         string `json:"status"`
 	Manual         bool   `json:"manual"`
 	LastActivityAt int64  `json:"last_activity_at"`
-	ActiveChannel  string `json:"active_channel"`
+	ActiveChannel  string `json:"active_channel" db:"-"`
 }
 
 func (o *Status) ToJson() string {

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -808,12 +808,12 @@ func TestChannelStoreUpdateLastViewedAt(t *testing.T) {
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	Must(store.Channel().SaveMember(&m1))
 
-	err := (<-store.Channel().UpdateLastViewedAt(m1.ChannelId, m1.UserId)).Err
+	err := (<-store.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, m1.UserId)).Err
 	if err != nil {
 		t.Fatal("failed to update", err)
 	}
 
-	err = (<-store.Channel().UpdateLastViewedAt(m1.ChannelId, "missing id")).Err
+	err = (<-store.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, "missing id")).Err
 	if err != nil {
 		t.Fatal("failed to update")
 	}

--- a/store/sql_upgrade.go
+++ b/store/sql_upgrade.go
@@ -225,6 +225,9 @@ func UpgradeDatabaseToVersion36(sqlStore *SqlStore) {
 	// Add a Position column to users.
 	sqlStore.CreateColumnIfNotExists("Users", "Position", "varchar(64)", "varchar(64)", "")
 
+	// Remove ActiveChannel column from Status
+	sqlStore.RemoveColumnIfExists("Status", "ActiveChannel")
+
 	//saveSchemaVersion(sqlStore, VERSION_3_6_0)
 	//}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -110,7 +110,7 @@ type ChannelStore interface {
 	GetMemberCount(channelId string, allowFromCache bool) StoreChannel
 	RemoveMember(channelId string, userId string) StoreChannel
 	PermanentDeleteMembersByUser(userId string) StoreChannel
-	UpdateLastViewedAt(channelId string, userId string) StoreChannel
+	UpdateLastViewedAt(channelIds []string, userId string) StoreChannel
 	SetLastViewedAt(channelId string, userId string, newLastViewedAt int64) StoreChannel
 	IncrementMentionCount(channelId string, userId string) StoreChannel
 	AnalyticsTypeCount(teamId string, channelType string) StoreChannel

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -1397,7 +1397,7 @@ export default class Client {
             end(this.handleResponse.bind(this, 'updateLastViewedAt', success, error));
     }
 
-    // SCHEDULED FOR DEPRECATION IN 3.8 - use viewChannel instead
+    // SCHEDULED FOR DEPRECATION IN 3.8
     setLastViewedAt(channelId, lastViewedAt, success, error) {
         request.
         post(`${this.getChannelNeededRoute(channelId)}/set_last_viewed_at`).


### PR DESCRIPTION
#### Summary
* Remove ActiveChannel column from Status table, only keep it in the cache
* Change UpdateLastViewedAt store function to take a list of channel IDs
* Remove ability to set manual time from /view endpoint, it was not being used and is still available through the old endpoint
* Remove unbounded go routines

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5073

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#63)
- [x] All new/modified APIs include changes to the drivers
- [x] Touches critical sections of the codebase (unreads)
