### PR TITLE
Fix policy application in team edition.

### DIFF
--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -170,6 +170,20 @@ func TestCreateChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+
+	channel4 := model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel5 := model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
+	if _, err := Client.CreateChannel(&channel4); err != nil {
+		t.Fatal("should have succeeded")
+	}
+	if _, err := Client.CreateChannel(&channel5); err != nil {
+		t.Fatal("should have succeeded")
+	}
+
 	*utils.Cfg.TeamSettings.RestrictPublicChannelCreation = model.PERMISSIONS_ALL
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_ALL
 	utils.SetDefaultRolesBasedOnConfig()
@@ -374,16 +388,19 @@ func TestUpdateChannel(t *testing.T) {
 
 	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	utils.SetDefaultRolesBasedOnConfig()
 	MakeUserChannelUser(th.BasicUser, channel2)
 	MakeUserChannelUser(th.BasicUser, channel3)
 	store.ClearChannelCaches()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
-		t.Fatal("should have errored not team admin")
+		t.Fatal("should have errored not channel admin")
 	}
 	if _, err := Client.UpdateChannel(channel3); err == nil {
-		t.Fatal("should have errored not team admin")
+		t.Fatal("should have errored not channel admin")
 	}
 
 	UpdateUserToTeamAdmin(th.BasicUser, team)
