### PR TITLE
PLT-5722 Fix formatText to fail gracefully when input is not text

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -17,7 +17,7 @@
     "intl": "1.2.5",
     "jasny-bootstrap": "3.1.3",
     "jquery": "3.1.1",
-    "marked": "mattermost/marked#328857681dcc98a3d75633d6c0effa7c29b6cceb",
+    "marked": "mattermost/marked#8f5902fff9bad793cd6c66e0c44002c9e79e1317",
     "match-at": "0.1.0",
     "object-assign": "4.1.1",
     "pdfjs-dist": "1.7.235",

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -30,6 +30,10 @@ const cjkPattern = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-
 //      links to the relevant channel.
 // - team - The current team.
 export function formatText(text, inputOptions) {
+    if (!text || typeof text !== 'string') {
+        return '';
+    }
+
     let output = text;
 
     const options = Object.assign({}, inputOptions);


### PR DESCRIPTION
I haven't confirmed 100% that this fixes the reported issue as I was not able to get it to reproduce, but I'm almost certain the cause of their issue was that the Gitlab slash commands were sending non-string values for a parameter that expected to be a string. I think there's also some changes in the server code preventing this as well, but it's better to be extra safe.

Also, I took out the disclaimer that the markdown parser added to errors to report it to their repository since any errors are usually from our code.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5722
https://github.com/mattermost/platform/issues/5520
https://github.com/mattermost/platform/issues/5538
https://gitlab.com/gitlab-org/gitlab-mattermost/issues/99
https://gitlab.com/gitlab-org/gitlab-ce/issues/28640