### PR TITLE
Add ability to use 'me' in place of user id for APIv4

### DIFF
--- a/api4/context.go
+++ b/api4/context.go
@@ -333,6 +333,10 @@ func (c *Context) RequireUserId() *Context {
 		return c
 	}
 
+	if c.Params.UserId == model.ME {
+		c.Params.UserId = c.Session.UserId
+	}
+
 	if len(c.Params.UserId) != 26 {
 		c.SetInvalidUrlParam("user_id")
 	}

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -75,6 +75,23 @@ func TestCreateUser(t *testing.T) {
 	}
 }
 
+func TestGetMe(t *testing.T) {
+	th := Setup().InitBasic()
+	defer TearDown()
+	Client := th.Client
+
+	ruser, resp := Client.GetMe("")
+	CheckNoError(t, resp)
+
+	if ruser.Id != th.BasicUser.Id {
+		t.Fatal("wrong user")
+	}
+
+	Client.Logout()
+	_, resp = Client.GetMe("")
+	CheckUnauthorizedStatus(t, resp)
+}
+
 func TestGetUser(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer TearDown()

--- a/model/client4.go
+++ b/model/client4.go
@@ -349,6 +349,16 @@ func (c *Client4) CreateUser(user *User) (*User, *Response) {
 	}
 }
 
+// GetMe returns the logged in user.
+func (c *Client4) GetMe(etag string) (*User, *Response) {
+	if r, err := c.DoApiGet(c.GetUserRoute(ME), etag); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return UserFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // GetUser returns a user based on the provided user id string.
 func (c *Client4) GetUser(userId, etag string) (*User, *Response) {
 	if r, err := c.DoApiGet(c.GetUserRoute(userId), etag); err != nil {

--- a/model/user.go
+++ b/model/user.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	ME                      = "me"
 	USER_NOTIFY_ALL         = "all"
 	USER_NOTIFY_MENTION     = "mention"
 	USER_NOTIFY_NONE        = "none"


### PR DESCRIPTION
#### Summary
Add ability to use 'me' in place of user id for APIv4. When 'me' is specified, the logged in user's user id is used.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#169)
- [x] All new/modified APIs include changes to the drivers