### PR TITLE
Implement user sessions endpoints for APIv4

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -34,6 +34,9 @@ func InitUser() {
 	BaseRoutes.UserByUsername.Handle("", ApiSessionRequired(getUserByUsername)).Methods("GET")
 	BaseRoutes.UserByEmail.Handle("", ApiSessionRequired(getUserByEmail)).Methods("GET")
 
+	BaseRoutes.User.Handle("/sessions", ApiSessionRequired(getSessions)).Methods("GET")
+	BaseRoutes.User.Handle("/sessions/revoke", ApiSessionRequired(revokeSession)).Methods("POST")
+
 }
 
 func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -475,4 +478,54 @@ func Logout(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	ReturnStatusOK(w)
+}
+
+func getSessions(c *Context, w http.ResponseWriter, r *http.Request) {
+    c.RequireUserId()
+    if c.Err != nil {
+        return
+    }
+
+    if !app.SessionHasPermissionToUser(c.Session, c.Params.UserId) {
+        c.SetPermissionError(model.PERMISSION_EDIT_OTHER_USERS)
+        return
+    }
+
+    if sessions, err := app.GetSessions(c.Params.UserId); err != nil {
+        c.Err = err
+        return
+    } else {
+        for _, session := range sessions {
+            session.Sanitize()
+        }
+
+        w.Write([]byte(model.SessionsToJson(sessions)))
+        return
+    }
+}
+
+func revokeSession(c *Context, w http.ResponseWriter, r *http.Request) {
+    c.RequireUserId()
+    if c.Err != nil {
+        return
+    }
+
+    if !app.SessionHasPermissionToUser(c.Session, c.Params.UserId) {
+        c.SetPermissionError(model.PERMISSION_EDIT_OTHER_USERS)
+        return
+    }
+
+    props := model.MapFromJson(r.Body)
+    sessionId := props["session_id"]
+
+    if sessionId == "" {
+        c.SetInvalidParam("session_id")
+    }
+
+    if err := app.RevokeSessionById(sessionId); err != nil {
+        c.Err = err
+        return
+    }
+
+    ReturnStatusOK(w)
 }

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -814,6 +814,9 @@ func TestGetSessions(t *testing.T) {
 	_, resp := Client.GetSessions(user.Id, "")
 	CheckNoError(t, resp)
 
+	_, resp = Client.RevokeSession("junk", model.NewId())
+	CheckBadRequestStatus(t, resp)
+
 	_, resp = Client.GetSessions(th.BasicUser2.Id, "")
 	CheckForbiddenStatus(t, resp)
 
@@ -853,6 +856,9 @@ func TestRevokeSessions(t *testing.T) {
 
 	_, resp = Client.RevokeSession(th.BasicUser2.Id, model.NewId())
 	CheckForbiddenStatus(t, resp)
+
+	_, resp = Client.RevokeSession("junk", model.NewId())
+	CheckBadRequestStatus(t, resp)
 
 	_, resp = Client.RevokeSession(user.Id, session.Id)
 	CheckNoError(t, resp)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -889,13 +889,11 @@ func TestRevokeSessions(t *testing.T) {
 	if len(sessions) == 0 {
 		t.Fatal("sessions should exist")
 	}
-
 	for _, session := range sessions {
 		if session.UserId != th.SystemAdminUser.Id {
 			t.Fatal("user id does not match session user id")
 		}
-    }
-
+	}
 	session = sessions[0]
 
 	_, resp = th.SystemAdminClient.RevokeSession(th.SystemAdminUser.Id, session.Id)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -811,7 +811,12 @@ func TestGetSessions(t *testing.T) {
 	user := th.BasicUser
 
 	Client.Login(user.Email, user.Password)
-	_, resp := Client.GetSessions(user.Id, "")
+	sessions, resp := Client.GetSessions(user.Id, "")
+	for _, session := range sessions {
+		if session.UserId != user.Id {
+			t.Fatal("user id does not match session user id")
+		}
+    }
 	CheckNoError(t, resp)
 
 	_, resp = Client.RevokeSession("junk", model.NewId())
@@ -849,6 +854,13 @@ func TestRevokeSessions(t *testing.T) {
 	if len(sessions) == 0 {
 		t.Fatal("sessions should exist")
 	}
+
+	for _, session := range sessions {
+		if session.UserId != user.Id {
+			t.Fatal("user id does not match session user id")
+		}
+    }
+
 	session := sessions[0]
 
 	_, resp := Client.RevokeSession(user.Id, model.NewId())
@@ -860,7 +872,10 @@ func TestRevokeSessions(t *testing.T) {
 	_, resp = Client.RevokeSession("junk", model.NewId())
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.RevokeSession(user.Id, session.Id)
+	status, resp := Client.RevokeSession(user.Id, session.Id)
+	if status == false {
+		t.Fatal("user session revoke unsuccessful")
+	}
 	CheckNoError(t, resp)
 
 	Client.Logout()
@@ -874,6 +889,13 @@ func TestRevokeSessions(t *testing.T) {
 	if len(sessions) == 0 {
 		t.Fatal("sessions should exist")
 	}
+
+	for _, session := range sessions {
+		if session.UserId != th.SystemAdminUser.Id {
+			t.Fatal("user id does not match session user id")
+		}
+    }
+
 	session = sessions[0]
 
 	_, resp = th.SystemAdminClient.RevokeSession(th.SystemAdminUser.Id, session.Id)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -811,12 +811,13 @@ func TestGetSessions(t *testing.T) {
 	user := th.BasicUser
 
 	Client.Login(user.Email, user.Password)
+	
 	sessions, resp := Client.GetSessions(user.Id, "")
 	for _, session := range sessions {
 		if session.UserId != user.Id {
 			t.Fatal("user id does not match session user id")
 		}
-    }
+	}
 	CheckNoError(t, resp)
 
 	_, resp = Client.RevokeSession("junk", model.NewId())
@@ -854,13 +855,11 @@ func TestRevokeSessions(t *testing.T) {
 	if len(sessions) == 0 {
 		t.Fatal("sessions should exist")
 	}
-
 	for _, session := range sessions {
 		if session.UserId != user.Id {
 			t.Fatal("user id does not match session user id")
 		}
-    }
-
+	}
 	session := sessions[0]
 
 	_, resp := Client.RevokeSession(user.Id, model.NewId())

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -802,3 +802,84 @@ func TestResetPassword(t *testing.T) {
 	_, resp = Client.SendPasswordResetEmail(user.Email)
 	CheckBadRequestStatus(t, resp)
 }
+
+func TestGetSessions(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	Client := th.Client
+
+	user := th.BasicUser
+
+	Client.Login(user.Email, user.Password)
+	_, resp := Client.GetSessions(user.Id, "")
+	CheckNoError(t, resp)
+
+	_, resp = Client.GetSessions(th.BasicUser2.Id, "")
+	CheckForbiddenStatus(t, resp)
+
+	_, resp = Client.GetSessions(model.NewId(), "")
+	CheckForbiddenStatus(t, resp)
+
+	Client.Logout()
+	_, resp = Client.GetSessions(th.BasicUser2.Id, "")
+	CheckUnauthorizedStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.GetSessions(user.Id, "")
+	CheckNoError(t, resp)
+
+	_, resp = th.SystemAdminClient.GetSessions(th.BasicUser2.Id, "")
+	CheckNoError(t, resp)
+
+	_, resp = th.SystemAdminClient.GetSessions(model.NewId(), "")
+	CheckNoError(t, resp)
+
+}
+
+func TestRevokeSessions(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	user := th.BasicUser
+	Client.Login(user.Email, user.Password)
+	sessions, _ := Client.GetSessions(user.Id, "")
+	if len(sessions) == 0 {
+		t.Fatal("sessions should exist")
+	}
+	session := sessions[0]
+
+	_, resp := Client.RevokeSession(user.Id, model.NewId())
+	CheckBadRequestStatus(t, resp)
+
+	_, resp = Client.RevokeSession(th.BasicUser2.Id, model.NewId())
+	CheckForbiddenStatus(t, resp)
+
+	_, resp = Client.RevokeSession(user.Id, session.Id)
+	CheckNoError(t, resp)
+
+	Client.Logout()
+	_, resp = Client.RevokeSession(user.Id, model.NewId())
+	CheckUnauthorizedStatus(t, resp)
+
+
+	_, resp = th.SystemAdminClient.RevokeSession(user.Id, model.NewId())
+	CheckBadRequestStatus(t, resp)
+
+	sessions, _ = Client.GetSessions(th.BasicUser2.Id, "")
+	if len(sessions) == 0 {
+		t.Fatal("sessions should exist")
+	}
+	session = sessions[0]
+
+	_, resp = th.SystemAdminClient.RevokeSession(th.BasicUser2.Id, session.Id)
+	CheckNoError(t, resp)
+
+	sessions, _ = Client.GetSessions(th.SystemAdminUser.Id, "")
+	if len(sessions) == 0 {
+		t.Fatal("sessions should exist")
+	}
+	session = sessions[0]
+
+	_, resp = th.SystemAdminClient.RevokeSession(th.SystemAdminUser.Id, session.Id)
+	CheckNoError(t, resp)
+
+}

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -805,6 +805,7 @@ func TestResetPassword(t *testing.T) {
 
 func TestGetSessions(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
 	Client := th.Client
 
 	user := th.BasicUser
@@ -860,20 +861,10 @@ func TestRevokeSessions(t *testing.T) {
 	_, resp = Client.RevokeSession(user.Id, model.NewId())
 	CheckUnauthorizedStatus(t, resp)
 
-
 	_, resp = th.SystemAdminClient.RevokeSession(user.Id, model.NewId())
 	CheckBadRequestStatus(t, resp)
 
-	sessions, _ = Client.GetSessions(th.BasicUser2.Id, "")
-	if len(sessions) == 0 {
-		t.Fatal("sessions should exist")
-	}
-	session = sessions[0]
-
-	_, resp = th.SystemAdminClient.RevokeSession(th.BasicUser2.Id, session.Id)
-	CheckNoError(t, resp)
-
-	sessions, _ = Client.GetSessions(th.SystemAdminUser.Id, "")
+	sessions, _ = th.SystemAdminClient.GetSessions(th.SystemAdminUser.Id, "")
 	if len(sessions) == 0 {
 		t.Fatal("sessions should exist")
 	}

--- a/app/session.go
+++ b/app/session.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"net/http"
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
@@ -148,6 +149,7 @@ func RevokeSessionsForDeviceId(userId string, deviceId string, currentSessionId 
 
 func RevokeSessionById(sessionId string) *model.AppError {
 	if result := <-Srv.Store.Session().Get(sessionId); result.Err != nil {
+		result.Err.StatusCode = http.StatusBadRequest
 		return result.Err
 	} else {
 		return RevokeSession(result.Data.(*model.Session))

--- a/model/client4.go
+++ b/model/client4.go
@@ -399,6 +399,27 @@ func (c *Client4) ResetPassword(code, newPassword string) (bool, *Response) {
 	}
 }
 
+// GetSessions returns a list of sessions based on the provided user id string.
+func (c *Client4) GetSessions(userId, etag string) ([]*Session, *Response) {
+	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/sessions", etag); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return SessionsFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// RevokeSession revokes a user session based on the provided user id and session id strings.
+func (c *Client4) RevokeSession(userId, sessionId string) (bool, *Response) {
+	requestBody := map[string]string{"session_id": sessionId}
+	if r, err := c.DoApiPost(c.GetUserRoute(userId)+"/sessions/revoke", MapToJson(requestBody)); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // Team Section
 
 // CreateTeam creates a team in the system based on the provided team struct.


### PR DESCRIPTION
#### Summary
- Added `GET /users/{user_id}/sessions` endpoint
- Added `POST /users/{user_id}/sessions/revoke` endpoint

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs) (mattermost/mattermost-api-reference/pull/98)
- [x] All new/modified APIs include changes to the drivers
