### PR TITLE
Add http_proxy support for http client

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -530,11 +530,11 @@ func getOpenGraphMetadata(c *Context, w http.ResponseWriter, r *http.Request) {
 	og := app.GetOpenGraphMetadata(url)
 
 	ogJSON, err := og.ToJSON()
+	openGraphDataCache.AddWithExpiresInSecs(props["url"], ogJSON, 3600) // Cache would expire after 1 hour
 	if err != nil {
 		w.Write([]byte(`{"url": ""}`))
 		return
 	}
 
-	openGraphDataCache.AddWithExpiresInSecs(props["url"], ogJSON, 3600) // Cache would expire after 1 houre
 	w.Write(ogJSON)
 }


### PR DESCRIPTION
- if `http_proxy` environment variable is set, respect it when creating http client
- otherwise initialize a http client with timeout settings

Fix https://github.com/mattermost/platform/issues/5522
