### PR TITLE
Defering calculations for determining if user scrolled to bottom or n…

### DIFF
--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -120,16 +120,9 @@ export default class PostList extends React.Component {
                 break;
             }
         }
-        this.wasAtBottom = this.isAtBottom();
         if (!this.jumpToPostNode && childNodes.length > 0) {
             this.jumpToPostNode = childNodes[childNodes.length - 1];
         }
-
-        // --- --------
-
-        this.props.postListScrolled(this.isAtBottom());
-        this.prevScrollHeight = this.refs.postlist.scrollHeight;
-        this.prevOffsetTop = this.jumpToPostNode.offsetTop;
 
         this.updateFloatingTimestamp();
 
@@ -138,6 +131,15 @@ export default class PostList extends React.Component {
                 isScrolling: true
             });
         }
+
+        // Postpone all DOM related calculations to next frame.
+        // scrollHeight etc might return wrong data at this point
+        setTimeout(() => {
+            this.wasAtBottom = this.isAtBottom();
+            this.props.postListScrolled(this.isAtBottom());
+            this.prevScrollHeight = this.refs.postlist.scrollHeight;
+            this.prevOffsetTop = this.jumpToPostNode.offsetTop;
+        }, 0);
 
         this.scrollStopAction.fireAfter(Constants.SCROLL_DELAY);
     }


### PR DESCRIPTION
#### Summary
Fixes the bug reported in [PLT-5348](https://mattermost.atlassian.net/browse/PLT-5348) and #5013 that in some cases the new message indicator doesn't disappear when switching channels.

Solved by adding a delay of 0ms to calculations involving scrollHeight/scrollTop and related properties. The slight delay improves the accuracy in responsive views. 

#### Ticket Link
[PLT-5348](https://mattermost.atlassian.net/browse/PLT-5348)

#### Checklist
Non applicable

