### PR TITLE
[PLT-5770] Sort Favorite Channels Alphabetically Regardless of Type

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -636,13 +636,15 @@ export default class Sidebar extends React.Component {
         this.lastUnreadChannel = null;
 
         // create elements for all 4 types of channels
-        const favoriteItems = this.state.favoriteChannels.map((channel, index, arr) => {
-            if (channel.type === Constants.DM_CHANNEL) {
-                return this.createChannelElement(channel, index, arr, this.handleLeaveDirectChannel);
-            }
+        const favoriteItems = this.state.favoriteChannels.
+            sort(Utils.sortTeamsByDisplayName).
+            map((channel, index, arr) => {
+                if (channel.type === Constants.DM_CHANNEL) {
+                    return this.createChannelElement(channel, index, arr, this.handleLeaveDirectChannel);
+                }
 
-            return this.createChannelElement(channel);
-        });
+                return this.createChannelElement(channel);
+            });
 
         const publicChannelItems = this.state.publicChannels.map(this.createChannelElement);
 


### PR DESCRIPTION
#### Summary
The `Favorite Channels` section is now alphabetically sorted regardless of whether the channel is `private` or `public`.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5770
https://github.com/mattermost/platform/issues/5737

#### Checklist
- [x] Has UI changes
