### PR TITLE
PLT-5548 Prevent server start if defaultLocate is not available

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5580,6 +5580,10 @@
     "translation": "An error occurred while saving the file to {{.Filename}}"
   },
   {
+    "id": "utils.config.validate_locale.app_error",
+    "translation": "Unable to load mattermost configuration file:  AvailableLocales must include DefaultClientLocale"
+  },
+  {
     "id": "utils.diagnostic.analytics_not_found.app_error",
     "translation": "Analytics not initialized"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5580,6 +5580,14 @@
     "translation": "An error occurred while saving the file to {{.Filename}}"
   },
   {
+    "id": "utils.config.supported_client_locale.app_error",
+    "translation": "Unable to load mattermost configuration file:  DefaultClientLocale must be one of the supported locales"
+  },
+  {
+    "id": "utils.config.supported_server_locale.app_error",
+    "translation": "Unable to load mattermost configuration file:  DefaultServerLocale must be one of the supported locales"
+  },
+  {
     "id": "utils.config.validate_locale.app_error",
     "translation": "Unable to load mattermost configuration file:  AvailableLocales must include DefaultClientLocale"
   },

--- a/utils/config.go
+++ b/utils/config.go
@@ -392,6 +392,15 @@ func ValidateLdapFilter(cfg *model.Config) *model.AppError {
 }
 
 func ValidateLocales(cfg *model.Config) *model.AppError {
+	locales := GetSupportedLocales()
+	if _, ok := locales[*cfg.LocalizationSettings.DefaultServerLocale]; !ok {
+		return model.NewLocAppError("ValidateLocales", "utils.config.supported_server_locale.app_error", nil, "")
+	}
+
+	if _, ok := locales[*cfg.LocalizationSettings.DefaultClientLocale]; !ok {
+		return model.NewLocAppError("ValidateLocales", "utils.config.supported_client_locale.app_error", nil, "")
+	}
+
 	if len(*cfg.LocalizationSettings.AvailableLocales) > 0 {
 		for _, word := range strings.Split(*cfg.LocalizationSettings.AvailableLocales, ",") {
 			if word == *cfg.LocalizationSettings.DefaultClientLocale {

--- a/utils/config.go
+++ b/utils/config.go
@@ -196,6 +196,10 @@ func LoadConfig(fileName string) {
 		}
 	}
 
+	if err := ValidateLocales(&config); err != nil {
+		panic(T(err.Id))
+	}
+
 	if err := ValidateLdapFilter(&config); err != nil {
 		panic(T(err.Id))
 	}
@@ -384,6 +388,20 @@ func ValidateLdapFilter(cfg *model.Config) *model.AppError {
 			return err
 		}
 	}
+	return nil
+}
+
+func ValidateLocales(cfg *model.Config) *model.AppError {
+	if len(*cfg.LocalizationSettings.AvailableLocales) > 0 {
+		for _, word := range strings.Split(*cfg.LocalizationSettings.AvailableLocales, ",") {
+			if word == *cfg.LocalizationSettings.DefaultClientLocale {
+				return nil
+			}
+		}
+
+		return model.NewLocAppError("ValidateLocales", "utils.config.validate_locale.app_error", nil, "")
+	}
+
 	return nil
 }
 

--- a/utils/i18n.go
+++ b/utils/i18n.go
@@ -94,6 +94,10 @@ func GetTranslationsAndLocale(w http.ResponseWriter, r *http.Request) (i18n.Tran
 	return translations, model.DEFAULT_LOCALE
 }
 
+func GetSupportedLocales() map[string]string {
+	return locales
+}
+
 func TfuncWithFallback(pref string) i18n.TranslateFunc {
 	t, _ := i18n.Tfunc(pref)
 	return func(translationID string, args ...interface{}) string {


### PR DESCRIPTION
#### Summary
Prevent the server from starting if the default Client locale is not set as an available locale

We need to generate documentation for this as this might be a breaking change for servers that are misconfigured right now.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5548

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (config and server start up)
