### PR TITLE
Add error page on root.html

### DIFF
--- a/webapp/root.html
+++ b/webapp/root.html
@@ -34,10 +34,52 @@
 
     <!-- CSS Should always go first -->
     <link rel='stylesheet' class='code_theme'>
+    <style>
+        .error-screen {
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            padding-top: 50px;
+            max-width: 750px;
+            font-size: 14px;
+            color: #333333;
+            margin: auto;
+            display: none;
+            line-height: 1.5;
+        }
 
+        .error-screen h2 {
+            font-size: 30px;
+            font-weight: normal;
+            line-height: 1.2;
+        }
+
+        .error-screen ul {
+            padding-left: 15px;
+            line-height: 1.7;
+            margin-top: 0;
+            margin-bottom: 10px;
+        }
+
+        .error-screen hr {
+            color: #ddd;
+            margin-top: 20px;
+            margin-bottom: 20px;
+            border: 0;
+            border-top: 1px solid #eee;
+        }
+
+        .error-screen-visible {
+            display: block;
+        }
+    </style>
 </head>
 <body>
     <div id='root'>
+        <div class='error-screen'>
+            <h2>Cannot connect to Mattermost</h2>
+            <hr/>
+            <p>We’re having trouble connecting to Mattermost. If refreshing this page (Ctrl+R or Command+R) does not work, please verify that your computer is connected to the internet.</p>
+            <br/>
+        </div>
         <div
             class='loading-screen'
             style='position: relative'
@@ -50,6 +92,9 @@
         </div>
     </div>
     <script>
+        if (typeof window.setup_root !== 'function') {
+            document.querySelector('.error-screen').classList.add('error-screen-visible');
+        }
         window.setup_root();
     </script>
     <noscript>


### PR DESCRIPTION
#### Summary
In cases when the user lose internet connection when the javascript is being loaded, the function `window.setup_root` may not yet be defined. This would cause a blank screen on the desktop apps. This PR adds an error message to root.html:
![screen shot 2017-01-03 at 3 46 35 pm](https://cloud.githubusercontent.com/assets/910657/21627384/3beafc1a-d1cc-11e6-8d34-345b72771edb.png)

#### Ticket Link
[Discussion link](https://pre-release.mattermost.com/core/pl/699shbzyhjy3be1ga4unr4jkuo)

#### Checklist
- [x] Has UI changes