### PR TITLE
[PLT-5445] Mobile view: Set focus back to message box after uploading a file

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -315,7 +315,8 @@ export default class CreateComment extends React.Component {
     }
 
     handleUploadClick() {
-        this.focusTextbox();
+        // [PLT-5445] Mobile view: Set focus back to message box after uploading a file
+        this.focusTextbox(true);
     }
 
     handleUploadStart(clientIds) {

--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -45,7 +45,7 @@ export default class CreateComment extends React.Component {
         this.handleChange = this.handleChange.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
         this.handleBlur = this.handleBlur.bind(this);
-        this.handleUploadClick = this.handleUploadClick.bind(this);
+        this.handleFileUploadChange = this.handleFileUploadChange.bind(this);
         this.handleUploadStart = this.handleUploadStart.bind(this);
         this.handleFileUploadComplete = this.handleFileUploadComplete.bind(this);
         this.handleUploadError = this.handleUploadError.bind(this);
@@ -314,7 +314,7 @@ export default class CreateComment extends React.Component {
         }
     }
 
-    handleUploadClick() {
+    handleFileUploadChange() {
         // [PLT-5445] Mobile view: Set focus back to message box after uploading a file
         this.focusTextbox(true);
     }
@@ -401,9 +401,9 @@ export default class CreateComment extends React.Component {
         draft.uploadsInProgress = uploadsInProgress;
         PostStore.storeCommentDraft(this.props.rootId, draft);
 
-        const enableAddButton = this.handleEnableAddButton(this.state.message, fileInfos);
+        this.setState({fileInfos, uploadsInProgress});
 
-        this.setState({fileInfos, uploadsInProgress, enableAddButton});
+        this.handleFileUploadChange();
     }
 
     componentWillReceiveProps(newProps) {
@@ -525,7 +525,7 @@ export default class CreateComment extends React.Component {
                             <FileUpload
                                 ref='fileUpload'
                                 getFileCount={this.getFileCount}
-                                onClick={this.handleUploadClick}
+                                onFileUploadChange={this.handleFileUploadChange}
                                 onUploadStart={this.handleUploadStart}
                                 onFileUpload={this.handleFileUploadComplete}
                                 onUploadError={this.handleUploadError}

--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -315,7 +315,6 @@ export default class CreateComment extends React.Component {
     }
 
     handleFileUploadChange() {
-        // [PLT-5445] Mobile view: Set focus back to message box after uploading a file
         this.focusTextbox(true);
     }
 

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -245,7 +245,8 @@ export default class CreatePost extends React.Component {
     }
 
     handleUploadClick() {
-        this.focusTextbox();
+        // [PLT-5445] Mobile view: Set focus back to message box after uploading a file
+        this.focusTextbox(true);
     }
 
     handleUploadStart(clientIds, channelId) {

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -46,7 +46,7 @@ export default class CreatePost extends React.Component {
         this.handleSubmit = this.handleSubmit.bind(this);
         this.postMsgKeyPress = this.postMsgKeyPress.bind(this);
         this.handleChange = this.handleChange.bind(this);
-        this.handleUploadClick = this.handleUploadClick.bind(this);
+        this.handleFileUploadChange = this.handleFileUploadChange.bind(this);
         this.handleUploadStart = this.handleUploadStart.bind(this);
         this.handleFileUploadComplete = this.handleFileUploadComplete.bind(this);
         this.handleUploadError = this.handleUploadError.bind(this);
@@ -244,7 +244,7 @@ export default class CreatePost extends React.Component {
         PostStore.storeCurrentDraft(draft);
     }
 
-    handleUploadClick() {
+    handleFileUploadChange() {
         // [PLT-5445] Mobile view: Set focus back to message box after uploading a file
         this.focusTextbox(true);
     }
@@ -338,6 +338,8 @@ export default class CreatePost extends React.Component {
         const enableSendButton = this.handleEnableSendButton(this.state.message, fileInfos);
 
         this.setState({fileInfos, uploadsInProgress, enableSendButton});
+
+        this.handleFileUploadChange();
     }
 
     componentWillMount() {
@@ -578,7 +580,7 @@ export default class CreatePost extends React.Component {
                         <FileUpload
                             ref='fileUpload'
                             getFileCount={this.getFileCount}
-                            onClick={this.handleUploadClick}
+                            onFileUploadChange={this.handleFileUploadChange}
                             onUploadStart={this.handleUploadStart}
                             onFileUpload={this.handleFileUploadComplete}
                             onUploadError={this.handleUploadError}

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -245,7 +245,6 @@ export default class CreatePost extends React.Component {
     }
 
     handleFileUploadChange() {
-        // [PLT-5445] Mobile view: Set focus back to message box after uploading a file
         this.focusTextbox(true);
     }
 

--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -126,6 +126,8 @@ class FileUpload extends React.Component {
 
             Utils.clearFileInput(e.target);
         }
+
+        this.props.onFileUploadChange();
     }
 
     handleDrop(e) {
@@ -190,6 +192,8 @@ class FileUpload extends React.Component {
                 self.handleDrop(e);
             }
         });
+
+        this.props.onFileUploadChange();
     }
 
     componentWillUnmount() {
@@ -289,6 +293,8 @@ class FileUpload extends React.Component {
                 this.props.onUploadStart([clientId], channelId);
             }
         }
+
+        this.props.onFileUploadChange();
     }
 
     keyUpload(e) {
@@ -369,6 +375,7 @@ FileUpload.propTypes = {
     onClick: React.PropTypes.func,
     onFileUpload: React.PropTypes.func,
     onUploadStart: React.PropTypes.func,
+    onFileUploadChange: React.PropTypes.func,
     onTextDrop: React.PropTypes.func,
     channelId: React.PropTypes.string,
     postType: React.PropTypes.string


### PR DESCRIPTION
#### Summary
In Mobile view, focus is set back to message box after uploading a file.

#### Ticket Link
Jira ticket: [PLT-5445](https://mattermost.atlassian.net/browse/PLT-5445)
Github issue: #5354 

#### Checklist
- [x ] Has UI changes
