### PR TITLE
Slack format for Slash command messages

### DIFF
--- a/api/command.go
+++ b/api/command.go
@@ -134,7 +134,6 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 				return
 			} else {
 				team = tr.Data.(*model.Team)
-
 			}
 
 			var user *model.User
@@ -247,23 +246,7 @@ func handleResponse(c *Context, w http.ResponseWriter, response *model.CommandRe
 		}
 	}
 
-	if response.ResponseType == model.COMMAND_RESPONSE_TYPE_IN_CHANNEL {
-		post.Message = response.Text
-		post.UserId = c.Session.UserId
-		if _, err := CreatePost(c, post, true); err != nil {
-			c.Err = model.NewLocAppError("command", "api.command.execute_command.save.app_error", nil, "")
-		}
-	} else if response.ResponseType == model.COMMAND_RESPONSE_TYPE_EPHEMERAL && response.Text != "" {
-		post.Message = response.Text
-		post.CreateAt = model.GetMillis()
-		post.UserId = c.Session.UserId
-		post.ParentId = ""
-		SendEphemeralPost(
-			c.TeamId,
-			c.Session.UserId,
-			post,
-		)
-	}
+	CreateCommandPost(c, post, response)
 
 	w.Write([]byte(response.ToJson()))
 }

--- a/api/post.go
+++ b/api/post.go
@@ -174,10 +174,6 @@ func CreatePost(c *Context, post *model.Post, triggerWebhooks bool) (*model.Post
 }
 
 func CreateWebhookPost(c *Context, channelId, text, overrideUsername, overrideIconUrl string, props model.StringInterface, postType string) (*model.Post, *model.AppError) {
-	// parse links into Markdown format
-	linkWithTextRegex := regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
-	text = linkWithTextRegex.ReplaceAllString(text, "[${2}](${1})")
-
 	post := &model.Post{UserId: c.Session.UserId, ChannelId: channelId, Message: text, Type: postType}
 	post.AddProp("from_webhook", "true")
 
@@ -198,38 +194,7 @@ func CreateWebhookPost(c *Context, channelId, text, overrideUsername, overrideIc
 	if len(props) > 0 {
 		for key, val := range props {
 			if key == "attachments" {
-				if list, success := val.([]interface{}); success {
-					// parse attachment links into Markdown format
-					for i, aInt := range list {
-						attachment := aInt.(map[string]interface{})
-						if aText, ok := attachment["text"].(string); ok {
-							aText = linkWithTextRegex.ReplaceAllString(aText, "[${2}](${1})")
-							attachment["text"] = aText
-							list[i] = attachment
-						}
-						if aText, ok := attachment["pretext"].(string); ok {
-							aText = linkWithTextRegex.ReplaceAllString(aText, "[${2}](${1})")
-							attachment["pretext"] = aText
-							list[i] = attachment
-						}
-						if fVal, ok := attachment["fields"]; ok {
-							if fields, ok := fVal.([]interface{}); ok {
-								// parse attachment field links into Markdown format
-								for j, fInt := range fields {
-									field := fInt.(map[string]interface{})
-									if fValue, ok := field["value"].(string); ok {
-										fValue = linkWithTextRegex.ReplaceAllString(fValue, "[${2}](${1})")
-										field["value"] = fValue
-										fields[j] = field
-									}
-								}
-								attachment["fields"] = fields
-								list[i] = attachment
-							}
-						}
-					}
-					post.AddProp(key, list)
-				}
+				createSlackPost(post, val)
 			} else if key != "override_icon_url" && key != "override_username" && key != "from_webhook" {
 				post.AddProp(key, val)
 			}
@@ -241,6 +206,72 @@ func CreateWebhookPost(c *Context, channelId, text, overrideUsername, overrideIc
 	}
 
 	return post, nil
+}
+
+func CreateCommandPost(c *Context, post *model.Post, response *model.CommandResponse) {
+	post.Message = response.Text
+	post.UserId = c.Session.UserId
+	post.CreateAt = model.GetMillis()
+
+	if response.Attachments != nil {
+		createSlackPost(post, response.Attachments)
+	}
+
+	switch response.ResponseType {
+	case model.COMMAND_RESPONSE_TYPE_IN_CHANNEL:
+		if _, err := CreatePost(c, post, true); err != nil {
+			c.Err = model.NewLocAppError("command", "api.command.execute_command.save.app_error", nil, "")
+		}
+	case model.COMMAND_RESPONSE_TYPE_EPHEMERAL:
+		if response.Text == "" {
+			return
+		}
+
+		post.ParentId = ""
+		SendEphemeralPost(c.TeamId, c.Session.UserId, post)
+	}
+}
+
+// This method only parses and processes the attachments,
+// all else should be set in the post which is passed
+func createSlackPost(post *model.Post, attachments interface{}) {
+	post.Type = model.POST_SLACK_ATTACHMENT
+
+	// parse links into Markdown format
+	linkWithTextRegex := regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
+	post.Message = linkWithTextRegex.ReplaceAllString(post.Message, "[${2}](${1})")
+
+	if list, success := attachments.([]interface{}); success {
+		for i, aInt := range list {
+			attachment := aInt.(map[string]interface{})
+			if aText, ok := attachment["text"].(string); ok {
+				aText = linkWithTextRegex.ReplaceAllString(aText, "[${2}](${1})")
+				attachment["text"] = aText
+				list[i] = attachment
+			}
+			if aText, ok := attachment["pretext"].(string); ok {
+				aText = linkWithTextRegex.ReplaceAllString(aText, "[${2}](${1})")
+				attachment["pretext"] = aText
+				list[i] = attachment
+			}
+			if fVal, ok := attachment["fields"]; ok {
+				if fields, ok := fVal.([]interface{}); ok {
+					// parse attachment field links into Markdown format
+					for j, fInt := range fields {
+						field := fInt.(map[string]interface{})
+						if fValue, ok := field["value"].(string); ok {
+							fValue = linkWithTextRegex.ReplaceAllString(fValue, "[${2}](${1})")
+							field["value"] = fValue
+							fields[j] = field
+						}
+					}
+					attachment["fields"] = fields
+					list[i] = attachment
+				}
+			}
+		}
+		post.AddProp("attachments", list)
+	}
 }
 
 func handlePostEvents(c *Context, post *model.Post, triggerWebhooks bool) {

--- a/webapp/components/post_view/components/post_body_additional_content.jsx
+++ b/webapp/components/post_view/components/post_body_additional_content.jsx
@@ -136,7 +136,7 @@ export default class PostBodyAdditionalContent extends React.Component {
     }
 
     generateStaticEmbed() {
-        if (this.props.post.type === Constants.POST_TYPE_ATTACHMENT) {
+        if (this.props.post.props && this.props.post.props.attachments) {
             return this.getSlackAttachment();
         }
 


### PR DESCRIPTION
Right now these are mutually exclusive. I proposed a Format column, however, a one liner, [proposed by @jwilander](https://pre-release.mattermost.com/core/pl/fbhro674biyo3gjqxagy9ennae) fixed this. So no need for a potentially expensive migration.

Note, we do the same check twice now, while executing `generateStaticEmbed()`. However, `attachments` in `getSlackAttachments` could still be `[]` so I don't think we can remove the one in `getSlackAttachments`.

Visual difference between `in_channel` and `ephemeral`:

<img width="898" alt="screen shot 2017-01-06 at 15 12 24" src="https://cloud.githubusercontent.com/assets/2529595/21720454/a2507f6c-d423-11e6-8e60-bbe2eaf0f454.png">


#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [X] Has UI changes
