### PR TITLE
PLT-5380 Moved link preview image to top right corner of preview area

### DIFF
--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -1191,7 +1191,7 @@
         cursor: pointer;
         display: inline-block;
         font: normal normal normal 14px/1 FontAwesome;
-        margin: 0 0 10px;
+        margin: 0;
         text-rendering: auto;
 
         &.pull-left {

--- a/webapp/sass/layout/_webhooks.scss
+++ b/webapp/sass/layout/_webhooks.scss
@@ -127,16 +127,22 @@
             margin-bottom: 1em;
             max-height: 300px;
             max-width: 500px;
+
             &.attachment__image--openraph {
                 margin-bottom: 0;
                 max-height: 80px;
-                max-width: 400px;
+                max-width: 200px;
+
                 &.loading {
                     height: 80px;
                 }
+
                 &.large_image {
-                    max-width: 150px;
-                    max-height: 150px;
+                    border-radius: 3px;
+                    margin-top: 10px;
+                    max-height: 200px;
+                    max-width: 400px;
+
                     &.loading {
                         height: 150px;
                     }

--- a/webapp/sass/layout/_webhooks.scss
+++ b/webapp/sass/layout/_webhooks.scss
@@ -38,6 +38,9 @@
 
 .post {
     .attachment {
+        &.attachment--opengraph {
+            max-width: 800px;
+        }
         .attachment__content {
             border-radius: 4px;
             border-style: solid;
@@ -68,8 +71,26 @@
             &.attachment__container--danger {
                 border-left-color: #e40303;
             }
+            &.attachment__container--opengraph {
+                display: table;
+                table-layout: fixed;
+                width: 100%;
+                margin: 0;
+                padding-bottom: 13px;
+                div {
+                    margin: 0;
+                }
+            }
             .sitename {
                 color: #A3A3A3;
+            }
+        }
+
+        .attachment__body__wrap {
+            &.attachment__body__wrap--opengraph {
+                display: table-cell;
+                width: 100%;
+                vertical-align: top;
             }
         }
 
@@ -83,13 +104,11 @@
             &.attachment__body--no_thumb {
                 width: 100%;
             }
-            .attachment__image {
-                margin-bottom: 0;
-                max-height: 150px;
-                max-width: 150px;
-                &.loading {
-                    height: 150px;
-                }
+            &.attachment__body--opengraph {
+                float: none;
+                padding-right: 0;
+                width: 100%;
+                word-wrap: break-word;
             }
         }
 
@@ -97,10 +116,32 @@
             display: inline-block;
         }
 
+        .attachment__image__container--openraph {
+            display: table-cell;
+            vertical-align: top;
+            padding-top: 3px;
+            padding-left: 15px;
+        }
+
         .attachment__image {
             margin-bottom: 1em;
             max-height: 300px;
             max-width: 500px;
+            &.attachment__image--openraph {
+                margin-bottom: 0;
+                max-height: 80px;
+                max-width: 400px;
+                &.loading {
+                    height: 80px;
+                }
+                &.large_image {
+                    max-width: 150px;
+                    max-height: 150px;
+                    &.loading {
+                        height: 150px;
+                    }
+                }
+            }
         }
 
         .attachment__author-name {
@@ -120,6 +161,14 @@
                 text-overflow: ellipsis;
                 overflow: hidden;
                 white-space: nowrap;
+            }
+
+            &.attachment__title--opengraph {
+                height: auto;
+                word-wrap: break-word;
+                &.is-url {
+                    word-break: break-all
+                }
             }
         }
 

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -1210,6 +1210,15 @@
             }
         }
     }
+    .post {
+        .attachment {
+            .attachment__image {
+                &.attachment__image--openraph {
+                    max-width: 200px;
+                }
+            }
+        }
+    }
 }
 
 @media screen and (max-width: 640px) {
@@ -1385,6 +1394,16 @@
             text-align: left;
         }
     }
+
+    .post {
+        .attachment {
+            .attachment__image {
+                &.attachment__image--openraph {
+                    max-width: 200px;
+                }
+            }
+        }
+    }
 }
 
 @media screen and (max-width: 550px) {
@@ -1414,6 +1433,15 @@
         left: 15px;
         top: 60px;
         width: calc(100% - 30px);
+    }
+    .post {
+        .attachment {
+            .attachment__image {
+                &.attachment__image--openraph {
+                    max-width: 180px;
+                }
+            }
+        }
     }
 }
 
