### PR TITLE
Add Floating Timestamp to Right Hand Side on Mobile #5163

### DIFF
--- a/webapp/components/post_view/components/floating_timestamp.jsx
+++ b/webapp/components/post_view/components/floating_timestamp.jsx
@@ -37,6 +37,10 @@ export default class FloatingTimestamp extends React.Component {
             className += ' scrolling';
         }
 
+        if (this.props.isRhsPost) {
+            className += ' rhs';
+        }
+
         return (
             <div className={className}>
                 <div>
@@ -50,5 +54,6 @@ export default class FloatingTimestamp extends React.Component {
 FloatingTimestamp.propTypes = {
     isScrolling: React.PropTypes.bool.isRequired,
     isMobile: React.PropTypes.bool,
-    createAt: React.PropTypes.number
+    createAt: React.PropTypes.number,
+    isRhsPost: React.PropTypes.bool
 };

--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -314,6 +314,10 @@
         @include opacity(.8);
     }
 
+    &.rhs {
+        top: 98px;
+    }
+
     > div {
         @include border-radius(3px);
         @include font-smoothing(initial);


### PR DESCRIPTION
#### Summary
Added floating timestamp to right hand side on mobile.

This PR only satifies (hopefully) as per stated in the reference issue but it might also be better to add date separator in the RHS comment and only reflect time (hh:mm) per RHS comment. This might be for another issue if you will.

Thanks. 

#### Ticket Link
Github issue: #5163 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Has UI changes
