### PR TITLE
PLT-5490: Add machine readable timestamps for search results

### DIFF
--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -79,7 +79,10 @@ export default class SearchResultsItem extends React.Component {
 
     timeTag(post) {
         return (
-            <time className='search-item-time'>
+            <time
+                className='search-item-time'
+                dateTime={Utils.getDateForUnixTicks(post.create_at).toISOString()}
+            >
                 <FormattedDate
                     value={post.create_at}
                     hour12={!this.props.useMilitaryTime}


### PR DESCRIPTION
#### Summary
Small change: Search results now also include timestamps in machine readable format.

#### Ticket Link
https://github.com/mattermost/platform/issues/5425
https://mattermost.atlassian.net/browse/PLT-5490

#### Checklist
- [x] Has UI changes
