### PR TITLE
Fixing client test errors. 

### DIFF
--- a/cmd/platform/test.go
+++ b/cmd/platform/test.go
@@ -60,18 +60,34 @@ func executeTestCommand(cmd *exec.Cmd) {
 	cmdOutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		CommandPrintErrorln("Failed to run tests")
+		os.Exit(1)
+		return
+	}
+
+	cmdErrOutPipe, err := cmd.StderrPipe()
+	if err != nil {
+		CommandPrintErrorln("Failed to run tests")
+		os.Exit(1)
 		return
 	}
 
 	cmdOutReader := bufio.NewScanner(cmdOutPipe)
+	cmdErrOutReader := bufio.NewScanner(cmdErrOutPipe)
 	go func() {
 		for cmdOutReader.Scan() {
 			fmt.Println(cmdOutReader.Text())
 		}
 	}()
 
+	go func() {
+		for cmdErrOutReader.Scan() {
+			fmt.Println(cmdErrOutReader.Text())
+		}
+	}()
+
 	if err := cmd.Run(); err != nil {
 		CommandPrintErrorln("Client Tests failed")
+		os.Exit(1)
 		return
 	}
 }


### PR DESCRIPTION
Fixing client tests so std error is output and 1 is returned on failure so `make test` fails. 