### PR TITLE
Implement DELETE /users/{user_id endpoint for APIv4 - rebase cleanup

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -219,6 +219,37 @@ func TestUpdateUser(t *testing.T) {
 	CheckNoError(t, resp)
 }
 
+func TestDeleteUser(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	Client := th.Client
+	
+	user := th.BasicUser
+	th.LoginBasic()
+
+	testUser := th.SystemAdminUser
+	_, resp := Client.DeleteUser(testUser.Id)
+	CheckForbiddenStatus(t, resp)
+
+	Client.Logout()
+	
+	_, resp = Client.DeleteUser(user.Id)
+	CheckUnauthorizedStatus(t, resp)
+
+	Client.Login(testUser.Email, testUser.Password)
+
+	user.Id = model.NewId()
+	_, resp = Client.DeleteUser(user.Id)
+	CheckNotFoundStatus(t, resp)
+
+	user.Id = "junk"
+	_, resp = Client.DeleteUser(user.Id)
+	CheckBadRequestStatus(t, resp)
+
+	_, resp = Client.DeleteUser(testUser.Id)
+	CheckNoError(t, resp)
+
+}
+
 func TestUpdateUserRoles(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	Client := th.Client

--- a/model/client4.go
+++ b/model/client4.go
@@ -285,6 +285,16 @@ func (c *Client4) UpdateUserRoles(userId, roles string) (bool, *Response) {
 	}
 }
 
+// DeleteUser deactivates a user in the system based on the provided user id string.
+func (c *Client4) DeleteUser(userId string) (bool, *Response) {
+	if r, err := c.DoApiDelete(c.GetUserRoute(userId), ""); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // Team Section
 
 // CreateTeam creates a team in the system based on the provided team struct.


### PR DESCRIPTION
#### Summary

Implement DELETE `/users/{user_id}` endpoint for APIv4. 
This is a cleanup of rebase commits from mattermost/platform/pull/5268

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#81)
- [x] All new/modified APIs include changes to the drivers
