### PR TITLE
PLT-4858: Allow system admin to delete all channels.

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -243,14 +243,11 @@ func UpdateChannelMemberNotifyProps(data map[string]string, channelId string, us
 
 func DeleteChannel(channel *model.Channel, userId string) *model.AppError {
 	uc := Srv.Store.User().Get(userId)
-	scm := Srv.Store.Channel().GetMember(channel.Id, userId)
 	ihc := Srv.Store.Webhook().GetIncomingByChannel(channel.Id)
 	ohc := Srv.Store.Webhook().GetOutgoingByChannel(channel.Id)
 
 	if uresult := <-uc; uresult.Err != nil {
 		return uresult.Err
-	} else if scmresult := <-scm; scmresult.Err != nil {
-		return scmresult.Err
 	} else if ihcresult := <-ihc; ihcresult.Err != nil {
 		return ihcresult.Err
 	} else if ohcresult := <-ohc; ohcresult.Err != nil {
@@ -259,7 +256,6 @@ func DeleteChannel(channel *model.Channel, userId string) *model.AppError {
 		user := uresult.Data.(*model.User)
 		incomingHooks := ihcresult.Data.([]*model.IncomingWebhook)
 		outgoingHooks := ohcresult.Data.([]*model.OutgoingWebhook)
-		// Don't need to do anything with channel member, just wanted to confirm it exists
 
 		if channel.DeleteAt > 0 {
 			err := model.NewLocAppError("deleteChannel", "api.channel.delete_channel.deleted.app_error", nil, "")


### PR DESCRIPTION
### Summary
Allow system admin to delete all channels.

The app-package refactor means that the check for a Channel Member
object before allowing to delete the channel is now redundant, as the
check is already carried out by using HasPermissionToChannel() on the
user requesting it. As a result, System Admins can now delete channels
through the API even if they aren't members.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4858

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
