### PR TITLE
PLT-5279: Show username for slash cmd notification.

### DIFF
--- a/api/command.go
+++ b/api/command.go
@@ -233,8 +233,6 @@ func handleResponse(c *Context, w http.ResponseWriter, response *model.CommandRe
 			post.AddProp("override_username", cmd.Username)
 		} else if len(response.Username) != 0 {
 			post.AddProp("override_username", response.Username)
-		} else {
-			post.AddProp("override_username", model.DEFAULT_WEBHOOK_USERNAME)
 		}
 	}
 


### PR DESCRIPTION
#### Summary
If integrations overriding usernames is *on* don't override the username unless the slash command is either configured with a username, or provides one in it's response.

Fixes "webhook posted xxxxx" appearing in notifications in this scenario previously.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5279