### PR TITLE
PLT-5284 Fix webhook notifications for channel creator is not in

### DIFF
--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -24,7 +24,7 @@ func TestSendNotifications(t *testing.T) {
 		t.Fatal(postErr)
 	}
 
-	mentions, err := SendNotifications(post1, th.BasicTeam, th.BasicChannel)
+	mentions, err := SendNotifications(post1, th.BasicTeam, th.BasicChannel, th.BasicUser)
 	if err != nil {
 		t.Fatal(err)
 	} else if mentions == nil {

--- a/app/post.go
+++ b/app/post.go
@@ -99,15 +99,15 @@ func handlePostEvents(post *model.Post, teamId string, triggerWebhooks bool) *mo
 		channel = result.Data.(*model.Channel)
 	}
 
-	if _, err := SendNotifications(post, team, channel); err != nil {
-		return err
-	}
-
 	var user *model.User
 	if result := <-uchan; result.Err != nil {
 		return result.Err
 	} else {
 		user = result.Data.(*model.User)
+	}
+
+	if _, err := SendNotifications(post, team, channel, user); err != nil {
+		return err
 	}
 
 	if triggerWebhooks {


### PR DESCRIPTION
#### Summary
If a user leaves a channel, still send notifications for posts created by webhooks.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5284