### PR TITLE
Ensured getPostsSince route doesn't return a null posts field

### DIFF
--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -584,6 +584,8 @@ func (s SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCache
 
 			list := &model.PostList{Order: make([]string, 0, len(posts))}
 
+			list.MakeNonNil()
+
 			var latestUpdate int64 = 0
 
 			for _, p := range posts {


### PR DESCRIPTION
I noticed this while working on the RN app that this api call can return a null posts map if no posts have changed while other calls will return an empty posts map in those cases.