### PR TITLE
GH-4907 Move Client.updatePost call into an action

### DIFF
--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -366,7 +366,13 @@ export function createPost(post, doLoadPost, success, error) {
 export function updatePost(post, success) {
     Client.updatePost(
         post,
-        success,
+        () => {
+            loadPosts(post.channel_id);
+            
+            if (success) {
+                success();
+            }
+        },
         (err) => {
             AsyncClient.dispatchError(err, 'updatePost');
         });

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -363,6 +363,15 @@ export function createPost(post, doLoadPost, success, error) {
     );
 }
 
+export function updatePost(post, success) {
+    Client.updatePost(
+        post,
+        success,
+        (err) => {
+            AsyncClient.dispatchError(err, 'updatePost');
+        });
+}
+
 export function removePostFromStore(post) {
     PostStore.removePost(post);
     PostStore.emitChange();

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -368,7 +368,7 @@ export function updatePost(post, success) {
         post,
         () => {
             loadPosts(post.channel_id);
-            
+
             if (success) {
                 success();
             }

--- a/webapp/components/edit_post_modal.jsx
+++ b/webapp/components/edit_post_modal.jsx
@@ -9,7 +9,7 @@ import MessageHistoryStore from 'stores/message_history_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
-import {loadPosts, updatePost} from 'actions/post_actions.jsx';
+import {updatePost} from 'actions/post_actions.jsx';
 
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
@@ -92,7 +92,6 @@ export default class EditPostModal extends React.Component {
         updatePost(
             updatedPost,
             () => {
-                loadPosts(updatedPost.channel_id);
                 window.scrollTo(0, 0);
             });
 

--- a/webapp/components/edit_post_modal.jsx
+++ b/webapp/components/edit_post_modal.jsx
@@ -9,11 +9,9 @@ import MessageHistoryStore from 'stores/message_history_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
-import {loadPosts} from 'actions/post_actions.jsx';
+import {loadPosts, updatePost} from 'actions/post_actions.jsx';
 
-import Client from 'client/web_client.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
-import * as AsyncClient from 'utils/async_client.jsx';
 import * as Utils from 'utils/utils.jsx';
 import Constants from 'utils/constants.jsx';
 const KeyCodes = Constants.KeyCodes;
@@ -91,16 +89,12 @@ export default class EditPostModal extends React.Component {
             return;
         }
 
-        Client.updatePost(
+        updatePost(
             updatedPost,
             () => {
                 loadPosts(updatedPost.channel_id);
                 window.scrollTo(0, 0);
-            },
-            (err) => {
-                AsyncClient.dispatchError(err, 'updatePost');
-            }
-        );
+            });
 
         $('#edit_post').modal('hide');
     }


### PR DESCRIPTION
#### Summary
Client.updatePost where called from components so they needed to be moved inside action and call that action from component instead

#### Ticket Link
fixes #4907

#### Checklist
- [x] Has UI changes
