### PR TITLE
Use Client APIs to resolve URLs

### DIFF
--- a/webapp/client/test_web_client.jsx
+++ b/webapp/client/test_web_client.jsx
@@ -1,0 +1,7 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import Client from './client.jsx';
+
+var WebClient = new Client();
+export default WebClient;

--- a/webapp/client/web_client.jsx
+++ b/webapp/client/web_client.jsx
@@ -50,7 +50,7 @@ class WebClientClass extends Client {
             return;
         }
 
-        if (err.status === HTTP_UNAUTHORIZED && res.req.url !== '/api/v3/users/login') {
+        if (err.status === HTTP_UNAUTHORIZED && res.req.url !== this.getUsersRoute() + '/login') {
             GlobalActions.emitUserLoggedOutEvent('/login');
         }
 

--- a/webapp/stores/emoji_store.jsx
+++ b/webapp/stores/emoji_store.jsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import Client from '../client/web_client.jsx';
 import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import Constants from 'utils/constants.jsx';
 import EventEmitter from 'events';
@@ -148,8 +149,7 @@ class EmojiStore extends EventEmitter {
 
     getEmojiImageUrl(emoji) {
         if (emoji.id) {
-            // must match Client.getCustomEmojiImageUrl
-            return `/api/v3/emoji/${emoji.id}`;
+            return Client.getCustomEmojiImageUrl(emoji.id);
         }
 
         const filename = emoji.filename || emoji.aliases[0];

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -159,6 +159,7 @@ if (TEST) {
     config.entry = ['babel-polyfill', './root.jsx'];
     config.target = 'node';
     config.externals = [nodeExternals()];
+    config.resolve.alias['./client/web_client.jsx'] = path.resolve(__dirname, 'client/test_web_client.jsx');
 } else {
     // For some reason these break mocha. So they go here.
     config.plugins.push(


### PR DESCRIPTION
#### Summary
Some code in `webapp` don't use APIs provided by `Client` to resolve URLs, so let them do.

I would like @hmhealey to review this since the comment in `getEmojiImageUrl`, added with commit dc2f2a800105b77e665ec2a00c6290f35b1a2ba3 seems implying something why it doesn't use `Client.getCustomEmojiImageUrl`. For me, `Client.getCustomEmojiImageUrl` looks OK.

#### Ticket Link
Nothing.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)