@@ -1521,6 +1549,16 @@
     .integration__icon {
         display: none;
     }
+
+    .post {
+        .attachment {
+            .attachment__image {
+                &.attachment__image--openraph {
+                    max-width: 120px;
+                }
+            }
+        }
+    }
 }
 
 @media screen and (max-height: 640px) {
@@ -1550,6 +1588,13 @@
             .col__name {
                 .user-popover {
                     max-width: 105px;
+                }
+            }
+        }
+        .attachment {
+            .attachment__image {
+                &.attachment__image--openraph {
+                    max-width: 80px;
                 }
             }
         }

--- a/webapp/sass/responsive/_tablet.scss
+++ b/webapp/sass/responsive/_tablet.scss
@@ -128,6 +128,19 @@
             }
         }
     }
+    .post {
+        .attachment {
+            .attachment__image {
+                &.attachment__image--openraph {
+                    max-height: 70px;
+                    max-width: 300px;
+                    &.loading {
+                        height: 70px;
+                    }
+                }
+            }
+        }
+    }
 }
 
 // Tablet and desktop

--- a/webapp/tests/utils_get_nearest_point.test.jsx
+++ b/webapp/tests/utils_get_nearest_point.test.jsx
@@ -24,12 +24,10 @@ describe('CommonUtils.getNearestPoint', function() {
                 nearestPointLte: {x: 1, y: 1}
             }
         ]) {
-            const nearestPointData = CommonUtils.getNearestPoint(data.pivotPoint, data.points);
+            const nearestPoint = CommonUtils.getNearestPoint(data.pivotPoint, data.points);
 
-            assert.equal(nearestPointData.nearestPoint.x, data.nearestPoint.x);
-            assert.equal(nearestPointData.nearestPoint.y, data.nearestPoint.y);
-            assert.equal(nearestPointData.nearestPointLte.x, data.nearestPointLte.x);
-            assert.equal(nearestPointData.nearestPointLte.y, data.nearestPointLte.y);
+            assert.equal(nearestPoint.x, data.nearestPoint.x);
+            assert.equal(nearestPoint.y, data.nearestPoint.y);
         }
     });
 });

--- a/webapp/utils/commons.jsx
+++ b/webapp/utils/commons.jsx
@@ -8,7 +8,6 @@ export function getDistanceBW2Points(point1, point2, xAttr = 'x', yAttr = 'y') {
   */
 export function getNearestPoint(pivotPoint, points, xAttr = 'x', yAttr = 'y') {
     var nearestPoint = {};
-    var nearestPointLte = {};  // Nearest point smaller than or equal to point
     for (const point of points) {
         if (typeof nearestPoint[xAttr] === 'undefined' || typeof nearestPoint[yAttr] === 'undefined') {
             nearestPoint = point;
@@ -16,21 +15,6 @@ export function getNearestPoint(pivotPoint, points, xAttr = 'x', yAttr = 'y') {
         // Check for bestImage
             nearestPoint = point;
         }
-
-        if (typeof nearestPointLte[xAttr] === 'undefined' || typeof nearestPointLte[yAttr] === 'undefined') {
-            if (point[xAttr] <= pivotPoint[xAttr] && point[yAttr] <= pivotPoint[yAttr]) {
-                nearestPointLte = point;
-            }
-        } else if (
-        // Check for bestImageLte
-            getDistanceBW2Points(point, pivotPoint, xAttr, yAttr) < getDistanceBW2Points(nearestPointLte, pivotPoint, xAttr, yAttr) &&
-            point[xAttr] <= pivotPoint[xAttr] && point[yAttr] <= pivotPoint[yAttr]
-        ) {
-            nearestPointLte = point;
-        }
     }
-    return {
-        nearestPoint,
-        nearestPointLte
-    };
+    return nearestPoint;
 }


### PR DESCRIPTION
#### Summary
Moved link preview image to top right corner of preview area

Additionally:
* Reduced max size of link preview image to 100X100 pixels (from 150X150 pixels)
* Added logic to hide image area if image loading fails

#### Ticket Link
JIRA Ticket: https://mattermost.atlassian.net/browse/PLT-5380

#### Checklist
- [x] Has UI changes