### PR TITLE
[IMPORTANT] return posted message without waiting for email and push notifications

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -156,7 +156,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 			}
 
 			if userAllowsEmails && status.Status != model.STATUS_ONLINE && profileMap[id].DeleteAt == 0 {
-				sendNotificationEmail(post, profileMap[id], channel, team, senderName[id], sender)
+				go sendNotificationEmail(post, profileMap[id], channel, team, senderName[id], sender)
 			}
 		}
 	}
@@ -253,7 +253,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 			}
 
 			if DoesStatusAllowPushNotification(profileMap[id], status, post.ChannelId) {
-				sendPushNotification(post, profileMap[id], channel, senderName[id], true)
+				go sendPushNotification(post, profileMap[id], channel, senderName[id], true)
 			}
 		}
 
@@ -266,7 +266,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 				}
 
 				if DoesStatusAllowPushNotification(profileMap[id], status, post.ChannelId) {
-					sendPushNotification(post, profileMap[id], channel, senderName[id], false)
+					go sendPushNotification(post, profileMap[id], channel, senderName[id], false)
 				}
 			}
 		}


### PR DESCRIPTION
It was fixed once at [here](https://github.com/mattermost/platform/commit/36f62c9e82350f58c902f64a5d3304872431ad41), but it didn't apply to v3.6.