### PR TITLE
Add Props field to Channel

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -30,20 +30,21 @@ const (
 )
 
 type Channel struct {
-	Id            string `json:"id"`
-	CreateAt      int64  `json:"create_at"`
-	UpdateAt      int64  `json:"update_at"`
-	DeleteAt      int64  `json:"delete_at"`
-	TeamId        string `json:"team_id"`
-	Type          string `json:"type"`
-	DisplayName   string `json:"display_name"`
-	Name          string `json:"name"`
-	Header        string `json:"header"`
-	Purpose       string `json:"purpose"`
-	LastPostAt    int64  `json:"last_post_at"`
-	TotalMsgCount int64  `json:"total_msg_count"`
-	ExtraUpdateAt int64  `json:"extra_update_at"`
-	CreatorId     string `json:"creator_id"`
+	Id            string    `json:"id"`
+	CreateAt      int64     `json:"create_at"`
+	UpdateAt      int64     `json:"update_at"`
+	DeleteAt      int64     `json:"delete_at"`
+	TeamId        string    `json:"team_id"`
+	Type          string    `json:"type"`
+	DisplayName   string    `json:"display_name"`
+	Name          string    `json:"name"`
+	Header        string    `json:"header"`
+	Purpose       string    `json:"purpose"`
+	LastPostAt    int64     `json:"last_post_at"`
+	TotalMsgCount int64     `json:"total_msg_count"`
+	ExtraUpdateAt int64     `json:"extra_update_at"`
+	CreatorId     string    `json:"creator_id"`
+	Props         StringMap `json:"props,omitempty"`
 }
 
 func (o *Channel) ToJson() string {
@@ -123,6 +124,10 @@ func (o *Channel) PreSave() {
 	o.CreateAt = GetMillis()
 	o.UpdateAt = o.CreateAt
 	o.ExtraUpdateAt = o.CreateAt
+	if o.Props == nil {
+		o.Props = make(map[string]string)
+	}
+
 }
 
 func (o *Channel) PreUpdate() {

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -66,6 +66,7 @@ func NewSqlChannelStore(sqlStore *SqlStore) ChannelStore {
 		table.ColMap("Header").SetMaxSize(1024)
 		table.ColMap("Purpose").SetMaxSize(250)
 		table.ColMap("CreatorId").SetMaxSize(26)
+		table.ColMap("Props").SetMaxSize(4000)
 
 		tablem := db.AddTableWithName(model.ChannelMember{}, "ChannelMembers").SetKeys(false, "ChannelId", "UserId")
 		tablem.ColMap("ChannelId").SetMaxSize(26)

--- a/store/sql_upgrade.go
+++ b/store/sql_upgrade.go
@@ -237,5 +237,6 @@ func UpgradeDatabaseToVersion37(sqlStore *SqlStore) {
 	// if shouldPerformUpgrade(sqlStore, VERSION_3_6_0, VERSION_3_7_0) {
 	// Add EditAt column to Posts
 	sqlStore.CreateColumnIfNotExists("Posts", "EditAt", " bigint", " bigint", "0")
+	sqlStore.CreateColumnIfNotExists("Channels", "Props", "varchar(4000)", "varchar(4000)", "{}")
 	// }
 }


### PR DESCRIPTION
To allow the storage of arbitrary metadata on a channel, this adds the
Props field, which is a map of names to values.

This is useful to enable application specific functionality, such as
storing a dynamic channel priority or sort order.