### PR TITLE
[PLT-5667] Automatically convert usernames to lowercase letters on sign in

### DIFF
--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -89,7 +89,7 @@ export default class LoginController extends React.Component {
         }
 
         // don't trim the password since we support spaces in passwords
-        loginId = loginId.trim();
+        loginId = loginId.trim().toLowerCase();
 
         if (!loginId) {
             // it's slightly weird to be constructing the message ID, but it's a bit nicer than triply nested if statements


### PR DESCRIPTION
#### Summary
Automatically convert usernames to lowercase letters on signin.
when you create a username like TEst123 and try to login on mattermost using Postgres as DB it is not possible since the username are stored as lower case.
using mysql this issue does not happen.


#### Ticket Link
GH - https://github.com/mattermost/platform/issues/5585#issuecomment-283716131
Jira - https://mattermost.atlassian.net/browse/PLT-5667
