### PR TITLE
Invalidate AllChannelMembers cache for user on UpdateMember called.

### DIFF
--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -659,6 +659,8 @@ func (s SqlChannelStore) UpdateMember(member *model.ChannelMember) StoreChannel 
 			result.Data = member
 		}
 
+		s.InvalidateAllChannelMembersForUser(member.UserId)
+
 		storeChannel <- result
 		close(storeChannel)
 	}()


### PR DESCRIPTION
#### Summary
Invalidate the AllChannelMembersCache for the user when ChannelStore.UpdateMember is called.

This fixes a problem where when the ChannelMember's roles are changed, then the old ones are still found by permissions checking functions from the cache.