### PR TITLE
PLT-5814 Prevent double join calls when joining a public channel

### DIFF
--- a/webapp/actions/channel_actions.jsx
+++ b/webapp/actions/channel_actions.jsx
@@ -292,6 +292,7 @@ export function joinChannel(channel, success, error) {
         channel.id,
         () => {
             ChannelStore.removeMoreChannel(channel.id);
+            ChannelStore.storeChannel(channel);
 
             if (success) {
                 success();


### PR DESCRIPTION
#### Summary
Prevent double join calls when joining a public channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5814