### PR TITLE
PLT-5253 Disabled mangling of email addresses in markdown autolinks

### DIFF
--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -252,7 +252,8 @@ export function format(text, options = {}) {
         renderer: new MattermostMarkdownRenderer(null, options),
         sanitize: true,
         gfm: true,
-        tables: true
+        tables: true,
+        mangle: false
     };
 
     return marked(text, markdownOptions);


### PR DESCRIPTION
I'm not sure why feature exists in marked, but it caused `http://` to be added to the beginning of `mailto:` links

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5253