### PR TITLE
PLT-5238: Show error on execute invalid slash command.

### DIFF
--- a/webapp/actions/channel_actions.jsx
+++ b/webapp/actions/channel_actions.jsx
@@ -48,7 +48,14 @@ export function executeCommand(message, args, success, error) {
             msg = '/shortcuts';
         }
     }
-    Client.executeCommand(msg, args, success, error);
+    Client.executeCommand(msg, args, success,
+        (err) => {
+            AsyncClient.dispatchError(err, 'executeCommand');
+
+            if (error) {
+                error(err);
+            }
+        });
 }
 
 export function setChannelAsRead(channelIdParam) {


### PR DESCRIPTION
#### Summary
Show error when user tries to execute an invalid slash command.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5238