### PR TITLE
Fix issue introduced by adding webapp/utils/url.jsx

### DIFF
--- a/webapp/components/new_channel_modal.jsx
+++ b/webapp/components/new_channel_modal.jsx
@@ -4,6 +4,7 @@
 import $ from 'jquery';
 import ReactDOM from 'react-dom';
 
+import {getShortenedTeamURL} from 'utils/url.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as ChannelUtils from 'utils/channel_utils.jsx';
@@ -189,7 +190,7 @@ export default class NewChannelModal extends React.Component {
             break;
         }
 
-        const prettyTeamURL = Utils.getShortenedTeamURL();
+        const prettyTeamURL = getShortenedTeamURL();
 
         return (
             <span>


### PR DESCRIPTION
#### Summary
New location for getShortenedTeamURL() was missing in new channel modal.
#### Ticket Link
https://pre-release.mattermost.com/core/pl/y7ty8h5h6pnizyn3xco419xx7a
