### PR TITLE
Fix push notifications where channel is set to all activity

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -752,7 +752,13 @@ func DoesNotifyPropsAllowPushNotification(user *model.User, channelNotifyProps m
 
 	if channelNotify == model.USER_NOTIFY_NONE {
 		return false
-	} else if (userNotify == model.USER_NOTIFY_MENTION || channelNotify == model.CHANNEL_NOTIFY_MENTION) && !wasMentioned {
+	}
+
+	if channelNotify == model.CHANNEL_NOTIFY_MENTION && !wasMentioned {
+		return false
+	}
+
+	if userNotify == model.USER_NOTIFY_MENTION && (!ok || channelNotify == model.CHANNEL_NOTIFY_DEFAULT) && !wasMentioned {
 		return false
 	}
 

--- a/app/notification.go
+++ b/app/notification.go
@@ -258,8 +258,8 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 				status = &model.Status{UserId: id, Status: model.STATUS_OFFLINE, Manual: false, LastActivityAt: 0, ActiveChannel: ""}
 			}
 
-			if DoesStatusAllowPushNotification(profileMap[id], channelMemberNotifyPropsMap[id], status, post.ChannelId) {
-				sendPushNotification(post, profileMap[id], channel, senderName[id], channelMemberNotifyPropsMap[id], true)
+			if DoesStatusAllowPushNotification(profileMap[id], channelMemberNotifyPropsMap[id], true, status, post.ChannelId) {
+				sendPushNotification(post, profileMap[id], channel, senderName[id], true)
 			}
 		}
 
@@ -271,8 +271,8 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 					status = &model.Status{UserId: id, Status: model.STATUS_OFFLINE, Manual: false, LastActivityAt: 0, ActiveChannel: ""}
 				}
 
-				if DoesStatusAllowPushNotification(profileMap[id], channelMemberNotifyPropsMap[id], status, post.ChannelId) {
-					sendPushNotification(post, profileMap[id], channel, senderName[id], channelMemberNotifyPropsMap[id], false)
+				if DoesStatusAllowPushNotification(profileMap[id], channelMemberNotifyPropsMap[id], false, status, post.ChannelId) {
+					sendPushNotification(post, profileMap[id], channel, senderName[id], false)
 				}
 			}
 		}
@@ -456,21 +456,13 @@ func GetMessageForNotification(post *model.Post, translateFunc i18n.TranslateFun
 	}
 }
 
