### PR TITLE
[APIV4] DELETE /hooks/outgoing/{hook_id} - delete outgoing webhook endpoint for apiV4

### DIFF
--- a/api4/webhook.go
+++ b/api4/webhook.go
@@ -23,8 +23,9 @@ func InitWebhook() {
 
 	BaseRoutes.OutgoingHooks.Handle("", ApiSessionRequired(createOutgoingHook)).Methods("POST")
 	BaseRoutes.OutgoingHooks.Handle("", ApiSessionRequired(getOutgoingHooks)).Methods("GET")
-	BaseRoutes.OutgoingHook.Handle("", ApiSessionRequired(updateOutcomingHook)).Methods("PUT")
 	BaseRoutes.OutgoingHook.Handle("", ApiSessionRequired(getOutgoingHook)).Methods("GET")
+	BaseRoutes.OutgoingHook.Handle("", ApiSessionRequired(updateOutgoingHook)).Methods("PUT")
+	BaseRoutes.OutgoingHook.Handle("", ApiSessionRequired(deleteOutgoingHook)).Methods("DELETE")
 	BaseRoutes.OutgoingHook.Handle("/regen_token", ApiSessionRequired(regenOutgoingHookToken)).Methods("POST")
 }
 
@@ -226,7 +227,7 @@ func deleteIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func updateOutcomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
+func updateOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.RequireHookId()
 	if c.Err != nil {
 		return
@@ -394,4 +395,39 @@ func regenOutgoingHookToken(c *Context, w http.ResponseWriter, r *http.Request) 
 	} else {
 		w.Write([]byte(rhook.ToJson()))
 	}
+}
+
+func deleteOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireHookId()
+	if c.Err != nil {
+		return
+	}
+
+	hook, err := app.GetOutgoingWebhook(c.Params.HookId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	c.LogAudit("attempt")
+
+	if !app.SessionHasPermissionToTeam(c.Session, hook.TeamId, model.PERMISSION_MANAGE_WEBHOOKS) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_WEBHOOKS)
+		return
+	}
+
+	if c.Session.UserId != hook.CreatorId && !app.SessionHasPermissionToTeam(c.Session, hook.TeamId, model.PERMISSION_MANAGE_OTHERS_WEBHOOKS) {
+		c.LogAudit("fail - inappropriate permissions")
+		c.SetPermissionError(model.PERMISSION_MANAGE_OTHERS_WEBHOOKS)
+		return
+	}
+
+	if err := app.DeleteOutgoingWebhook(hook.Id); err != nil {
+		c.LogAudit("fail")
+		c.Err = err
+		return
+	}
+
+	c.LogAudit("success")
+	ReturnStatusOK(w)
 }

--- a/model/client4.go
+++ b/model/client4.go
@@ -1383,6 +1383,16 @@ func (c *Client4) RegenOutgoingHookToken(hookId string) (*OutgoingWebhook, *Resp
 	}
 }
 
+// DeleteOutgoingWebhook delete the outgoing webhook on the system requested by Hook Id.
+func (c *Client4) DeleteOutgoingWebhook(hookId string) (bool, *Response) {
+	if r, err := c.DoApiDelete(c.GetOutgoingWebhookRoute(hookId)); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // Preferences Section
 
 // GetPreferences returns the user's preferences.


### PR DESCRIPTION
#### Summary
This PR implements the DELETE /hooks/outgoing/{hook_id}

#### Ticket Link
n/a

#### Checklist
- [x] Added or updated unit tests
- [x] API documentation already in the repo
- [x] All new/modified APIs include changes to the drivers
