### PR TITLE
Implement admin LDAP endpoints for APIv4

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -67,6 +67,8 @@ type Routes struct {
 	Compliance *mux.Router // 'api/v4/compliance'
 	Cluster    *mux.Router // 'api/v4/cluster'
 
+	LDAP *mux.Router // 'api/v4/ldap'
+
 	System *mux.Router // 'api/v4/system'
 
 	Preferences *mux.Router // 'api/v4/preferences'
@@ -139,6 +141,7 @@ func InitApi(full bool) {
 	BaseRoutes.Admin = BaseRoutes.ApiRoot.PathPrefix("/admin").Subrouter()
 	BaseRoutes.Compliance = BaseRoutes.ApiRoot.PathPrefix("/compliance").Subrouter()
 	BaseRoutes.Cluster = BaseRoutes.ApiRoot.PathPrefix("/cluster").Subrouter()
+	BaseRoutes.LDAP = BaseRoutes.ApiRoot.PathPrefix("/ldap").Subrouter()
 	BaseRoutes.System = BaseRoutes.ApiRoot.PathPrefix("/system").Subrouter()
 	BaseRoutes.Preferences = BaseRoutes.User.PathPrefix("/preferences").Subrouter()
 	BaseRoutes.License = BaseRoutes.ApiRoot.PathPrefix("/license").Subrouter()
@@ -160,6 +163,7 @@ func InitApi(full bool) {
 	InitSaml()
 	InitCompliance()
 	InitCluster()
+	InitLdap()
 
 	app.Srv.Router.Handle("/api/v4/{anything:.*}", http.HandlerFunc(Handle404))
 

--- a/api4/ldap.go
+++ b/api4/ldap.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"net/http"
+
+	l4g "github.com/alecthomas/log4go"
+	"github.com/mattermost/platform/app"
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+func InitLdap() {
+	l4g.Debug(utils.T("api.ldap.init.debug"))
+
+	BaseRoutes.LDAP.Handle("/sync", ApiSessionRequired(syncLdap)).Methods("POST")
+	BaseRoutes.LDAP.Handle("/test", ApiSessionRequired(testLdap)).Methods("POST")
+}
+
+func syncLdap(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	app.SyncLdap()
+
+	ReturnStatusOK(w)
+}
+
+func testLdap(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	if err := app.TestLdap(); err != nil {
+		c.Err = err
+		return
+	}
+
+	ReturnStatusOK(w)
+}

--- a/api4/ldap_test.go
+++ b/api4/ldap_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"testing"
+)
+
+func TestLdapTest(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+
+	_, resp := th.Client.TestLdap()
+	CheckForbiddenStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.TestLdap()
+	CheckNotImplementedStatus(t, resp)
+}
+
+func TestLdapSync(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+
+	_, resp := th.SystemAdminClient.SyncLdap()
+	CheckNoError(t, resp)
+
+	_, resp = th.Client.SyncLdap()
+	CheckForbiddenStatus(t, resp)
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -84,6 +84,10 @@
     "translation": "Image storage is not configured."
   },
   {
+    "id": "api.ldap.init.debug",
+    "translation": "Initializing LDAP API routes"
+  },
+  {
     "id": "api.admin.init.debug",
     "translation": "Initializing admin API routes"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -186,6 +186,10 @@ func (c *Client4) GetSamlRoute() string {
 	return fmt.Sprintf("/saml")
 }
 
+func (c *Client4) GetLdapRoute() string {
+	return fmt.Sprintf("/ldap")
+}
+
 func (c *Client4) DoApiGet(url string, etag string) (*http.Response, *AppError) {
 	return c.DoApiRequest(http.MethodGet, url, "", etag)
 }
@@ -1459,5 +1463,28 @@ func (c *Client4) GetClusterStatus() ([]*ClusterInfo, *Response) {
 	} else {
 		defer closeBody(r)
 		return ClusterInfosFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// LDAP Section
+
+// SyncLdap will force a sync with the configured LDAP server.
+func (c *Client4) SyncLdap() (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetLdapRoute()+"/sync", ""); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
+// TestLdap will attempt to connect to the configured LDAP server and return OK if configured
+// correctly.
+func (c *Client4) TestLdap() (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetLdapRoute()+"/test", ""); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
 	}
 }


### PR DESCRIPTION
#### Summary
Implement admin LDAP endpoints for APIv4.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#140)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