-func sendPushNotification(post *model.Post, user *model.User, channel *model.Channel, senderName string, channelNotifyProps model.StringMap, wasMentioned bool) *model.AppError {
+func sendPushNotification(post *model.Post, user *model.User, channel *model.Channel, senderName string, wasMentioned bool) *model.AppError {
 	sessions, err := getMobileAppSessions(user.Id)
 	if err != nil {
 		return err
 	}
 
 	var channelName string
-
-	if channelNotify, ok := channelNotifyProps[model.PUSH_NOTIFY_PROP]; ok {
-		if channelNotify == model.USER_NOTIFY_NONE {
-			return nil
-		} else if channelNotify == model.CHANNEL_NOTIFY_MENTION && !wasMentioned {
-			return nil
-		}
-	}
 
 	if channel.Type == model.CHANNEL_DIRECT {
 		channelName = senderName

--- a/app/notification.go
+++ b/app/notification.go
@@ -102,10 +102,10 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 
 		// find which users in the channel are set up to always receive mobile notifications
 		for _, profile := range profileMap {
-			if (profile.NotifyProps[model.PUSH_NOTIFY_PROP] == model.USER_NOTIFY_ALL &&
+			if (profile.NotifyProps[model.PUSH_NOTIFY_PROP] == model.USER_NOTIFY_ALL ||
+				channelMemberNotifyPropsMap[profile.Id][model.PUSH_NOTIFY_PROP] == model.CHANNEL_NOTIFY_ALL) &&
 				(post.UserId != profile.Id || post.Props["from_webhook"] == "true") &&
-				!post.IsSystemMessage()) ||
-				channelMemberNotifyPropsMap[profile.Id][model.PUSH_NOTIFY_PROP] == model.CHANNEL_NOTIFY_ALL {
+				!post.IsSystemMessage() {
 				allActivityPushUserIds = append(allActivityPushUserIds, profile.Id)
 			}
 		}

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -311,3 +311,293 @@ func TestGetMentionKeywords(t *testing.T) {
 		t.Fatal("should've mentioned user3 and user4 with @all")
 	}
 }
+
+func TestDoesNotifyPropsAllowPushNotification(t *testing.T) {
+	userNotifyProps := make(map[string]string)
+	channelNotifyProps := make(map[string]string)
+
+	user := &model.User{Id: model.NewId(), Email: "unit@test.com"}
+
+	post := &model.Post{UserId: user.Id, ChannelId: model.NewId()}
+
+	// When the post is a System Message
+	systemPost := &model.Post{UserId: user.Id, Type: model.POST_JOIN_CHANNEL}
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_ALL
+	user.NotifyProps = userNotifyProps
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, systemPost, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, systemPost, true) {
+		t.Fatal("Should have returned false")
+	}
+
+	// When default is ALL and no channel props is set
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned true")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// When default is MENTION and no channel props is set
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_MENTION
+	user.NotifyProps = userNotifyProps
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// When default is NONE and no channel props is set
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_NONE
+	user.NotifyProps = userNotifyProps
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned false")
+	}
+
+	// WHEN default is ALL and channel is DEFAULT
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_ALL
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_DEFAULT
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned true")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// WHEN default is MENTION and channel is DEFAULT
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_MENTION
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_DEFAULT
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// WHEN default is NONE and channel is DEFAULT
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_NONE
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_DEFAULT
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned false")
+	}
+
+	// WHEN default is ALL and channel is ALL
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_ALL
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_ALL
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned true")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// WHEN default is MENTION and channel is ALL
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_MENTION
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_ALL
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned true")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// WHEN default is NONE and channel is ALL
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_NONE
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_ALL
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned true")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// WHEN default is ALL and channel is MENTION
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_ALL
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_MENTION
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// WHEN default is MENTION and channel is MENTION
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_MENTION
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_MENTION
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// WHEN default is NONE and channel is MENTION
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_NONE
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_MENTION
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if !DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned true")
+	}
+
+	// WHEN default is ALL and channel is NONE
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_ALL
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_NONE
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned false")
+	}
+
+	// WHEN default is MENTION and channel is NONE
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_MENTION
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_NONE
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned false")
+	}
+
+	// WHEN default is NONE and channel is NONE
+	userNotifyProps[model.PUSH_NOTIFY_PROP] = model.USER_NOTIFY_NONE
+	user.NotifyProps = userNotifyProps
+	channelNotifyProps[model.PUSH_NOTIFY_PROP] = model.CHANNEL_NOTIFY_NONE
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, false) {
+		t.Fatal("Should have returned false")
+	}
+
+	if DoesNotifyPropsAllowPushNotification(user, channelNotifyProps, post, true) {
+		t.Fatal("Should have returned false")
+	}
+}
+
+func TestDoesStatusAllowPushNotification(t *testing.T) {
+	userNotifyProps := make(map[string]string)
+	userId := model.NewId()
+	channelId := model.NewId()
+
+	offline := &model.Status{UserId: userId, Status: model.STATUS_OFFLINE, Manual: false, LastActivityAt: 0, ActiveChannel: ""}
+	away := &model.Status{UserId: userId, Status: model.STATUS_AWAY, Manual: false, LastActivityAt: 0, ActiveChannel: ""}
+	online := &model.Status{UserId: userId, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: model.GetMillis(), ActiveChannel: ""}
+
+	userNotifyProps["push_status"] = model.STATUS_ONLINE
+	// WHEN props is ONLINE and user is offline
+	if !DoesStatusAllowPushNotification(userNotifyProps, offline, channelId) {
+		t.Fatal("Should have been true")
+	}
+
+	if !DoesStatusAllowPushNotification(userNotifyProps, offline, "") {
+		t.Fatal("Should have been true")
+	}
+
+	// WHEN props is ONLINE and user is away
+	if !DoesStatusAllowPushNotification(userNotifyProps, away, channelId) {
+		t.Fatal("Should have been true")
+	}
+
+	if !DoesStatusAllowPushNotification(userNotifyProps, away, "") {
+		t.Fatal("Should have been true")
+	}
+
+	// WHEN props is ONLINE and user is online
+	if !DoesStatusAllowPushNotification(userNotifyProps, online, channelId) {
+		t.Fatal("Should have been true")
+	}
+
+	if DoesStatusAllowPushNotification(userNotifyProps, online, "") {
+		t.Fatal("Should have been false")
+	}
+
+	userNotifyProps["push_status"] = model.STATUS_AWAY
+	// WHEN props is AWAY and user is offline
+	if !DoesStatusAllowPushNotification(userNotifyProps, offline, channelId) {
+		t.Fatal("Should have been true")
+	}
+
+	if !DoesStatusAllowPushNotification(userNotifyProps, offline, "") {
+		t.Fatal("Should have been true")
+	}
+
+	// WHEN props is AWAY and user is away
+	if !DoesStatusAllowPushNotification(userNotifyProps, away, channelId) {
+		t.Fatal("Should have been true")
+	}
+
+	if !DoesStatusAllowPushNotification(userNotifyProps, away, "") {
+		t.Fatal("Should have been true")
+	}
+
+	// WHEN props is AWAY and user is online
+	if DoesStatusAllowPushNotification(userNotifyProps, online, channelId) {
+		t.Fatal("Should have been false")
+	}
+
+	if DoesStatusAllowPushNotification(userNotifyProps, online, "") {
+		t.Fatal("Should have been false")
+	}
+
+	userNotifyProps["push_status"] = model.STATUS_OFFLINE
+	// WHEN props is AWAY and user is offline
+	if !DoesStatusAllowPushNotification(userNotifyProps, offline, channelId) {
+		t.Fatal("Should have been true")
+	}
+
+	if !DoesStatusAllowPushNotification(userNotifyProps, offline, "") {
+		t.Fatal("Should have been true")
+	}
+
+	// WHEN props is AWAY and user is away
+	if DoesStatusAllowPushNotification(userNotifyProps, away, channelId) {
+		t.Fatal("Should have been false")
+	}
+
+	if DoesStatusAllowPushNotification(userNotifyProps, away, "") {
+		t.Fatal("Should have been false")
+	}
+
+	// WHEN props is AWAY and user is online
+	if DoesStatusAllowPushNotification(userNotifyProps, online, channelId) {
+		t.Fatal("Should have been false")
+	}
+
+	if DoesStatusAllowPushNotification(userNotifyProps, online, "") {
+		t.Fatal("Should have been false")
+	}
+}

