### PR TITLE
Fix deviceId string split problem when deviceId contains colon itself

### DIFF
--- a/model/push_notification.go
+++ b/model/push_notification.go
@@ -42,14 +42,13 @@ func (me *PushNotification) ToJson() string {
 	b, err := json.Marshal(me)
 	if err != nil {
 		return ""
-	} else {
-		return string(b)
 	}
+
+	return string(b)
 }
 
 func (me *PushNotification) SetDeviceIdAndPlatform(deviceId string) {
-
-	parts := strings.Split(deviceId, ":")
+	parts := strings.SplitN(deviceId, ":", 2)
 	if len(parts) == 2 {
 		me.Platform = parts[0]
 		me.DeviceId = parts[1]
@@ -62,7 +61,7 @@ func PushNotificationFromJson(data io.Reader) *PushNotification {
 	err := decoder.Decode(&me)
 	if err == nil {
 		return &me
-	} else {
-		return nil
 	}
+
+	return nil
 }


### PR DESCRIPTION
I have no idea how the `DeviceId` string in `Sessions` table generated, but we have some values like:
```
android:cjSh65Rtfzs:APA91bFjeoagQgUN5KT-WWSj-jOpthDlrW8XHeU1Jb2qv3hS7kfTfIvvqEwhI-Hu2SgVkd5JPyr3wlBjqUAXypsswEC4YrWLPlzDvLKCYtApWVPLAYvV-vl1Av7cOvgIgZo_sbmbi_2o
```

which contains more than one `:` in it, so 
```
strings.split()...
if len(parts)==2...
```
would not match the result string slice, this PR fixes the issue.