### PR TITLE
fix: stop docker containers when running make stop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ run: run-server run-client
 
 run-fullmap: run-server run-client-fullmap
 
-stop-server:
+stop-server: stop-docker
 	@echo Stopping mattermost
 
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")


### PR DESCRIPTION
#### Summary
Stop docker containers when stopping development environment with `make stop`

Fixes #5402 