### PR TITLE
enable saml for RN app

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -1451,7 +1451,14 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, c.GetSiteURL()+val, http.StatusFound)
 			return
 		}
-		http.Redirect(w, r, app.GetProtocol(r)+"://"+r.Host, http.StatusFound)
+
+		if action == "mobile" {
+			user.Sanitize(map[string]bool{})
+
+			w.Write([]byte(""))
+		} else {
+			http.Redirect(w, r, app.GetProtocol(r)+"://"+r.Host, http.StatusFound)
+		}
 	}
 }
 

--- a/api/user.go
+++ b/api/user.go
@@ -1453,8 +1453,6 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		if action == "mobile" {
-			user.Sanitize(map[string]bool{})
-
 			w.Write([]byte(""))
 		} else {
 			http.Redirect(w, r, app.GetProtocol(r)+"://"+r.Host, http.StatusFound)


### PR DESCRIPTION
#### Summary
This PR enables SAML to be used in RN by setting an action we get a response instead of a redirect, allowing the app to take control
