### PR TITLE
Implement GET /cluster/status endpoint for APIv4

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -59,13 +59,11 @@ type Routes struct {
 	OutgoingHooks *mux.Router // 'api/v4/hooks/outgoing'
 	OutgoingHook  *mux.Router // 'api/v4/hooks/outgoing/{hook_id:[A-Za-z0-9]+}'
 
-	OAuth *mux.Router // 'api/v4/oauth'
-
-	SAML *mux.Router // 'api/v4/saml'
-
-	Admin *mux.Router // 'api/v4/admin'
-
+	Admin      *mux.Router // 'api/v4/admin'
+	OAuth      *mux.Router // 'api/v4/oauth'
+	SAML       *mux.Router // 'api/v4/saml'
 	Compliance *mux.Router // 'api/v4/compliance'
+	Cluster    *mux.Router // 'api/v4/cluster'
 
 	System *mux.Router // 'api/v4/system'
 
@@ -137,6 +135,7 @@ func InitApi(full bool) {
 	BaseRoutes.OAuth = BaseRoutes.ApiRoot.PathPrefix("/oauth").Subrouter()
 	BaseRoutes.Admin = BaseRoutes.ApiRoot.PathPrefix("/admin").Subrouter()
 	BaseRoutes.Compliance = BaseRoutes.ApiRoot.PathPrefix("/compliance").Subrouter()
+	BaseRoutes.Cluster = BaseRoutes.ApiRoot.PathPrefix("/cluster").Subrouter()
 	BaseRoutes.System = BaseRoutes.ApiRoot.PathPrefix("/system").Subrouter()
 	BaseRoutes.Preferences = BaseRoutes.User.PathPrefix("/preferences").Subrouter()
 	BaseRoutes.License = BaseRoutes.ApiRoot.PathPrefix("/license").Subrouter()
@@ -157,6 +156,7 @@ func InitApi(full bool) {
 	InitPreference()
 	InitSaml()
 	InitCompliance()
+	InitCluster()
 
 	app.Srv.Router.Handle("/api/v4/{anything:.*}", http.HandlerFunc(Handle404))
 

--- a/api4/cluster.go
+++ b/api4/cluster.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"net/http"
+
+	l4g "github.com/alecthomas/log4go"
+	"github.com/mattermost/platform/app"
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+func InitCluster() {
+	l4g.Debug(utils.T("api.cluster.init.debug"))
+
+	BaseRoutes.Cluster.Handle("/status", ApiSessionRequired(getClusterStatus)).Methods("GET")
+}
+
+func getClusterStatus(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	infos := app.GetClusterStatus()
+	w.Write([]byte(model.ClusterInfosToJson(infos)))
+}

--- a/api4/cluster_test.go
+++ b/api4/cluster_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"testing"
+)
+
+func TestGetClusterStatus(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+
+	_, resp := th.Client.GetClusterStatus()
+	CheckForbiddenStatus(t, resp)
+
+	infos, resp := th.SystemAdminClient.GetClusterStatus()
+	CheckNoError(t, resp)
+
+	if infos == nil {
+		t.Fatal("should not be nil")
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -72,6 +72,10 @@
     "translation": "Error reading log file"
   },
   {
+    "id": "api.cluster.init.debug",
+    "translation": "Initializing cluster API routes"
+  },
+  {
     "id": "api.admin.get_brand_image.not_available.app_error",
     "translation": "Custom branding is not configured or supported on this server"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -154,6 +154,10 @@ func (c *Client4) GetDatabaseRoute() string {
 	return fmt.Sprintf("/database")
 }
 
+func (c *Client4) GetClusterRoute() string {
+	return fmt.Sprintf("/cluster")
+}
+
 func (c *Client4) GetIncomingWebhooksRoute() string {
 	return fmt.Sprintf("/hooks/incoming")
 }
@@ -1412,5 +1416,17 @@ func (c *Client4) DownloadComplianceReport(reportId string) ([]byte, *Response) 
 	} else {
 		defer closeBody(rp)
 		return data, BuildResponse(rp)
+	}
+}
+
+// Cluster Section
+
+// GetClusterStatus returns the status of all the configured cluster nodes.
+func (c *Client4) GetClusterStatus() ([]*ClusterInfo, *Response) {
+	if r, err := c.DoApiGet(c.GetClusterRoute()+"/status", ""); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return ClusterInfosFromJson(r.Body), BuildResponse(r)
 	}
 }


### PR DESCRIPTION
#### Summary
Implement GET /cluster/status endpoint for APIv4.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#141)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
