### PR TITLE
PLT-5269 Remove Blue Bar From Link Previews

### DIFF
--- a/webapp/sass/layout/_webhooks.scss
+++ b/webapp/sass/layout/_webhooks.scss
@@ -72,6 +72,9 @@
                 border-left-color: #e40303;
             }
             &.attachment__container--opengraph {
+                padding-left: 5px;
+                border-left-style: none;
+                border-left-color: transparent;
                 display: table;
                 table-layout: fixed;
                 width: 100%;


### PR DESCRIPTION
#### Summary
Removed the blue bar from link previews. The bar is still shown for incoming webhook attachments.

#### Ticket Link
https://github.com/mattermost/platform/issues/5466
https://mattermost.atlassian.net/browse/PLT-5269

#### Checklist
- [x] Has UI changes