### PR TITLE
Fix load profile for new DM message

### DIFF
--- a/webapp/actions/user_actions.jsx
+++ b/webapp/actions/user_actions.jsx
@@ -277,6 +277,10 @@ export function loadProfilesAndTeamMembersForDMSidebar() {
                 name: teammateId,
                 value: 'true'
             });
+
+            if (!UserStore.hasProfile(teammateId)) {
+                profilesToLoad.push(teammateId);
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Fix showing username if you're not online and you get a new DM and then load the app.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5563