### PR TITLE
PLT-5379 Fix the error occuring while fetching OG metadata for links which don't exist.

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -444,6 +444,7 @@ func getOpenGraphMetadata(c *Context, w http.ResponseWriter, r *http.Request) {
 	ogJson, err := og.ToJSON()
 	if err != nil {
 		w.Write([]byte(`{"url": ""}`))
+		return
 	}
 	w.Write(ogJson)
 }

--- a/app/post.go
+++ b/app/post.go
@@ -488,10 +488,10 @@ func GetOpenGraphMetadata(url string) *opengraph.OpenGraph {
 	og := opengraph.NewOpenGraph()
 
 	res, err := http.Get(url)
-	defer CloseBody(res)
 	if err != nil {
 		return og
 	}
+	defer CloseBody(res)
 
 	if err := og.ProcessHTML(res.Body); err != nil {
 		return og


### PR DESCRIPTION
#### Summary
This error was a side effect of changes done in PR https://github.com/mattermost/platform/pull/5181. In this PR logic to close response was added. But in cases when some error occurs while getting the response, function to close response should not be called, as response is null in those cases.
Moreover, the error was only occurring on the server and wasn't causing any error on the client until refactoring of code was done in PR https://github.com/mattermost/platform/pull/5170.

#### Ticket Link
JIRA ticker: https://mattermost.atlassian.net/browse/PLT-5379
