### PR TITLE
PLT-5670 Correct typo in app/email.go

### DIFF
--- a/app/email.go
+++ b/app/email.go
@@ -105,13 +105,13 @@ func SendVerifyEmail(userId, userEmail, locale, siteURL string) *model.AppError 
 func SendSignInChangeEmail(email, method, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
-	subject := T("api.templates.singin_change_email.subject",
+	subject := T("api.templates.signin_change_email.subject",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
 	bodyPage := utils.NewHTMLTemplate("signin_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.signin_change_email.body.title")
-	bodyPage.Html["Info"] = template.HTML(T("api.templates.singin_change_email.body.info",
+	bodyPage.Html["Info"] = template.HTML(T("api.templates.signin_change_email.body.info",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"], "Method": method}))
 
 	if err := utils.SendMail(email, subject, bodyPage.Render()); err != nil {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2192,11 +2192,11 @@
     "translation": "{{ .SiteName }} Team Setup"
   },
   {
-    "id": "api.templates.singin_change_email.body.info",
+    "id": "api.templates.signin_change_email.body.info",
     "translation": "You updated your sign-in method on {{ .SiteName }} to {{.Method}}.<br>If this change wasn't initiated by you, please contact your system administrator."
   },
   {
-    "id": "api.templates.singin_change_email.subject",
+    "id": "api.templates.signin_change_email.subject",
     "translation": "[{{ .SiteName }}] You updated your sign-in method on {{ .SiteName }}"
   },
   {


### PR DESCRIPTION
#### Summary
Corrected typos of `signup` in `app/email.go`. The localization file was also updated to correct the typo.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5670
https://github.com/mattermost/platform/issues/5557

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
