### PR TITLE
PLT-5188: Reinstate delete option on system messages.

### DIFF
--- a/webapp/components/post_view/components/post_info.jsx
+++ b/webapp/components/post_view/components/post_info.jsx
@@ -53,10 +53,8 @@ export default class PostInfo extends React.Component {
     }
 
     createDropdown() {
-        var post = this.props.post;
-
-        this.canDelete = PostUtils.canDeletePost(post);
-        this.canEdit = PostUtils.canEditPost(post, this.editDisableAction);
+        const post = this.props.post;
+        const isSystemMessage = post.type && post.type.startsWith(Constants.SYSTEM_MESSAGE_PREFIX);
 
         if (post.state === Constants.POST_FAILED || post.state === Constants.POST_LOADING) {
             return '';
@@ -131,22 +129,24 @@ export default class PostInfo extends React.Component {
             }
         }
 
-        dropdownContents.push(
-            <li
-                key='copyLink'
-                role='presentation'
-            >
-                <a
-                    href='#'
-                    onClick={this.handlePermalink}
+        if (!isSystemMessage) {
+            dropdownContents.push(
+                <li
+                    key='copyLink'
+                    role='presentation'
                 >
-                    <FormattedMessage
-                        id='post_info.permalink'
-                        defaultMessage='Permalink'
-                    />
-                </a>
-            </li>
-        );
+                    <a
+                        href='#'
+                        onClick={this.handlePermalink}
+                    >
+                        <FormattedMessage
+                            id='post_info.permalink'
+                            defaultMessage='Permalink'
+                        />
+                    </a>
+                </li>
+            );
+        }
 
         if (this.canDelete) {
             dropdownContents.push(
@@ -267,6 +267,9 @@ export default class PostInfo extends React.Component {
         var commentCountText = this.props.commentCount;
         const flagIcon = Constants.FLAG_ICON_SVG;
 
+        this.canDelete = PostUtils.canDeletePost(post);
+        this.canEdit = PostUtils.canEditPost(post, this.editDisableAction);
+
         if (this.props.commentCount >= 1) {
             showCommentClass = ' icon--show';
         } else {
@@ -296,7 +299,7 @@ export default class PostInfo extends React.Component {
                     {this.createRemovePostButton()}
                 </li>
             );
-        } else if (!PostUtils.isSystemMessage(post)) {
+        } else {
             options = (
                 <li className='col col__reply'>
                     <div

--- a/webapp/components/post_view/components/post_info.jsx
+++ b/webapp/components/post_view/components/post_info.jsx
@@ -54,7 +54,7 @@ export default class PostInfo extends React.Component {
 
     createDropdown() {
         const post = this.props.post;
-        const isSystemMessage = post.type && post.type.startsWith(Constants.SYSTEM_MESSAGE_PREFIX);
+        const isSystemMessage = PostUtils.isSystemMessage(post);
 
         if (post.state === Constants.POST_FAILED || post.state === Constants.POST_LOADING) {
             return '';
@@ -300,17 +300,20 @@ export default class PostInfo extends React.Component {
                 </li>
             );
         } else {
-            options = (
-                <li className='col col__reply'>
-                    <div
-                        className='dropdown'
-                        ref='dotMenu'
-                    >
-                        {this.createDropdown()}
-                    </div>
-                    {comments}
-                </li>
-            );
+            const dropdown = this.createDropdown();
+            if (dropdown) {
+                options = (
+                    <li className='col col__reply'>
+                        <div
+                            className='dropdown'
+                            ref='dotMenu'
+                        >
+                            {dropdown}
+                        </div>
+                        {comments}
+                    </li>
+                );
+            }
         }
 
         let flag;

--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -518,6 +518,17 @@
     position: relative;
     word-wrap: break-word;
 
+    &.post--system {
+        .post__header {
+            .col__reply {
+                min-width: 0;
+            }
+            .dropdown {
+                margin-right: 0;
+            }
+        }
+    }
+
     &:hover {
         .dropdown,
         .comment-icon__container,


### PR DESCRIPTION
#### Summary
Reinstates the [...] menu on system messages, with a delete option. Available to either a) the user who triggered the message, or b) team/system admins.

**Q1:** Should the person who triggered the message be allowed to delete it, or just admins?
**Q2:** How should the UI look? Current appearance in screenshot below, which has empty space where the reply arrow would normally be:

![screenshot_20170118_104342](https://cloud.githubusercontent.com/assets/1198059/22061169/a8a74fac-dd6b-11e6-99ee-4e07e2991658.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5188

#### Checklist
- [x] Has UI changes