### PR TITLE
Fix permission grants for channel management.

### DIFF
--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -346,6 +346,17 @@ func TestUpdateChannel(t *testing.T) {
 		t.Fatal("should have errored not team admin")
 	}
 
+	UpdateUserToTeamAdmin(th.BasicUser, team)
+	app.InvalidateAllCaches()
+	if _, err := Client.UpdateChannel(channel2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.UpdateChannel(channel3); err != nil {
+		t.Fatal(err)
+	}
+	UpdateUserToNonTeamAdmin(th.BasicUser, team)
+	app.InvalidateAllCaches()
+
 	MakeUserChannelAdmin(th.BasicUser, channel2)
 	MakeUserChannelAdmin(th.BasicUser, channel3)
 	store.ClearChannelCaches()
@@ -1284,6 +1295,28 @@ func TestDeleteChannel(t *testing.T) {
 	if _, err := Client.DeleteChannel(channel3.Id); err != nil {
 		t.Fatal(err)
 	}
+
+	th.LoginSystemAdmin()
+
+	channel2 = th.CreateChannel(Client, team)
+	channel3 = th.CreatePrivateChannel(Client, team)
+
+	Client.Must(Client.AddChannelMember(channel2.Id, th.BasicUser.Id))
+	Client.Must(Client.AddChannelMember(channel3.Id, th.BasicUser.Id))
+	UpdateUserToTeamAdmin(th.BasicUser, team)
+
+	Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+	app.InvalidateAllCaches()
+
+	if _, err := Client.DeleteChannel(channel2.Id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.DeleteChannel(channel3.Id); err != nil {
+		t.Fatal(err)
+	}
+
+	UpdateUserToNonTeamAdmin(th.BasicUser, team)
+	app.InvalidateAllCaches()
 
 	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_TEAM_ADMIN

--- a/utils/authorization.go
+++ b/utils/authorization.go
@@ -34,6 +34,10 @@ func SetDefaultRolesBasedOnConfig() {
 		)
 		break
 	case model.PERMISSIONS_CHANNEL_ADMIN:
+		model.ROLE_TEAM_ADMIN.Permissions = append(
+			model.ROLE_TEAM_ADMIN.Permissions,
+			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+		)
 		model.ROLE_CHANNEL_ADMIN.Permissions = append(
 			model.ROLE_CHANNEL_ADMIN.Permissions,
 			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
@@ -55,6 +59,10 @@ func SetDefaultRolesBasedOnConfig() {
 		)
 		break
 	case model.PERMISSIONS_CHANNEL_ADMIN:
+		model.ROLE_TEAM_ADMIN.Permissions = append(
+			model.ROLE_TEAM_ADMIN.Permissions,
+			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+		)
 		model.ROLE_CHANNEL_ADMIN.Permissions = append(
 			model.ROLE_CHANNEL_ADMIN.Permissions,
 			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
@@ -91,6 +99,10 @@ func SetDefaultRolesBasedOnConfig() {
 		)
 		break
 	case model.PERMISSIONS_CHANNEL_ADMIN:
+		model.ROLE_TEAM_ADMIN.Permissions = append(
+			model.ROLE_TEAM_ADMIN.Permissions,
+			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+		)
 		model.ROLE_CHANNEL_ADMIN.Permissions = append(
 			model.ROLE_CHANNEL_ADMIN.Permissions,
 			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
@@ -112,6 +124,10 @@ func SetDefaultRolesBasedOnConfig() {
 		)
 		break
 	case model.PERMISSIONS_CHANNEL_ADMIN:
+		model.ROLE_TEAM_ADMIN.Permissions = append(
+			model.ROLE_TEAM_ADMIN.Permissions,
+			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
+		)
 		model.ROLE_CHANNEL_ADMIN.Permissions = append(
 			model.ROLE_CHANNEL_ADMIN.Permissions,
 			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,


### PR DESCRIPTION
#### Summary
Fix permission grants for channel management.

When selecting the Channel, Team & System level for channel permissions,
they must be explicitly granted to the Channel *and* the Team admins.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
