### PR TITLE
PLT-5137 Don't sanitize company name out of license

### DIFF
--- a/utils/license.go
+++ b/utils/license.go
@@ -168,7 +168,6 @@ func GetSanitizedClientLicense() map[string]string {
 	if IsLicensed {
 		delete(sanitizedLicense, "Name")
 		delete(sanitizedLicense, "Email")
-		delete(sanitizedLicense, "Company")
 		delete(sanitizedLicense, "PhoneNumber")
 		delete(sanitizedLicense, "IssuedAt")
 		delete(sanitizedLicense, "StartsAt")


### PR DESCRIPTION
#### Summary
So non-admin users don't see a blank field in the about modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5137