### PR TITLE
PLT-5652 Fixed pasting text sending the caret to the end of the post textbox

### DIFF
--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -292,9 +292,11 @@ class FileUpload extends React.Component {
 
                 this.props.onUploadStart([clientId], channelId);
             }
-        }
 
-        this.props.onFileUploadChange();
+            if (numToUpload > 0) {
+                this.props.onFileUploadChange();
+            }
+        }
     }
 
     keyUpload(e) {


### PR DESCRIPTION
The handler to move focus back to the textbox fired any time the user pasted anything as opposed to just when they post files

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5652
