### PR TITLE
PLT-4096 fix error/panic on replying to integrations.

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -624,9 +624,10 @@ func sendNotifications(c *Context, post *model.Post, team *model.Team, channel *
 				list := result.Data.(*model.PostList)
 
 				for _, threadPost := range list.Posts {
-					profile := profileMap[threadPost.UserId]
-					if profile.NotifyProps["comments"] == "any" || (profile.NotifyProps["comments"] == "root" && threadPost.Id == list.Order[0]) {
-						mentionedUserIds[threadPost.UserId] = true
+					if profile, ok := profileMap[threadPost.UserId]; ok {
+						if profile.NotifyProps["comments"] == "any" || (profile.NotifyProps["comments"] == "root" && threadPost.Id == list.Order[0]) {
+							mentionedUserIds[threadPost.UserId] = true
+						}
 					}
 				}
 			}


### PR DESCRIPTION
#### Summary
Fixes a panic (and an incorrect client side error) when commenting in RHS in reply to a message posted by an integration.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4906