### PR TITLE
Fix warning when opening rhs

### DIFF
--- a/webapp/components/rhs_thread.jsx
+++ b/webapp/components/rhs_thread.jsx
@@ -335,7 +335,7 @@ export default class RhsThread extends React.Component {
         var currentId = UserStore.getCurrentId();
         var searchForm;
         if (currentId != null) {
-            searchForm = <SearchBox isCommentsPage='true'/>;
+            searchForm = <SearchBox isCommentsPage={true}/>;
         }
 
         let profile;


### PR DESCRIPTION
#### Summary
Fixes warning in js-console when opening rhs:

```
Warning: Failed prop type: Invalid prop `isCommentsPage` of type `string` supplied to `SearchBar`, expected `boolean`.
```