### PR TITLE
fix: notification duration "Unlimited" fixed

### DIFF
--- a/webapp/stores/notification_store.jsx
+++ b/webapp/stores/notification_store.jsx
@@ -97,7 +97,9 @@ class NotificationStoreClass extends EventEmitter {
             }
 
             let duration = Constants.DEFAULT_NOTIFICATION_DURATION;
-            if (user.notify_props && user.notify_props.desktop_duration) {
+            if (user.notify_props && (user.notify_props.desktop_duration === 0 || user.notify_props.desktop_duration === '0')) {
+                duration = 0;
+            } else if (user.notify_props && user.notify_props.desktop_duration) {
                 duration = parseInt(user.notify_props.desktop_duration, 10) * 1000;
             }
 


### PR DESCRIPTION
It did not work because value of Unlimited is stored as `0` and the if statement `user.notify_props && user.notify_props.desktop_duration` will implicitly be false hence it ends up using the value of `Constants.DEFAULT_NOTIFICATION_DURATION`.

#### Summary
Fix the "Unlimited" notification duration for Mattermost Desktop. Before this fix it did not work to choose the "Unlimited" option in the [Account Settings -> Notifications -> Notification duration]. It ended up hiding after a few (5) seconds. The other options (3 seconds, 5 seconds, 10 seconds), however, work as expected.

#### Ticket Link
None created

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
