### PR TITLE
PLT-5163 Fixed channel mention autocomplete to not match completed mentions

### DIFF
--- a/webapp/components/suggestion/channel_mention_provider.jsx
+++ b/webapp/components/suggestion/channel_mention_provider.jsx
@@ -56,6 +56,18 @@ export default class ChannelMentionProvider extends Provider {
         if (captured) {
             const prefix = captured[3];
 
+            if ((/\s/).test(prefix)) {
+                // If there's a space, there's a chance that we've already completed this mention
+                const firstWordOfPrefix = prefix.split(' ')[0];
+
+                for (const channel of ChannelStore.getChannels()) {
+                    if (firstWordOfPrefix === channel.name) {
+                        // We've already mentioned this channel so there's nothing else to look for
+                        return;
+                    }
+                }
+            }
+
             this.startNewRequest(prefix);
 
             autocompleteChannels(


### PR DESCRIPTION
Because autocompleting a channel mention doesn't have a clear ending delimiter (because a channel's display name can contain spaces), we need to check if what we're autocompleting has already been a match.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5163
