### PR TITLE
Removed index on Teams.Description column

### DIFF
--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -462,19 +462,19 @@ func (ss *SqlStore) AlterColumnTypeIfExists(tableName string, columnName string,
 	return true
 }
 
-func (ss *SqlStore) CreateUniqueIndexIfNotExists(indexName string, tableName string, columnName string) {
-	ss.createIndexIfNotExists(indexName, tableName, columnName, INDEX_TYPE_DEFAULT, true)
+func (ss *SqlStore) CreateUniqueIndexIfNotExists(indexName string, tableName string, columnName string) bool {
+	return ss.createIndexIfNotExists(indexName, tableName, columnName, INDEX_TYPE_DEFAULT, true)
 }
 
-func (ss *SqlStore) CreateIndexIfNotExists(indexName string, tableName string, columnName string) {
-	ss.createIndexIfNotExists(indexName, tableName, columnName, INDEX_TYPE_DEFAULT, false)
+func (ss *SqlStore) CreateIndexIfNotExists(indexName string, tableName string, columnName string) bool {
+	return ss.createIndexIfNotExists(indexName, tableName, columnName, INDEX_TYPE_DEFAULT, false)
 }
 
-func (ss *SqlStore) CreateFullTextIndexIfNotExists(indexName string, tableName string, columnName string) {
-	ss.createIndexIfNotExists(indexName, tableName, columnName, INDEX_TYPE_FULL_TEXT, false)
+func (ss *SqlStore) CreateFullTextIndexIfNotExists(indexName string, tableName string, columnName string) bool {
+	return ss.createIndexIfNotExists(indexName, tableName, columnName, INDEX_TYPE_FULL_TEXT, false)
 }
 
-func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, columnName string, indexType string, unique bool) {
+func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, columnName string, indexType string, unique bool) bool {
 
 	uniqueStr := ""
 	if unique {
@@ -485,7 +485,7 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 		_, err := ss.GetMaster().SelectStr("SELECT $1::regclass", indexName)
 		// It should fail if the index does not exist
 		if err == nil {
-			return
+			return false
 		}
 
 		query := ""
@@ -512,7 +512,7 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 		}
 
 		if count > 0 {
-			return
+			return false
 		}
 
 		fullTextIndex := ""
@@ -531,15 +531,17 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 		time.Sleep(time.Second)
 		os.Exit(EXIT_CREATE_INDEX_MISSING)
 	}
+
+	return true
 }
 
-func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) {
+func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) bool {
 
 	if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 		_, err := ss.GetMaster().SelectStr("SELECT $1::regclass", indexName)
 		// It should fail if the index does not exist
-		if err == nil {
-			return
+		if err != nil {
+			return false
 		}
 
 		_, err = ss.GetMaster().Exec("DROP INDEX " + indexName)
@@ -548,6 +550,8 @@ func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) {
 			time.Sleep(time.Second)
 			os.Exit(EXIT_REMOVE_INDEX_POSTGRES)
 		}
+
+		return true
 	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 
 		count, err := ss.GetMaster().SelectInt("SELECT COUNT(0) AS index_exists FROM information_schema.statistics WHERE TABLE_SCHEMA = DATABASE() and table_name = ? AND index_name = ?", tableName, indexName)
@@ -558,7 +562,7 @@ func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) {
 		}
 
 		if count <= 0 {
-			return
+			return false
 		}
 
 		_, err = ss.GetMaster().Exec("DROP INDEX " + indexName + " ON " + tableName)
@@ -572,6 +576,8 @@ func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) {
 		time.Sleep(time.Second)
 		os.Exit(EXIT_REMOVE_INDEX_MISSING)
 	}
+
+	return true
 }
 
 func IsUniqueConstraintError(err string, indexName []string) bool {

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -557,7 +557,7 @@ func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) {
 			os.Exit(EXIT_REMOVE_INDEX_MYSQL)
 		}
 
-		if count > 0 {
+		if count <= 0 {
 			return
 		}
 

--- a/store/sql_store_test.go
+++ b/store/sql_store_test.go
@@ -118,3 +118,51 @@ func TestAlertDbCmds(t *testing.T) {
 		t.Fatal("Column should not exist")
 	}
 }
+
+func TestCreateIndexIfNotExists(t *testing.T) {
+	Setup()
+
+	sqlStore := store.(*SqlStore)
+
+	defer sqlStore.RemoveColumnIfExists("Systems", "Test")
+	if !sqlStore.CreateColumnIfNotExists("Systems", "Test", "VARCHAR(50)", "VARCHAR(50)", "") {
+		t.Fatal("Failed to create test column")
+	}
+
+	defer sqlStore.RemoveIndexIfExists("idx_systems_create_index_test", "Systems")
+	if !sqlStore.CreateIndexIfNotExists("idx_systems_create_index_test", "Systems", "Test") {
+		t.Fatal("Should've created test index")
+	}
+
+	if sqlStore.CreateIndexIfNotExists("idx_systems_create_index_test", "Systems", "Test") {
+		t.Fatal("Shouldn't have created index that already exists")
+	}
+}
+
+func TestRemoveIndexIfExists(t *testing.T) {
+	Setup()
+
+	sqlStore := store.(*SqlStore)
+
+	defer sqlStore.RemoveColumnIfExists("Systems", "Test")
+	if !sqlStore.CreateColumnIfNotExists("Systems", "Test", "VARCHAR(50)", "VARCHAR(50)", "") {
+		t.Fatal("Failed to create test column")
+	}
+
+	if sqlStore.RemoveIndexIfExists("idx_systems_remove_index_test", "Systems") {
+		t.Fatal("Should've failed to remove index that doesn't exist")
+	}
+
+	defer sqlStore.RemoveIndexIfExists("idx_systems_remove_index_test", "Systems")
+	if !sqlStore.CreateIndexIfNotExists("idx_systems_remove_index_test", "Systems", "Test") {
+		t.Fatal("Should've created test index")
+	}
+
+	if !sqlStore.RemoveIndexIfExists("idx_systems_remove_index_test", "Systems") {
+		t.Fatal("Should've removed index that exists")
+	}
+
+	if sqlStore.RemoveIndexIfExists("idx_systems_remove_index_test", "Systems") {
+		t.Fatal("Should've failed to remove index that was already removed")
+	}
+}

--- a/store/sql_team_store.go
+++ b/store/sql_team_store.go
@@ -44,7 +44,7 @@ func NewSqlTeamStore(sqlStore *SqlStore) TeamStore {
 
 func (s SqlTeamStore) CreateIndexesIfNotExists() {
 	s.CreateIndexIfNotExists("idx_teams_name", "Teams", "Name")
-	s.CreateIndexIfNotExists("idx_teams_description", "Teams", "Description")
+	s.RemoveIndexIfExists("idx_teams_description", "Teams")
 	s.CreateIndexIfNotExists("idx_teams_invite_id", "Teams", "InviteId")
 	s.CreateIndexIfNotExists("idx_teams_update_at", "Teams", "UpdateAt")
 	s.CreateIndexIfNotExists("idx_teams_create_at", "Teams", "CreateAt")


### PR DESCRIPTION
This column is too long so it fails to create the index when MySQL is configured to use certain character sets

#### Ticket Link
https://github.com/mattermost/platform/issues/5079