### PR TITLE
Fix keyboard shortcuts not to trigger on AltGr key

### DIFF
--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -32,7 +32,7 @@ export function isMac() {
 }
 
 export function cmdOrCtrlPressed(e) {
-    return (isMac() && e.metaKey) || (!isMac() && e.ctrlKey);
+    return (isMac() && e.metaKey) || (!isMac() && e.ctrlKey && !e.altKey);
 }
 
 export function isInRole(roles, inRole) {


### PR DESCRIPTION
#### Summary
On Windows when pressing AltGr it will trigger event with same properties as left Ctrl key. Check explicitly that altKey is false otherwise on some keyboard layouts input of special characters is blocked.

#### Ticket Link
Fixes issue #5495 
