### PR TITLE
Timestamp permalinks on desktop app should open in a new browser tab

### DIFF
--- a/webapp/components/post_view/components/post_time.jsx
+++ b/webapp/components/post_view/components/post_time.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import Constants from 'utils/constants.jsx';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-import {getDateForUnixTicks, isMobile, updateWindowDimensions} from 'utils/utils.jsx';
+import {getDateForUnixTicks, isMobile, updateWindowDimensions, openInNewTab} from 'utils/utils.jsx';
 
 import {Link} from 'react-router/es6';
 import TeamStore from 'stores/team_store.jsx';
@@ -55,8 +55,7 @@ export default class PostTime extends React.Component {
             this.renderTimeTag() :
             (
                 <Link
-                    to={`/${this.state.currentTeamDisplayName}/pl/${this.props.postId}`}
-                    target='_blank'
+                    onClick={openInNewTab.bind(this, `/${this.state.currentTeamDisplayName}/pl/${this.props.postId}`)}
                     className='post__permalink'
                 >
                     {this.renderTimeTag()}

--- a/webapp/components/rhs_comment.jsx
+++ b/webapp/components/rhs_comment.jsx
@@ -270,8 +270,7 @@ export default class RhsComment extends React.Component {
             this.timeTag(post, timeOptions) :
             (
                 <Link
-                    to={`/${this.state.currentTeamDisplayName}/pl/${post.id}`}
-                    target='_blank'
+                    onClick={Utils.openInNewTab.bind(this, `/${this.state.currentTeamDisplayName}/pl/${post.id}`)}
                     className='post__permalink'
                 >
                     {this.timeTag(post, timeOptions)}

--- a/webapp/components/rhs_root_post.jsx
+++ b/webapp/components/rhs_root_post.jsx
@@ -134,8 +134,7 @@ export default class RhsRootPost extends React.Component {
             this.timeTag(post, timeOptions) :
             (
                 <Link
-                    to={`/${this.state.currentTeamDisplayName}/pl/${post.id}`}
-                    target='_blank'
+                    onClick={Utils.openInNewTab.bind(this, `/${this.state.currentTeamDisplayName}/pl/${post.id}`)}
                     className='post__permalink'
                 >
                     {this.timeTag(post, timeOptions)}

--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -95,8 +95,7 @@ export default class SearchResultsItem extends React.Component {
             this.timeTag(post) :
             (
                 <Link
-                    to={`/${this.state.currentTeamDisplayName}/pl/${post.id}`}
-                    target='_blank'
+                    onClick={Utils.openInNewTab.bind(this, `/${this.state.currentTeamDisplayName}/pl/${post.id}`)}
                     className='post__permalink'
                 >
                     {this.timeTag(post)}

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -1303,3 +1303,8 @@ export function isEmptyObject(object) {
 export function updateWindowDimensions(component) {
     component.setState({width: window.innerWidth, height: window.innerHeight});
 }
+
+export function openInNewTab(url) {
+    let origin = window.location.host;
+    window.open(origin + url, '_blank');
+}

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -1305,6 +1305,6 @@ export function updateWindowDimensions(component) {
 }
 
 export function openInNewTab(url) {
-    let origin = window.location.host;
+    const origin = window.location.host;
     window.open(origin + url, '_blank');
 }


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Timestamp permalinks on desktop app should open in a new browser tab

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5535

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
