### PR TITLE
PLT-4273 Store posts for focus view in regular post store as well

### DIFF
--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -632,9 +632,12 @@ PostStore.dispatchToken = AppDispatcher.register((payload) => {
 
     switch (action.type) {
     case ActionTypes.RECEIVED_POSTS: {
-        const id = PostStore.currentFocusedPostId !== null && action.isPost ? PostStore.currentFocusedPostId : action.id;
-        PostStore.storePosts(id, makePostListNonNull(action.post_list), action.checkLatest);
-        PostStore.checkBounds(id, action.numRequested, makePostListNonNull(action.post_list), action.before);
+        if (PostStore.currentFocusedPostId !== null && action.isPost) {
+            PostStore.storePosts(PostStore.currentFocusedPostId, makePostListNonNull(action.post_list), action.checkLatest);
+            PostStore.checkBounds(PostStore.currentFocusedPostId, action.numRequested, makePostListNonNull(action.post_list), action.before);
+        }
+        PostStore.storePosts(action.id, makePostListNonNull(action.post_list), action.checkLatest);
+        PostStore.checkBounds(action.id, action.numRequested, makePostListNonNull(action.post_list), action.before);
         PostStore.emitChange();
         break;
     }


### PR DESCRIPTION
#### Summary
Fixes a bug where sometimes the RHS would not display properly when switching out of focus view to another channel. Does so by storing posts received for a focus view in the regular spot as well as the special spot for focus posts.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4273