### PR TITLE
Fix - PLT-5723 /msg command opens a new tab

### DIFF
--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -133,7 +133,7 @@ export default class CreatePost extends React.Component {
                     }
 
                     if (data.goto_location && data.goto_location.length > 0) {
-                        if (data.goto_location.startsWith('/')) {
+                        if (data.goto_location.startsWith('/') || data.goto_location.includes(window.location.hostname)) {
                             browserHistory.push(data.goto_location);
                         } else {
                             window.open(data.goto_location);


### PR DESCRIPTION
#### Summary
PLT-5723 /msg command opens a new tab

When fixing the issue for this PR - https://github.com/mattermost/platform/pull/5507 was introduced a bug for an internal slash command called /msg.

The idea for this is when the goto_location contains an URL starting with / or with an URL that is the same hostname as the mattermost server, it should open in the same tab, which means open a channel.
When the goto_location come with an external URL (eg. http://www.mattermost.org or http://www.google.com) it should open this link in another tab and maintain the mattermost app opened.

@jasonblais I did some tests and for me was ok (also test the custom slash commands, same for the PR #5507)

Please retest the custom commands and the msg command.

please let me know when the test server are up and running then I can also test there and not on my machine :)

#### Ticket Link
Jira - https://mattermost.atlassian.net/browse/PLT-5723