@@ -410,6 +427,9 @@ func TestUpdateChannel(t *testing.T) {
 
 	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	utils.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
@@ -433,6 +453,9 @@ func TestUpdateChannel(t *testing.T) {
 
 	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	utils.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
@@ -443,6 +466,18 @@ func TestUpdateChannel(t *testing.T) {
 	}
 
 	th.LoginSystemAdmin()
+
+	if _, err := Client.UpdateChannel(channel2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.UpdateChannel(channel3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err != nil {
 		t.Fatal(err)
@@ -660,6 +695,18 @@ func TestUpdateChannelHeader(t *testing.T) {
 	if _, err := SystemAdminClient.UpdateChannelHeader(data3); err != nil {
 		t.Fatal(err)
 	}
+
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+
+	if _, err := SystemAdminClient.UpdateChannelHeader(data2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SystemAdminClient.UpdateChannelHeader(data3); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestUpdateChannelPurpose(t *testing.T) {
@@ -828,6 +875,17 @@ func TestUpdateChannelPurpose(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := SystemAdminClient.UpdateChannelPurpose(data3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+	if _, err := SystemAdminClient.UpdateChannelHeader(data2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SystemAdminClient.UpdateChannelHeader(data3); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1304,6 +1362,9 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
@@ -1357,6 +1418,9 @@ func TestDeleteChannel(t *testing.T) {
 	UpdateUserToNonTeamAdmin(th.BasicUser, team)
 	app.InvalidateAllCaches()
 
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
@@ -1389,6 +1453,9 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
@@ -1415,6 +1482,25 @@ func TestDeleteChannel(t *testing.T) {
 	}
 
 	th.LoginSystemAdmin()
+
+	if _, err := Client.DeleteChannel(channel2.Id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.DeleteChannel(channel3.Id); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+
+	channel2 = th.CreateChannel(Client, team)
+	channel3 = th.CreatePrivateChannel(Client, team)
+	Client.Must(Client.AddChannelMember(channel2.Id, th.BasicUser.Id))
+	Client.Must(Client.AddChannelMember(channel3.Id, th.BasicUser.Id))
+
+	Client.Login(th.BasicUser.Email, th.BasicUser.Password)
 
 	if _, err := Client.DeleteChannel(channel2.Id); err != nil {
 		t.Fatal(err)

--- a/api/context.go
+++ b/api/context.go
@@ -150,7 +150,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.RequestId)
-	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash))
+	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash, utils.IsLicensed))
 	if einterfaces.GetClusterInterface() != nil {
 		w.Header().Set(model.HEADER_CLUSTER_ID, einterfaces.GetClusterInterface().GetClusterId())
 	}

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -993,6 +993,19 @@ func TestDeletePosts(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+
+	time.Sleep(10 * time.Millisecond)
+	post7 := &model.Post{ChannelId: channel1.Id, Message: "a" + model.NewId() + "a"}
+	post7 = Client.Must(Client.CreatePost(post7)).Data.(*model.Post)
+
+	if _, err := Client.DeletePost(channel1.Id, post7.Id); err != nil {
+		t.Fatal(err)
+	}
+
 	SystemAdminClient.Must(SystemAdminClient.DeletePost(channel1.Id, post6a.Id))
 
 }

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -91,10 +91,10 @@ func TestCreateChannel(t *testing.T) {
 	}()
 	*utils.Cfg.TeamSettings.RestrictPublicChannelCreation = model.PERMISSIONS_ALL
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_ALL
-	utils.SetDefaultRolesBasedOnConfig()
 	utils.IsLicensed = true
 	utils.License = &model.License{Features: &model.Features{}}
 	utils.License.Features.SetDefaults()
+	utils.SetDefaultRolesBasedOnConfig()
 
 	channel.Name = GenerateTestChannelName()
 	_, resp = Client.CreateChannel(channel)
@@ -158,6 +158,19 @@ func TestCreateChannel(t *testing.T) {
 
 	private.Name = GenerateTestChannelName()
 	_, resp = th.SystemAdminClient.CreateChannel(private)
+	CheckNoError(t, resp)
+
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+
+	channel.Name = GenerateTestChannelName()
+	_, resp = Client.CreateChannel(channel)
+	CheckNoError(t, resp)
+
+	private.Name = GenerateTestChannelName()
+	_, resp = Client.CreateChannel(private)
 	CheckNoError(t, resp)
 
 	if r, err := Client.DoApiPost("/channels", "garbage"); err == nil {

--- a/api4/context.go
+++ b/api4/context.go
@@ -133,7 +133,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.RequestId)
-	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash))
+	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash, utils.IsLicensed))
 	if einterfaces.GetClusterInterface() != nil {
 		w.Header().Set(model.HEADER_CLUSTER_ID, einterfaces.GetClusterInterface().GetClusterId())
 	}

--- a/app/license.go
+++ b/app/license.go
@@ -76,6 +76,8 @@ func SaveLicense(licenseBytes []byte) (*model.License, *model.AppError) {
 		return nil, model.NewLocAppError("addLicense", model.INVALID_LICENSE_ERROR, nil, "")
 	}
 
+	ReloadConfig()
+
 	InvalidateAllCaches()
 
 	return license, nil
@@ -92,6 +94,8 @@ func RemoveLicense() *model.AppError {
 		utils.RemoveLicense()
 		return result.Err
 	}
+
+	ReloadConfig()
 
 	InvalidateAllCaches()
 

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -178,7 +178,7 @@ func (webCon *WebConn) IsAuthenticated() bool {
 
 func (webCon *WebConn) SendHello() {
 	msg := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_HELLO, "", "", webCon.UserId, nil)
-	msg.Add("server_version", fmt.Sprintf("%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash))
+	msg.Add("server_version", fmt.Sprintf("%v.%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash, utils.IsLicensed))
 	msg.DoPreComputeJson()
 	webCon.Send <- msg
 }

--- a/utils/authorization.go
+++ b/utils/authorization.go
@@ -11,134 +11,176 @@ func SetDefaultRolesBasedOnConfig() {
 	// Reset the roles to default to make this logic easier
 	model.InitalizeRoles()
 
-	switch *Cfg.TeamSettings.RestrictPublicChannelCreation {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPublicChannelCreation {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
 		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPublicChannelManagement {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPublicChannelManagement {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		case model.PERMISSIONS_CHANNEL_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+			)
+			model.ROLE_CHANNEL_ADMIN.Permissions = append(
+				model.ROLE_CHANNEL_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 		)
-		break
-	case model.PERMISSIONS_CHANNEL_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
-		)
-		model.ROLE_CHANNEL_ADMIN.Permissions = append(
-			model.ROLE_CHANNEL_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
-		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPublicChannelDeletion {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPublicChannelDeletion {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_CHANNEL_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+			)
+			model.ROLE_CHANNEL_ADMIN.Permissions = append(
+				model.ROLE_CHANNEL_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 		)
-		break
-	case model.PERMISSIONS_CHANNEL_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
-		)
-		model.ROLE_CHANNEL_ADMIN.Permissions = append(
-			model.ROLE_CHANNEL_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
-		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPrivateChannelCreation {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPrivateChannelCreation {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
 		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPrivateChannelManagement {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPrivateChannelManagement {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		case model.PERMISSIONS_CHANNEL_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+			)
+			model.ROLE_CHANNEL_ADMIN.Permissions = append(
+				model.ROLE_CHANNEL_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 		)
-		break
-	case model.PERMISSIONS_CHANNEL_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
-		)
-		model.ROLE_CHANNEL_ADMIN.Permissions = append(
-			model.ROLE_CHANNEL_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
-		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPrivateChannelDeletion {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPrivateChannelDeletion {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_CHANNEL_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
+			)
+			model.ROLE_CHANNEL_ADMIN.Permissions = append(
+				model.ROLE_CHANNEL_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 		)
-		break
-	case model.PERMISSIONS_CHANNEL_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
-		)
-		model.ROLE_CHANNEL_ADMIN.Permissions = append(
-			model.ROLE_CHANNEL_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
-		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
-		)
-		break
 	}
 
 	if !*Cfg.ServiceSettings.EnableOnlyAdminIntegrations {
@@ -167,8 +209,28 @@ func SetDefaultRolesBasedOnConfig() {
 		)
 	}
 
-	switch *Cfg.ServiceSettings.RestrictPostDelete {
-	case model.PERMISSIONS_DELETE_POST_ALL:
+	if IsLicensed {
+		switch *Cfg.ServiceSettings.RestrictPostDelete {
+		case model.PERMISSIONS_DELETE_POST_ALL:
+			model.ROLE_CHANNEL_USER.Permissions = append(
+				model.ROLE_CHANNEL_USER.Permissions,
+				model.PERMISSION_DELETE_POST.Id,
+			)
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_DELETE_POST.Id,
+				model.PERMISSION_DELETE_OTHERS_POSTS.Id,
+			)
+			break
+		case model.PERMISSIONS_DELETE_POST_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_DELETE_POST.Id,
+				model.PERMISSION_DELETE_OTHERS_POSTS.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_CHANNEL_USER.Permissions = append(
 			model.ROLE_CHANNEL_USER.Permissions,
 			model.PERMISSION_DELETE_POST.Id,
@@ -178,14 +240,6 @@ func SetDefaultRolesBasedOnConfig() {
 			model.PERMISSION_DELETE_POST.Id,
 			model.PERMISSION_DELETE_OTHERS_POSTS.Id,
 		)
-		break
-	case model.PERMISSIONS_DELETE_POST_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_DELETE_POST.Id,
-			model.PERMISSION_DELETE_OTHERS_POSTS.Id,
-		)
-		break
 	}
 
 	if Cfg.TeamSettings.EnableTeamCreation {


### PR DESCRIPTION
#### Summary
Fix "Policy" application in team edition. This affects who can:
* CreatePublicChannels
* ManagePublicChannels
* DeletePublicChannels
* CreatePrivateChannels
* ManagePrivateChannels
* DeletePrivateChannels
* DeletePosts

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase: permissions, client-reload-on-config-change, license-add-and-remove.
