### PR TITLE
PLT-495 Improves slack markup conversion

### DIFF
--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -572,17 +572,23 @@ func SlackConvertPostsMarkup(posts map[string][]SlackPost) map[string][]SlackPos
 			regexp.MustCompile(`~([^~])+~`),
 			"~$0~",
 		},
+		// single paragraph blockquote
+		// Slack converts > character to &gt;
+		{
+			regexp.MustCompile(`&gt;`),
+			">",
+		},
 	}
 
 	regexReplaceAllStringFunc := []struct {
 		regex *regexp.Regexp
 		fn    func(string) string
 	}{
-		// blockquotes
+		// multiple paragraphs blockquotes
 		{
 			regexp.MustCompile(`(?sm)^>>>(.+)$`),
 			func(src string) string {
-				// remove >>> prefix, might has leading \n
+				// remove >>> prefix, might have leading \n
 				prefixRegexp := regexp.MustCompile(`^([\n])?>>>(.*)`)
 				src = prefixRegexp.ReplaceAllString(src, "$1$2")
 				// append > to start of line

--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -564,18 +564,18 @@ func SlackConvertPostsMarkup(posts map[string][]SlackPost) map[string][]SlackPos
 		},
 		// bold
 		{
-			regexp.MustCompile(`\*([^*]+)\*`),
-			"*$0*",
+			regexp.MustCompile(`(^|[\s.;,])\*(\S[^*\n]+)\*`),
+			"$1**$2**",
 		},
 		// strikethrough
 		{
-			regexp.MustCompile(`~([^~])+~`),
-			"~$0~",
+			regexp.MustCompile(`(^|[\s.;,])\~(\S[^~\n]+)\~`),
+			"$1~~$2~~",
 		},
 		// single paragraph blockquote
 		// Slack converts > character to &gt;
 		{
-			regexp.MustCompile(`&gt;`),
+			regexp.MustCompile(`(?sm)^&gt;`),
 			">",
 		},
 	}
@@ -586,10 +586,10 @@ func SlackConvertPostsMarkup(posts map[string][]SlackPost) map[string][]SlackPos
 	}{
 		// multiple paragraphs blockquotes
 		{
-			regexp.MustCompile(`(?sm)^>>>(.+)$`),
+			regexp.MustCompile(`(?sm)^>&gt;&gt;(.+)$`),
 			func(src string) string {
 				// remove >>> prefix, might have leading \n
-				prefixRegexp := regexp.MustCompile(`^([\n])?>>>(.*)`)
+				prefixRegexp := regexp.MustCompile(`^([\n])?>&gt;&gt;(.*)`)
 				src = prefixRegexp.ReplaceAllString(src, "$1$2")
 				// append > to start of line
 				appendRegexp := regexp.MustCompile(`(?m)^`)

--- a/app/slackimport_test.go
+++ b/app/slackimport_test.go
@@ -235,9 +235,14 @@ func TestSlackConvertPostsMarkup(t *testing.T) {
 		},
 		{
 			Text: `This message contains multiple paragraphs blockquotes
->>>first
+&gt;&gt;&gt;first
 second
 third`,
+		},
+		{
+			Text: `This message contains single paragraph blockquotes
+&gt;something
+&gt;another thing`,
 		},
 	}
 
@@ -261,13 +266,18 @@ third`,
 >second
 >third`,
 		},
+		{
+			Text: `This message contains single paragraph blockquotes
+>something
+>another thing`,
+		},
 	}
 
 	actualOutput := SlackConvertPostsMarkup(input)
 
 	for i := range actualOutput["test"] {
 		if actualOutput["test"][i].Text != expectedOutput["test"][i].Text {
-			t.Fatalf("Unexpected message after markup translation: %v", actualOutput["test"][i].Text)
+			t.Errorf("Unexpected message after markup translation: %v", actualOutput["test"][i].Text)
 		}
 	}
 }

