### PR TITLE
Implement PUT /users/{user_id}/password endpoint for APIv4

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -61,6 +61,8 @@ func Setup() *TestHelper {
 }
 
 func TearDown() {
+	utils.DisableDebugLogForTest()
+
 	options := map[string]bool{}
 	options[store.USER_SEARCH_OPTION_NAMES_ONLY_NO_FULL_NAME] = true
 	if result := <-app.Srv.Store.User().Search("", "fakeuser", options); result.Err != nil {
@@ -86,6 +88,8 @@ func TearDown() {
 			}
 		}
 	}
+
+	utils.EnableDebugLogForTest()
 }
 
 func (me *TestHelper) InitBasic() *TestHelper {
@@ -208,7 +212,7 @@ func (me *TestHelper) LoginBasicWithClient(client *model.Client4) {
 
 func (me *TestHelper) LoginBasic2WithClient(client *model.Client4) {
 	utils.DisableDebugLogForTest()
-	client.Login(me.BasicUser.Email, me.BasicUser.Password)
+	client.Login(me.BasicUser2.Email, me.BasicUser2.Password)
 	utils.EnableDebugLogForTest()
 }
 

--- a/api4/user.go
+++ b/api4/user.go
@@ -23,6 +23,7 @@ func InitUser() {
 	BaseRoutes.User.Handle("", ApiSessionRequired(updateUser)).Methods("PUT")
 	BaseRoutes.User.Handle("", ApiSessionRequired(deleteUser)).Methods("DELETE")
 	BaseRoutes.User.Handle("/roles", ApiSessionRequired(updateUserRoles)).Methods("PUT")
+	BaseRoutes.User.Handle("/password", ApiSessionRequired(updatePassword)).Methods("PUT")
 
 	BaseRoutes.Users.Handle("/login", ApiHandler(login)).Methods("POST")
 	BaseRoutes.Users.Handle("/logout", ApiHandler(logout)).Methods("POST")
@@ -279,6 +280,43 @@ func updateUserRoles(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	ReturnStatusOK(w)
+}
+
+func updatePassword(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireUserId()
+	if c.Err != nil {
+		return
+	}
+
+	props := model.MapFromJson(r.Body)
+
+	newPassword := props["new_password"]
+
+	c.LogAudit("attempted")
+
+	var err *model.AppError
+	if c.Params.UserId == c.Session.UserId {
+		currentPassword := props["current_password"]
+		if len(currentPassword) <= 0 {
+			c.SetInvalidParam("current_password")
+			return
+		}
+
+		err = app.UpdatePasswordAsUser(c.Params.UserId, currentPassword, newPassword, c.GetSiteURL())
+	} else if app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		err = app.UpdatePasswordByUserIdSendEmail(c.Params.UserId, newPassword, c.T("api.user.reset_password.method"), c.GetSiteURL())
+	} else {
+		err = model.NewAppError("updatePassword", "api.user.update_password.context.app_error", nil, "", http.StatusForbidden)
+	}
+
+	if err != nil {
+		c.LogAudit("failed")
+		c.Err = err
+		return
+	} else {
+		c.LogAudit("completed")
+		ReturnStatusOK(w)
+	}
 }
 
 func login(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/app/authentication.go
+++ b/app/authentication.go
@@ -4,12 +4,12 @@
 package app
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-
-	"net/http"
-	"strings"
 )
 
 func CheckPasswordAndAllCriteria(user *model.User, password string, mfaToken string) *model.AppError {
@@ -123,7 +123,7 @@ func CheckUserMfa(user *model.User, token string) *model.AppError {
 
 func checkUserLoginAttempts(user *model.User) *model.AppError {
 	if user.FailedAttempts >= utils.Cfg.ServiceSettings.MaximumLoginAttempts {
-		return model.NewLocAppError("checkUserLoginAttempts", "api.user.check_user_login_attempts.too_many.app_error", nil, "user_id="+user.Id)
+		return model.NewAppError("checkUserLoginAttempts", "api.user.check_user_login_attempts.too_many.app_error", nil, "user_id="+user.Id, http.StatusForbidden)
 	}
 
 	return nil

--- a/app/user.go
+++ b/app/user.go
@@ -764,22 +764,19 @@ func UpdatePasswordAsUser(userId, currentPassword, newPassword, siteURL string) 
 	}
 
 	if user == nil {
-		err = model.NewLocAppError("updatePassword", "api.user.update_password.valid_account.app_error", nil, "")
-		err.StatusCode = http.StatusBadRequest
+		err = model.NewAppError("updatePassword", "api.user.update_password.valid_account.app_error", nil, "", http.StatusBadRequest)
 		return err
 	}
 
 	if user.AuthData != nil && *user.AuthData != "" {
-		err = model.NewLocAppError("updatePassword", "api.user.update_password.oauth.app_error", nil, "auth_service="+user.AuthService)
-		err.StatusCode = http.StatusBadRequest
+		err = model.NewAppError("updatePassword", "api.user.update_password.oauth.app_error", nil, "auth_service="+user.AuthService, http.StatusBadRequest)
 		return err
 	}
 
 	if err := doubleCheckPassword(user, currentPassword); err != nil {
 		if err.Id == "api.user.check_user_password.invalid.app_error" {
-			err = model.NewLocAppError("updatePassword", "api.user.update_password.incorrect.app_error", nil, "")
+			err = model.NewAppError("updatePassword", "api.user.update_password.incorrect.app_error", nil, "", http.StatusBadRequest)
 		}
-		err.StatusCode = http.StatusForbidden
 		return err
 	}
 

--- a/model/client4.go
+++ b/model/client4.go
@@ -292,6 +292,17 @@ func (c *Client4) UpdateUser(user *User) (*User, *Response) {
 	}
 }
 
+// UpdateUserPassword updates a user's password. Must be logged in as the user or be a system administrator.
+func (c *Client4) UpdateUserPassword(userId, currentPassword, newPassword string) (bool, *Response) {
+	requestBody := map[string]string{"current_password": currentPassword, "new_password": newPassword}
+	if r, err := c.DoApiPut(c.GetUserRoute(userId)+"/password", MapToJson(requestBody)); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // UpdateUserRoles updates a user's roles in the system. A user can have "system_user" and "system_admin" roles.
 func (c *Client4) UpdateUserRoles(userId, roles string) (bool, *Response) {
 	requestBody := map[string]string{"roles": roles}

--- a/utils/config.go
+++ b/utils/config.go
@@ -68,7 +68,7 @@ func FindDir(dir string) string {
 func DisableDebugLogForTest() {
 	if l4g.Global["stdout"] != nil {
 		originalDisableDebugLvl = l4g.Global["stdout"].Level
-		l4g.Global["stdout"].Level = l4g.WARNING
+		l4g.Global["stdout"].Level = l4g.ERROR
 	}
 }
 


### PR DESCRIPTION
#### Summary
Implement PUT /users/{user_id}/password endpoint for APIv4.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#79)
- [x] All new/modified APIs include changes to the drivers
- [x] Touches critical sections of the codebase (password update)
