### PR TITLE
PLT-3535: Handle plus (+) sign in emails by ensuring the email is uri…

### DIFF
--- a/webapp/components/do_verify_email.jsx
+++ b/webapp/components/do_verify_email.jsx
@@ -24,7 +24,7 @@ export default class DoVerifyEmail extends React.Component {
             this.props.location.query.uid,
             this.props.location.query.hid,
             () => {
-                browserHistory.push('/login?extra=verified&email=' + this.props.location.query.email);
+                browserHistory.push('/login?extra=verified&email=' + encodeURIComponent(this.props.location.query.email));
             },
             (err) => {
                 this.setState({verifyStatus: 'failure', serverError: err.message});


### PR DESCRIPTION
#### Summary
If a verified email contained plus signs (+), the automatically filled email address converted them to whitespace. This has been fixed now by uri encoding the email address on login redirect.

Details of the problem here: https://mattermost.atlassian.net/browse/PLT-3535?focusedCommentId=29216&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-29216

#### Ticket Link
Original PR of email autofill: https://github.com/mattermost/platform/issues/4362
https://mattermost.atlassian.net/browse/PLT-3535

#### Checklist
- [x] Has UI changes
- [x] Touches critical sections of the codebase (email verification)
