### PR TITLE
In mobile web view, the send icon should show as disabled until there is a valid message in the input box #5006

### DIFF
--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -400,6 +400,10 @@
             &:active {
                 @include opacity(.75);
             }
+
+            &.disabled {
+                color: grey;
+            }
         }
 
         .custom-textarea {


### PR DESCRIPTION
#### Summary
In mobile web view, the send icon is disabled until there is a valid input either message in the input box or file(s) that is ready to be uploaded.

#### Ticket Link
GitHub issue: #5006 

#### Checklist
- [x] Has UI changes
