### PR TITLE
PLT-5334: Show Create Team menu option to Sysadmins even when Team Creation is disabled.

### DIFF
--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -319,7 +319,7 @@ export default class SidebarHeaderDropdown extends React.Component {
         const teams = [];
         let moreTeams = false;
 
-        if (config.EnableTeamCreation === 'true') {
+        if (config.EnableTeamCreation === 'true' || UserStore.isSystemAdminForCurrentUser()) {
             teams.push(
                 <li key='newTeam_li'>
                     <Link


### PR DESCRIPTION
#### Summary
Show Create Team menu option to Sysadmins even when Team Creation is disabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5334