### PR TITLE
PLT-5792 Fixed all ephemeral posts using system message icons

### DIFF
--- a/webapp/components/post_view/components/post.jsx
+++ b/webapp/components/post_view/components/post.jsx
@@ -204,9 +204,7 @@ export default class Post extends React.Component {
                     src={PostUtils.getProfilePicSrcForPost(post, timestamp)}
                 />
             );
-        }
-
-        if (PostUtils.isSystemMessage(post)) {
+        } else if (PostUtils.isSystemMessage(post)) {
             profilePic = (
                 <span
                     className='icon'


### PR DESCRIPTION
All ephemeral messages use the `system_ephemeral` post type, so there's many places where they're treated as system messages (like when rendering profile pictures)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5792

#### Checklist
- Has UI changes