### PR TITLE
PLT-5569 Added a unique prefix to text formatting entities

### DIFF
--- a/webapp/tests/emoticons.test.jsx
+++ b/webapp/tests/emoticons.test.jsx
@@ -14,25 +14,25 @@ describe('Emoticons', function() {
 
         assert.equal(
             Emoticons.handleEmoticons(':goat: :dash:', new Map(), emojis),
-            'MM_EMOTICON0 MM_EMOTICON1',
+            '$MM_EMOTICON0 $MM_EMOTICON1',
             'should replace emoticons with tokens'
         );
 
         assert.equal(
             Emoticons.handleEmoticons(':goat::dash:', new Map(), emojis),
-            'MM_EMOTICON0MM_EMOTICON1',
+            '$MM_EMOTICON0$MM_EMOTICON1',
             'should replace emoticons not separated by whitespace'
         );
 
         assert.equal(
             Emoticons.handleEmoticons('/:goat:..:dash:)', new Map(), emojis),
-            '/MM_EMOTICON0..MM_EMOTICON1)',
+            '/$MM_EMOTICON0..$MM_EMOTICON1)',
             'should replace emoticons separated by punctuation'
         );
 
         assert.equal(
             Emoticons.handleEmoticons('asdf:goat:asdf:dash:asdf', new Map(), emojis),
-            'asdfMM_EMOTICON0asdfMM_EMOTICON1asdf',
+            'asdf$MM_EMOTICON0asdf$MM_EMOTICON1asdf',
             'should replace emoticons separated by text'
         );
 

--- a/webapp/tests/formatting_at_mentions.test.jsx
+++ b/webapp/tests/formatting_at_mentions.test.jsx
@@ -11,43 +11,43 @@ describe('TextFormatting.AtMentions', function() {
     it('At mentions', function() {
         assert.equal(
             TextFormatting.autolinkAtMentions('@user', new Map(), {user: {}}),
-            'MM_ATMENTION0',
+            '$MM_ATMENTION0',
             'should replace explicit mention with token'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('abc"@user"def', new Map(), {user: {}}),
-            'abc"MM_ATMENTION0"def',
+            'abc"$MM_ATMENTION0"def',
             'should replace explicit mention surrounded by punctuation with token'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@user1 @user2', new Map(), {user1: {}, user2: {}}),
-            'MM_ATMENTION0 MM_ATMENTION1',
+            '$MM_ATMENTION0 $MM_ATMENTION1',
             'should replace multiple explicit mentions with tokens'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@us_-e.r', new Map(), {'us_-e.r': {}}),
-            'MM_ATMENTION0',
+            '$MM_ATMENTION0',
             'should replace multiple explicit mentions containing punctuation with token'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@us_-e.r', new Map(), {'us_-e.r': {}}),
-            'MM_ATMENTION0',
+            '$MM_ATMENTION0',
             'should replace multiple explicit mentions containing valid punctuation with token'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@user.', new Map(), {user: {}}),
-            'MM_ATMENTION0.',
+            '$MM_ATMENTION0.',
             'should replace explicit mention followed by period with token'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@user.', new Map(), {'user.': {}}),
-            'MM_ATMENTION0',
+            '$MM_ATMENTION0',
             'should replace explicit mention ending with period with token'
         );
     });
@@ -56,13 +56,13 @@ describe('TextFormatting.AtMentions', function() {
         // PLT-4454 Assume users exist for things that look like at mentions until we support the new mention syntax
         assert.equal(
             TextFormatting.autolinkAtMentions('@user', new Map(), {}),
-            'MM_ATMENTION0',
+            '$MM_ATMENTION0',
             'should imply user exists and replace mention with token'
         );
 
         assert.equal(
             TextFormatting.autolinkAtMentions('@user.', new Map(), {}),
-            'MM_ATMENTION0.',
+            '$MM_ATMENTION0.',
             'should assume username doesn\'t end in punctuation'
         );
     });

--- a/webapp/utils/emoticons.jsx
+++ b/webapp/utils/emoticons.jsx
@@ -31,7 +31,7 @@ export function handleEmoticons(text, tokens, emojis) {
 
     function replaceEmoticonWithToken(fullMatch, prefix, matchText, name) {
         const index = tokens.size;
-        const alias = `MM_EMOTICON${index}`;
+        const alias = `$MM_EMOTICON${index}`;
 
         if (emojis.has(name)) {
             const path = EmojiStore.getEmojiImageUrl(emojis.get(name));

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -127,7 +127,7 @@ function autolinkEmails(text, tokens) {
         }
 
         const index = tokens.size;
-        const alias = `MM_EMAIL${index}`;
+        const alias = `$MM_EMAIL${index}`;
 
         tokens.set(alias, {
             value: `<a class="theme" href="${url}">${linkText}</a>`,
@@ -160,7 +160,7 @@ export function autolinkAtMentions(text, tokens, usernameMap) {
 
     function addToken(username, mention) {
         const index = tokens.size;
-        const alias = `MM_ATMENTION${index}`;
+        const alias = `$MM_ATMENTION${index}`;
 
         tokens.set(alias, {
             value: `<a class='mention-link' href='#' data-mention='${username}'>${mention}</a>`,
@@ -199,7 +199,7 @@ function autolinkChannelMentions(text, tokens, channelNamesMap, team) {
     }
     function addToken(channelName, mention, displayName) {
         const index = tokens.size;
-        const alias = `MM_CHANNELMENTION${index}`;
+        const alias = `$MM_CHANNELMENTION${index}`;
         let href = '#';
         if (team) {
             href = '/' + team.name + '/channels/' + channelName;
@@ -260,7 +260,7 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
     for (const [alias, token] of tokens) {
         if (mentionKeys.indexOf(token.originalText) !== -1) {
             const index = tokens.size + newTokens.size;
-            const newAlias = `MM_SELFMENTION${index}`;
+            const newAlias = `$MM_SELFMENTION${index}`;
 
             newTokens.set(newAlias, {
                 value: `<span class='mention--highlight'>${alias}</span>`,
@@ -278,7 +278,7 @@ function highlightCurrentMentions(text, tokens, mentionKeys = []) {
     // look for self mentions in the text
     function replaceCurrentMentionWithToken(fullMatch, prefix, mention) {
         const index = tokens.size;
-        const alias = `MM_SELFMENTION${index}`;
+        const alias = `$MM_SELFMENTION${index}`;
 
         tokens.set(alias, {
             value: `<span class='mention--highlight'>${mention}</span>`,
@@ -306,7 +306,7 @@ function autolinkHashtags(text, tokens) {
     for (const [alias, token] of tokens) {
         if (token.originalText.lastIndexOf('#', 0) === 0) {
             const index = tokens.size + newTokens.size;
-            const newAlias = `MM_HASHTAG${index}`;
+            const newAlias = `$MM_HASHTAG${index}`;
 
             newTokens.set(newAlias, {
                 value: `<a class='mention-link' href='#' data-hashtag='${token.originalText}'>${token.originalText}</a>`,
@@ -326,7 +326,7 @@ function autolinkHashtags(text, tokens) {
     // look for hashtags in the text
     function replaceHashtagWithToken(fullMatch, prefix, originalText) {
         const index = tokens.size;
-        const alias = `MM_HASHTAG${index}`;
+        const alias = `$MM_HASHTAG${index}`;
 
         if (text.length < Constants.MIN_HASHTAG_LINK_LENGTH + 1) {
             // too short to be a hashtag
@@ -433,7 +433,7 @@ export function highlightSearchTerms(text, tokens, searchPatterns) {
 
     function replaceSearchTermWithToken(match, prefix, word) {
         const index = tokens.size;
-        const alias = `MM_SEARCHTERM${index}`;
+        const alias = `$MM_SEARCHTERM${index}`;
 
         tokens.set(alias, {
             value: `<span class='search-highlight'>${word}</span>`,
@@ -449,7 +449,7 @@ export function highlightSearchTerms(text, tokens, searchPatterns) {
         for (const [alias, token] of tokens) {
             if (pattern.test(token.originalText)) {
                 const index = tokens.size + newTokens.size;
-                const newAlias = `MM_SEARCHTERM${index}`;
+                const newAlias = `$MM_SEARCHTERM${index}`;
 
                 newTokens.set(newAlias, {
                     value: `<span class='search-highlight'>${alias}</span>`,


### PR DESCRIPTION
This is to fix a case where `#@hmhealey` is transformed into `#MM_MENTION0` and then that is accidentally converted into a hashtag, causing the final output to be garbled.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5569