### PR TITLE
Websocket CORS Support

### DIFF
--- a/api/websocket.go
+++ b/api/websocket.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -25,8 +26,9 @@ func connect(c *Context, w http.ResponseWriter, r *http.Request) {
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:  SOCKET_MAX_MESSAGE_SIZE_KB,
 		WriteBufferSize: SOCKET_MAX_MESSAGE_SIZE_KB,
-		CheckOrigin: func(r *http.Request) bool {
-			return true
+		CheckOrigin:     func (r *http.Request) bool {
+			origin := r.Header.Get("Origin")
+			return *utils.Cfg.ServiceSettings.AllowCorsFrom == "*" || strings.Contains(*utils.Cfg.ServiceSettings.AllowCorsFrom, origin)
 		},
 	}
 

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -22,14 +22,24 @@ func InitWebSocket() {
 	HubStart()
 }
 
+type OriginCheckerProc func(*http.Request) bool
+	
+func OriginChecker(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	return *utils.Cfg.ServiceSettings.AllowCorsFrom == "*" || strings.Contains(*utils.Cfg.ServiceSettings.AllowCorsFrom, origin)
+}
+
 func connect(c *Context, w http.ResponseWriter, r *http.Request) {
+	
+	var originChecker OriginCheckerProc = nil
+	if len(*utils.Cfg.ServiceSettings.AllowCorsFrom) > 0 {
+		originChecker = OriginChecker
+	}
+
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:  SOCKET_MAX_MESSAGE_SIZE_KB,
 		WriteBufferSize: SOCKET_MAX_MESSAGE_SIZE_KB,
-		CheckOrigin:     func (r *http.Request) bool {
-			origin := r.Header.Get("Origin")
-			return *utils.Cfg.ServiceSettings.AllowCorsFrom == "*" || strings.Contains(*utils.Cfg.ServiceSettings.AllowCorsFrom, origin)
-		},
+		CheckOrigin:     originChecker,
 	}
 
 	ws, err := upgrader.Upgrade(w, r, nil)


### PR DESCRIPTION
Honor 'AllowCorsFrom' config setting when upgrading HTTP sockets to web sockets.

#### Ticket Link
NONE

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [X ] Touches critical sections of the codebase (auth, upgrade, etc.)
