### PR TITLE
PLT-5765 Passed SiteURL to SendNotifications

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -152,7 +152,7 @@ func (me *TestHelper) CreateUser(client *model.Client) *model.User {
 func LinkUserToTeam(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	err := app.JoinUserToTeam(team, user)
+	err := app.JoinUserToTeam(team, user, utils.GetSiteURL())
 	if err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()

--- a/api/channel.go
+++ b/api/channel.go
@@ -206,7 +206,7 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		if oldChannelDisplayName != channel.DisplayName {
-			if err := app.PostUpdateChannelDisplayNameMessage(c.Session.UserId, channel.Id, c.TeamId, oldChannelDisplayName, channel.DisplayName); err != nil {
+			if err := app.PostUpdateChannelDisplayNameMessage(c.Session.UserId, channel.Id, c.TeamId, oldChannelDisplayName, channel.DisplayName, c.GetSiteURL()); err != nil {
 				l4g.Error(err.Error())
 			}
 		}
@@ -254,7 +254,7 @@ func updateChannelHeader(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	} else {
-		if err := app.PostUpdateChannelHeaderMessage(c.Session.UserId, channel.Id, c.TeamId, oldChannelHeader, channelHeader); err != nil {
+		if err := app.PostUpdateChannelHeaderMessage(c.Session.UserId, channel.Id, c.TeamId, oldChannelHeader, channelHeader, c.GetSiteURL()); err != nil {
 			l4g.Error(err.Error())
 		}
 		c.LogAudit("name=" + channel.Name)
@@ -300,7 +300,7 @@ func updateChannelPurpose(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	} else {
-		if err := app.PostUpdateChannelPurposeMessage(c.Session.UserId, channel.Id, c.TeamId, oldChannelPurpose, channelPurpose); err != nil {
+		if err := app.PostUpdateChannelPurposeMessage(c.Session.UserId, channel.Id, c.TeamId, oldChannelPurpose, channelPurpose, c.GetSiteURL()); err != nil {
 			l4g.Error(err.Error())
 		}
 		c.LogAudit("name=" + channel.Name)
@@ -411,7 +411,7 @@ func join(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err = app.JoinChannel(channel, c.Session.UserId); err != nil {
+	if err = app.JoinChannel(channel, c.Session.UserId, c.GetSiteURL()); err != nil {
 		c.Err = err
 		return
 	}
@@ -424,7 +424,7 @@ func leave(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	id := params["channel_id"]
 
-	err := app.LeaveChannel(id, c.Session.UserId)
+	err := app.LeaveChannel(id, c.Session.UserId, c.GetSiteURL())
 	if err != nil {
 		c.Err = err
 		return
@@ -466,7 +466,7 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	err = app.DeleteChannel(channel, c.Session.UserId)
+	err = app.DeleteChannel(channel, c.Session.UserId, c.GetSiteURL())
 	if err != nil {
 		c.Err = err
 		return
@@ -647,7 +647,7 @@ func addMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go app.PostAddToChannelMessage(oUser, nUser, channel)
+	go app.PostAddToChannelMessage(oUser, nUser, channel, c.GetSiteURL())
 
 	app.UpdateChannelLastViewedAt([]string{id}, oUser.Id)
 	w.Write([]byte(cm.ToJson()))
@@ -682,7 +682,7 @@ func removeMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = app.RemoveUserFromChannel(userIdToRemove, c.Session.UserId, channel); err != nil {
+	if err = app.RemoveUserFromChannel(userIdToRemove, c.Session.UserId, channel, c.GetSiteURL()); err != nil {
 		c.Err = err
 		return
 	}

--- a/api/command.go
+++ b/api/command.go
@@ -251,7 +251,7 @@ func handleResponse(c *Context, w http.ResponseWriter, response *model.CommandRe
 		}
 	}
 
-	if _, err := app.CreateCommandPost(post, c.TeamId, response); err != nil {
+	if _, err := app.CreateCommandPost(post, c.TeamId, response, c.GetSiteURL()); err != nil {
 		l4g.Error(err.Error())
 	}
 

--- a/api/command_echo.go
+++ b/api/command_echo.go
@@ -88,7 +88,7 @@ func (me *EchoProvider) DoCommand(c *Context, args *model.CommandArgs, message s
 
 		time.Sleep(time.Duration(delay) * time.Second)
 
-		if _, err := app.CreatePost(post, c.TeamId, true); err != nil {
+		if _, err := app.CreatePost(post, c.TeamId, true, c.GetSiteURL()); err != nil {
 			l4g.Error(c.T("api.command_echo.create.app_error"), err)
 		}
 	}()

--- a/api/command_join.go
+++ b/api/command_join.go
@@ -45,7 +45,7 @@ func (me *JoinProvider) DoCommand(c *Context, args *model.CommandArgs, message s
 				return &model.CommandResponse{Text: c.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 
-			if err := app.JoinChannel(channel, c.Session.UserId); err != nil {
+			if err := app.JoinChannel(channel, c.Session.UserId, c.GetSiteURL()); err != nil {
 				return &model.CommandResponse{Text: c.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 

--- a/api/command_loadtest.go
+++ b/api/command_loadtest.go
@@ -359,7 +359,7 @@ func (me *LoadTestProvider) UrlCommand(c *Context, channelId string, message str
 		post.ChannelId = channelId
 		post.UserId = c.Session.UserId
 
-		if _, err := app.CreatePost(post, c.TeamId, false); err != nil {
+		if _, err := app.CreatePost(post, c.TeamId, false, c.GetSiteURL()); err != nil {
 			return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 	}
@@ -398,7 +398,7 @@ func (me *LoadTestProvider) JsonCommand(c *Context, channelId string, message st
 		post.Message = message
 	}
 
-	if _, err := app.CreatePost(post, c.TeamId, false); err != nil {
+	if _, err := app.CreatePost(post, c.TeamId, false, c.GetSiteURL()); err != nil {
 		return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 	return &model.CommandResponse{Text: "Loaded data", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}

--- a/api/command_msg.go
+++ b/api/command_msg.go
@@ -86,7 +86,7 @@ func (me *msgProvider) DoCommand(c *Context, args *model.CommandArgs, message st
 		post.Message = parsedMessage
 		post.ChannelId = targetChannelId
 		post.UserId = c.Session.UserId
-		if _, err := app.CreatePost(post, c.TeamId, true); err != nil {
+		if _, err := app.CreatePost(post, c.TeamId, true, c.GetSiteURL()); err != nil {
 			return &model.CommandResponse{Text: c.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 	}

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -285,7 +285,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		action := props["action"]
 		switch action {
 		case model.OAUTH_ACTION_SIGNUP:
-			if user, err := app.CreateOAuthUser(service, body, teamId); err != nil {
+			if user, err := app.CreateOAuthUser(service, body, teamId, c.GetSiteURL()); err != nil {
 				c.Err = err
 			} else {
 				doLogin(c, w, r, user, "")
@@ -297,7 +297,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		case model.OAUTH_ACTION_LOGIN:
 			user := LoginByOAuth(c, w, r, service, body)
 			if len(teamId) > 0 {
-				c.Err = app.AddUserToTeamByTeamId(teamId, user)
+				c.Err = app.AddUserToTeamByTeamId(teamId, user, c.GetSiteURL())
 			}
 			if c.Err == nil {
 				if val, ok := props["redirect_to"]; ok {

--- a/api/post.go
+++ b/api/post.go
@@ -58,7 +58,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 		post.CreateAt = 0
 	}
 
-	rp, err := app.CreatePostAsUser(post)
+	rp, err := app.CreatePostAsUser(post, c.GetSiteURL())
 	if err != nil {
 		c.Err = err
 		return
@@ -284,7 +284,7 @@ func getPermalinkTmp(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if list, err := app.GetPermalinkPost(postId, c.Session.UserId); err != nil {
+	if list, err := app.GetPermalinkPost(postId, c.Session.UserId, c.GetSiteURL()); err != nil {
 		c.Err = err
 		return
 	} else if HandleEtag(list.Etag(), "Get Permalink TMP", w, r) {

--- a/api/team.go
+++ b/api/team.go
@@ -61,7 +61,7 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rteam, err := app.CreateTeamWithUser(team, c.Session.UserId)
+	rteam, err := app.CreateTeamWithUser(team, c.Session.UserId, c.GetSiteURL())
 	if err != nil {
 		c.Err = err
 		return
@@ -153,7 +153,7 @@ func addUserToTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := app.AddUserToTeam(c.TeamId, userId); err != nil {
+	if _, err := app.AddUserToTeam(c.TeamId, userId, c.GetSiteURL()); err != nil {
 		c.Err = err
 		return
 	}
@@ -195,9 +195,9 @@ func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request)
 	var err *model.AppError
 
 	if len(hash) > 0 {
-		team, err = app.AddUserToTeamByHash(c.Session.UserId, hash, data)
+		team, err = app.AddUserToTeamByHash(c.Session.UserId, hash, data, c.GetSiteURL())
 	} else if len(inviteId) > 0 {
-		team, err = app.AddUserToTeamByInviteId(inviteId, c.Session.UserId)
+		team, err = app.AddUserToTeamByInviteId(inviteId, c.Session.UserId, c.GetSiteURL())
 	} else {
 		c.Err = model.NewLocAppError("addUserToTeamFromInvite", "api.user.create_user.signup_link_invalid.app_error", nil, "")
 		return

--- a/api/user.go
+++ b/api/user.go
@@ -89,7 +89,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	var ruser *model.User
 	var err *model.AppError
 	if len(hash) > 0 {
-		ruser, err = app.CreateUserWithHash(user, hash, r.URL.Query().Get("d"))
+		ruser, err = app.CreateUserWithHash(user, hash, r.URL.Query().Get("d"), c.GetSiteURL())
 	} else if len(inviteId) > 0 {
 		ruser, err = app.CreateUserWithInviteId(user, inviteId, c.GetSiteURL())
 	} else {
@@ -158,7 +158,7 @@ func LoginByOAuth(c *Context, w http.ResponseWriter, r *http.Request, service st
 	var err *model.AppError
 	if user, err = app.GetUserByAuth(&authData, service); err != nil {
 		if err.Id == store.MISSING_AUTH_ACCOUNT_ERROR {
-			if user, err = app.CreateOAuthUser(service, bytes.NewReader(buf.Bytes()), ""); err != nil {
+			if user, err = app.CreateOAuthUser(service, bytes.NewReader(buf.Bytes()), "", c.GetSiteURL()); err != nil {
 				c.Err = err
 				return nil
 			}
@@ -1411,7 +1411,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 		relayProps = model.MapFromJson(strings.NewReader(stateStr))
 	}
 
-	if user, err := samlInterface.DoLogin(encodedXML, relayProps); err != nil {
+	if user, err := samlInterface.DoLogin(encodedXML, relayProps, c.GetSiteURL()); err != nil {
 		c.Err = err
 		c.Err.StatusCode = http.StatusFound
 		return

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -374,7 +374,7 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	parsedRequest := model.IncomingWebhookRequestFromJson(payload)
 
-	err := app.HandleIncomingWebhook(id, parsedRequest)
+	err := app.HandleIncomingWebhook(id, parsedRequest, c.GetSiteURL())
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -296,7 +296,7 @@ func (me *TestHelper) UpdateActiveUser(user *model.User, active bool) {
 func LinkUserToTeam(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	err := app.JoinUserToTeam(team, user)
+	err := app.JoinUserToTeam(team, user, utils.GetSiteURL())
 	if err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -298,7 +298,7 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = app.RemoveUserFromChannel(c.Params.UserId, c.Session.UserId, channel); err != nil {
+	if err = app.RemoveUserFromChannel(c.Params.UserId, c.Session.UserId, channel, c.GetSiteURL()); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/post.go
+++ b/api4/post.go
@@ -45,7 +45,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 		post.CreateAt = 0
 	}
 
-	rp, err := app.CreatePostAsUser(post)
+	rp, err := app.CreatePostAsUser(post, c.GetSiteURL())
 	if err != nil {
 		c.Err = err
 		return
@@ -224,4 +224,3 @@ func getFileInfosForPost(c *Context, w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(model.FileInfosToJson(infos)))
 	}
 }
-

--- a/api4/team.go
+++ b/api4/team.go
@@ -41,7 +41,7 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rteam, err := app.CreateTeamWithUser(team, c.Session.UserId)
+	rteam, err := app.CreateTeamWithUser(team, c.Session.UserId, c.GetSiteURL())
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/user.go
+++ b/api4/user.go
@@ -59,7 +59,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	var ruser *model.User
 	var err *model.AppError
 	if len(hash) > 0 {
-		ruser, err = app.CreateUserWithHash(user, hash, r.URL.Query().Get("d"))
+		ruser, err = app.CreateUserWithHash(user, hash, r.URL.Query().Get("d"), c.GetSiteURL())
 	} else if len(inviteId) > 0 {
 		ruser, err = app.CreateUserWithInviteId(user, inviteId, c.GetSiteURL())
 	} else {

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -161,7 +161,7 @@ func (me *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
-	if post, err = CreatePost(post, channel.TeamId, false); err != nil {
+	if post, err = CreatePost(post, channel.TeamId, false, utils.GetSiteURL()); err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()
 		time.Sleep(time.Second)
@@ -174,7 +174,7 @@ func (me *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 func LinkUserToTeam(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	err := JoinUserToTeam(team, user)
+	err := JoinUserToTeam(team, user, utils.GetSiteURL())
 	if err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()

--- a/app/command.go
+++ b/app/command.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mattermost/platform/model"
 )
 
-func CreateCommandPost(post *model.Post, teamId string, response *model.CommandResponse) (*model.Post, *model.AppError) {
+func CreateCommandPost(post *model.Post, teamId string, response *model.CommandResponse, siteURL string) (*model.Post, *model.AppError) {
 	post.Message = parseSlackLinksToMarkdown(response.Text)
 	post.CreateAt = model.GetMillis()
 
@@ -17,7 +17,7 @@ func CreateCommandPost(post *model.Post, teamId string, response *model.CommandR
 
 	switch response.ResponseType {
 	case model.COMMAND_RESPONSE_TYPE_IN_CHANNEL:
-		return CreatePost(post, teamId, true)
+		return CreatePost(post, teamId, true, siteURL)
 	case model.COMMAND_RESPONSE_TYPE_EPHEMERAL:
 		if response.Text == "" {
 			return post, nil

--- a/app/import.go
+++ b/app/import.go
@@ -865,7 +865,7 @@ func OldImportUser(team *model.Team, user *model.User) *model.User {
 			l4g.Error(utils.T("api.import.import_user.set_email.error"), cresult.Err)
 		}
 
-		if err := JoinUserToTeam(team, user); err != nil {
+		if err := JoinUserToTeam(team, user, utils.GetSiteURL()); err != nil {
 			l4g.Error(utils.T("api.import.import_user.join_team.error"), err)
 		}
 

--- a/app/notification.go
+++ b/app/notification.go
@@ -24,7 +24,7 @@ import (
 	"github.com/nicksnyder/go-i18n/i18n"
 )
 
-func SendNotifications(post *model.Post, team *model.Team, channel *model.Channel, sender *model.User) ([]string, *model.AppError) {
+func SendNotifications(post *model.Post, team *model.Team, channel *model.Channel, sender *model.User, siteURL string) ([]string, *model.AppError) {
 	pchan := Srv.Store.User().GetAllProfilesInChannel(channel.Id, true)
 	cmnchan := Srv.Store.Channel().GetAllChannelMembersNotifyPropsForChannel(channel.Id, true)
 	var fchan store.StoreChannel
@@ -171,7 +171,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 			}
 
 			if userAllowsEmails && status.Status != model.STATUS_ONLINE && profileMap[id].DeleteAt == 0 {
-				sendNotificationEmail(post, profileMap[id], channel, team, senderName, sender)
+				sendNotificationEmail(post, profileMap[id], channel, team, senderName, sender, siteURL)
 			}
 		}
 	}
@@ -317,7 +317,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 	return mentionedUsersList, nil
 }
 
-func sendNotificationEmail(post *model.Post, user *model.User, channel *model.Channel, team *model.Team, senderName string, sender *model.User) *model.AppError {
+func sendNotificationEmail(post *model.Post, user *model.User, channel *model.Channel, team *model.Team, senderName string, sender *model.User, siteURL string) *model.AppError {
 	if channel.IsGroupOrDirect() && channel.TeamId != team.Id {
 		// this message is a cross-team DM/GM so we need to find a team that the recipient is on to use in the link
 		if result := <-Srv.Store.Team().GetTeamsByUserId(user.Id); result.Err != nil {
@@ -368,7 +368,7 @@ func sendNotificationEmail(post *model.Post, user *model.User, channel *model.Ch
 	var mailTemplate string
 	var mailParameters map[string]interface{}
 
-	teamURL := utils.GetSiteURL() + "/" + team.Name
+	teamURL := siteURL + "/" + team.Name
 	tm := time.Unix(post.CreateAt/1000, 0)
 
 	userLocale := utils.GetUserTranslations(user.Locale)
@@ -406,7 +406,7 @@ func sendNotificationEmail(post *model.Post, user *model.User, channel *model.Ch
 	subject := fmt.Sprintf("[%v] %v", utils.Cfg.TeamSettings.SiteName, userLocale(mailTemplate, mailParameters))
 
 	bodyPage := utils.NewHTMLTemplate("post_body", user.Locale)
-	bodyPage.Props["SiteURL"] = utils.GetSiteURL()
+	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["PostMessage"] = GetMessageForNotification(post, userLocale)
 	if team.Name != "select_team" {
 		bodyPage.Props["TeamLink"] = teamURL + "/pl/" + post.Id

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -18,7 +18,7 @@ func TestSendNotifications(t *testing.T) {
 		UserId:    th.BasicUser.Id,
 		ChannelId: th.BasicChannel.Id,
 		Message:   "@" + th.BasicUser2.Username,
-	}, th.BasicTeam.Id, true)
+	}, th.BasicTeam.Id, true, utils.GetSiteURL())
 
 	if postErr != nil {
 		t.Fatal(postErr)

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
 )
 
 func TestSendNotifications(t *testing.T) {
@@ -24,7 +25,7 @@ func TestSendNotifications(t *testing.T) {
 		t.Fatal(postErr)
 	}
 
-	mentions, err := SendNotifications(post1, th.BasicTeam, th.BasicChannel, th.BasicUser)
+	mentions, err := SendNotifications(post1, th.BasicTeam, th.BasicChannel, th.BasicUser, utils.GetSiteURL())
 	if err != nil {
 		t.Fatal(err)
 	} else if mentions == nil {

--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -167,7 +167,7 @@ func SlackAddUsers(teamId string, slackusers []SlackUser, log *bytes.Buffer) map
 		if result := <-Srv.Store.User().GetByEmail(email); result.Err == nil {
 			existingUser := result.Data.(*model.User)
 			addedUsers[sUser.Id] = existingUser
-			if err := JoinUserToTeam(team, addedUsers[sUser.Id]); err != nil {
+			if err := JoinUserToTeam(team, addedUsers[sUser.Id], utils.GetSiteURL()); err != nil {
 				log.WriteString(utils.T("api.slackimport.slack_add_users.merge_existing_failed", map[string]interface{}{"Email": existingUser.Email, "Username": existingUser.Username}))
 			} else {
 				log.WriteString(utils.T("api.slackimport.slack_add_users.merge_existing", map[string]interface{}{"Email": existingUser.Email, "Username": existingUser.Username}))

--- a/app/team.go
+++ b/app/team.go
@@ -29,7 +29,7 @@ func CreateTeam(team *model.Team) (*model.Team, *model.AppError) {
 	}
 }
 
-func CreateTeamWithUser(team *model.Team, userId string) (*model.Team, *model.AppError) {
+func CreateTeamWithUser(team *model.Team, userId string, siteURL string) (*model.Team, *model.AppError) {
 	var user *model.User
 	var err *model.AppError
 	if user, err = GetUser(userId); err != nil {
@@ -47,7 +47,7 @@ func CreateTeamWithUser(team *model.Team, userId string) (*model.Team, *model.Ap
 		return nil, err
 	}
 
-	if err = JoinUserToTeam(rteam, user); err != nil {
+	if err = JoinUserToTeam(rteam, user, siteURL); err != nil {
 		return nil, err
 	}
 
@@ -137,7 +137,7 @@ func UpdateTeamMemberRoles(teamId string, userId string, newRoles string) (*mode
 	return member, nil
 }
 
-func AddUserToTeam(teamId string, userId string) (*model.Team, *model.AppError) {
+func AddUserToTeam(teamId string, userId string, siteURL string) (*model.Team, *model.AppError) {
 	tchan := Srv.Store.Team().Get(teamId)
 	uchan := Srv.Store.User().Get(userId)
 
@@ -155,22 +155,22 @@ func AddUserToTeam(teamId string, userId string) (*model.Team, *model.AppError) 
 		user = result.Data.(*model.User)
 	}
 
-	if err := JoinUserToTeam(team, user); err != nil {
+	if err := JoinUserToTeam(team, user, siteURL); err != nil {
 		return nil, err
 	}
 
 	return team, nil
 }
 
-func AddUserToTeamByTeamId(teamId string, user *model.User) *model.AppError {
+func AddUserToTeamByTeamId(teamId string, user *model.User, siteURL string) *model.AppError {
 	if result := <-Srv.Store.Team().Get(teamId); result.Err != nil {
 		return result.Err
 	} else {
-		return JoinUserToTeam(result.Data.(*model.Team), user)
+		return JoinUserToTeam(result.Data.(*model.Team), user, siteURL)
 	}
 }
 
-func AddUserToTeamByHash(userId string, hash string, data string) (*model.Team, *model.AppError) {
+func AddUserToTeamByHash(userId string, hash string, data string, siteURL string) (*model.Team, *model.AppError) {
 	props := model.MapFromJson(strings.NewReader(data))
 
 	if !model.ComparePassword(hash, fmt.Sprintf("%v:%v", data, utils.Cfg.EmailSettings.InviteSalt)) {
@@ -199,14 +199,14 @@ func AddUserToTeamByHash(userId string, hash string, data string) (*model.Team, 
 		user = result.Data.(*model.User)
 	}
 
-	if err := JoinUserToTeam(team, user); err != nil {
+	if err := JoinUserToTeam(team, user, siteURL); err != nil {
 		return nil, err
 	}
 
 	return team, nil
 }
 
-func AddUserToTeamByInviteId(inviteId string, userId string) (*model.Team, *model.AppError) {
+func AddUserToTeamByInviteId(inviteId string, userId string, siteURL string) (*model.Team, *model.AppError) {
 	tchan := Srv.Store.Team().GetByInviteId(inviteId)
 	uchan := Srv.Store.User().Get(userId)
 
@@ -224,7 +224,7 @@ func AddUserToTeamByInviteId(inviteId string, userId string) (*model.Team, *mode
 		user = result.Data.(*model.User)
 	}
 
-	if err := JoinUserToTeam(team, user); err != nil {
+	if err := JoinUserToTeam(team, user, siteURL); err != nil {
 		return nil, err
 	}
 
@@ -269,7 +269,7 @@ func joinUserToTeam(team *model.Team, user *model.User) (bool, *model.AppError) 
 	return false, nil
 }
 
-func JoinUserToTeam(team *model.Team, user *model.User) *model.AppError {
+func JoinUserToTeam(team *model.Team, user *model.User, siteURL string) *model.AppError {
 
 	if alreadyAdded, err := joinUserToTeam(team, user); err != nil {
 		return err
@@ -284,7 +284,7 @@ func JoinUserToTeam(team *model.Team, user *model.User) *model.AppError {
 	}
 
 	// Soft error if there is an issue joining the default channels
-	if err := JoinDefaultChannels(team.Id, user, channelRole); err != nil {
+	if err := JoinDefaultChannels(team.Id, user, channelRole, siteURL); err != nil {
 		l4g.Error(utils.T("api.user.create_user.joining.error"), user.Id, team.Id, err)
 	}
 

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
 )
 
 func TestCreateTeam(t *testing.T) {

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -42,12 +42,12 @@ func TestCreateTeamWithUser(t *testing.T) {
 		Type:        model.TEAM_OPEN,
 	}
 
-	if _, err := CreateTeamWithUser(team, th.BasicUser.Id); err != nil {
+	if _, err := CreateTeamWithUser(team, th.BasicUser.Id, utils.GetSiteURL()); err != nil {
 		t.Log(err)
 		t.Fatal("Should create a new team with existing user")
 	}
 
-	if _, err := CreateTeamWithUser(team, model.NewId()); err == nil {
+	if _, err := CreateTeamWithUser(team, model.NewId(), utils.GetSiteURL()); err == nil {
 		t.Fatal("Should not create a new team - user does not exist")
 	}
 
@@ -63,7 +63,7 @@ func TestCreateTeamWithUser(t *testing.T) {
 	}
 
 	//Fail to create a team with user when user has set email without domain
-	if _, err := CreateTeamWithUser(team2, ruser.Id); err == nil {
+	if _, err := CreateTeamWithUser(team2, ruser.Id, utils.GetSiteURL()); err == nil {
 		t.Log(err.Message)
 		t.Fatal("Should not create a team with user when user has set email without domain")
 	} else {
@@ -95,7 +95,7 @@ func TestAddUserToTeam(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
 	ruser, _ := CreateUser(&user)
 
-	if _, err := AddUserToTeam(th.BasicTeam.Id, ruser.Id); err != nil {
+	if _, err := AddUserToTeam(th.BasicTeam.Id, ruser.Id, utils.GetSiteURL()); err != nil {
 		t.Log(err)
 		t.Fatal("Should add user to the team")
 	}
@@ -107,7 +107,7 @@ func TestAddUserToTeamByTeamId(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
 	ruser, _ := CreateUser(&user)
 
-	if err := AddUserToTeamByTeamId(th.BasicTeam.Id, ruser); err != nil {
+	if err := AddUserToTeamByTeamId(th.BasicTeam.Id, ruser, utils.GetSiteURL()); err != nil {
 		t.Log(err)
 		t.Fatal("Should add user to the team")
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mattermost/platform/utils"
 )
 
-func CreateUserWithHash(user *model.User, hash string, data string) (*model.User, *model.AppError) {
+func CreateUserWithHash(user *model.User, hash string, data string, siteURL string) (*model.User, *model.AppError) {
 	if err := IsUserSignUpAllowed(); err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func CreateUserWithHash(user *model.User, hash string, data string) (*model.User
 		return nil, err
 	}
 
-	if err := JoinUserToTeam(team, ruser); err != nil {
+	if err := JoinUserToTeam(team, ruser, siteURL); err != nil {
 		return nil, err
 	}
 
@@ -91,7 +91,7 @@ func CreateUserWithInviteId(user *model.User, inviteId string, siteURL string) (
 		return nil, err
 	}
 
-	if err := JoinUserToTeam(team, ruser); err != nil {
+	if err := JoinUserToTeam(team, ruser, siteURL); err != nil {
 		return nil, err
 	}
 
@@ -216,7 +216,7 @@ func createUser(user *model.User) (*model.User, *model.AppError) {
 	}
 }
 
-func CreateOAuthUser(service string, userData io.Reader, teamId string) (*model.User, *model.AppError) {
+func CreateOAuthUser(service string, userData io.Reader, teamId string, siteURL string) (*model.User, *model.AppError) {
 	if !utils.Cfg.TeamSettings.EnableUserCreation {
 		return nil, model.NewAppError("CreateOAuthUser", "api.user.create_user.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
@@ -268,7 +268,7 @@ func CreateOAuthUser(service string, userData io.Reader, teamId string) (*model.
 	}
 
 	if len(teamId) > 0 {
-		err = AddUserToTeamByTeamId(teamId, user)
+		err = AddUserToTeamByTeamId(teamId, user, siteURL)
 		if err != nil {
 			return nil, err
 		}

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -70,7 +70,7 @@ func TestCreateOAuthUser(t *testing.T) {
 	glUser := oauthgitlab.GitLabUser{Id: int64(r.Intn(1000)), Username: "joram" + model.NewId(), Email: model.NewId() + "@simulator.amazonses.com", Name: "Joram Wilander"}
 
 	json := glUser.ToJson()
-	user, err := CreateOAuthUser(model.USER_AUTH_SERVICE_GITLAB, strings.NewReader(json), th.BasicTeam.Id)
+	user, err := CreateOAuthUser(model.USER_AUTH_SERVICE_GITLAB, strings.NewReader(json), th.BasicTeam.Id, utils.GetSiteURL())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestCreateOAuthUser(t *testing.T) {
 	}()
 	utils.Cfg.TeamSettings.EnableUserCreation = false
 
-	_, err = CreateOAuthUser(model.USER_AUTH_SERVICE_GITLAB, strings.NewReader(json), th.BasicTeam.Id)
+	_, err = CreateOAuthUser(model.USER_AUTH_SERVICE_GITLAB, strings.NewReader(json), th.BasicTeam.Id, utils.GetSiteURL())
 	if err == nil {
 		t.Fatal("should have failed - user creation disabled")
 	}
@@ -253,7 +253,7 @@ func createGitlabUser(t *testing.T, email string, username string) (*model.User,
 	var user *model.User
 	var err *model.AppError
 
-	if user, err = CreateOAuthUser("gitlab", bytes.NewReader(gitlabUser), ""); err != nil {
+	if user, err = CreateOAuthUser("gitlab", bytes.NewReader(gitlabUser), "", utils.GetSiteURL()); err != nil {
 		t.Fatal("unable to create the user")
 	}
 

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -24,7 +24,7 @@ const (
 	TRIGGERWORDS_STARTSWITH = 1
 )
 
-func handleWebhookEvents(post *model.Post, team *model.Team, channel *model.Channel, user *model.User) *model.AppError {
+func handleWebhookEvents(post *model.Post, team *model.Team, channel *model.Channel, user *model.User, siteURL string) *model.AppError {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return nil
 	}
@@ -107,7 +107,7 @@ func handleWebhookEvents(post *model.Post, team *model.Team, channel *model.Chan
 						respProps := model.MapFromJson(resp.Body)
 
 						if text, ok := respProps["text"]; ok {
-							if _, err := CreateWebhookPost(hook.CreatorId, hook.TeamId, post.ChannelId, text, respProps["username"], respProps["icon_url"], post.Props, post.Type); err != nil {
+							if _, err := CreateWebhookPost(hook.CreatorId, hook.TeamId, post.ChannelId, text, respProps["username"], respProps["icon_url"], post.Props, post.Type, siteURL); err != nil {
 								l4g.Error(utils.T("api.post.handle_webhook_events_and_forget.create_post.error"), err)
 							}
 						}
@@ -121,7 +121,7 @@ func handleWebhookEvents(post *model.Post, team *model.Team, channel *model.Chan
 	return nil
 }
 
-func CreateWebhookPost(userId, teamId, channelId, text, overrideUsername, overrideIconUrl string, props model.StringInterface, postType string) (*model.Post, *model.AppError) {
+func CreateWebhookPost(userId, teamId, channelId, text, overrideUsername, overrideIconUrl string, props model.StringInterface, postType string, siteURL string) (*model.Post, *model.AppError) {
 	// parse links into Markdown format
 	linkWithTextRegex := regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
 	text = linkWithTextRegex.ReplaceAllString(text, "[${2}](${1})")
@@ -188,7 +188,7 @@ func CreateWebhookPost(userId, teamId, channelId, text, overrideUsername, overri
 		}
 	}
 
-	if _, err := CreatePost(post, teamId, false); err != nil {
+	if _, err := CreatePost(post, teamId, false, siteURL); err != nil {
 		return nil, model.NewLocAppError("CreateWebhookPost", "api.post.create_webhook_post.creating.app_error", nil, "err="+err.Message)
 	}
 
@@ -427,7 +427,7 @@ func RegenOutgoingWebhookToken(hook *model.OutgoingWebhook) (*model.OutgoingWebh
 	}
 }
 
-func HandleIncomingWebhook(hookId string, req *model.IncomingWebhookRequest) *model.AppError {
+func HandleIncomingWebhook(hookId string, req *model.IncomingWebhookRequest, siteURL string) *model.AppError {
 	if !utils.Cfg.ServiceSettings.EnableIncomingWebhooks {
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
@@ -518,7 +518,7 @@ func HandleIncomingWebhook(hookId string, req *model.IncomingWebhookRequest) *mo
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.permissions.app_error", nil, "", http.StatusForbidden)
 	}
 
-	if _, err := CreateWebhookPost(hook.UserId, hook.TeamId, channel.Id, text, overrideUsername, overrideIconUrl, req.Props, webhookType); err != nil {
+	if _, err := CreateWebhookPost(hook.UserId, hook.TeamId, channel.Id, text, overrideUsername, overrideIconUrl, req.Props, webhookType, siteURL); err != nil {
 		return err
 	}
 

--- a/cmd/platform/channel.go
+++ b/cmd/platform/channel.go
@@ -168,7 +168,7 @@ func removeUserFromChannel(channel *model.Channel, user *model.User, userArg str
 		CommandPrintErrorln("Can't find user '" + userArg + "'")
 		return
 	}
-	if err := app.RemoveUserFromChannel(user.Id, "", channel); err != nil {
+	if err := app.RemoveUserFromChannel(user.Id, "", channel, utils.GetSiteURL()); err != nil {
 		CommandPrintErrorln("Unable to remove '" + userArg + "' from " + channel.Name + ". Error: " + err.Error())
 	}
 }

--- a/cmd/platform/oldcommands.go
+++ b/cmd/platform/oldcommands.go
@@ -274,7 +274,7 @@ func cmdCreateUser() {
 		}
 
 		if team != nil {
-			err = app.JoinUserToTeam(team, ruser)
+			err = app.JoinUserToTeam(team, ruser, utils.GetSiteURL())
 			if err != nil {
 				l4g.Error("%v", err)
 				flushLogAndExit(1)
@@ -546,7 +546,7 @@ func cmdLeaveChannel() {
 			channel = result.Data.(*model.Channel)
 		}
 
-		err := app.RemoveUserFromChannel(user.Id, user.Id, channel)
+		err := app.RemoveUserFromChannel(user.Id, user.Id, channel, utils.GetSiteURL())
 		if err != nil {
 			l4g.Error("%v", err)
 			flushLogAndExit(1)
@@ -673,7 +673,7 @@ func cmdJoinTeam() {
 			user = result.Data.(*model.User)
 		}
 
-		err := app.JoinUserToTeam(team, user)
+		err := app.JoinUserToTeam(team, user, utils.GetSiteURL())
 		if err != nil {
 			l4g.Error("%v", err)
 			flushLogAndExit(1)

--- a/cmd/platform/team.go
+++ b/cmd/platform/team.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -154,7 +155,7 @@ func addUserToTeam(team *model.Team, user *model.User, userArg string) {
 		CommandPrintErrorln("Can't find user '" + userArg + "'")
 		return
 	}
-	if err := app.JoinUserToTeam(team, user); err != nil {
+	if err := app.JoinUserToTeam(team, user, utils.GetSiteURL()); err != nil {
 		CommandPrintErrorln("Unable to add '" + userArg + "' to " + team.Name)
 	}
 }

--- a/einterfaces/saml.go
+++ b/einterfaces/saml.go
@@ -10,7 +10,7 @@ import (
 type SamlInterface interface {
 	ConfigureSP() *model.AppError
 	BuildRequest(relayState string) (*model.SamlAuthRequest, *model.AppError)
-	DoLogin(encodedXML string, relayState map[string]string) (*model.User, *model.AppError)
+	DoLogin(encodedXML string, relayState map[string]string, siteURL string) (*model.User, *model.AppError)
 	GetMetadata() (string, *model.AppError)
 }
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -211,7 +211,7 @@ func TestIncomingWebhook(t *testing.T) {
 	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = ApiClient.Must(ApiClient.CreateTeam(team)).Data.(*model.Team)
 
-	app.JoinUserToTeam(team, user)
+	app.JoinUserToTeam(team, user, utils.GetSiteURL())
 
 	app.UpdateUserRoles(user.Id, model.ROLE_SYSTEM_ADMIN.Id)
 	ApiClient.SetTeamId(team.Id)


### PR DESCRIPTION
I think we really need to revisit SiteURL in 3.8.

To summarize my changes:
- test code uses `utils.GetSiteURL()` wherever it isn't going through the API
- the CLI uses `utils.GetSiteURL()`
- api and api4 packages get the site URL from the api context
- the bulk import and slack import code in the app package get the site URL from `utils.GetSiteURL()`
- the rest of the app package has siteURL parameters wherever necessary

Enterprise PR: https://github.com/mattermost/enterprise/pull/117

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5765

#### Checklist
- Has enterprise changes (please link)
- Touches critical sections of the codebase (auth, upgrade, etc.)
