### PR TITLE
PLT-5332/PLT-5362 Updated marked

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -16,7 +16,7 @@
     "intl": "1.2.5",
     "jasny-bootstrap": "3.1.3",
     "jquery": "3.1.1",
-    "marked": "mattermost/marked#1adb66d8df3d582f4434e8e6cd401715463643d9",
+    "marked": "mattermost/marked#328857681dcc98a3d75633d6c0effa7c29b6cceb",
     "match-at": "0.1.0",
     "object-assign": "4.1.0",
     "pdfjs-dist": "1.6.319",


### PR DESCRIPTION
- To allow escaping of the pipe character in tables (https://github.com/mattermost/marked/commit/3ebc142710237f554fb4bb1e01c790972291b13b)
- To make it harder to unintentionally use reference-style links (eg. `[link]: http://www.google.ca` still defines a reference, but `[user]: Hey` doesn't) (https://github.com/mattermost/marked/commit/328857681dcc98a3d75633d6c0effa7c29b6cceb)

Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5332
https://mattermost.atlassian.net/browse/PLT-5362

#### Checklist
- Added or updated unit tests (required for all new features)
