### PR TITLE
[PLT-5815] Allow Saving of Identical Team Names

### DIFF
--- a/webapp/components/team_general_tab.jsx
+++ b/webapp/components/team_general_tab.jsx
@@ -106,14 +106,11 @@ class GeneralTab extends React.Component {
         let valid = true;
 
         const name = this.state.name.trim();
-        if (!name) {
+        if (name) {
+            state.clientError = '';
+        } else {
             state.clientError = Utils.localizeMessage('general_tab.required', 'This field is required');
             valid = false;
-        } else if (name === this.props.team.display_name) {
-            state.clientError = Utils.localizeMessage('general_tab.chooseName', 'Please choose a new name for your team');
-            valid = false;
-        } else {
-            state.clientError = '';
         }
 
         this.setState(state);

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1330,7 +1330,6 @@
   "flag_post.flag": "Flag for follow up",
   "flag_post.unflag": "Unflag",
   "general_tab.chooseDescription": "Please choose a new description for your team",
-  "general_tab.chooseName": "Please choose a new name for your team",
   "general_tab.codeDesc": "Click 'Edit' to regenerate Invite Code.",
   "general_tab.codeLongDesc": "The Invite Code is used as part of the URL in the team invitation link created by {getTeamInviteLink} in the main menu. Regenerating creates a new team invitation link and invalidates the previous link.",
   "general_tab.codeTitle": "Invite Code",


### PR DESCRIPTION
#### Summary
When someone goes to edit their team name, and saves without changing the name, an error will not be thrown unlike before.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5815
https://github.com/mattermost/platform/issues/5722

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
