### PR TITLE
PLT-5907: Fix Create Channel in More Channels dialog.

### DIFF
--- a/webapp/components/more_channels.jsx
+++ b/webapp/components/more_channels.jsx
@@ -10,6 +10,7 @@ import TeamStore from 'stores/team_store.jsx';
 import Constants from 'utils/constants.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
 import {joinChannel, searchMoreChannels} from 'actions/channel_actions.jsx';
+import {showCreateOption} from 'utils/channel_utils.jsx';
 
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
@@ -157,14 +158,9 @@ export default class MoreChannels extends React.Component {
         const isAdmin = TeamStore.isTeamAdminForCurrentTeam() || UserStore.isSystemAdminForCurrentUser();
         const isSystemAdmin = UserStore.isSystemAdminForCurrentUser();
 
-        if (global.window.mm_license.IsLicensed === 'true') {
-            if (global.window.mm_config.RestrictPublicChannelManagement === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
-                createNewChannelButton = null;
-                createChannelHelpText = null;
-            } else if (global.window.mm_config.RestrictPublicChannelManagement === Constants.PERMISSIONS_TEAM_ADMIN && !isAdmin) {
-                createNewChannelButton = null;
-                createChannelHelpText = null;
-            }
+        if (!showCreateOption(Constants.OPEN_CHANNEL, isAdmin, isSystemAdmin)) {
+            createNewChannelButton = null;
+            createChannelHelpText = null;
         }
 
         return (


### PR DESCRIPTION
#### Summary
Fix Create Channel button in More Channels dialog to only display when the user actually has the permissions to create a new public channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5907