### PR TITLE
PLT-5365 Import of basic user properties.

### DIFF
--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -178,7 +178,7 @@ func SlackAddUsers(teamId string, slackusers []SlackUser, log *bytes.Buffer) map
 			Password:  password,
 		}
 
-		if mUser := ImportUser(team, &newUser); mUser != nil {
+		if mUser := OldImportUser(team, &newUser); mUser != nil {
 			addedUsers[sUser.Id] = mUser
 			log.WriteString(utils.T("api.slackimport.slack_add_users.email_pwd", map[string]interface{}{"Email": newUser.Email, "Password": password}))
 		} else {
@@ -210,7 +210,7 @@ func SlackAddBotUser(teamId string, log *bytes.Buffer) *model.User {
 		Password:  password,
 	}
 
-	if mUser := ImportUser(team, &botUser); mUser != nil {
+	if mUser := OldImportUser(team, &botUser); mUser != nil {
 		log.WriteString(utils.T("api.slackimport.slack_add_bot_user.email_pwd", map[string]interface{}{"Email": botUser.Email, "Password": password}))
 		return mUser
 	} else {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2804,6 +2804,10 @@
     "translation": "Import data line has type \"channel\" but the channel object is null."
   },
   {
+    "id": "app.import.import_line.null_user.error",
+    "translation": "Import data line has type \"user\" but the user objcet is null."
+  },
+  {
     "id": "app.import.import_line.unknown_line_type.error",
     "translation": "Import data line has unknown type \"{{.Type}}\"."
   },
@@ -2898,6 +2902,50 @@
   {
     "id": "app.import.validate_channel_import_data.purpose_length.error",
     "translation": "Channel purpose is too long."
+  },
+  {
+    "id": "app.import.validate_user_import_data.username_missing.error",
+    "translation": "Missing require user property: username."
+  },
+  {
+    "id": "app.import.validate_user_import_data.username_invalid.error",
+    "translation": "Username is not valid."
+  },
+  {
+    "id": "app.import.validate_user_import_data.email_missing.error",
+    "translation": "Missing required user property: email."
+  },
+  {
+    "id": "app.import.validate_user_import_data.email_length.error",
+    "translation": "User email has an invalid length."
+  },
+  {
+    "id": "app.import.validate_user_import_data.auth_service_length.error",
+    "translation": "User AuthService should not be empty if it is provided."
+  },
+  {
+    "id": "app.import.validate_user_import_data.auth_data_length.error",
+    "translation": "User AuthData is too long."
+  },
+  {
+    "id": "app.import.validate_user_import_data.nickname_length.error",
+    "translation": "User nickname is too long."
+  },
+  {
+    "id": "app.import.validate_user_import_data.first_name_length.error",
+    "translation": "User First Name is too long."
+  },
+  {
+    "id": "app.import.validate_user_import_data.last_name_length.error",
+    "translation": "User Last Name is too long."
+  },
+  {
+    "id": "app.import.validate_user_import_data.position_length.error",
+    "translation": "User Position is too long."
+  },
+  {
+    "id": "app.import.validate_user_import_data.roles_invalid.error",
+    "translation": "User roles are not valid."
   },
   {
     "id": "authentication.permissions.create_team_roles.description",

--- a/model/user.go
+++ b/model/user.go
@@ -22,6 +22,13 @@ const (
 	DEFAULT_LOCALE             = "en"
 	USER_AUTH_SERVICE_EMAIL    = "email"
 	USER_AUTH_SERVICE_USERNAME = "username"
+
+	USER_EMAIL_MAX_LENGTH     = 128
+	USER_NICKNAME_MAX_RUNES   = 64
+	USER_POSITION_MAX_RUNES   = 35
+	USER_FIRST_NAME_MAX_RUNES = 64
+	USER_LAST_NAME_MAX_RUNES  = 64
+	USER_AUTH_DATA_MAX_LENGTH = 128
 )
 
 type User struct {
@@ -72,27 +79,27 @@ func (u *User) IsValid() *AppError {
 		return NewAppError("User.IsValid", "model.user.is_valid.username.app_error", nil, "user_id="+u.Id, http.StatusBadRequest)
 	}
 
-	if len(u.Email) > 128 || len(u.Email) == 0 {
+	if len(u.Email) > USER_EMAIL_MAX_LENGTH || len(u.Email) == 0 {
 		return NewAppError("User.IsValid", "model.user.is_valid.email.app_error", nil, "user_id="+u.Id, http.StatusBadRequest)
 	}
 
-	if utf8.RuneCountInString(u.Nickname) > 64 {
+	if utf8.RuneCountInString(u.Nickname) > USER_NICKNAME_MAX_RUNES {
 		return NewAppError("User.IsValid", "model.user.is_valid.nickname.app_error", nil, "user_id="+u.Id, http.StatusBadRequest)
 	}
 
-	if utf8.RuneCountInString(u.Position) > 35 {
+	if utf8.RuneCountInString(u.Position) > USER_POSITION_MAX_RUNES {
 		return NewAppError("User.IsValid", "model.user.is_valid.position.app_error", nil, "user_id="+u.Id, http.StatusBadRequest)
 	}
 
-	if utf8.RuneCountInString(u.FirstName) > 64 {
+	if utf8.RuneCountInString(u.FirstName) > USER_FIRST_NAME_MAX_RUNES {
 		return NewAppError("User.IsValid", "model.user.is_valid.first_name.app_error", nil, "user_id="+u.Id, http.StatusBadRequest)
 	}
 
-	if utf8.RuneCountInString(u.LastName) > 64 {
+	if utf8.RuneCountInString(u.LastName) > USER_LAST_NAME_MAX_RUNES {
 		return NewAppError("User.IsValid", "model.user.is_valid.last_name.app_error", nil, "user_id="+u.Id, http.StatusBadRequest)
 	}
 
-	if u.AuthData != nil && len(*u.AuthData) > 128 {
+	if u.AuthData != nil && len(*u.AuthData) > USER_AUTH_DATA_MAX_LENGTH {
 		return NewAppError("User.IsValid", "model.user.is_valid.auth_data.app_error", nil, "user_id="+u.Id, http.StatusBadRequest)
 	}
 


### PR DESCRIPTION
#### Summary
Importing of basic user properties in the bulk Importer.

Team/Channel memberships, and default preferences will follow in subsequent PRs.

Note for reviewers: this makes some small changes to the implementation of app.CreateUser and app.UpdateUser to avoid emails and web socket messages being triggered when bulk importing users.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5365

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates
