### PR TITLE
PLT-5479: Import Slack team without emails.

### DIFF
--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -155,6 +155,11 @@ func SlackAddUsers(teamId string, slackusers []SlackUser, log *bytes.Buffer) map
 		}
 
 		email := sUser.Profile["email"]
+		if email == "" {
+			email = sUser.Username + "@example.com"
+			log.WriteString(utils.T("api.slackimport.slack_add_users.missing_email_address", map[string]interface{}{"Email": email, "Username": sUser.Username}))
+			l4g.Warn(utils.T("api.slackimport.slack_add_users.missing_email_address.warn", map[string]interface{}{"Email": email, "Username": sUser.Username}))
+		}
 
 		password := model.NewId()
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1720,6 +1720,14 @@
     "translation": "Failed to add user to channel: {{.Username}}\r\n"
   },
   {
+    "id": "api.slackimport.slack_add_users.missing_email_address",
+    "translation": "User {{.Username}} does not have an email address in the Slack export. Using {{.Email}} as a placeholder. The user should update their email address once logged in to the system.\r\n"
+  },
+  {
+    "id": "api.slackimport.slack_add_users.missing_email_address.warn",
+    "translation": "User {{.Username}} does not have an email address in the Slack export. Using {{.Email}} as a placeholder. The user should update their email address once logged in to the system."
+  },
+  {
     "id": "api.slackimport.slack_add_channels.import_failed",
     "translation": "Failed to import: {{.DisplayName}}\r\n"
   },


### PR DESCRIPTION
#### Summary
Import Slack team without emails.

Use a fake email address for now, and inform the user doing the import
clearly that this has been done.

#### Ticket Link
#5528 
https://mattermost.atlassian.net/browse/PLT-5479

#### Checklist
- [x] Includes text changes and localization file updates
