### PR TITLE
PLT-4918 Don't autocomplete users by email

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -2859,7 +2859,17 @@ func autocompleteUsersInTeam(c *Context, w http.ResponseWriter, r *http.Request)
 func autocompleteUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 	term := r.URL.Query().Get("term")
 
-	uchan := Srv.Store.User().Search("", term, map[string]bool{})
+	searchOptions := map[string]bool{}
+
+	hideFullName := !utils.Cfg.PrivacySettings.ShowFullName
+	if hideFullName && !HasPermissionToContext(c, model.PERMISSION_MANAGE_SYSTEM) {
+		searchOptions[store.USER_SEARCH_OPTION_NAMES_ONLY_NO_FULL_NAME] = true
+		c.Err = nil
+	} else {
+		searchOptions[store.USER_SEARCH_OPTION_NAMES_ONLY] = true
+	}
+
+	uchan := Srv.Store.User().Search("", term, searchOptions)
 
 	var profiles []*model.User
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -2387,6 +2387,15 @@ func TestAutocompleteUsers(t *testing.T) {
 		}
 	}
 
+	if result, err := Client.AutocompleteUsers("amazonses"); err != nil {
+		t.Fatal(err)
+	} else {
+		users := result.Data.([]*model.User)
+		if len(users) != 0 {
+			t.Fatal("should have returned 0 users - email should not autocomplete")
+		}
+	}
+
 	if result, err := Client.AutocompleteUsers(""); err != nil {
 		t.Fatal(err)
 	} else {


### PR DESCRIPTION
#### Summary
Don't use email to autocomplete users in the channel switcher (and other places).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4918