### PR TITLE
fix cloning channels

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -109,7 +109,9 @@ export default class Sidebar extends React.Component {
         const teamMembers = TeamStore.getMyTeamMembers();
         const currentChannelId = ChannelStore.getCurrentId();
         const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 999);
-        const channelList = ChannelUtils.buildDisplayableChannelList(Object.assign([], ChannelStore.getAll()));
+
+        const allChannels = ChannelStore.getAll().map(channel => Object.assign({}, channel));
+        const channelList = ChannelUtils.buildDisplayableChannelList(allChannels);
 
         return {
             activeId: currentChannelId,

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -110,7 +110,7 @@ export default class Sidebar extends React.Component {
         const currentChannelId = ChannelStore.getCurrentId();
         const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 999);
 
-        const allChannels = ChannelStore.getAll().map(channel => Object.assign({}, channel));
+        const allChannels = ChannelStore.getAll().map((channel) => Object.assign({}, channel));
         const channelList = ChannelUtils.buildDisplayableChannelList(allChannels);
 
         return {


### PR DESCRIPTION
#### Summary

This PR will fix channels info at the left sidebar. The`webapp/components/sidebar.jsx` component has inconsistent inner state. The following lines will expose the bug:
``` javascript
  ChannelStore.getCurrent().display_name = 'blah';
  ChannelStore.emitChange(); // has no desirable effect
```

#### Checklist
- [x] Has UI changes