### PR TITLE
Make all emails with the same pattern on subject

### DIFF
--- a/app/email.go
+++ b/app/email.go
@@ -101,8 +101,8 @@ func SendVerifyEmail(userId, userEmail, locale, siteURL string) *model.AppError 
 func SendSignInChangeEmail(email, method, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
-	subject := T("api.templates.singin_change_email.subject",
-		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
+	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.singin_change_email.subject",
+		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]}))
 
 	bodyPage := utils.NewHTMLTemplate("signin_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -122,7 +122,8 @@ func SendWelcomeEmail(userId string, email string, verified bool, locale, siteUR
 
 	rawUrl, _ := url.Parse(siteURL)
 
-	subject := T("api.templates.welcome_subject", map[string]interface{}{"ServerURL": rawUrl.Host})
+	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.welcome_subject",
+		map[string]interface{}{"ServerURL": rawUrl.Host}))
 
 	bodyPage := utils.NewHTMLTemplate("welcome_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -153,8 +154,8 @@ func SendWelcomeEmail(userId string, email string, verified bool, locale, siteUR
 func SendPasswordChangeEmail(email, method, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
-	subject := T("api.templates.password_change_subject",
-		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName, "SiteName": utils.Cfg.TeamSettings.SiteName})
+	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.password_change_subject",
+		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName, "SiteName": utils.Cfg.TeamSettings.SiteName}))
 
 	bodyPage := utils.NewHTMLTemplate("password_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -172,8 +173,8 @@ func SendPasswordChangeEmail(email, method, locale, siteURL string) *model.AppEr
 func SendMfaChangeEmail(email string, activated bool, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
-	subject := T("api.templates.mfa_change_subject",
-		map[string]interface{}{"SiteName": utils.Cfg.TeamSettings.SiteName})
+	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.mfa_change_subject",
+		map[string]interface{}{"SiteName": utils.Cfg.TeamSettings.SiteName}))
 
 	bodyPage := utils.NewHTMLTemplate("mfa_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -202,8 +203,8 @@ func SendInviteEmails(team *model.Team, senderName string, invites []string, sit
 		if len(invite) > 0 {
 			senderRole := utils.T("api.team.invite_members.member")
 
-			subject := utils.T("api.templates.invite_subject",
-				map[string]interface{}{"SenderName": senderName, "TeamDisplayName": team.DisplayName, "SiteName": utils.ClientCfg["SiteName"]})
+			subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, utils.T("api.templates.invite_subject",
+				map[string]interface{}{"SenderName": senderName, "TeamDisplayName": team.DisplayName, "SiteName": utils.ClientCfg["SiteName"]}))
 
 			bodyPage := utils.NewHTMLTemplate("invite_body", model.DEFAULT_LOCALE)
 			bodyPage.Props["SiteURL"] = siteURL

--- a/app/email.go
+++ b/app/email.go
@@ -170,6 +170,28 @@ func SendPasswordChangeEmail(email, method, locale, siteURL string) *model.AppEr
 	return nil
 }
 
+func SendPasswordResetEmail(email string, recovery *model.PasswordRecovery, locale, siteURL string) (bool, *model.AppError) {
+
+	T := utils.GetUserTranslations(locale)
+
+	link := fmt.Sprintf("%s/reset_password_complete?code=%s", siteURL, url.QueryEscape(recovery.Code))
+
+	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.reset_subject"))
+
+	bodyPage := utils.NewHTMLTemplate("reset_body", locale)
+	bodyPage.Props["SiteURL"] = siteURL
+	bodyPage.Props["Title"] = T("api.templates.reset_body.title")
+	bodyPage.Html["Info"] = template.HTML(T("api.templates.reset_body.info"))
+	bodyPage.Props["ResetUrl"] = link
+	bodyPage.Props["Button"] = T("api.templates.reset_body.button")
+
+	if err := utils.SendMail(email, subject, bodyPage.Render()); err != nil {
+		return false, model.NewLocAppError("SendPasswordReset", "api.user.send_password_reset.send.app_error", nil, "err="+err.Message)
+	}
+
+	return true, nil
+}
+
 func SendMfaChangeEmail(email string, activated bool, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 

--- a/app/email.go
+++ b/app/email.go
@@ -16,8 +16,9 @@ import (
 func SendChangeUsernameEmail(oldUsername, newUsername, email, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
-	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.username_change_subject",
-		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName}))
+	subject := T("api.templates.username_change_subject",
+		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
+		"TeamDisplayName": utils.Cfg.TeamSettings.SiteName})
 
 	bodyPage := utils.NewHTMLTemplate("email_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -37,8 +38,10 @@ func SendEmailChangeVerifyEmail(userId, newUserEmail, locale, siteURL string) *m
 
 	link := fmt.Sprintf("%s/do_verify_email?uid=%s&hid=%s&email=%s", siteURL, userId, model.HashPassword(userId+utils.Cfg.EmailSettings.InviteSalt), url.QueryEscape(newUserEmail))
 
-	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.email_change_verify_subject",
-		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName}))
+	subject := T("api.templates.email_change_verify_subject",
+		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
+		"TeamDisplayName": utils.Cfg.TeamSettings.SiteName})
+
 
 	bodyPage := utils.NewHTMLTemplate("email_change_verify_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -58,8 +61,9 @@ func SendEmailChangeVerifyEmail(userId, newUserEmail, locale, siteURL string) *m
 func SendEmailChangeEmail(oldEmail, newEmail, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
-	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.email_change_subject",
-		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName}))
+	subject := T("api.templates.email_change_subject",
+		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
+		"TeamDisplayName": utils.Cfg.TeamSettings.SiteName})
 
 	bodyPage := utils.NewHTMLTemplate("email_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -101,8 +105,8 @@ func SendVerifyEmail(userId, userEmail, locale, siteURL string) *model.AppError 
 func SendSignInChangeEmail(email, method, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
-	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.singin_change_email.subject",
-		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]}))
+	subject := T("api.templates.singin_change_email.subject",
+		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
 	bodyPage := utils.NewHTMLTemplate("signin_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -122,8 +126,9 @@ func SendWelcomeEmail(userId string, email string, verified bool, locale, siteUR
 
 	rawUrl, _ := url.Parse(siteURL)
 
-	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.welcome_subject",
-		map[string]interface{}{"ServerURL": rawUrl.Host}))
+	subject := T("api.templates.welcome_subject",
+		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
+		"ServerURL": rawUrl.Host})
 
 	bodyPage := utils.NewHTMLTemplate("welcome_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -154,8 +159,9 @@ func SendWelcomeEmail(userId string, email string, verified bool, locale, siteUR
 func SendPasswordChangeEmail(email, method, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
-	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.password_change_subject",
-		map[string]interface{}{"TeamDisplayName": utils.Cfg.TeamSettings.SiteName, "SiteName": utils.Cfg.TeamSettings.SiteName}))
+	subject := T("api.templates.password_change_subject",
+		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
+		"TeamDisplayName": utils.Cfg.TeamSettings.SiteName})
 
 	bodyPage := utils.NewHTMLTemplate("password_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -176,7 +182,8 @@ func SendPasswordResetEmail(email string, recovery *model.PasswordRecovery, loca
 
 	link := fmt.Sprintf("%s/reset_password_complete?code=%s", siteURL, url.QueryEscape(recovery.Code))
 
-	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.reset_subject"))
+	subject := T("api.templates.reset_subject",
+		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
 	bodyPage := utils.NewHTMLTemplate("reset_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -195,8 +202,8 @@ func SendPasswordResetEmail(email string, recovery *model.PasswordRecovery, loca
 func SendMfaChangeEmail(email string, activated bool, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
-	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, T("api.templates.mfa_change_subject",
-		map[string]interface{}{"SiteName": utils.Cfg.TeamSettings.SiteName}))
+	subject := T("api.templates.mfa_change_subject",
+		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
 	bodyPage := utils.NewHTMLTemplate("mfa_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
@@ -225,8 +232,10 @@ func SendInviteEmails(team *model.Team, senderName string, invites []string, sit
 		if len(invite) > 0 {
 			senderRole := utils.T("api.team.invite_members.member")
 
-			subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, utils.T("api.templates.invite_subject",
-				map[string]interface{}{"SenderName": senderName, "TeamDisplayName": team.DisplayName, "SiteName": utils.ClientCfg["SiteName"]}))
+			subject := utils.T("api.templates.invite_subject",
+				map[string]interface{}{"SenderName": senderName,
+				"TeamDisplayName": team.DisplayName,
+				"SiteName": utils.ClientCfg["SiteName"]})
 
 			bodyPage := utils.NewHTMLTemplate("invite_body", model.DEFAULT_LOCALE)
 			bodyPage.Props["SiteURL"] = siteURL

--- a/app/email_test.go
+++ b/app/email_test.go
@@ -34,7 +34,7 @@ func TestSendChangeUsernameEmail(t *testing.T) {
 			t.Fatal("Wrong To recipient")
 		} else {
 			if resultsEmail, err := utils.GetMessageFromMailbox(emailTo, resultsMailbox[0].ID); err == nil {
-				if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+				if resultsEmail.Subject != expectedSubject {
 					t.Log(resultsEmail.Subject)
 					t.Fatal("Wrong Subject")
 				}
@@ -70,7 +70,7 @@ func TestSendEmailChangeVerifyEmail(t *testing.T) {
 			t.Fatal("Wrong To recipient")
 		} else {
 			if resultsEmail, err := utils.GetMessageFromMailbox(newUserEmail, resultsMailbox[0].ID); err == nil {
-				if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+				if resultsEmail.Subject != expectedSubject {
 					t.Log(resultsEmail.Subject)
 					t.Fatal("Wrong Subject")
 				}
@@ -110,7 +110,7 @@ func TestSendEmailChangeEmail(t *testing.T) {
 			t.Fatal("Wrong To recipient")
 		} else {
 			if resultsEmail, err := utils.GetMessageFromMailbox(oldEmail, resultsMailbox[0].ID); err == nil {
-				if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+				if resultsEmail.Subject != expectedSubject {
 					t.Log(resultsEmail.Subject)
 					t.Fatal("Wrong Subject")
 				}
@@ -146,7 +146,7 @@ func TestSendVerifyEmail(t *testing.T) {
 			t.Fatal("Wrong To recipient")
 		} else {
 			if resultsEmail, err := utils.GetMessageFromMailbox(userEmail, resultsMailbox[0].ID); err == nil {
-				if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+				if resultsEmail.Subject != expectedSubject {
 					t.Log(resultsEmail.Subject)
 					t.Fatal("Wrong Subject")
 				}
@@ -172,7 +172,7 @@ func TestSendSignInChangeEmail(t *testing.T) {
 	var siteURL string = ""
 	var method string = "AD/LDAP"
 	var expectedPartialMessage string = "You updated your sign-in method on Mattermost to " + method + "."
-	var expectedSubject string = "You updated your sign-in method on " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] You updated your sign-in method on " + utils.Cfg.TeamSettings.SiteName
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)
@@ -186,7 +186,7 @@ func TestSendSignInChangeEmail(t *testing.T) {
 			t.Fatal("Wrong To recipient")
 		} else {
 			if resultsEmail, err := utils.GetMessageFromMailbox(email, resultsMailbox[0].ID); err == nil {
-				if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+				if resultsEmail.Subject != expectedSubject {
 					t.Log(resultsEmail.Subject)
 					t.Fatal("Wrong Subject")
 				}
@@ -223,7 +223,7 @@ func TestSendWelcomeEmail(t *testing.T) {
 			t.Fatal("Wrong To recipient")
 		} else {
 			if resultsEmail, err := utils.GetMessageFromMailbox(email, resultsMailbox[0].ID); err == nil {
-				if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+				if resultsEmail.Subject != expectedSubject {
 					t.Log(resultsEmail.Subject)
 					t.Fatal("Wrong Subject")
 				}
@@ -292,7 +292,7 @@ func TestSendPasswordChangeEmail(t *testing.T) {
 			t.Fatal("Wrong To recipient")
 		} else {
 			if resultsEmail, err := utils.GetMessageFromMailbox(email, resultsMailbox[0].ID); err == nil {
-				if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+				if resultsEmail.Subject != expectedSubject {
 					t.Log(resultsEmail.Subject)
 					t.Fatal("Wrong Subject")
 				}
@@ -328,7 +328,7 @@ func TestSendMfaChangeEmail(t *testing.T) {
 			t.Fatal("Wrong To recipient")
 		} else {
 			if resultsEmail, err := utils.GetMessageFromMailbox(email, resultsMailbox[0].ID); err == nil {
-				if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+				if resultsEmail.Subject != expectedSubject {
 					t.Log(resultsEmail.Subject)
 					t.Fatal("Wrong Subject")
 				}
@@ -376,7 +376,7 @@ func TestSendInviteEmails(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	invites := []string{email1, email2}
 	var expectedPartialMessage string = "The team member *" + senderName + "* , has invited you to join *" + th.BasicTeam.DisplayName + "*"
-	var expectedSubject string = senderName + " invited you to join " + th.BasicTeam.DisplayName + " Team on " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] " + senderName + " invited you to join " + th.BasicTeam.DisplayName + " Team on " + utils.Cfg.TeamSettings.SiteName
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email1)
@@ -389,7 +389,7 @@ func TestSendInviteEmails(t *testing.T) {
 		t.Fatal("Wrong To recipient")
 	} else {
 		if resultsEmail, err := utils.GetMessageFromMailbox(email1, resultsMailbox[0].ID); err == nil {
-			if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+			if resultsEmail.Subject != expectedSubject {
 				t.Log(resultsEmail.Subject)
 				t.Log(expectedSubject)
 				t.Fatal("Wrong Subject")
@@ -440,7 +440,7 @@ func TestSendPasswordReset(t *testing.T) {
 			t.Fatal("Wrong To recipient")
 		} else {
 			if resultsEmail, err := utils.GetMessageFromMailbox(th.BasicUser.Email, resultsMailbox[0].ID); err == nil {
-				if !strings.Contains(resultsEmail.Subject, expectedSubject) {
+				if resultsEmail.Subject != expectedSubject {
 					t.Log(resultsEmail.Subject)
 					t.Fatal("Wrong Subject")
 				}

--- a/app/email_test.go
+++ b/app/email_test.go
@@ -20,7 +20,7 @@ func TestSendChangeUsernameEmail(t *testing.T) {
 	var locale string = "en"
 	var siteURL string = ""
 	var expectedPartialMessage string = "Your username for " + utils.Cfg.TeamSettings.SiteName + " has been changed to " + newUsername + "."
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your username has changed
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your username has changed"
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(emailTo)
@@ -56,7 +56,7 @@ func TestSendEmailChangeVerifyEmail(t *testing.T) {
 	var locale string = "en"
 	var siteURL string = ""
 	var expectedPartialMessage string = "You updated your email"
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Verify new email address
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Verify new email address"
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(newUserEmail)
@@ -96,7 +96,7 @@ func TestSendEmailChangeEmail(t *testing.T) {
 	var locale string = "en"
 	var siteURL string = ""
 	var expectedPartialMessage string = "Your email address for Mattermost has been changed to " + newUserEmail
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your email address has changed
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your email address has changed"
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(oldEmail)
@@ -278,7 +278,7 @@ func TestSendPasswordChangeEmail(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	var method string = "using a reset password link"
 	var expectedPartialMessage string = "Your password has been updated for " + utils.Cfg.TeamSettings.SiteName + " on " + siteURL + " by " + method
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your password has been updated
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your password has been updated"
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)
@@ -314,7 +314,7 @@ func TestSendMfaChangeEmail(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	var activated bool = true
 	var expectedPartialMessage string = "Multi-factor authentication has been added to your account on " + siteURL + "."
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your MFA has been updated
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your MFA has been updated"
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)
@@ -376,7 +376,7 @@ func TestSendInviteEmails(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	invites := []string{email1, email2}
 	var expectedPartialMessage string = "The team member *" + senderName + "* , has invited you to join *" + th.BasicTeam.DisplayName + "*"
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] " + senderName + " invited you to join " + th.BasicTeam.DisplayName + " Team
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] " + senderName + " invited you to join " + th.BasicTeam.DisplayName + " Team"
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email1)

--- a/app/email_test.go
+++ b/app/email_test.go
@@ -20,7 +20,7 @@ func TestSendChangeUsernameEmail(t *testing.T) {
 	var locale string = "en"
 	var siteURL string = ""
 	var expectedPartialMessage string = "Your username for " + utils.Cfg.TeamSettings.SiteName + " has been changed to " + newUsername + "."
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your username has changed for " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your username has changed
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(emailTo)
@@ -56,7 +56,7 @@ func TestSendEmailChangeVerifyEmail(t *testing.T) {
 	var locale string = "en"
 	var siteURL string = ""
 	var expectedPartialMessage string = "You updated your email"
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Verify new email address for " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Verify new email address
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(newUserEmail)
@@ -96,7 +96,7 @@ func TestSendEmailChangeEmail(t *testing.T) {
 	var locale string = "en"
 	var siteURL string = ""
 	var expectedPartialMessage string = "Your email address for Mattermost has been changed to " + newUserEmail
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your email address has changed for " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your email address has changed
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(oldEmail)
@@ -278,7 +278,7 @@ func TestSendPasswordChangeEmail(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	var method string = "using a reset password link"
 	var expectedPartialMessage string = "Your password has been updated for " + utils.Cfg.TeamSettings.SiteName + " on " + siteURL + " by " + method
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your password has been updated for " + utils.Cfg.TeamSettings.SiteName + " on " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your password has been updated
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)
@@ -314,7 +314,7 @@ func TestSendMfaChangeEmail(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	var activated bool = true
 	var expectedPartialMessage string = "Multi-factor authentication has been added to your account on " + siteURL + "."
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your MFA has been updated on " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your MFA has been updated
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)
@@ -376,7 +376,7 @@ func TestSendInviteEmails(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	invites := []string{email1, email2}
 	var expectedPartialMessage string = "The team member *" + senderName + "* , has invited you to join *" + th.BasicTeam.DisplayName + "*"
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] " + senderName + " invited you to join " + th.BasicTeam.DisplayName + " Team on " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] " + senderName + " invited you to join " + th.BasicTeam.DisplayName + " Team
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email1)

--- a/app/email_test.go
+++ b/app/email_test.go
@@ -18,8 +18,8 @@ func TestSendChangeUsernameEmail(t *testing.T) {
 	var newUsername string = "fancyusername"
 	var locale string = "en"
 	var siteURL string = ""
-	var expectedPartialMessage string = "Your username for Mattermost has been changed to " + newUsername + "."
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your username has changed for Mattermost"
+	var expectedPartialMessage string = "Your username for "+ utils.Cfg.TeamSettings.SiteName + " has been changed to " + newUsername + "."
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your username has changed for " + utils.Cfg.TeamSettings.SiteName
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(emailTo)
@@ -55,7 +55,7 @@ func TestSendEmailChangeVerifyEmail(t *testing.T) {
 	var locale string = "en"
 	var siteURL string = ""
 	var expectedPartialMessage string = "You updated your email"
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Verify new email address for Mattermost"
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Verify new email address for " + utils.Cfg.TeamSettings.SiteName
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(newUserEmail)
@@ -95,7 +95,7 @@ func TestSendEmailChangeEmail(t *testing.T) {
 	var locale string = "en"
 	var siteURL string = ""
 	var expectedPartialMessage string = "Your email address for Mattermost has been changed to " + newUserEmail
-	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your email address has changed for Mattermost"
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your email address has changed for " + utils.Cfg.TeamSettings.SiteName
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(oldEmail)
@@ -171,7 +171,7 @@ func TestSendSignInChangeEmail(t *testing.T) {
 	var siteURL string = ""
 	var method string = "AD/LDAP"
 	var expectedPartialMessage string = "You updated your sign-in method on Mattermost to " + method + "."
-	var expectedSubject string = "You updated your sign-in method on Mattermost"
+	var expectedSubject string = "You updated your sign-in method on " + utils.Cfg.TeamSettings.SiteName
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)
@@ -208,7 +208,7 @@ func TestSendWelcomeEmail(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	var verified bool = true
 	var expectedPartialMessage string = "Mattermost lets you share messages and files from your PC or phone, with instant search and archiving"
-	var expectedSubject string = "You joined test.mattermost.io"
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] You joined test.mattermost.io"
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)
@@ -277,7 +277,7 @@ func TestSendPasswordChangeEmail(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	var method string = "using a reset password link"
 	var expectedPartialMessage string = "Your password has been updated for " + utils.Cfg.TeamSettings.SiteName + " on " + siteURL + " by " + method
-	var expectedSubject string = "Your password has been updated for " + utils.Cfg.TeamSettings.SiteName + " on " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your password has been updated for " + utils.Cfg.TeamSettings.SiteName + " on " + utils.Cfg.TeamSettings.SiteName
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)
@@ -313,7 +313,7 @@ func TestSendMfaChangeEmail(t *testing.T) {
 	var siteURL string = "http://test.mattermost.io"
 	var activated bool = true
 	var expectedPartialMessage string = "Multi-factor authentication has been added to your account on " + siteURL + "."
-	var expectedSubject string = "Your MFA has been updated on " + utils.Cfg.TeamSettings.SiteName
+	var expectedSubject string = "[" + utils.Cfg.TeamSettings.SiteName + "] Your MFA has been updated on " + utils.Cfg.TeamSettings.SiteName
 
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)

--- a/app/user.go
+++ b/app/user.go
@@ -1023,7 +1023,7 @@ func SendPasswordReset(email string, siteURL string) (bool, *model.AppError) {
 	}
 
 	if user.AuthData != nil && len(*user.AuthData) != 0 {
-		return false, model.NewLocAppError("SendPasswordReset", "api.user.send_password_reset.sso.app_error", nil, "userId="+user.Id)
+		return false, model.NewAppError("SendPasswordReset", "api.user.send_password_reset.sso.app_error", nil, "userId="+user.Id, http.StatusBadRequest)
 	}
 
 	var recovery *model.PasswordRecovery

--- a/app/user.go
+++ b/app/user.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"hash/fnv"
-	"html/template"
 	"image"
 	"image/color"
 	"image/draw"
@@ -18,7 +17,6 @@ import (
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -984,42 +982,6 @@ func UpdatePasswordSendEmail(user *model.User, newPassword, method, siteURL stri
 	return nil
 }
 
-func SendPasswordReset(email string, siteURL string) (bool, *model.AppError) {
-	var user *model.User
-	var err *model.AppError
-	if user, err = GetUserByEmail(email); err != nil {
-		return false, nil
-	}
-
-	if user.AuthData != nil && len(*user.AuthData) != 0 {
-		return false, model.NewAppError("SendPasswordReset", "api.user.send_password_reset.sso.app_error", nil, "userId="+user.Id, http.StatusBadRequest)
-	}
-
-	var recovery *model.PasswordRecovery
-	if recovery, err = CreatePasswordRecovery(user.Id); err != nil {
-		return false, err
-	}
-
-	T := utils.GetUserTranslations(user.Locale)
-
-	link := fmt.Sprintf("%s/reset_password_complete?code=%s", siteURL, url.QueryEscape(recovery.Code))
-
-	subject := T("api.templates.reset_subject")
-
-	bodyPage := utils.NewHTMLTemplate("reset_body", user.Locale)
-	bodyPage.Props["SiteURL"] = siteURL
-	bodyPage.Props["Title"] = T("api.templates.reset_body.title")
-	bodyPage.Html["Info"] = template.HTML(T("api.templates.reset_body.info"))
-	bodyPage.Props["ResetUrl"] = link
-	bodyPage.Props["Button"] = T("api.templates.reset_body.button")
-
-	if err := utils.SendMail(email, subject, bodyPage.Render()); err != nil {
-		return false, model.NewLocAppError("SendPasswordReset", "api.user.send_password_reset.send.app_error", nil, "err="+err.Message)
-	}
-
-	return true, nil
-}
-
 func ResetPasswordFromCode(code, newPassword, siteURL string) *model.AppError {
 	var recovery *model.PasswordRecovery
 	var err *model.AppError
@@ -1051,6 +1013,29 @@ func ResetPasswordFromCode(code, newPassword, siteURL string) *model.AppError {
 	}
 
 	return nil
+}
+
+func SendPasswordReset(email string, siteURL string) (bool, *model.AppError) {
+	var user *model.User
+	var err *model.AppError
+	if user, err = GetUserByEmail(email); err != nil {
+		return false, nil
+	}
+
+	if user.AuthData != nil && len(*user.AuthData) != 0 {
+		return false, model.NewLocAppError("SendPasswordReset", "api.user.send_password_reset.sso.app_error", nil, "userId="+user.Id)
+	}
+
+	var recovery *model.PasswordRecovery
+	if recovery, err = CreatePasswordRecovery(user.Id); err != nil {
+		return false, err
+	}
+
+	if _, err := SendPasswordResetEmail(email, recovery, user.Locale, siteURL); err != nil {
+		return false, model.NewLocAppError("SendPasswordReset", "api.user.send_password_reset.send.app_error", nil, "err="+err.Message)
+	}
+
+	return true, nil
 }
 
 func CreatePasswordRecovery(userId string) (*model.PasswordRecovery, *model.AppError) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2021,7 +2021,7 @@
   },
   {
     "id": "api.templates.email_change_subject",
-    "translation": "Your email address has changed for {{.TeamDisplayName}}"
+    "translation": "[{{ .SiteName }}] Your email address has changed for {{.TeamDisplayName}}"
   },
   {
     "id": "api.templates.email_change_verify_body.button",
@@ -2037,7 +2037,7 @@
   },
   {
     "id": "api.templates.email_change_verify_subject",
-    "translation": "Verify new email address for {{.TeamDisplayName}}"
+    "translation": "[{{ .SiteName }}] Verify new email address for {{.TeamDisplayName}}"
   },
   {
     "id": "api.templates.email_footer",
@@ -2093,7 +2093,7 @@
   },
   {
     "id": "api.templates.invite_subject",
-    "translation": "{{ .SenderName }} invited you to join {{ .TeamDisplayName }} Team on {{.SiteName}}"
+    "translation": "[{{ .SiteName }}] {{ .SenderName }} invited you to join {{ .TeamDisplayName }} Team on {{.SiteName}}"
   },
   {
     "id": "api.templates.mfa_activated_body.info",
@@ -2105,7 +2105,7 @@
   },
   {
     "id": "api.templates.mfa_change_subject",
-    "translation": "Your MFA has been updated on {{ .SiteName }}"
+    "translation": "[{{ .SiteName }}] Your MFA has been updated on {{ .SiteName }}"
   },
   {
     "id": "api.templates.mfa_deactivated_body.info",
@@ -2125,7 +2125,7 @@
   },
   {
     "id": "api.templates.password_change_subject",
-    "translation": "Your password has been updated for {{.TeamDisplayName}} on {{ .SiteName }}"
+    "translation": "[{{ .SiteName }}] Your password has been updated for {{.TeamDisplayName}} on {{ .SiteName }}"
   },
   {
     "id": "api.templates.post_body.button",
@@ -2157,7 +2157,7 @@
   },
   {
     "id": "api.templates.reset_subject",
-    "translation": "Reset your password"
+    "translation": "[{{ .SiteName }}] Reset your password"
   },
   {
     "id": "api.templates.signin_change_email.body.method_email",
@@ -2189,7 +2189,7 @@
   },
   {
     "id": "api.templates.singin_change_email.subject",
-    "translation": "You updated your sign-in method on {{ .SiteName }}"
+    "translation": "[{{ .SiteName }}] You updated your sign-in method on {{ .SiteName }}"
   },
   {
     "id": "api.templates.upgrade_30_body.info",
@@ -2209,7 +2209,7 @@
   },
   {
     "id": "api.templates.username_change_subject",
-    "translation": "Your username has changed for {{.TeamDisplayName}}"
+    "translation": "[{{ .SiteName }}] Your username has changed for {{.TeamDisplayName}}"
   },
   {
     "id": "api.templates.verify_body.button",
@@ -2253,7 +2253,7 @@
   },
   {
     "id": "api.templates.welcome_subject",
-    "translation": "You joined {{ .ServerURL }}"
+    "translation": "[{{ .SiteName }}] You joined {{ .ServerURL }}"
   },
   {
     "id": "api.user.activate_mfa.email_and_ldap_only.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2021,7 +2021,7 @@
   },
   {
     "id": "api.templates.email_change_subject",
-    "translation": "[{{ .SiteName }}] Your email address has changed for {{.TeamDisplayName}}"
+    "translation": "[{{ .SiteName }}] Your email address has changed"
   },
   {
     "id": "api.templates.email_change_verify_body.button",
@@ -2037,7 +2037,7 @@
   },
   {
     "id": "api.templates.email_change_verify_subject",
-    "translation": "[{{ .SiteName }}] Verify new email address for {{.TeamDisplayName}}"
+    "translation": "[{{ .SiteName }}] Verify new email address"
   },
   {
     "id": "api.templates.email_footer",
@@ -2093,7 +2093,7 @@
   },
   {
     "id": "api.templates.invite_subject",
-    "translation": "[{{ .SiteName }}] {{ .SenderName }} invited you to join {{ .TeamDisplayName }} Team on {{.SiteName}}"
+    "translation": "[{{ .SiteName }}] {{ .SenderName }} invited you to join {{ .TeamDisplayName }} Team"
   },
   {
     "id": "api.templates.mfa_activated_body.info",
@@ -2105,7 +2105,7 @@
   },
   {
     "id": "api.templates.mfa_change_subject",
-    "translation": "[{{ .SiteName }}] Your MFA has been updated on {{ .SiteName }}"
+    "translation": "[{{ .SiteName }}] Your MFA has been updated"
   },
   {
     "id": "api.templates.mfa_deactivated_body.info",
@@ -2125,7 +2125,7 @@
   },
   {
     "id": "api.templates.password_change_subject",
-    "translation": "[{{ .SiteName }}] Your password has been updated for {{.TeamDisplayName}} on {{ .SiteName }}"
+    "translation": "[{{ .SiteName }}] Your password has been updated"
   },
   {
     "id": "api.templates.post_body.button",
@@ -2209,7 +2209,7 @@
   },
   {
     "id": "api.templates.username_change_subject",
-    "translation": "[{{ .SiteName }}] Your username has changed for {{.TeamDisplayName}}"
+    "translation": "[{{ .SiteName }}] Your username has changed"
   },
   {
     "id": "api.templates.verify_body.button",


### PR DESCRIPTION
#### Summary
Emails sent by the app/email.go didnt follow the same pattern in the subject line, now it follow :)

#### Ticket Link
N/A

#### Checklist
- [X] Added or updated unit tests (required for all new features)
