### PR TITLE
add missing id to use for translation - user settings/security/mfa

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -2244,6 +2244,8 @@
   "user.settings.security.switchSaml": "Switch to using SAML SSO",
   "user.settings.security.title": "Security Settings",
   "user.settings.security.viewHistory": "View Access History",
+  "user.settings.security.active": "Active",
+  "user.settings.security.inactive": "Inactive",
   "user_list.notFound": "No users found",
   "user_profile.send.dm": "Send Message",
   "user_profile.webrtc.call": "Start Video Call",


### PR DESCRIPTION
#### Summary
Was using Mattermost in pt-BR :) and notice that this two texts was not translated. and saw the is missing in the i18n. Added now for translation.

#### Ticket Link
N/A

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json]