### PR TITLE
PLT-5529 Fix system admin loading members for teams not on

### DIFF
--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -106,12 +106,8 @@ function preNeedsTeam(nextState, replace, callback) {
     if (nextState.location.pathname.indexOf('/channels/') > -1 ||
         nextState.location.pathname.indexOf('/pl/') > -1) {
         AsyncClient.getMyTeamsUnread();
-        const teams = TeamStore.getAll();
-        for (const id in teams) {
-            if (teams.hasOwnProperty(id)) {
-                AsyncClient.getMyChannelMembersForTeam(id);
-            }
-        }
+        const members = TeamStore.getMyTeamMembers();
+        members.forEach((m) => AsyncClient.getMyChannelMembersForTeam(m.team_id));
     }
 
     const d1 = $.Deferred(); //eslint-disable-line new-cap


### PR DESCRIPTION
#### Summary
Use team members over teams for pulling channel members.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5529