### PR TITLE
Add port 587 (used for STARTTLS) as an example SMTP port

### DIFF
--- a/webapp/components/admin_console/email_settings.jsx
+++ b/webapp/components/admin_console/email_settings.jsx
@@ -255,7 +255,7 @@ export default class EmailSettings extends AdminSettings {
                             defaultMessage='SMTP Server Port:'
                         />
                     }
-                    placeholder={Utils.localizeMessage('admin.email.smtpPortExample', 'Ex: "25", "465"')}
+                    placeholder={Utils.localizeMessage('admin.email.smtpPortExample', 'Ex: "25", "465", "587"')}
                     helpText={
                         <FormattedMessage
                             id='admin.email.smtpPortDescription'

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -281,7 +281,7 @@
   "admin.email.smtpPasswordExample": "Ex: \"yourpassword\", \"jcuS8PuvcpGhpgHhlcpT1Mx42pnqMxQY\"",
   "admin.email.smtpPasswordTitle": "SMTP Server Password:",
   "admin.email.smtpPortDescription": "Port of SMTP email server.",
-  "admin.email.smtpPortExample": "Ex: \"25\", \"465\"",
+  "admin.email.smtpPortExample": "Ex: \"25\", \"465\", \"587\"",
   "admin.email.smtpPortTitle": "SMTP Server Port:",
   "admin.email.smtpServerDescription": "Location of SMTP email server.",
   "admin.email.smtpServerExample": "Ex: \"smtp.yourcompany.com\", \"email-smtp.us-east-1.amazonaws.com\"",


### PR DESCRIPTION
SMTP email submission with STARTTLS (which is an actual standard, as opposed to TLS over port 465) is done over port 587, give that as an example port when setting up email.