### PR TITLE
PLT-4845: Slack import of channel purpose changed messages.

### DIFF
--- a/api/slackimport.go
+++ b/api/slackimport.go
@@ -331,6 +331,54 @@ func SlackAddPosts(teamId string, channel *model.Channel, posts []SlackPost, use
 				CreateAt:  SlackConvertTimeStamp(sPost.TimeStamp),
 			}
 			ImportPost(&newPost)
+		case sPost.Type == "message" && sPost.SubType == "channel_topic":
+			if sPost.User == "" {
+				l4g.Debug(utils.T("api.slackimport.slack_add_posts.msg_no_usr.debug"))
+				continue
+			} else if users[sPost.User] == nil {
+				l4g.Debug(utils.T("api.slackimport.slack_add_posts.user_no_exists.debug"), sPost.User)
+				continue
+			}
+			newPost := model.Post{
+				UserId:    users[sPost.User].Id,
+				ChannelId: channel.Id,
+				Message:   sPost.Text,
+				CreateAt:  SlackConvertTimeStamp(sPost.TimeStamp),
+				Type:      model.POST_HEADER_CHANGE,
+			}
+			ImportPost(&newPost)
+		case sPost.Type == "message" && sPost.SubType == "channel_purpose":
+			if sPost.User == "" {
+				l4g.Debug(utils.T("api.slackimport.slack_add_posts.msg_no_usr.debug"))
+				continue
+			} else if users[sPost.User] == nil {
+				l4g.Debug(utils.T("api.slackimport.slack_add_posts.user_no_exists.debug"), sPost.User)
+				continue
+			}
+			newPost := model.Post{
+				UserId:    users[sPost.User].Id,
+				ChannelId: channel.Id,
+				Message:   sPost.Text,
+				CreateAt:  SlackConvertTimeStamp(sPost.TimeStamp),
+				Type:      model.POST_PURPOSE_CHANGE,
+			}
+			ImportPost(&newPost)
+		case sPost.Type == "message" && sPost.SubType == "channel_name":
+			if sPost.User == "" {
+				l4g.Debug(utils.T("api.slackimport.slack_add_posts.msg_no_usr.debug"))
+				continue
+			} else if users[sPost.User] == nil {
+				l4g.Debug(utils.T("api.slackimport.slack_add_posts.user_no_exists.debug"), sPost.User)
+				continue
+			}
+			newPost := model.Post{
+				UserId:    users[sPost.User].Id,
+				ChannelId: channel.Id,
+				Message:   sPost.Text,
+				CreateAt:  SlackConvertTimeStamp(sPost.TimeStamp),
+				Type:      model.POST_DISPLAYNAME_CHANGE,
+			}
+			ImportPost(&newPost)
 		default:
 			l4g.Warn(utils.T("api.slackimport.slack_add_posts.unsupported.warn"), sPost.Type, sPost.SubType)
 		}


### PR DESCRIPTION
#### Summary
Slack import of channel purpose changed messages.

Also includes channel header changed messages and channel name changed
messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4845