### PR TITLE
Implement posts endpoints for APIv4 

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -203,12 +203,31 @@ func (me *TestHelper) CreatePost() *model.Post {
 	return me.CreatePostWithClient(me.Client, me.BasicChannel)
 }
 
+func (me *TestHelper) CreateMessagePost(message string) *model.Post {
+	return me.CreateMessagePostWithClient(me.Client, me.BasicChannel, message)
+}
+
 func (me *TestHelper) CreatePostWithClient(client *model.Client4, channel *model.Channel) *model.Post {
 	id := model.NewId()
 
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   "message_" + id,
+	}
+
+	utils.DisableDebugLogForTest()
+	rpost, resp := client.CreatePost(post)
+	if resp.Error != nil {
+		panic(resp.Error)
+	}
+	utils.EnableDebugLogForTest()
+	return rpost
+}
+
+func (me *TestHelper) CreateMessagePostWithClient(client *model.Client4, channel *model.Channel, message string) *model.Post {
+	post := &model.Post{
+		ChannelId: channel.Id,
+		Message:   message,
 	}
 
 	utils.DisableDebugLogForTest()

--- a/api4/post.go
+++ b/api4/post.go
@@ -114,7 +114,7 @@ func deletePost(c *Context, w http.ResponseWriter, r *http.Request) {
 	if _, err := app.DeletePost(c.Params.PostId); err != nil {
 		c.Err = err
 		return
-	} 
+	}
 
 	ReturnStatusOK(w)
 }

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/app"
+	"github.com/mattermost/platform/model"
 )
 
 func TestCreatePost(t *testing.T) {
@@ -230,7 +230,7 @@ func TestDeletePost(t *testing.T) {
 	post := th.CreatePost()
 	user := th.CreateUser()
 
- 	Client.Logout()
+	Client.Logout()
 	Client.Login(user.Email, user.Password)
 
 	_, resp = Client.DeletePost(post.Id)
@@ -288,7 +288,6 @@ func TestGetPostThread(t *testing.T) {
 	CheckNoError(t, resp)
 }
 
-
 func TestSearchPosts(t *testing.T) {
 	th := Setup().InitBasic()
 	defer TearDown()
@@ -299,13 +298,13 @@ func TestSearchPosts(t *testing.T) {
 	_ = th.CreateMessagePost(message)
 
 	message = "search for post2"
-	post2 := th.CreateMessagePost(message)	
+	post2 := th.CreateMessagePost(message)
 
 	message = "#hashtag search for post3"
-	post3 := th.CreateMessagePost(message)	
+	post3 := th.CreateMessagePost(message)
 
 	message = "hashtag for post4"
-	_ = th.CreateMessagePost(message)	
+	_ = th.CreateMessagePost(message)
 
 	posts, resp := Client.SearchPosts(th.BasicTeam.Id, "search", false)
 	CheckNoError(t, resp)
@@ -315,7 +314,7 @@ func TestSearchPosts(t *testing.T) {
 
 	posts, resp = Client.SearchPosts(th.BasicTeam.Id, "post2", false)
 	CheckNoError(t, resp)
-	if len(posts.Order) != 1 && posts.Order[0] == post2.Id  {
+	if len(posts.Order) != 1 && posts.Order[0] == post2.Id {
 		t.Fatal("wrong search")
 	}
 
@@ -325,7 +324,7 @@ func TestSearchPosts(t *testing.T) {
 		t.Fatal("wrong search")
 	}
 
-	if posts, resp = Client.SearchPosts(th.BasicTeam.Id, "*", false); len(posts.Order) != 0{
+	if posts, resp = Client.SearchPosts(th.BasicTeam.Id, "*", false); len(posts.Order) != 0 {
 		t.Fatal("searching for just * shouldn't return any results")
 	}
 
@@ -397,47 +396,47 @@ func TestSearchPostsInChannel(t *testing.T) {
 	_ = th.CreateMessagePostWithClient(Client, channel, message)
 
 	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel:", false); len(posts.Order) != 0 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
 	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "in:", false); len(posts.Order) != 0 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
-	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel:" + th.BasicChannel.Name, false); len(posts.Order) != 2 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel:"+th.BasicChannel.Name, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
-	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "in:" + th.BasicChannel2.Name, false); len(posts.Order) != 2 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "in:"+th.BasicChannel2.Name, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
-	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel:" + th.BasicChannel2.Name, false); len(posts.Order) != 2 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel:"+th.BasicChannel2.Name, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
-	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "ChAnNeL:" + th.BasicChannel2.Name, false); len(posts.Order) != 2 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "ChAnNeL:"+th.BasicChannel2.Name, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
 	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "sgtitlereview", false); len(posts.Order) != 2 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
 	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "sgtitlereview channel:"+th.BasicChannel.Name, false); len(posts.Order) != 1 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
 	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "sgtitlereview in: "+th.BasicChannel2.Name, false); len(posts.Order) != 1 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
 	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "sgtitlereview channel: "+th.BasicChannel2.Name, false); len(posts.Order) != 1 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
 	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel: "+th.BasicChannel2.Name+" channel: "+channel.Name, false); len(posts.Order) != 3 {
-		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
 }

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -7,8 +7,10 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/app"
 )
 
 func TestCreatePost(t *testing.T) {
@@ -284,4 +286,222 @@ func TestGetPostThread(t *testing.T) {
 
 	list, resp = th.SystemAdminClient.GetPostThread(th.BasicPost.Id, "")
 	CheckNoError(t, resp)
+}
+
+
+func TestSearchPosts(t *testing.T) {
+	th := Setup().InitBasic()
+	defer TearDown()
+	th.LoginBasic()
+	Client := th.Client
+
+	message := "search for post1"
+	_ = th.CreateMessagePost(message)
+
+	message = "search for post2"
+	post2 := th.CreateMessagePost(message)	
+
+	message = "#hashtag search for post3"
+	post3 := th.CreateMessagePost(message)	
+
+	message = "hashtag for post4"
+	_ = th.CreateMessagePost(message)	
+
+	posts, resp := Client.SearchPosts(th.BasicTeam.Id, "search", false)
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 {
+		t.Fatal("wrong search")
+	}
+
+	posts, resp = Client.SearchPosts(th.BasicTeam.Id, "post2", false)
+	CheckNoError(t, resp)
+	if len(posts.Order) != 1 && posts.Order[0] == post2.Id  {
+		t.Fatal("wrong search")
+	}
+
+	posts, resp = Client.SearchPosts(th.BasicTeam.Id, "#hashtag", false)
+	CheckNoError(t, resp)
+	if len(posts.Order) != 1 && posts.Order[0] == post3.Id {
+		t.Fatal("wrong search")
+	}
+
+	if posts, resp = Client.SearchPosts(th.BasicTeam.Id, "*", false); len(posts.Order) != 0{
+		t.Fatal("searching for just * shouldn't return any results")
+	}
+
+	posts, resp = Client.SearchPosts(th.BasicTeam.Id, "post1 post2", true)
+	CheckNoError(t, resp)
+	if len(posts.Order) != 2 {
+		t.Fatal("wrong search results")
+	}
+
+	_, resp = Client.SearchPosts("junk", "#sgtitlereview", false)
+	CheckBadRequestStatus(t, resp)
+
+	_, resp = Client.SearchPosts(model.NewId(), "#sgtitlereview", false)
+	CheckForbiddenStatus(t, resp)
+
+	_, resp = Client.SearchPosts(th.BasicTeam.Id, "", false)
+	CheckBadRequestStatus(t, resp)
+
+	Client.Logout()
+	_, resp = Client.SearchPosts(th.BasicTeam.Id, "#sgtitlereview", false)
+	CheckUnauthorizedStatus(t, resp)
+
+}
+
+func TestSearchHashtagPosts(t *testing.T) {
+	th := Setup().InitBasic()
+	defer TearDown()
+	th.LoginBasic()
+	Client := th.Client
+
+	message := "#sgtitlereview with space"
+	_ = th.CreateMessagePost(message)
+
+	message = "#sgtitlereview\n with return"
+	_ = th.CreateMessagePost(message)
+
+	message = "no hashtag"
+	_ = th.CreateMessagePost(message)
+
+	posts, resp := Client.SearchPosts(th.BasicTeam.Id, "#sgtitlereview", false)
+	CheckNoError(t, resp)
+	if len(posts.Order) != 2 {
+		t.Fatal("wrong search results")
+	}
+
+	Client.Logout()
+	_, resp = Client.SearchPosts(th.BasicTeam.Id, "#sgtitlereview", false)
+	CheckUnauthorizedStatus(t, resp)
+}
+
+func TestSearchPostsInChannel(t *testing.T) {
+	th := Setup().InitBasic()
+	defer TearDown()
+	th.LoginBasic()
+	Client := th.Client
+
+	channel := th.CreatePublicChannel()
+
+	message := "sgtitlereview with space"
+	_ = th.CreateMessagePost(message)
+
+	message = "sgtitlereview\n with return"
+	_ = th.CreateMessagePostWithClient(Client, th.BasicChannel2, message)
+
+	message = "other message with no return"
+	_ = th.CreateMessagePostWithClient(Client, th.BasicChannel2, message)
+
+	message = "other message with no return"
+	_ = th.CreateMessagePostWithClient(Client, channel, message)
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel:", false); len(posts.Order) != 0 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "in:", false); len(posts.Order) != 0 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel:" + th.BasicChannel.Name, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "in:" + th.BasicChannel2.Name, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel:" + th.BasicChannel2.Name, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "ChAnNeL:" + th.BasicChannel2.Name, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "sgtitlereview", false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "sgtitlereview channel:"+th.BasicChannel.Name, false); len(posts.Order) != 1 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "sgtitlereview in: "+th.BasicChannel2.Name, false); len(posts.Order) != 1 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "sgtitlereview channel: "+th.BasicChannel2.Name, false); len(posts.Order) != 1 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "channel: "+th.BasicChannel2.Name+" channel: "+channel.Name, false); len(posts.Order) != 3 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))	
+	}
+
+}
+
+func TestSearchPostsFromUser(t *testing.T) {
+	th := Setup().InitBasic()
+	defer TearDown()
+	Client := th.Client
+
+	th.LoginTeamAdmin()
+	user := th.CreateUser()
+	LinkUserToTeam(user, th.BasicTeam)
+	app.AddUserToChannel(user, th.BasicChannel)
+	app.AddUserToChannel(user, th.BasicChannel2)
+
+	message := "sgtitlereview with space"
+	_ = th.CreateMessagePost(message)
+
+	Client.Logout()
+	th.LoginBasic2()
+
+	message = "sgtitlereview\n with return"
+	_ = th.CreateMessagePostWithClient(Client, th.BasicChannel2, message)
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "from: "+th.TeamAdminUser.Username, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "from: "+th.BasicUser2.Username, false); len(posts.Order) != 1 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "from: "+th.BasicUser2.Username+" sgtitlereview", false); len(posts.Order) != 1 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
+	}
+
+	message = "hullo"
+	_ = th.CreateMessagePost(message)
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "from: "+th.BasicUser2.Username+" in:"+th.BasicChannel.Name, false); len(posts.Order) != 1 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
+	}
+
+	Client.Login(user.Email, user.Password)
+
+	// wait for the join/leave messages to be created for user3 since they're done asynchronously
+	time.Sleep(100 * time.Millisecond)
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "from: "+th.BasicUser2.Username, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "from: "+th.BasicUser2.Username+" from: "+user.Username, false); len(posts.Order) != 2 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
+	}
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "from: "+th.BasicUser2.Username+" from: "+user.Username+" in:"+th.BasicChannel2.Name, false); len(posts.Order) != 1 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
+	}
+
+	message = "coconut"
+	_ = th.CreateMessagePostWithClient(Client, th.BasicChannel2, message)
+
+	if posts, _ := Client.SearchPosts(th.BasicTeam.Id, "from: "+th.BasicUser2.Username+" from: "+user.Username+" in:"+th.BasicChannel2.Name+" coconut", false); len(posts.Order) != 1 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
+	}
 }

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -207,6 +207,44 @@ func TestGetPost(t *testing.T) {
 	CheckNoError(t, resp)
 }
 
