### PR TITLE
Added SmartOS / Solaris support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,11 @@ build-windows: .prebuild prepare-enterprise
 	@echo Build Windows amd64
 	env GOOS=windows GOARCH=amd64 $(GO) install $(GOFLAGS) $(GO_LINKER_FLAGS) ./cmd/platform
 
-build: build-linux build-windows build-osx
+build-solaris: .prebuild prepare-enterprise
+	@echo Build Solaris amd64
+	env GOOS=solaris GOARCH=amd64 $(GO) install $(GOFLAGS) $(GO_LINKER_FLAGS) ./cmd/platform
+
+build: build-linux build-windows build-osx build-solaris
 
 build-client:
 	@echo Building mattermost web app
@@ -356,6 +360,18 @@ endif
 	tar -C dist -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-osx-amd64.tar.gz mattermost
 	@# Cleanup
 	rm -f $(DIST_PATH)/bin/platform
+
+	@# Make solaris package
+	@# Copy binary
+ifeq ($(BUILDER_GOOS_GOARCH),"solaris_amd64")
+	cp $(GOPATH)/bin/platform $(DIST_PATH)/bin # from native bin dir, not cross-compiled
+else
+	cp $(GOPATH)/bin/solaris_amd64/platform $(DIST_PATH)/bin # from cross-compiled bin dir
+endif
+	@# Package
+	tar -C dist -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-solaris-amd64.tar.gz mattermost
+	@# Don't clean up native package so dev machines will have an unzipped package available
+	@#rm -f $(DIST_PATH)/bin/platform
 
 	@# Make windows package
 	@# Copy binary

--- a/utils/html_fallback.go
+++ b/utils/html_fallback.go
@@ -1,7 +1,13 @@
-// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-// +build !solaris
+// +build solaris
+
+// Implementation of 'html.go' for OS'es that are not supported by fsnotify. This implementation does not support
+// hot-swapping of templates and will only load them at the startup of mattermost.
+
+// Solaris FEN support is something that is currently being integrated in to fsnotify. However FEN support
+// does not support cross compilation.
 
 package utils
 
@@ -12,7 +18,6 @@ import (
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/nicksnyder/go-i18n/i18n"
-	"gopkg.in/fsnotify.v1"
 )
 
 // Global storage for templates
@@ -40,33 +45,6 @@ func InitHTMLWithDir(dir string) {
 	var err error
 	if htmlTemplates, err = template.ParseGlob(templatesDir + "*.html"); err != nil {
 		l4g.Error(T("api.api.init.parsing_templates.error"), err)
-	}
-
-	// Watch the templates folder for changes.
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		l4g.Error(T("web.create_dir.error"), err)
-	}
-
-	go func() {
-		for {
-			select {
-			case event := <-watcher.Events:
-				if event.Op&fsnotify.Write == fsnotify.Write {
-					l4g.Info(T("web.reparse_templates.info"), event.Name)
-					if htmlTemplates, err = template.ParseGlob(templatesDir + "*.html"); err != nil {
-						l4g.Error(T("web.parsing_templates.error"), err)
-					}
-				}
-			case err := <-watcher.Errors:
-				l4g.Error(T("web.dir_fail.error"), err)
-			}
-		}
-	}()
-
-	err = watcher.Add(templatesDir)
-	if err != nil {
-		l4g.Error(T("web.watcher_fail.error"), err)
 	}
 }
 


### PR DESCRIPTION
#### Summary
I've added preliminary support for SmartOS / Solaris! This is interesting for people who want to run Mattermost on the Joyent Public Cloud (or private cloud with Triton like we do) or just on SmartOS.

Mattermost just works on SmartOS however fsnotify doesn't have support for FEN (The Solaris equivelant of Linux inotify). This leads to spamming of logs. There is actually an pull request open for FEN support in fsnotify (fsnotify/fsnotify#196). However this is not yet merged and also this code (unlike Linux, Windows and Darwin support) will only compile on Solaris. Which is kinda of a bummer for cross compiling. I think the the hot-swapping of templates is only done during development? Therefor I thought it would be better to just not support hot-template-reloading on Solaris and any other OS fsnotify might not support. It's just not worth the trouble of breaking cross compilation. I wanted to also add some documentation to make it obvious the Solaris build doesn't support hot-swapping templates but I couldn't find any documentation regarding template hot-swapping (so there was nothing to modify).

#### Ticket Link
I tried to create a Jira account so I could create a JIRA issue (as per procedure) but logging in to Atlassian cloud proved troublesom. I couldn't login with GitHub (only Google). I then tried to create an account and apparently I already had one so I tried to reset my password. That lead to an E-Mail with a link which displayed the following error when I clicked on it: `Illegal request-target, unexpected character '=' at position 471`. No idea what it is but it seems like a nice attack vector ;-). Anywho at that point I gave up trying to create a JIRA ticket.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
