### PR TITLE
PLT-5548: Default client locale is validated on server startup against available locales

### DIFF
--- a/utils/i18n.go
+++ b/utils/i18n.go
@@ -24,7 +24,20 @@ func TranslationsPreInit() {
 
 func InitTranslations(localizationSettings model.LocalizationSettings) {
 	settings = localizationSettings
+	validateDefaultClientLocale()
 	T = GetTranslationsBySystemLocale()
+}
+
+func validateDefaultClientLocale() {
+	if *settings.AvailableLocales != "" {
+		if !strings.Contains(*settings.AvailableLocales, *settings.DefaultClientLocale) {
+			panic("Unable to load mattermost configuration file: AvailableLocales must include DefaultClientLocale.")
+		}
+	}
+
+	if locales[*settings.DefaultClientLocale] == "" {
+		panic("Failed to load system translations for DefaultClientLocale")
+	}
 }
 
 func InitTranslationsWithDir(dir string) {


### PR DESCRIPTION
#### Summary
On server startup the DefaultClientLocale is now validated against AvailableLocales, if it has been set.

Also additionally if AvailableLocales has not been set, the DefaultClientLocale is validated against those locales that the server automatically finds on startup.

If the validation fails, the server exits with a panic and spits out either one of these messages:

- `Unable to load mattermost configuration file: AvailableLocales must include DefaultClientLocale.`
- `Failed to load system translations for DefaultClientLocale`

This should match the configuration behaviour as stated in https://docs.mattermost.com/administration/config-settings.html

#### Ticket Link
https://github.com/mattermost/platform/issues/5462
https://mattermost.atlassian.net/browse/PLT-5548
