### PR TITLE
#5108 Use <time> element for channel headers and search result headers

### DIFF
--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -354,7 +354,7 @@ export default class PostList extends React.Component {
                 />
             );
 
-            const currentPostDay = Utils.getDateForUnixTicks(post.create_at);
+            const currentPostDay = new Date(Utils.getDateForUnixTicks(post.create_at).setUTCHours(0, 0, 0, 0));
             if (currentPostDay.toDateString() !== previousPostDay.toDateString()) {
                 postCtls.push(
                     <div
@@ -363,13 +363,15 @@ export default class PostList extends React.Component {
                     >
                         <hr className='separator__hr'/>
                         <div className='separator__text'>
-                            <FormattedDate
-                                value={currentPostDay}
-                                weekday='short'
-                                month='short'
-                                day='2-digit'
-                                year='numeric'
-                            />
+                            <time dateTime={currentPostDay.toISOString()}>
+                                <FormattedDate
+                                    value={currentPostDay}
+                                    weekday='short'
+                                    month='short'
+                                    day='2-digit'
+                                    year='numeric'
+                                />
+                            </time>
                         </div>
                     </div>
                 );

--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -241,17 +241,20 @@ export default class SearchResultsItem extends React.Component {
             );
         }
 
+        const postCreateDate = new Date(Utils.getDateForUnixTicks(post.create_at).setUTCHours(0, 0, 0, 0));
         return (
             <div className='search-item__container'>
                 <div className='date-separator'>
                     <hr className='separator__hr'/>
                     <div className='separator__text'>
-                        <FormattedDate
-                            value={post.create_at}
-                            day='numeric'
-                            month='long'
-                            year='numeric'
-                        />
+                        <time dateTime={postCreateDate.toISOString()}>
+                            <FormattedDate
+                                value={postCreateDate}
+                                day='numeric'
+                                month='long'
+                                year='numeric'
+                            />
+                        </time>
                     </div>
                 </div>
                 <div


### PR DESCRIPTION
#### Summary
This PR enables use of HTML5 `<time>` element for channel and search result headers.

Initial request from @yurikhan in https://github.com/mattermost/platform/issues/5108 only for post-time. 
@jasonblais asked me to adapt the channel and search result headers as well (as long as there are no side-effects).
I can't see any side-effect for this - at least not from a design perspective. 
So feedback is more than welcome!

#### Ticket Link
https://github.com/mattermost/platform/issues/5108

#### Checklist
- [x] Has UI changes
