### PR TITLE
PLT-5135: Fix left channel in more channels list.

### DIFF
--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -284,7 +284,12 @@ class ChannelStoreClass extends EventEmitter {
 
     getMoreChannelsList(teamId = TeamStore.getCurrentId()) {
         const teamChannels = this.moreChannels[teamId] || {};
-        return Object.keys(teamChannels).map((cid) => teamChannels[cid]);
+
+        if (!Utils) {
+            Utils = require('utils/utils.jsx'); //eslint-disable-line global-require
+        }
+
+        return Object.keys(teamChannels).map((cid) => teamChannels[cid]).sort(Utils.sortByDisplayName);
     }
 
     storeStats(stats) {


### PR DESCRIPTION
#### Summary
Fix just-left channel appearing in more channels list.

The problem was it was not being sorted, so appeared at the bottom of the more channels list.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5135