### PR TITLE
Implement brand image endpoints for APIv4

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -230,12 +230,6 @@ func getAnalytics(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func uploadBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
-		c.Err = model.NewLocAppError("uploadBrandImage", "api.admin.upload_brand_image.storage.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
-		return
-	}
-
 	if r.ContentLength > *utils.Cfg.FileSettings.MaxFileSize {
 		c.Err = model.NewLocAppError("uploadBrandImage", "api.admin.upload_brand_image.too_large.app_error", nil, "")
 		c.Err.StatusCode = http.StatusRequestEntityTooLarge

--- a/api4/api.go
+++ b/api4/api.go
@@ -69,6 +69,8 @@ type Routes struct {
 
 	LDAP *mux.Router // 'api/v4/ldap'
 
+	Brand *mux.Router // 'api/v4/brand'
+
 	System *mux.Router // 'api/v4/system'
 
 	Preferences *mux.Router // 'api/v4/preferences'
@@ -142,6 +144,7 @@ func InitApi(full bool) {
 	BaseRoutes.Compliance = BaseRoutes.ApiRoot.PathPrefix("/compliance").Subrouter()
 	BaseRoutes.Cluster = BaseRoutes.ApiRoot.PathPrefix("/cluster").Subrouter()
 	BaseRoutes.LDAP = BaseRoutes.ApiRoot.PathPrefix("/ldap").Subrouter()
+	BaseRoutes.Brand = BaseRoutes.ApiRoot.PathPrefix("/brand").Subrouter()
 	BaseRoutes.System = BaseRoutes.ApiRoot.PathPrefix("/system").Subrouter()
 	BaseRoutes.Preferences = BaseRoutes.User.PathPrefix("/preferences").Subrouter()
 	BaseRoutes.License = BaseRoutes.ApiRoot.PathPrefix("/license").Subrouter()
@@ -164,6 +167,7 @@ func InitApi(full bool) {
 	InitCompliance()
 	InitCluster()
 	InitLdap()
+	InitBrand()
 
 	app.Srv.Router.Handle("/api/v4/{anything:.*}", http.HandlerFunc(Handle404))
 

--- a/api4/brand.go
+++ b/api4/brand.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"net/http"
+
+	l4g "github.com/alecthomas/log4go"
+	"github.com/mattermost/platform/app"
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+func InitBrand() {
+	l4g.Debug(utils.T("api.brand.init.debug"))
+
+	BaseRoutes.Brand.Handle("/image", ApiHandlerTrustRequester(getBrandImage)).Methods("GET")
+	BaseRoutes.Brand.Handle("/image", ApiSessionRequired(uploadBrandImage)).Methods("POST")
+}
+
+func getBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
+	// No permission check required
+
+	if img, err := app.GetBrandImage(); err != nil {
+		w.Write(nil)
+	} else {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(img)
+	}
+}
+
+func uploadBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
+	if r.ContentLength > *utils.Cfg.FileSettings.MaxFileSize {
+		c.Err = model.NewAppError("uploadBrandImage", "api.admin.upload_brand_image.too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	if err := r.ParseMultipartForm(*utils.Cfg.FileSettings.MaxFileSize); err != nil {
+		c.Err = model.NewAppError("uploadBrandImage", "api.admin.upload_brand_image.parse.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	m := r.MultipartForm
+
+	imageArray, ok := m.File["image"]
+	if !ok {
+		c.Err = model.NewAppError("uploadBrandImage", "api.admin.upload_brand_image.no_file.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	if len(imageArray) <= 0 {
+		c.Err = model.NewAppError("uploadBrandImage", "api.admin.upload_brand_image.array.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	if err := app.SaveBrandImage(imageArray[0]); err != nil {
+		c.Err = err
+		return
+	}
+
+	c.LogAudit("")
+
+	ReturnStatusOK(w)
+}

--- a/api4/brand_test.go
+++ b/api4/brand_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"testing"
+)
+
+func TestGetBrandImage(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	data, resp := Client.GetBrandImage()
+	CheckNoError(t, resp)
+
+	if len(data) != 0 {
+		t.Fatal("no image uploaded - should be empty")
+	}
+
+	Client.Logout()
+	data, resp = Client.GetBrandImage()
+	CheckNoError(t, resp)
+
+	if len(data) != 0 {
+		t.Fatal("no image uploaded - should be empty")
+	}
+
+	data, resp = th.SystemAdminClient.GetBrandImage()
+	CheckNoError(t, resp)
+
+	if len(data) != 0 {
+		t.Fatal("no image uploaded - should be empty")
+	}
+}
+
+func TestUploadBrandImage(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	data, err := readTestFile("test.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ok, resp := Client.UploadBrandImage(data)
+	CheckForbiddenStatus(t, resp)
+	if ok {
+		t.Fatal("Should return false, set brand image not allowed")
+	}
+
+	Client.Logout()
+	_, resp = Client.UploadBrandImage(data)
+	CheckUnauthorizedStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.UploadBrandImage(data)
+	CheckNotImplementedStatus(t, resp)
+}

--- a/api4/brand_test.go
+++ b/api4/brand_test.go
@@ -4,6 +4,7 @@
 package api4
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -51,9 +52,17 @@ func TestUploadBrandImage(t *testing.T) {
 		t.Fatal("Should return false, set brand image not allowed")
 	}
 
+	// status code returns either forbidden or unauthorized
+	// note: forbidden is set as default at Client4.SetProfileImage when request is terminated early by server
 	Client.Logout()
 	_, resp = Client.UploadBrandImage(data)
-	CheckUnauthorizedStatus(t, resp)
+	if resp.StatusCode == http.StatusForbidden {
+		CheckForbiddenStatus(t, resp)
+	} else if resp.StatusCode == http.StatusUnauthorized {
+		CheckUnauthorizedStatus(t, resp)
+	} else {
+		t.Fatal("Should have failed either forbidden or unauthorized")
+	}
 
 	_, resp = th.SystemAdminClient.UploadBrandImage(data)
 	CheckNotImplementedStatus(t, resp)

--- a/app/brand.go
+++ b/app/brand.go
@@ -13,11 +13,13 @@ import (
 )
 
 func SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
+	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+		return model.NewAppError("SaveBrandImage", "api.admin.upload_brand_image.storage.app_error", nil, "", http.StatusNotImplemented)
+	}
+
 	brandInterface := einterfaces.GetBrandInterface()
 	if brandInterface == nil {
-		err := model.NewLocAppError("SaveBrandImage", "api.admin.upload_brand_image.not_available.app_error", nil, "")
-		err.StatusCode = http.StatusNotImplemented
-		return err
+		return model.NewAppError("SaveBrandImage", "api.admin.upload_brand_image.not_available.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	if err := brandInterface.SaveBrandImage(imageData); err != nil {
@@ -29,16 +31,12 @@ func SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
 
 func GetBrandImage() ([]byte, *model.AppError) {
 	if len(utils.Cfg.FileSettings.DriverName) == 0 {
-		err := model.NewLocAppError("GetBrandImage", "api.admin.get_brand_image.storage.app_error", nil, "")
-		err.StatusCode = http.StatusNotImplemented
-		return nil, err
+		return nil, model.NewAppError("GetBrandImage", "api.admin.get_brand_image.storage.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	brandInterface := einterfaces.GetBrandInterface()
 	if brandInterface == nil {
-		err := model.NewLocAppError("GetBrandImage", "api.admin.get_brand_image.not_available.app_error", nil, "")
-		err.StatusCode = http.StatusNotImplemented
-		return nil, err
+		return nil, model.NewAppError("GetBrandImage", "api.admin.get_brand_image.not_available.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	if img, err := brandInterface.GetBrandImage(); err != nil {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -152,6 +152,10 @@
     "translation": "Unable to upload file. File is too large."
   },
   {
+    "id": "api.brand.init.debug",
+    "translation": "Initializing brand API routes"
+  },
+  {
     "id": "api.api.init.parsing_templates.debug",
     "translation": "Parsing server templates at %v"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -1530,7 +1530,7 @@ func (c *Client4) UploadBrandImage(data []byte) (bool, *Response) {
 	}
 
 	if rp, err := c.HttpClient.Do(rq); err != nil {
-		return false, &Response{StatusCode: http.StatusBadRequest, Error: NewAppError(c.GetBrandRoute()+"/image", "model.client.connecting.app_error", nil, err.Error(), http.StatusBadRequest)}
+		return false, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.GetBrandRoute()+"/image", "model.client.connecting.app_error", nil, err.Error(), http.StatusForbidden)}
 	} else if rp.StatusCode >= 300 {
 		return false, &Response{StatusCode: rp.StatusCode, Error: AppErrorFromJson(rp.Body)}
 	} else {


### PR DESCRIPTION
#### Summary
Implement brand image endpoints for APIv4.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#142)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
