### PR TITLE
Final fixes for moving unread handling to client

### DIFF
--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -1469,6 +1469,15 @@ export default class Client {
         end(this.handleResponse.bind(this, 'getMyChannelMembers', success, error));
     }
 
+    getMyChannelMembersForTeam(teamId, success, error) {
+        request.
+        get(`${this.getTeamsRoute()}/${teamId}/channels/members`).
+        set(this.defaultHeaders).
+        type('application/json').
+        accept('application/json').
+        end(this.handleResponse.bind(this, 'getMyChannelMembersForTeam', success, error));
+    }
+
     getChannelByName(channelName, success, error) {
         request.
         get(`${this.getChannelsRoute()}/name/${channelName}`).

--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -102,7 +102,12 @@ function preNeedsTeam(nextState, replace, callback) {
         nextState.location.pathname.indexOf('/pl/') > -1) {
         loadProfilesAndTeamMembersForDMSidebar();
         AsyncClient.getMyTeamsUnread();
-        AsyncClient.getMyChannelMembers();
+        const teams = TeamStore.getAll();
+        for (const id in teams) {
+            if (teams.hasOwnProperty(id)) {
+                AsyncClient.getMyChannelMembersForTeam(id);
+            }
+        }
     }
 
     const d1 = $.Deferred(); //eslint-disable-line new-cap

--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -10,6 +10,7 @@ import UserStore from 'stores/user_store.jsx';
 var Utils;
 import {ActionTypes, Constants} from 'utils/constants.jsx';
 const NotificationPrefs = Constants.NotificationPrefs;
+const PostTypes = Constants.PostTypes;
 
 const CHANGE_EVENT = 'change';
 const STATS_EVENT = 'stats';
@@ -500,6 +501,10 @@ ChannelStore.dispatchToken = AppDispatcher.register((payload) => {
         break;
 
     case ActionTypes.RECEIVED_POST:
+        if (action.post.type === PostTypes.JOIN_LEAVE || action.post.type === PostTypes.JOIN_CHANNEL || action.post.type === PostTypes.LEAVE_CHANNEL) {
+            return;
+        }
+
         var id = action.post.channel_id;
         var teamId = action.websocketMessageProps ? action.websocketMessageProps.team_id : null;
 

--- a/webapp/stores/team_store.jsx
+++ b/webapp/stores/team_store.jsx
@@ -8,6 +8,8 @@ import ChannelStore from 'stores/channel_store.jsx';
 
 import Constants from 'utils/constants.jsx';
 const NotificationPrefs = Constants.NotificationPrefs;
+const PostTypes = Constants.PostTypes;
+
 import {getSiteURL} from 'utils/url.jsx';
 const ActionTypes = Constants.ActionTypes;
 
@@ -395,6 +397,10 @@ TeamStore.dispatchToken = AppDispatcher.register((payload) => {
         }
         break;
     case ActionTypes.RECEIVED_POST:
+        if (action.post.type === PostTypes.JOIN_LEAVE || action.post.type === PostTypes.JOIN_CHANNEL || action.post.type === PostTypes.LEAVE_CHANNEL) {
+            return;
+        }
+
         var id = action.websocketMessageProps ? action.websocketMessageProps.team_id : '';
         if (TeamStore.getCurrentId() !== id && id.length > 0) {
             TeamStore.incrementMessages(id, action.post.channel_id);

--- a/webapp/tests/client_channel.test.jsx
+++ b/webapp/tests/client_channel.test.jsx
@@ -352,6 +352,21 @@ describe('Client.Channels', function() {
         });
     });
 
+    it('getMyChannelMembersForTeam', function(done) {
+        TestHelper.initBasic(() => {
+            TestHelper.basicClient().getMyChannelMembersForTeam(
+                TestHelper.basicTeam().id,
+                function(data) {
+                    assert.equal(data.length > 0, true);
+                    done();
+                },
+                function(err) {
+                    done(new Error(err.message));
+                }
+            );
+        });
+    });
+
     it('getChannelStats', function(done) {
         TestHelper.initBasic(() => {
             TestHelper.basicClient().getChannelStats(

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -138,6 +138,35 @@ export function getMyChannelMembers() {
     });
 }
 
+export function getMyChannelMembersForTeam(teamId) {
+    return new Promise((resolve, reject) => {
+        if (isCallInProgress(`getMyChannelMembers${teamId}`)) {
+            resolve();
+            return;
+        }
+
+        callTracker[`getMyChannelMembers${teamId}`] = utils.getTimestamp();
+
+        Client.getMyChannelMembersForTeam(
+            teamId,
+            (data) => {
+                callTracker[`getMyChannelMembers${teamId}`] = 0;
+
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_MY_CHANNEL_MEMBERS,
+                    members: data
+                });
+                resolve();
+            },
+            (err) => {
+                callTracker[`getMyChannelMembers${teamId}`] = 0;
+                dispatchError(err, 'getMyChannelMembersForTeam');
+                reject();
+            }
+        );
+    });
+}
+
 export function viewChannel(channelId = ChannelStore.getCurrentId(), prevChannelId = '', time = 0) {
     if (channelId == null || !Client.teamId) {
         return;


### PR DESCRIPTION
#### Summary
* Get all channel members on first load
* Don't mark channels unread for join/leave messages