### PR TITLE
Add help text for 'Words that trigger mentions'

### DIFF
--- a/webapp/components/user_settings/user_settings_notifications.jsx
+++ b/webapp/components/user_settings/user_settings_notifications.jsx
@@ -608,6 +608,18 @@ export default class NotificationsTab extends React.Component {
                 </div>
             );
 
+            const extraInfo = (
+                <span>
+                    <FormattedMessage
+                        id='user.settings.notifications.mentionsInfo'
+                        defaultMessage='Mentions trigger when someone sends a message that includes your username (@{username}) or any of the options selected above.'
+                        values={{
+                            username: user.username
+                        }}
+                    />
+                </span>
+            );
+
             keysSection = (
                 <SettingItemMax
                     title={Utils.localizeMessage('user.settings.notifications.wordsTrigger', 'Words that trigger mentions')}
@@ -615,10 +627,11 @@ export default class NotificationsTab extends React.Component {
                     submit={this.handleSubmit}
                     server_error={serverError}
                     updateSection={this.handleCancel}
+                    extraInfo={extraInfo}
                 />
             );
         } else {
-            let keys = [];
+            let keys = ['@' + user.username];
             if (this.state.firstNameKey) {
                 keys.push(user.first_name);
             }

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -2128,6 +2128,7 @@
   "user.settings.notifications.emailNotifications": "Email notifications",
   "user.settings.notifications.header": "Notifications",
   "user.settings.notifications.info": "Desktop notifications are available on Edge, Firefox, Safari, Chrome and Mattermost Desktop Apps.",
+  "user.settings.notifications.mentionsInfo": "Mentions trigger when someone sends a message that includes your username (\"@{username}\") or any of the options selected above.",
   "user.settings.notifications.never": "Never",
   "user.settings.notifications.noWords": "No words configured",
   "user.settings.notifications.off": "Off",


### PR DESCRIPTION
#### Summary
For Account Settings -> Notifications -> Words that Trigger Mentions:

1. In the collapsed help text,  "@username" is included as part of the listed words.
2. When the setting is expanded, there's help text that says "Mentions trigger when someone sends a message that includes your username (@lf.brock) or any of the options selected above."

![t](https://cloud.githubusercontent.com/assets/13632558/23086839/86155472-f53d-11e6-9ced-1e58a24ac838.png)
![info](https://cloud.githubusercontent.com/assets/13632558/23086844/8d152c66-f53d-11e6-81d4-3fbcb81779ad.png)



#### Ticket Link
[JIRA ticket](https://mattermost.atlassian.net/browse/PLT-5516)
[Github issue](https://github.com/mattermost/platform/issues/5424)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
