### PR TITLE
PLT-5746 Add sync logic for DMs/GMs when network reconnects

### DIFF
--- a/webapp/actions/channel_actions.jsx
+++ b/webapp/actions/channel_actions.jsx
@@ -9,14 +9,14 @@ import ChannelStore from 'stores/channel_store.jsx';
 import * as ChannelUtils from 'utils/channel_utils.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 
-import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
+import {loadProfilesForSidebar, loadNewDMIfNeeded, loadNewGMIfNeeded} from 'actions/user_actions.jsx';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 
 import Client from 'client/web_client.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
-import {Preferences, ActionTypes} from 'utils/constants.jsx';
+import {Constants, Preferences, ActionTypes} from 'utils/constants.jsx';
 
 import {browserHistory} from 'react-router/es6';
 
@@ -283,8 +283,29 @@ export function unmarkFavorite(channelId) {
 }
 
 export function loadChannelsForCurrentUser() {
-    AsyncClient.getChannels();
-    AsyncClient.getMyChannelMembers();
+    AsyncClient.getChannels().then(() => {
+        AsyncClient.getMyChannelMembers().then(() => {
+            loadDMsAndGMsForUnreads();
+        });
+    });
+}
+
+export function loadDMsAndGMsForUnreads() {
+    const unreads = ChannelStore.getUnreadCounts();
+    for (const id in unreads) {
+        if (!unreads.hasOwnProperty(id)) {
+            continue;
+        }
+
+        if (unreads[id].msgs > 0 || unreads[id].mentions > 0) {
+            const channel = ChannelStore.get(id);
+            if (channel && channel.type === Constants.DM_CHANNEL) {
+                loadNewDMIfNeeded(Utils.getUserIdFromChannelName(channel));
+            } else if (channel && channel.type === Constants.GM_CHANNEL) {
+                loadNewGMIfNeeded(channel.id);
+            }
+        }
+    }
 }
 
 export function joinChannel(channel, success, error) {

--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -46,10 +46,10 @@ export function emitChannelClickEvent(channel) {
     }
     function switchToChannel(chan) {
         const channelMember = ChannelStore.getMyMember(chan.id);
-        const getMyChannelMembersPromise = AsyncClient.getChannelMember(chan.id, UserStore.getCurrentId());
+        const getMyChannelMemberPromise = AsyncClient.getChannelMember(chan.id, UserStore.getCurrentId());
         const oldChannelId = ChannelStore.getCurrentId();
 
-        getMyChannelMembersPromise.then(() => {
+        getMyChannelMemberPromise.then(() => {
             AsyncClient.getChannelStats(chan.id, true);
             AsyncClient.viewChannel(chan.id, oldChannelId);
             loadPosts(chan.id);

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -89,6 +89,26 @@ export function reconnect(includeWebSocket = true) {
     ErrorStore.emitChange();
 }
 
+let intervalId = '';
+const SYNC_INTERVAL_MILLISECONDS = 1000 * 60 * 15; // 15 minutes
+
+export function startPeriodicSync() {
+    clearInterval(intervalId);
+
+    intervalId = setInterval(
+        () => {
+            if (UserStore.getCurrentUser() != null) {
+                reconnect(false);
+            }
+        },
+        SYNC_INTERVAL_MILLISECONDS
+    );
+}
+
+export function stopPeriodicSync() {
+    clearInterval(intervalId);
+}
+
 function handleFirstConnect() {
     ErrorStore.clearLastError();
     ErrorStore.emitChange();

--- a/webapp/components/needs_team.jsx
+++ b/webapp/components/needs_team.jsx
@@ -14,6 +14,8 @@ import PreferenceStore from 'stores/preference_store.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
 import {startPeriodicStatusUpdates, stopPeriodicStatusUpdates} from 'actions/status_actions.jsx';
+import {startPeriodicSync, stopPeriodicSync} from 'actions/websocket_actions.jsx';
+
 import Constants from 'utils/constants.jsx';
 const TutorialSteps = Constants.TutorialSteps;
 const Preferences = Constants.Preferences;
@@ -94,6 +96,7 @@ export default class NeedsTeam extends React.Component {
         GlobalActions.viewLoggedIn();
 
         startPeriodicStatusUpdates();
+        startPeriodicSync();
 
         // Set up tracking for whether the window is active
         window.isActive = true;
@@ -140,6 +143,7 @@ export default class NeedsTeam extends React.Component {
             iNoBounce.disable();
         }
         stopPeriodicStatusUpdates();
+        stopPeriodicSync();
     }
 
     render() {

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -64,26 +64,31 @@ export function checkVersion() {
 }
 
 export function getChannels() {
-    if (isCallInProgress('getChannels')) {
-        return null;
-    }
-
-    callTracker.getChannels = utils.getTimestamp();
-
-    return Client.getChannels(
-        (data) => {
-            callTracker.getChannels = 0;
-
-            AppDispatcher.handleServerAction({
-                type: ActionTypes.RECEIVED_CHANNELS,
-                channels: data
-            });
-        },
-        (err) => {
-            callTracker.getChannels = 0;
-            dispatchError(err, 'getChannels');
+    return new Promise((resolve, reject) => {
+        if (isCallInProgress('getChannels')) {
+            resolve();
+            return;
         }
-    );
+
+        callTracker.getChannels = utils.getTimestamp();
+
+        Client.getChannels(
+            (data) => {
+                callTracker.getChannels = 0;
+
+                AppDispatcher.handleServerAction({
+                    type: ActionTypes.RECEIVED_CHANNELS,
+                    channels: data
+                });
+                resolve();
+            },
+            (err) => {
+                callTracker.getChannels = 0;
+                dispatchError(err, 'getChannels');
+                reject();
+            }
+        );
+    });
 }
 
 export function getChannel(id) {
@@ -130,7 +135,7 @@ export function getMyChannelMembers() {
                 resolve();
             },
             (err) => {
-                callTracker.getChannelsUnread = 0;
+                callTracker.getMyChannelMembers = 0;
                 dispatchError(err, 'getMyChannelMembers');
                 reject();
             }


### PR DESCRIPTION
#### Summary
* Add sync logic for DMs/GMs when network reconnects
* Add 15 minute sync interval for reconnect logic (temporary solution for 3.7 to catch any missed events due to network issues that don't trigger the reconnect logic)
* Fix bug where `AsyncClient.getMyChannelMembers` could get blocked on making requests

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5746