### PR TITLE
Fixing issue with safari not closing RHS while in small mobile view

### DIFF
--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -315,7 +315,7 @@ export default class CreateComment extends React.Component {
     }
 
     handleFileUploadChange() {
-        this.focusTextbox(true);
+        this.focusTextbox();
     }
 
     handleUploadStart(clientIds) {


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/PLT-5664

Appears to be an issue with only Safari where setting the focus to the text box before the animation finishes cause the animation to stop.  This will partially revert PLT-5445 setting focus in the RHS when opening.