+func TestDeletePost(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	_, resp := Client.DeletePost("")
+	CheckNotFoundStatus(t, resp)
+
+	_, resp = Client.DeletePost("junk")
+	CheckBadRequestStatus(t, resp)
+
+	_, resp = Client.DeletePost(th.BasicPost.Id)
+	CheckForbiddenStatus(t, resp)
+
+	Client.Login(th.TeamAdminUser.Email, th.TeamAdminUser.Password)
+	_, resp = Client.DeletePost(th.BasicPost.Id)
+	CheckNoError(t, resp)
+
+	post := th.CreatePost()
+	user := th.CreateUser()
+
+ 	Client.Logout()
+	Client.Login(user.Email, user.Password)
+
+	_, resp = Client.DeletePost(post.Id)
+	CheckForbiddenStatus(t, resp)
+
+	Client.Logout()
+	_, resp = Client.DeletePost(model.NewId())
+	CheckUnauthorizedStatus(t, resp)
+
+	status, resp := th.SystemAdminClient.DeletePost(post.Id)
+	if status == false {
+		t.Fatal("post should return status OK")
+	}
+	CheckNoError(t, resp)
+}
+
 func TestGetPostThread(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer TearDown()

--- a/app/post.go
+++ b/app/post.go
@@ -400,6 +400,7 @@ func GetPostsAroundPost(postId, channelId string, offset, limit int, before bool
 
 func DeletePost(postId string) (*model.Post, *model.AppError) {
 	if result := <-Srv.Store.Post().GetSingle(postId); result.Err != nil {
+		result.Err.StatusCode = http.StatusBadRequest
 		return nil, result.Err
 	} else {
 		post := result.Data.(*model.Post)

--- a/model/client4.go
+++ b/model/client4.go
@@ -665,7 +665,7 @@ func (c *Client4) GetPost(postId string, etag string) (*Post, *Response) {
 
 // DeletePost deletes a post from the provided post id string.
 func (c *Client4) DeletePost(postId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetPostRoute(postId), ""); err != nil {
+	if r, err := c.DoApiDelete(c.GetPostRoute(postId)); err != nil {
 		return false, &Response{StatusCode: r.StatusCode, Error: err}
 	} else {
 		defer closeBody(r)

--- a/model/client4.go
+++ b/model/client4.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strings"
+	"strconv"
 )
 
 type Response struct {
@@ -686,6 +687,17 @@ func (c *Client4) GetPostThread(postId string, etag string) (*PostList, *Respons
 func (c *Client4) GetPostsForChannel(channelId string, page, perPage int, etag string) (*PostList, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
 	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts"+query, etag); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return PostListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// SearchPosts returns any posts with matching terms string.
+func (c *Client4) SearchPosts(teamId string, terms string, isOrSearch bool) (*PostList, *Response) {
+	requestBody := map[string]string{"terms": terms, "is_or_search": strconv.FormatBool(isOrSearch)}
+	if r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/posts/search", MapToJson(requestBody)); err != nil {
 		return nil, &Response{StatusCode: r.StatusCode, Error: err}
 	} else {
 		defer closeBody(r)

--- a/model/client4.go
+++ b/model/client4.go
@@ -10,8 +10,8 @@ import (
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 type Response struct {

--- a/model/client4.go
+++ b/model/client4.go
@@ -662,6 +662,16 @@ func (c *Client4) GetPost(postId string, etag string) (*Post, *Response) {
 	}
 }
 
+// DeletePost deletes a post from the provided post id string.
+func (c *Client4) DeletePost(postId string) (bool, *Response) {
+	if r, err := c.DoApiDelete(c.GetPostRoute(postId), ""); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // GetPostThread gets a post with all the other posts in the same thread.
 func (c *Client4) GetPostThread(postId string, etag string) (*PostList, *Response) {
 	if r, err := c.DoApiGet(c.GetPostRoute(postId)+"/thread", etag); err != nil {


### PR DESCRIPTION
#### Summary
- Implement `DELETE /posts/{post_id}` 
- Implement `POST /team/{team_id}/posts/search`

#### Ticket Link
- mattermost/platform#5413 

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs) (mattermost/mattermost-api-reference/pull/104)
- [x] All new/modified APIs include changes to the drivers
