### PR TITLE
Fix channel created WS event

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -107,6 +107,7 @@ func CreateChannelWithUser(channel *model.Channel, userId string) (*model.Channe
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_CREATED, "", "", userId, nil)
 	message.Add("channel_id", channel.Id)
+	message.Add("team_id", channel.TeamId)
 	Publish(message)
 
 	return rchannel, nil

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -286,8 +286,9 @@ function handleUserUpdatedEvent(msg) {
 
 function handleChannelCreatedEvent(msg) {
     const channelId = msg.data.channel_id;
+    const teamId = msg.data.team_id;
 
-    if (!ChannelStore.getChannelById(channelId)) {
+    if (TeamStore.getCurrentId() === teamId && !ChannelStore.getChannelById(channelId)) {
         AsyncClient.getChannel(channelId);
     }
 }


### PR DESCRIPTION
This will handle when the created channel belongs to another team different than the current one