### PR TITLE
Partially reverted #5148

### DIFF
--- a/webapp/client/test_web_client.jsx
+++ b/webapp/client/test_web_client.jsx
@@ -1,7 +1,0 @@
-// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
-// See License.txt for license information.
-
-import Client from './client.jsx';
-
-var WebClient = new Client();
-export default WebClient;

--- a/webapp/stores/emoji_store.jsx
+++ b/webapp/stores/emoji_store.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import Client from '../client/web_client.jsx';
 import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import Constants from 'utils/constants.jsx';
 import EventEmitter from 'events';
@@ -149,7 +148,8 @@ class EmojiStore extends EventEmitter {
 
     getEmojiImageUrl(emoji) {
         if (emoji.id) {
-            return Client.getCustomEmojiImageUrl(emoji.id);
+            // must match Client.getCustomEmojiImageUrl
+            return `/api/v3/emoji/${emoji.id}`;
         }
 
         const filename = emoji.filename || emoji.aliases[0];

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -159,7 +159,6 @@ if (TEST) {
     config.entry = ['babel-polyfill', './root.jsx'];
     config.target = 'node';
     config.externals = [nodeExternals()];
-    config.resolve.alias['./client/web_client.jsx'] = path.resolve(__dirname, 'client/test_web_client.jsx');
 } else {
     // For some reason these break mocha. So they go here.
     config.plugins.push(


### PR DESCRIPTION
Fixes errors running client unit tests that indirectly import react-router. This worked somehow back when the PR was merged, but something has caused it to stop working both locally and on Jenkins.

Original PR: https://github.com/mattermost/platform/pull/5148