--- a/app/status.go
+++ b/app/status.go
@@ -236,10 +236,12 @@ func IsUserAway(lastActivityAt int64) bool {
 	return model.GetMillis()-lastActivityAt >= *utils.Cfg.TeamSettings.UserStatusAwayTimeout*1000
 }
 
-func DoesStatusAllowPushNotification(user *model.User, status *model.Status, channelId string) bool {
+func DoesStatusAllowPushNotification(user *model.User, channelNotifyProps model.StringMap, status *model.Status, channelId string) bool {
 	props := user.NotifyProps
 
-	if props["push"] == "none" {
+	if props[model.PUSH_NOTIFY_PROP] == model.USER_NOTIFY_NONE &&
+		(channelNotifyProps[model.PUSH_NOTIFY_PROP] == model.USER_NOTIFY_NONE ||
+		channelNotifyProps[model.PUSH_NOTIFY_PROP] == model.CHANNEL_NOTIFY_DEFAULT) {
 		return false
 	}
 

--- a/app/status.go
+++ b/app/status.go
@@ -236,12 +236,21 @@ func IsUserAway(lastActivityAt int64) bool {
 	return model.GetMillis()-lastActivityAt >= *utils.Cfg.TeamSettings.UserStatusAwayTimeout*1000
 }
 
-func DoesStatusAllowPushNotification(user *model.User, channelNotifyProps model.StringMap, status *model.Status, channelId string) bool {
+func DoesStatusAllowPushNotification(user *model.User, channelNotifyProps model.StringMap, wasMentioned bool, status *model.Status, channelId string) bool {
 	props := user.NotifyProps
 
+	channelNotify := ""
+	ok := false
+	if channelNotify, ok = channelNotifyProps[model.PUSH_NOTIFY_PROP]; ok {
+		if channelNotify == model.USER_NOTIFY_NONE {
+			return false
+		} else if channelNotify == model.CHANNEL_NOTIFY_MENTION && !wasMentioned {
+			return false
+		}
+	}
+
 	if props[model.PUSH_NOTIFY_PROP] == model.USER_NOTIFY_NONE &&
-		(channelNotifyProps[model.PUSH_NOTIFY_PROP] == model.USER_NOTIFY_NONE ||
-			channelNotifyProps[model.PUSH_NOTIFY_PROP] == model.CHANNEL_NOTIFY_DEFAULT) {
+		(!ok || channelNotify == model.CHANNEL_NOTIFY_DEFAULT) {
 		return false
 	}
 

--- a/app/status.go
+++ b/app/status.go
@@ -241,7 +241,7 @@ func DoesStatusAllowPushNotification(user *model.User, channelNotifyProps model.
 
 	if props[model.PUSH_NOTIFY_PROP] == model.USER_NOTIFY_NONE &&
 		(channelNotifyProps[model.PUSH_NOTIFY_PROP] == model.USER_NOTIFY_NONE ||
-		channelNotifyProps[model.PUSH_NOTIFY_PROP] == model.CHANNEL_NOTIFY_DEFAULT) {
+			channelNotifyProps[model.PUSH_NOTIFY_PROP] == model.CHANNEL_NOTIFY_DEFAULT) {
 		return false
 	}
 

--- a/app/status.go
+++ b/app/status.go
@@ -235,32 +235,3 @@ func GetStatus(userId string) (*model.Status, *model.AppError) {
 func IsUserAway(lastActivityAt int64) bool {
 	return model.GetMillis()-lastActivityAt >= *utils.Cfg.TeamSettings.UserStatusAwayTimeout*1000
 }
-
-func DoesStatusAllowPushNotification(user *model.User, channelNotifyProps model.StringMap, wasMentioned bool, status *model.Status, channelId string) bool {
-	props := user.NotifyProps
-
-	channelNotify := ""
-	ok := false
-	if channelNotify, ok = channelNotifyProps[model.PUSH_NOTIFY_PROP]; ok {
-		if channelNotify == model.USER_NOTIFY_NONE {
-			return false
-		} else if channelNotify == model.CHANNEL_NOTIFY_MENTION && !wasMentioned {
-			return false
-		}
-	}
-
-	if props[model.PUSH_NOTIFY_PROP] == model.USER_NOTIFY_NONE &&
-		(!ok || channelNotify == model.CHANNEL_NOTIFY_DEFAULT) {
-		return false
-	}
-
-	if pushStatus, ok := props["push_status"]; (pushStatus == model.STATUS_ONLINE || !ok) && (status.ActiveChannel != channelId || model.GetMillis()-status.LastActivityAt > model.STATUS_CHANNEL_TIMEOUT) {
-		return true
-	} else if pushStatus == model.STATUS_AWAY && (status.Status == model.STATUS_AWAY || status.Status == model.STATUS_OFFLINE) {
-		return true
-	} else if pushStatus == model.STATUS_OFFLINE && status.Status == model.STATUS_OFFLINE {
-		return true
-	}
-
-	return false
-}


### PR DESCRIPTION
#### Summary
This should fix the push notifications not being sent when: 
* The Notification global settings are set to something different than `all activity` and the channel is set to `all activity`
* The Notification global settings are set to something different than `never` and the channel setting is set to something else

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3193

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
