### PR TITLE
Fixed post height changes caused by reactions

### DIFF
--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -1252,6 +1252,10 @@
     min-width: 320px;
 }
 
+.post-reaction-list {
+    min-height: 30px;
+}
+
 .post-reaction {
     @include user-select(none);
     @include border-radius(3px);


### PR DESCRIPTION
I could've swore I had a minimum height in here before, but I might just be crazy. Regardless, this should prevent the scroll pop that's been happening recently