### PR TITLE
PLT-5050 (Server): API to update channel member roles.

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -45,6 +45,7 @@ func InitChannel() {
 	BaseRoutes.NeedChannel.Handle("/delete", ApiUserRequired(deleteChannel)).Methods("POST")
 	BaseRoutes.NeedChannel.Handle("/add", ApiUserRequired(addMember)).Methods("POST")
 	BaseRoutes.NeedChannel.Handle("/remove", ApiUserRequired(removeMember)).Methods("POST")
+	BaseRoutes.NeedChannel.Handle("/update_member_roles", ApiUserRequired(updateChannelMemberRoles)).Methods("POST")
 }
 
 func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -1324,4 +1325,50 @@ func getChannelMembersByIds(c *Context, w http.ResponseWriter, r *http.Request) 
 		w.Write([]byte(members.ToJson()))
 		return
 	}
+}
+
+func updateChannelMemberRoles(c *Context, w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	channelId := params["channel_id"]
+
+	props := model.MapFromJson(r.Body)
+
+	userId := props["user_id"]
+	if len(userId) != 26 {
+		c.SetInvalidParam("updateChannelMemberRoles", "user_id")
+		return
+	}
+
+	mchan := Srv.Store.Channel().GetMember(channelId, userId)
+
+	newRoles := props["new_roles"]
+	if !(model.IsValidUserRoles(newRoles)) {
+		c.SetInvalidParam("updateChannelMemberRoles", "new_roles")
+		return
+	}
+
+	if !HasPermissionToChannelContext(c, channelId, model.PERMISSION_MANAGE_CHANNEL_ROLES) {
+		return
+	}
+
+	var member model.ChannelMember
+	if result := <-mchan; result.Err != nil {
+		c.Err = result.Err
+		return
+	} else {
+		member = result.Data.(model.ChannelMember)
+	}
+
+	member.Roles = newRoles
+
+	if result := <-Srv.Store.Channel().UpdateMember(&member); result.Err != nil {
+		c.Err = result.Err
+		return
+	}
+
+	InvalidateCacheForUser(userId)
+
+	rdata := map[string]string{}
+	rdata["status"] = "ok"
+	w.Write([]byte(model.MapToJson(rdata)))
 }

--- a/model/authorization.go
+++ b/model/authorization.go
@@ -27,6 +27,7 @@ var PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS *Permission
 var PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS *Permission
 var PERMISSION_ASSIGN_SYSTEM_ADMIN_ROLE *Permission
 var PERMISSION_MANAGE_ROLES *Permission
+var PERMISSION_MANAGE_CHANNEL_ROLES *Permission
 var PERMISSION_CREATE_DIRECT_CHANNEL *Permission
 var PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES *Permission
 var PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES *Permission
@@ -122,6 +123,11 @@ func InitalizePermissions() {
 		"manage_roles",
 		"authentication.permissions.manage_roles.name",
 		"authentication.permissions.manage_roles.description",
+	}
+	PERMISSION_MANAGE_CHANNEL_ROLES = &Permission{
+		"manage_channel_roles",
+		"authentication.permissions.manage_channel_roles.name",
+		"authentication.permissions.manage_channel_roles.description",
 	}
 	PERMISSION_MANAGE_SYSTEM = &Permission{
 		"manage_system",
@@ -264,7 +270,9 @@ func InitalizeRoles() {
 		"channel_admin",
 		"authentication.roles.channel_admin.name",
 		"authentication.roles.channel_admin.description",
-		[]string{},
+		[]string{
+			PERMISSION_MANAGE_CHANNEL_ROLES.Id,
+		},
 	}
 	BuiltInRoles[ROLE_CHANNEL_ADMIN.Id] = ROLE_CHANNEL_ADMIN
 	ROLE_CHANNEL_GUEST = &Role{
@@ -296,6 +304,7 @@ func InitalizeRoles() {
 			PERMISSION_MANAGE_TEAM.Id,
 			PERMISSION_IMPORT_TEAM.Id,
 			PERMISSION_MANAGE_ROLES.Id,
+			PERMISSION_MANAGE_CHANNEL_ROLES.Id,
 			PERMISSION_MANAGE_OTHERS_WEBHOOKS.Id,
 			PERMISSION_MANAGE_SLASH_COMMANDS.Id,
 			PERMISSION_MANAGE_OTHERS_SLASH_COMMANDS.Id,

--- a/model/client.go
+++ b/model/client.go
@@ -2334,3 +2334,26 @@ func (c *Client) ListReactions(channelId string, postId string) ([]*Reaction, *A
 		return ReactionsFromJson(r.Body), nil
 	}
 }
+
+// Updates the user's roles in the channel by replacing them with the roles provided.
+func (c *Client) UpdateChannelRoles(channelId string, userId string, roles string) (map[string]string, *ResponseMetadata) {
+	data := make(map[string]string)
+	data["new_roles"] = roles
+	data["user_id"] = userId
+
+	if r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/update_member_roles", MapToJson(data)); err != nil {
+		metadata := ResponseMetadata{Error: err}
+		if r != nil {
+			metadata.StatusCode = r.StatusCode
+		}
+		return nil, &metadata
+	} else {
+		defer closeBody(r)
+		return MapFromJson(r.Body),
+			&ResponseMetadata{
+				StatusCode: r.StatusCode,
+				RequestId:  r.Header.Get(HEADER_REQUEST_ID),
+				Etag:       r.Header.Get(HEADER_ETAG_SERVER),
+			}
+	}
+}


### PR DESCRIPTION
#### Summary
PLT-5050 (Server). API to update channel member roles.

Implements API reference proposal https://github.com/mattermost/mattermost-api-reference/pull/66

Javscript driver coming in separate WebApp PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5050

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
