### PR TITLE
PLT-5028 Close confirm_integration On Enter Keypress

### DIFF
--- a/webapp/components/integrations/components/confirm_integration.jsx
+++ b/webapp/components/integrations/components/confirm_integration.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import BackstageHeader from 'components/backstage/components/backstage_header.jsx';
 import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
-import {Link} from 'react-router/es6';
+import {Link, browserHistory} from 'react-router/es6';
 
 import UserStore from 'stores/user_store.jsx';
 import IntegrationStore from 'stores/integration_store.jsx';
@@ -25,6 +25,7 @@ export default class ConfirmIntegration extends React.Component {
         super(props);
 
         this.handleIntegrationChange = this.handleIntegrationChange.bind(this);
+        this.handleKeyPress = this.handleKeyPress.bind(this);
 
         const userId = UserStore.getCurrentId();
 
@@ -38,10 +39,12 @@ export default class ConfirmIntegration extends React.Component {
 
     componentDidMount() {
         IntegrationStore.addChangeListener(this.handleIntegrationChange);
+        window.addEventListener('keypress', this.handleKeyPress);
     }
 
     componentWillUnmount() {
         IntegrationStore.removeChangeListener(this.handleIntegrationChange);
+        window.removeEventListener('keypress', this.handleKeyPress);
     }
 
     handleIntegrationChange() {
@@ -51,6 +54,12 @@ export default class ConfirmIntegration extends React.Component {
             oauthApps: IntegrationStore.getOAuthApps(userId),
             loading: !IntegrationStore.hasReceivedOAuthApps(userId)
         });
+    }
+
+    handleKeyPress(e) {
+        if (e.key === 'Enter') {
+            browserHistory.push('/' + this.props.team.name + '/integrations/' + this.state.type);
+        }
     }
 
     render() {


### PR DESCRIPTION
#### Summary
Add an key event listener on the integrations confirmation dialog such that when the `Enter` key is pressed, it performs the same action as clicking the `Done` button.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5028
