### PR TITLE
PLT-5027: Don't show own user in auto-complete list.

### DIFF
--- a/webapp/components/suggestion/at_mention_provider.jsx
+++ b/webapp/components/suggestion/at_mention_provider.jsx
@@ -5,6 +5,7 @@ import Suggestion from './suggestion.jsx';
 import Provider from './provider.jsx';
 
 import ChannelStore from 'stores/channel_store.jsx';
+import UserStore from 'stores/user_store.jsx';
 
 import {autocompleteUsersInChannel} from 'actions/user_actions.jsx';
 
@@ -142,7 +143,12 @@ export default class AtMentionProvider extends Provider {
                         });
                     }
 
-                    const users = members.concat(specialMentions).concat(nonmembers);
+                    let users = members.concat(specialMentions).concat(nonmembers);
+                    const me = UserStore.getCurrentUser();
+                    users = users.filter((user) => {
+                        return user.id !== me.id;
+                    });
+
                     const mentions = users.map((user) => '@' + user.username);
 
                     AppDispatcher.handleServerAction({


### PR DESCRIPTION
#### Summary

This PR resolves [PLT-5027](https://mattermost.atlassian.net/browse/PLT-5027) and the related GitHub issue, #4702.

The crux of the issue is that whenever the auto-complete menu opens for typing a mention, the current user's username is in the list. This is a problem if the user's name contains characters for special mentions, such as `Ch` (e.g., Chudy, my name). What happens here is that when a user goes to type a special mention, their own username matches the auto-complete, it is ranked higher than the special mention, and it interferes with the auto-complete. The end result possibly being that the auto-complete either requires user interaction beyond a simple acceptance (e.g., you have to use the arrow keys to move to another option) or the user has to type more than they should. By removing the current user from the list, we can lower the amount of noise in the results and improve user experience. Given that it is incredibly unlikely that a user will want to mention themselves, no one should miss this.

Closes #4702.

#### Ticket Link

GitHub as originally reported: #4702 

JIRA: <https://mattermost.atlassian.net/browse/PLT-5027>

#### Checklist

- [x] Has UI changes

#### Notes

* I'm happy to personally implement any and all requests.
* I'm not super great at React and JSX (more of a Python guy), so if there's some way to do this better or cleaner, please let me know! I'm always down to learn something new.
* ~~Locally, I'm getting two failing tests on components I didn't touch, but those also fail on `master`. I'm going to open this to see what Jenkins thinks.~~ Apparently, Jenkins is cool with my changes :+1:.