### PR TITLE
PLT-5210: Unify errors for invalid invite.

### DIFF
--- a/webapp/components/signup/signup_controller.jsx
+++ b/webapp/components/signup/signup_controller.jsx
@@ -79,11 +79,16 @@ export default class SignupController extends React.Component {
                             }
                         );
                     },
-                    (e) => {
+                    () => {
                         this.setState({ // eslint-disable-line react/no-did-mount-set-state
                             noOpenServerError: true,
                             loading: false,
-                            serverError: e.message
+                            serverError: (
+                                <FormattedMessage
+                                    id='signup_user_completed.invalid_invite'
+                                    defaultMessage='The invite link was invalid.  Please speak with your Administrator to receive an invitation.'
+                                />
+                            )
                         });
                     }
                 );


### PR DESCRIPTION
#### Summary
Shows same error for invalid invite code regardless of whether the user is logged in or not.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5210

#### Checklist
- [x] Has UI changes
