### PR TITLE
Adding permalink redirect after login if user is not logged in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.idea/
 logs
 .DS_Store
 node_modules

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -23,10 +23,16 @@ export default class Client {
             'X-Requested-With': 'XMLHttpRequest'
         };
 
+        this.redirect_url = window.location.href;
+
         this.translations = {
             connectionError: 'There appears to be a problem with your internet connection.',
             unknownError: 'We received an unexpected status code from the server.'
         };
+    }
+
+    getRedirectUrl() {
+        return this.redirect_url;
     }
 
     setUrl(url) {

--- a/webapp/components/root.jsx
+++ b/webapp/components/root.jsx
@@ -78,11 +78,12 @@ export default class Root extends React.Component {
             } else if (UserStore.getCurrentUser()) {
                 GlobalActions.redirectUserToDefaultTeam();
             } else {
-                let regUrl = /.+?\:\/\/.+?(\/.+?)(?:#|\?|$)/;
-                if ( !regUrl.exec(Client.getRedirectUrl()))
+                const regUrl = /.+?:\/\/.+?(\/.+?)(?:#|\?|$)/;
+                if (regUrl.exec(Client.getRedirectUrl())) {
+                    browserHistory.push('/login?redirect_to=' + Client.getRedirectUrl());
+                } else {
                     browserHistory.push('/login');
-                else
-                    browserHistory.push('/login?redirect_to='+Client.getRedirectUrl());
+                }
             }
         }
     }

--- a/webapp/components/root.jsx
+++ b/webapp/components/root.jsx
@@ -78,7 +78,11 @@ export default class Root extends React.Component {
             } else if (UserStore.getCurrentUser()) {
                 GlobalActions.redirectUserToDefaultTeam();
             } else {
-                browserHistory.push('/login');
+                let regUrl = /.+?\:\/\/.+?(\/.+?)(?:#|\?|$)/;
+                if ( !regUrl.exec(Client.getRedirectUrl()))
+                    browserHistory.push('/login');
+                else
+                    browserHistory.push('/login?redirect_to='+Client.getRedirectUrl());
             }
         }
     }


### PR DESCRIPTION
#### Summary
When I send a permalink if the user is logged in Mattermost redirect to the corresponding message and channel of the permalink but if the user has logged out it redirects to default channel. With this changes the add the corresponding redirect of permalink after user log in.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-2780

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)