--- a/app/slackimport_test.go
+++ b/app/slackimport_test.go
@@ -190,7 +190,7 @@ func TestSlackSanitiseChannelProperties(t *testing.T) {
 
 	c1s := SlackSanitiseChannelProperties(c1)
 	if c1.DisplayName != c1s.DisplayName || c1.Name != c1s.Name || c1.Purpose != c1s.Purpose || c1.Header != c1s.Header {
-		t.Fatalf("Unexpected alterations to the channel properties.")
+		t.Fatal("Unexpected alterations to the channel properties.")
 	}
 
 	c2 := model.Channel{

--- a/app/slackimport_test.go
+++ b/app/slackimport_test.go
@@ -227,14 +227,47 @@ func TestSlackConvertPostsMarkup(t *testing.T) {
 		{
 			Text: "This message contains a mailto link to <mailto:me@example.com|me@example.com> in it.",
 		},
+		{
+			Text: "This message contains a *bold* word.",
+		},
+		{
+			Text: "This message contains a ~strikethrough~ word.",
+		},
+		{
+			Text: `This message contains multiple paragraphs blockquotes
+>>>first
+second
+third`,
+		},
 	}
 
-	output := SlackConvertPostsMarkup(input)
-
-	if output["test"][0].Text != "This message contains a link to [Google](https://google.com)." {
-		t.Fatalf("Unexpected message after markup translation: %v", output["test"][0].Text)
+	expectedOutput := make(map[string][]SlackPost)
+	expectedOutput["test"] = []SlackPost{
+		{
+			Text: "This message contains a link to [Google](https://google.com).",
+		},
+		{
+			Text: "This message contains a mailto link to [me@example.com](mailto:me@example.com) in it.",
+		},
+		{
+			Text: "This message contains a **bold** word.",
+		},
+		{
+			Text: "This message contains a ~~strikethrough~~ word.",
+		},
+		{
+			Text: `This message contains multiple paragraphs blockquotes
+>first
+>second
+>third`,
+		},
 	}
-	if output["test"][1].Text != "This message contains a mailto link to [me@example.com](mailto:me@example.com) in it." {
-		t.Fatalf("Unexpected message after markup translation: %v", output["test"][0].Text)
+
+	actualOutput := SlackConvertPostsMarkup(input)
+
+	for i := range actualOutput["test"] {
+		if actualOutput["test"][i].Text != expectedOutput["test"][i].Text {
+			t.Fatalf("Unexpected message after markup translation: %v", actualOutput["test"][i].Text)
+		}
 	}
 }

--- a/app/slackimport_test.go
+++ b/app/slackimport_test.go
@@ -231,7 +231,27 @@ func TestSlackConvertPostsMarkup(t *testing.T) {
 			Text: "This message contains a *bold* word.",
 		},
 		{
+			Text: "This is not a * bold * word.",
+		},
+		{
+			Text: `There is *no bold word
+in this*.`,
+		},
+		{
+			Text: "*This* is not a*bold* word.*This* is a bold word, *and* this; *and* this too.",
+		},
+		{
 			Text: "This message contains a ~strikethrough~ word.",
+		},
+		{
+			Text: "This is not a ~ strikethrough ~ word.",
+		},
+		{
+			Text: `There is ~no strikethrough word
+in this~.`,
+		},
+		{
+			Text: "~This~ is not a~strikethrough~ word.~This~ is a strikethrough word, ~and~ this; ~and~ this too.",
 		},
 		{
 			Text: `This message contains multiple paragraphs blockquotes
@@ -243,6 +263,9 @@ third`,
 			Text: `This message contains single paragraph blockquotes
 &gt;something
 &gt;another thing`,
+		},
+		{
+			Text: "This message has no > block quote",
 		},
 	}
 
@@ -258,7 +281,27 @@ third`,
 			Text: "This message contains a **bold** word.",
 		},
 		{
+			Text: "This is not a * bold * word.",
+		},
+		{
+			Text: `There is *no bold word
+in this*.`,
+		},
+		{
+			Text: "**This** is not a*bold* word.**This** is a bold word, **and** this; **and** this too.",
+		},
+		{
 			Text: "This message contains a ~~strikethrough~~ word.",
+		},
+		{
+			Text: "This is not a ~ strikethrough ~ word.",
+		},
+		{
+			Text: `There is ~no strikethrough word
+in this~.`,
+		},
+		{
+			Text: "~~This~~ is not a~strikethrough~ word.~~This~~ is a strikethrough word, ~~and~~ this; ~~and~~ this too.",
 		},
 		{
 			Text: `This message contains multiple paragraphs blockquotes
@@ -270,6 +313,9 @@ third`,
 			Text: `This message contains single paragraph blockquotes
 >something
 >another thing`,
+		},
+		{
+			Text: "This message has no > block quote",
 		},
 	}
 


### PR DESCRIPTION
Slack markups:
* bold
* strikethrough
* blockquotes

#### Summary
Converts all slack markups to markdown.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-495

https://github.com/mattermost/platform/issues/4716

#### Checklist
- [x] Added or updated unit tests (required for all new features)

