### PR TITLE
Backport #5771 to 3.6. Don't apply policy settings to TE.

### DIFF
--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -169,6 +169,20 @@ func TestCreateChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+
+	channel4 := model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel5 := model.Channel{DisplayName: "Test API Name", Name: "a" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
+	if _, err := Client.CreateChannel(&channel4); err != nil {
+		t.Fatal("should have succeeded")
+	}
+	if _, err := Client.CreateChannel(&channel5); err != nil {
+		t.Fatal("should have succeeded")
+	}
+
 	*utils.Cfg.TeamSettings.RestrictPublicChannelCreation = model.PERMISSIONS_ALL
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_ALL
 	utils.SetDefaultRolesBasedOnConfig()
@@ -333,16 +347,19 @@ func TestUpdateChannel(t *testing.T) {
 
 	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	utils.SetDefaultRolesBasedOnConfig()
 	MakeUserChannelUser(th.BasicUser, channel2)
 	MakeUserChannelUser(th.BasicUser, channel3)
 	store.ClearChannelCaches()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
-		t.Fatal("should have errored not team admin")
+		t.Fatal("should have errored not channel admin")
 	}
 	if _, err := Client.UpdateChannel(channel3); err == nil {
-		t.Fatal("should have errored not team admin")
+		t.Fatal("should have errored not channel admin")
 	}
 
 	MakeUserChannelAdmin(th.BasicUser, channel2)
@@ -358,6 +375,9 @@ func TestUpdateChannel(t *testing.T) {
 
 	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	utils.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
@@ -381,6 +401,9 @@ func TestUpdateChannel(t *testing.T) {
 
 	*utils.Cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	utils.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
@@ -391,6 +414,18 @@ func TestUpdateChannel(t *testing.T) {
 	}
 
 	th.LoginSystemAdmin()
+
+	if _, err := Client.UpdateChannel(channel2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.UpdateChannel(channel3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err != nil {
 		t.Fatal(err)
@@ -608,6 +643,18 @@ func TestUpdateChannelHeader(t *testing.T) {
 	if _, err := SystemAdminClient.UpdateChannelHeader(data3); err != nil {
 		t.Fatal(err)
 	}
+
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+
+	if _, err := SystemAdminClient.UpdateChannelHeader(data2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SystemAdminClient.UpdateChannelHeader(data3); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestUpdateChannelPurpose(t *testing.T) {
@@ -765,6 +812,17 @@ func TestUpdateChannelPurpose(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := SystemAdminClient.UpdateChannelPurpose(data3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+	if _, err := SystemAdminClient.UpdateChannelHeader(data2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SystemAdminClient.UpdateChannelHeader(data3); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1242,6 +1300,9 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
@@ -1273,6 +1334,9 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
@@ -1305,6 +1369,9 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
 	*utils.Cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
@@ -1331,6 +1398,25 @@ func TestDeleteChannel(t *testing.T) {
 	}
 
 	th.LoginSystemAdmin()
+
+	if _, err := Client.DeleteChannel(channel2.Id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Client.DeleteChannel(channel3.Id); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that if unlicensed the policy restriction is not enforced.
+	utils.IsLicensed = false
+	utils.License = nil
+	utils.SetDefaultRolesBasedOnConfig()
+
+	channel2 = th.CreateChannel(Client, team)
+	channel3 = th.CreatePrivateChannel(Client, team)
+	Client.Must(Client.AddChannelMember(channel2.Id, th.BasicUser.Id))
+	Client.Must(Client.AddChannelMember(channel3.Id, th.BasicUser.Id))
+
+	Client.Login(th.BasicUser.Email, th.BasicUser.Password)
 
 	if _, err := Client.DeleteChannel(channel2.Id); err != nil {
 		t.Fatal(err)

--- a/api/context.go
+++ b/api/context.go
@@ -161,7 +161,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.RequestId)
-	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash))
+	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash, utils.IsLicensed))
 	if einterfaces.GetClusterInterface() != nil {
 		w.Header().Set(model.HEADER_CLUSTER_ID, einterfaces.GetClusterInterface().GetClusterId())
 	}

--- a/api/license.go
+++ b/api/license.go
@@ -141,6 +141,11 @@ func SaveLicense(licenseBytes []byte) (*model.License, *model.AppError) {
 		return nil, model.NewLocAppError("addLicense", INVALID_LICENSE_ERROR, nil, "")
 	}
 
+	utils.LoadConfig(utils.CfgFileName)
+
+	// start/restart email batching job if necessary
+	InitEmailBatching()
+
 	return license, nil
 }
 
@@ -168,6 +173,11 @@ func RemoveLicense() *model.AppError {
 		utils.RemoveLicense()
 		return result.Err
 	}
+
+	utils.LoadConfig(utils.CfgFileName)
+
+	// start/restart email batching job if necessary
+	InitEmailBatching()
 
 	return nil
 }

--- a/api/web_conn.go
+++ b/api/web_conn.go
@@ -177,7 +177,7 @@ func (webCon *WebConn) isAuthenticated() bool {
 
 func (webCon *WebConn) SendHello() {
 	msg := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_HELLO, "", "", webCon.UserId, nil)
-	msg.Add("server_version", fmt.Sprintf("%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash))
+	msg.Add("server_version", fmt.Sprintf("%v.%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.CfgHash, utils.IsLicensed))
 	msg.DoPreComputeJson()
 	webCon.Send <- msg
 }

--- a/utils/authorization.go
+++ b/utils/authorization.go
@@ -9,118 +9,160 @@ func SetDefaultRolesBasedOnConfig() {
 	// Reset the roles to default to make this logic easier
 	model.InitalizeRoles()
 
-	switch *Cfg.TeamSettings.RestrictPublicChannelCreation {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPublicChannelCreation {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
 		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPublicChannelManagement {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPublicChannelManagement {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		case model.PERMISSIONS_CHANNEL_ADMIN:
+			model.ROLE_CHANNEL_ADMIN.Permissions = append(
+				model.ROLE_CHANNEL_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 		)
-		break
-	case model.PERMISSIONS_CHANNEL_ADMIN:
-		model.ROLE_CHANNEL_ADMIN.Permissions = append(
-			model.ROLE_CHANNEL_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
-		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPublicChannelDeletion {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPublicChannelDeletion {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_CHANNEL_ADMIN:
+			model.ROLE_CHANNEL_ADMIN.Permissions = append(
+				model.ROLE_CHANNEL_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 		)
-		break
-	case model.PERMISSIONS_CHANNEL_ADMIN:
-		model.ROLE_CHANNEL_ADMIN.Permissions = append(
-			model.ROLE_CHANNEL_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
-		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPrivateChannelCreation {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPrivateChannelCreation {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
 		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPrivateChannelManagement {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPrivateChannelManagement {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		case model.PERMISSIONS_CHANNEL_ADMIN:
+			model.ROLE_CHANNEL_ADMIN.Permissions = append(
+				model.ROLE_CHANNEL_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 		)
-		break
-	case model.PERMISSIONS_CHANNEL_ADMIN:
-		model.ROLE_CHANNEL_ADMIN.Permissions = append(
-			model.ROLE_CHANNEL_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
-		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
-		)
-		break
 	}
 
-	switch *Cfg.TeamSettings.RestrictPrivateChannelDeletion {
-	case model.PERMISSIONS_ALL:
+	if IsLicensed {
+		switch *Cfg.TeamSettings.RestrictPrivateChannelDeletion {
+		case model.PERMISSIONS_ALL:
+			model.ROLE_TEAM_USER.Permissions = append(
+				model.ROLE_TEAM_USER.Permissions,
+				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_CHANNEL_ADMIN:
+			model.ROLE_CHANNEL_ADMIN.Permissions = append(
+				model.ROLE_CHANNEL_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		case model.PERMISSIONS_TEAM_ADMIN:
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
+			)
+			break
+		}
+	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
 			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 		)
-		break
-	case model.PERMISSIONS_CHANNEL_ADMIN:
-		model.ROLE_CHANNEL_ADMIN.Permissions = append(
-			model.ROLE_CHANNEL_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
-		)
-		break
-	case model.PERMISSIONS_TEAM_ADMIN:
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
-			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
-		)
-		break
 	}
 
 	if !*Cfg.ServiceSettings.EnableOnlyAdminIntegrations {


### PR DESCRIPTION
#### Summary
Backport #5771 to 3.6. Don't apply policy settings to TE.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase permissions, license add and remove, auto-reload-on-config-change.
