### PR TITLE
Fixing Link url when cancelling edit of incoming webhook

### DIFF
--- a/webapp/components/integrations/components/abstract_incoming_webhook.jsx
+++ b/webapp/components/integrations/components/abstract_incoming_webhook.jsx
@@ -215,7 +215,7 @@ export default class AbstractIncomingWebhook extends React.Component {
                             />
                             <Link
                                 className='btn btn-sm'
-                                to={`'/${this.props.team.name}/integrations/incoming_webhooks`}
+                                to={`/${this.props.team.name}/integrations/incoming_webhooks`}
                             >
                                 <FormattedMessage
                                     id='add_incoming_webhook.cancel'


### PR DESCRIPTION
#### Summary
The link to Cancel button on Edit of an Incoming Webhook is broken. This fixes it.

#### Checklist
- [x] Has UI changes