### PR TITLE
[PLT-5760] 'Other words' for mentions no longer includes '@username'

### DIFF
--- a/webapp/components/user_settings/user_settings_notifications.jsx
+++ b/webapp/components/user_settings/user_settings_notifications.jsx
@@ -64,6 +64,9 @@ function getNotificationsStateFromStores() {
             } else {
                 usernameKey = true;
                 keys.splice(keys.indexOf(user.username), 1);
+                if (keys.indexOf(`@${user.username}`) !== -1) {
+                    keys.splice(keys.indexOf(`@${user.username}`), 1);
+                }
             }
 
             customKeys = keys.join(',');


### PR DESCRIPTION
#### Summary
For new users, `@username` is no longer shown within the list of "Other non case sensitive words" under `Account Settings -> Notifications -> Words that trigger mentions`

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5760
https://github.com/mattermost/platform/issues/5729