### PR TITLE
Revert PLT-5140 for adding a loading screen while switching teams

### DIFF
--- a/webapp/components/channel_view.jsx
+++ b/webapp/components/channel_view.jsx
@@ -70,9 +70,7 @@ export default class ChannelView extends React.Component {
                 <ChannelHeader
                     channelId={this.state.channelId}
                 />
-                <PostViewCache
-                    channelId={this.state.channelId}
-                />
+                <PostViewCache/>
                 <div
                     className='post-create__container'
                     id='post-create'

--- a/webapp/components/post_view/post_view_cache.jsx
+++ b/webapp/components/post_view/post_view_cache.jsx
@@ -2,7 +2,6 @@
 // See License.txt for license information
 
 import PostViewController from './post_view_controller.jsx';
-import LoadingScreen from 'components/loading_screen.jsx';
 
 import ChannelStore from 'stores/channel_store.jsx';
 import UserStore from 'stores/user_store.jsx';
@@ -68,45 +67,25 @@ export default class PostViewCache extends React.Component {
         });
     }
 
-    shouldComponentUpdate(nextProps) {
-        return Boolean(nextProps.channelId);
-    }
-
     render() {
         const channels = this.state.channels;
         const currentChannelId = this.state.currentChannelId;
-        const valid = this.props.channelId === this.state.currentChannelId;
-        const postViews = [];
-        let content;
 
-        if (valid) {
-            for (let i = 0; i < channels.length; i++) {
-                postViews.push(
-                    <PostViewController
-                        key={'postviewcontroller_' + channels[i].id}
-                        channel={channels[i]}
-                        active={channels[i].id === currentChannelId}
-                    />
-                );
-            }
-            content = postViews;
-        } else {
-            content = (
-                <LoadingScreen
-                    position='absolute'
-                    key='loading'
+        const postViews = [];
+        for (let i = 0; i < channels.length; i++) {
+            postViews.push(
+                <PostViewController
+                    key={'postviewcontroller_' + channels[i].id}
+                    channel={channels[i]}
+                    active={channels[i].id === currentChannelId}
                 />
             );
         }
 
         return (
             <div id='post-list'>
-                {content}
+                {postViews}
             </div>
         );
     }
 }
-
-PostViewCache.propTypes = {
-    channelId: React.PropTypes.string.isRequired
-};


### PR DESCRIPTION
#### Summary
Reverts https://github.com/mattermost/platform/pull/5325

@jwilander helped investigate and it looks like #5325 is causing a performance regression with slow channel switching. He showed the difference in performance when switching between channels using the commit before and the commit of the PR above and there's a visible degradation in performance.

#### Ticket Link
N/A

#### Checklist
- [x] Has UI changes