### PR TITLE
Random fixes

### DIFF
--- a/webapp/components/channel_select.jsx
+++ b/webapp/components/channel_select.jsx
@@ -31,12 +31,13 @@ export default class ChannelSelect extends React.Component {
         super(props);
 
         this.handleChannelChange = this.handleChannelChange.bind(this);
+        this.filterChannels = this.filterChannels.bind(this);
         this.compareByDisplayName = this.compareByDisplayName.bind(this);
 
         AsyncClient.getMoreChannels(true);
 
         this.state = {
-            channels: ChannelStore.getAll().sort(this.compareByDisplayName)
+            channels: ChannelStore.getAll().filter(this.filterChannels).sort(this.compareByDisplayName)
         };
     }
 
@@ -50,8 +51,17 @@ export default class ChannelSelect extends React.Component {
 
     handleChannelChange() {
         this.setState({
-            channels: ChannelStore.getAll().concat(ChannelStore.getMoreAll()).sort(this.compareByDisplayName)
+            channels: ChannelStore.getAll().concat(ChannelStore.getMoreAll()).
+                filter(this.filterChannels).sort(this.compareByDisplayName)
         });
+    }
+
+    filterChannels(channel) {
+        if (channel.display_name) {
+            return true;
+        }
+
+        return false;
     }
 
     compareByDisplayName(channelA, channelB) {

--- a/webapp/components/sidebar_header.jsx
+++ b/webapp/components/sidebar_header.jsx
@@ -10,7 +10,7 @@ import * as Utils from 'utils/utils.jsx';
 import SidebarHeaderDropdown from './sidebar_header_dropdown.jsx';
 import {Tooltip, OverlayTrigger} from 'react-bootstrap';
 
-import {Preferences, TutorialSteps, OVERLAY_TIME_DELAY} from 'utils/constants.jsx';
+import {Preferences, TutorialSteps, Constants} from 'utils/constants.jsx';
 import {createMenuTip} from 'components/tutorial/tutorial_tip.jsx';
 
 export default class SidebarHeader extends React.Component {
@@ -78,7 +78,7 @@ export default class SidebarHeader extends React.Component {
             teamNameWithToolTip = (
                 <OverlayTrigger
                     trigger={['hover', 'focus']}
-                    delayShow={OVERLAY_TIME_DELAY}
+                    delayShow={Constants.OVERLAY_TIME_DELAY}
                     placement='bottom'
                     overlay={<Tooltip id='team-name__tooltip'>{this.props.teamDescription}</Tooltip>}
                     ref='descriptionOverlay'


### PR DESCRIPTION
#### Summary
2 fixes:
1. The `OVERLAY_TIME_DELAY` constant used in the sidebar_header was imported in the wrong way
2. in `channel_select` used for selecting channel when setting up a webhook failed if the channel doesn't have a `display_name` set

#### Ticket Link
No ticket for this