### PR TITLE
PLT-5037 Remove Back Link on Team Creation Page

### DIFF
--- a/webapp/components/create_team/components/display_name.jsx
+++ b/webapp/components/create_team/components/display_name.jsx
@@ -10,7 +10,6 @@ import logoImage from 'images/logo.png';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Link} from 'react-router/es6';
 import {FormattedMessage} from 'react-intl';
 
 export default class TeamSignupDisplayNamePage extends React.Component {
@@ -118,14 +117,6 @@ export default class TeamSignupDisplayNamePage extends React.Component {
                             defaultMessage='Next'
                         /><i className='fa fa-chevron-right'/>
                     </button>
-                    <div className='margin--extra'>
-                        <Link to='/select_team'>
-                            <FormattedMessage
-                                id='create_team.display_name.back'
-                                defaultMessage='Back to previous step'
-                            />
-                        </Link>
-                    </div>
                 </form>
             </div>
         );

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1212,7 +1212,6 @@
   "create_post.tutorialTip": "<h4>Sending Messages</h4><p>Type here to write a message and press <strong>ENTER</strong> to post it.</p><p>Click the <strong>Attachment</strong> button to upload an image or a file.</p>",
   "create_post.write": "Write a message...",
   "create_team.agreement": "By proceeding to create your account and use {siteName}, you agree to our <a href={TermsOfServiceLink}>Terms of Service</a> and <a href={PrivacyPolicyLink}>Privacy Policy</a>. If you do not agree, you cannot use {siteName}.",
-  "create_team.display_name.back": "Back to previous step",
   "create_team.display_name.charLength": "Name must be {min} or more characters up to a maximum of {max}. You can add a longer team description later.",
   "create_team.display_name.nameHelp": "Name your team in any language. Your team name shows in menus and headings.",
   "create_team.display_name.next": "Next",


### PR DESCRIPTION
#### Summary
Remove the `Back to previous step` link on the Team Creation page. This link is unnecessary as the `back` button accomplishes all the functionality that that link had.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5037

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates