### PR TITLE
PLT-5913: Remove id from heading markdown compilation

### DIFF
--- a/webapp/tests/formatting_hashtags.test.jsx
+++ b/webapp/tests/formatting_hashtags.test.jsx
@@ -11,7 +11,7 @@ describe('TextFormatting.Hashtags', function() {
     it('Not hashtags', function(done) {
         assert.equal(
             TextFormatting.formatText('# hashtag').trim(),
-            '<h1 id="hashtag" class="markdown__heading">hashtag</h1>'
+            '<h1 class="markdown__heading">hashtag</h1>'
         );
 
         assert.equal(

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -156,9 +156,8 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         return out;
     }
 
-    heading(text, level, raw) {
-        const id = `${this.options.headerPrefix}${raw.toLowerCase().replace(/[^\w]+/g, '-')}`;
-        return `<h${level} id="${id}" class="markdown__heading">${text}</h${level}>`;
+    heading(text, level) {
+        return `<h${level} class="markdown__heading">${text}</h${level}>`;
     }
 
     link(href, title, text) {


### PR DESCRIPTION
Heading markdown compilation id addition is unnecessary as we didn't
attach any style/effect to it, also it introduces duplicate DOM id.
So remove it from heading markdown translation.

Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Heading markdown compilation id addition is unnecessary as we didn't
attach any style/effect to it, also it introduces duplicate DOM id.
So remove it from heading markdown translation.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/PLT-5913

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
