### PR TITLE
Revert "#5108 Use <time> element for channel headers and search result headers"

### DIFF
--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -354,7 +354,7 @@ export default class PostList extends React.Component {
                 />
             );
 
-            const currentPostDay = new Date(Utils.getDateForUnixTicks(post.create_at).setUTCHours(0, 0, 0, 0));
+            const currentPostDay = Utils.getDateForUnixTicks(post.create_at);
             if (currentPostDay.toDateString() !== previousPostDay.toDateString()) {
                 postCtls.push(
                     <div
@@ -363,15 +363,13 @@ export default class PostList extends React.Component {
                     >
                         <hr className='separator__hr'/>
                         <div className='separator__text'>
-                            <time dateTime={currentPostDay.toISOString()}>
-                                <FormattedDate
-                                    value={currentPostDay}
-                                    weekday='short'
-                                    month='short'
-                                    day='2-digit'
-                                    year='numeric'
-                                />
-                            </time>
+                            <FormattedDate
+                                value={currentPostDay}
+                                weekday='short'
+                                month='short'
+                                day='2-digit'
+                                year='numeric'
+                            />
                         </div>
                     </div>
                 );

--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -286,20 +286,17 @@ export default class SearchResultsItem extends React.Component {
             );
         }
 
-        const postCreateDate = new Date(Utils.getDateForUnixTicks(post.create_at).setUTCHours(0, 0, 0, 0));
         return (
             <div className='search-item__container'>
                 <div className='date-separator'>
                     <hr className='separator__hr'/>
                     <div className='separator__text'>
-                        <time dateTime={postCreateDate.toISOString()}>
-                            <FormattedDate
-                                value={postCreateDate}
-                                day='numeric'
-                                month='long'
-                                year='numeric'
-                            />
-                        </time>
+                        <FormattedDate
+                            value={post.create_at}
+                            day='numeric'
+                            month='long'
+                            year='numeric'
+                        />
                     </div>
                 </div>
                 <div


### PR DESCRIPTION
Reverts mattermost/platform#5331

The current implementation contains a bug where the channel/search result header shows a day before the actual one (due to `setUTCHours(0, 0, 0, 0)` and then `FormattedDate` converts it into local timezone)

As discussed with @jasonblais the commit will be reverted. 

TBD
- Do we really need the dateTime attribute to be at UTC hour 0 (i.e. `2017-02-10T00:00:00.000Z`) in the header or can we simply use the date&time from first post?

