### PR TITLE
PLT-5174 Mobile view: Send message link in popover doesn't close RHS

### DIFF
--- a/webapp/components/profile_popover.jsx
+++ b/webapp/components/profile_popover.jsx
@@ -83,6 +83,7 @@ export default class ProfilePopover extends React.Component {
         openDirectChannelToUser(
             user,
             (channel) => {
+                GlobalActions.emitCloseRightHandSide();
                 this.setState({loadingDMChannel: -1});
                 if (this.props.hide) {
                     this.props.hide();

--- a/webapp/components/profile_popover.jsx
+++ b/webapp/components/profile_popover.jsx
@@ -83,7 +83,9 @@ export default class ProfilePopover extends React.Component {
         openDirectChannelToUser(
             user,
             (channel) => {
-                GlobalActions.emitCloseRightHandSide();
+                if (Utils.isMobile()) {
+                    GlobalActions.emitCloseRightHandSide();
+                }
                 this.setState({loadingDMChannel: -1});
                 if (this.props.hide) {
                     this.props.hide();


### PR DESCRIPTION
#### Summary
Fixed the issue of closing the right hand sidebar when click on send message button from profile popover in the mobile view

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5174
