### PR TITLE
PLT-5336: Allow Header of 1024 chars in New Channel Modal

### DIFF
--- a/webapp/components/new_channel_modal.jsx
+++ b/webapp/components/new_channel_modal.jsx
@@ -310,7 +310,7 @@ export default class NewChannelModal extends React.Component {
                                         ref='channel_header'
                                         rows='4'
                                         placeholder={Utils.localizeMessage('channel_modal.headerEx', 'E.g.: "[Link Title](http://example.com)"')}
-                                        maxLength='128'
+                                        maxLength='1024'
                                         value={this.props.channelData.header}
                                         onChange={this.handleChange}
                                         tabIndex='2'


### PR DESCRIPTION
#### Summary
Changes Header of New Channel modal from 128 to 1024 chars
#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5336