### PR TITLE
PLT-5025: Fix scroll to bottom delay loading channel.

### DIFF
--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -421,6 +421,11 @@ export default class PostList extends React.Component {
                     this.scrollToBottom();
                 }
             });
+
+            // This avoids the scroll jumping from top to bottom after the page has rendered (PLT-5025).
+            if (!this.refs.newMessageSeparator) {
+                this.scrollToBottom();
+            }
         } else if (this.props.scrollType === ScrollTypes.POST && this.props.scrollPostId) {
             window.requestAnimationFrame(() => {
                 const postNode = ReactDOM.findDOMNode(this.refs[this.props.scrollPostId]);


### PR DESCRIPTION
#### Summary
This fixes the issue where (particularly on slow devices like mobiles), when you open a channel, it shows the top of the page for a fraction of a second (or a few seconds on a slow Android) before scrolling to the bottom.

@jwilander requesting your review, as the reason for this issue is the scrolling of type NEW_MESSAGE being run asynchronously rather than immediately, which is code last touched by you, so hoping you will know if there are any non-obvious side effects of the way I've worked around the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5025

#### Checklist
- [x] Has UI changes