### PR TITLE
PLT-4898 Fix emoji reaction position for image thumbnails

### DIFF
--- a/webapp/components/file_attachment_list.jsx
+++ b/webapp/components/file_attachment_list.jsx
@@ -50,7 +50,7 @@ export default class FileAttachmentList extends React.Component {
 
         return (
             <div>
-                <div className='post-image__columns'>
+                <div className='post-image__columns clearfix'>
                     {postFiles}
                 </div>
                 <ViewImageModal


### PR DESCRIPTION
#### Summary
This PR fixes the issue where emoji reactions were positioned beside image thumbnails.
Emoji reactions are now positioned below.

#### Ticket Link
#5117 
https://mattermost.atlassian.net/browse/PLT-4898

#### Checklist
- [x] Has UI changes