### PR TITLE
PLT-4317: Fix Desktop App platform in sessions list.

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -636,6 +636,10 @@ func doLogin(c *Context, w http.ResponseWriter, r *http.Request, user *model.Use
 		bname = "unknown"
 	}
 
+	if strings.Contains(r.UserAgent(), "Mattermost") {
+		bname = "Desktop App"
+	}
+
 	if bversion == "" {
 		bversion = "0.0"
 	}

--- a/webapp/components/activity_log_modal.jsx
+++ b/webapp/components/activity_log_modal.jsx
@@ -134,6 +134,17 @@ export default class ActivityLogModal extends React.Component {
                 } else {
                     devicePicture = 'fa fa-linux';
                 }
+            } else if (currentSession.props.os.indexOf('Linux') !== -1) {
+                devicePicture = 'fa fa-linux';
+            }
+
+            if (currentSession.props.browser.indexOf('Desktop App') !== -1) {
+                devicePlatform = (
+                    <FormattedMessage
+                        id='activity_log_modal.desktop'
+                        defaultMessage='Native Desktop App'
+                    />
+                );
             }
 
             let moreInfo;

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -28,6 +28,7 @@
   "activity_log.sessionsDescription": "Sessions are created when you log in to a new browser on a device. Sessions let you use Mattermost without having to log in again for a time period specified by the System Admin. If you want to log out sooner, use the 'Logout' button below to end a session.",
   "activity_log_modal.android": "Android",
   "activity_log_modal.androidNativeApp": "Android Native App",
+  "activity_log_modal.desktop": "Native Desktop App",
   "activity_log_modal.iphoneNativeApp": "iPhone Native App",
   "add_command.autocomplete": "Autocomplete",
   "add_command.autocomplete.help": "(Optional) Show slash command in autocomplete list.",


### PR DESCRIPTION
#### Summary
Fix Desktop App displaying as Safari in the Account Settings -> Security -> Active Sessions list.

Incidentally fixes displaying the Linux icon next to sessions on Linux at the same time.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4317

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file updates
