### PR TITLE
PLT-5163 Fixed ChannelMentionProvider matching completed mentions

### DIFF
--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -153,6 +153,12 @@ export default class SuggestionBox extends React.Component {
         window.requestAnimationFrame(() => {
             Utils.setCaretPosition(textbox, prefix.length + term.length + 1);
         });
+
+        for (const provider of this.props.providers) {
+            if (provider.handleCompleteWord) {
+                provider.handleCompleteWord(term, matchedPretext);
+            }
+        }
     }
 
     handleKeyDown(e) {


### PR DESCRIPTION
This is a better fix than the one I submitted last week. It'll make it so you can still match channels like `~test channel` that exist at the same time as other ones named `~test`.

Some of the indentation changed so there's a clearer diff here: https://github.com/mattermost/platform/pull/5188/commits/cd25ec8b12da35e4094b405faef4576508e1f2d6?w=1

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5163
