### PR TITLE
PLT-5879: User email notification settings disabling.

### DIFF
--- a/webapp/components/user_settings/email_notification_setting.jsx
+++ b/webapp/components/user_settings/email_notification_setting.jsx
@@ -57,10 +57,42 @@ export default class EmailNotificationSetting extends React.Component {
     }
 
     render() {
+        if (global.window.mm_config.SendEmailNotifications !== 'true' && this.props.activeSection === 'email') {
+            const inputs = [];
+
+            inputs.push(
+                <div
+                    key='oauthEmailInfo'
+                    className='padding-top'
+                >
+                    <FormattedMessage
+                        id='user.settings.notifications.email.disabled_long'
+                        defaultMessage='Email notifications have been disabled by your System Administrator.'
+                    />
+                </div>
+            );
+
+            return (
+                <SettingItemMax
+                    title={localizeMessage('user.settings.notifications.emailNotifications', 'Email notifications')}
+                    inputs={inputs}
+                    server_error={this.state.serverError}
+                    updateSection={this.collapse}
+                />
+            );
+        }
+
         if (this.props.activeSection !== 'email') {
             let description;
 
-            if (this.props.enableEmail) {
+            if (global.window.mm_config.SendEmailNotifications !== 'true') {
+                description = (
+                    <FormattedMessage
+                        id='user.settings.notifications.email.disabled'
+                        defaultMessage='Disabled by System Administrator'
+                    />
+                );
+            } else if (this.props.enableEmail) {
                 switch (this.state.emailInterval) {
                 case Preferences.INTERVAL_IMMEDIATE:
                     description = (

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -2149,6 +2149,8 @@
   "user.settings.notifications.desktop.title": "Desktop notifications",
   "user.settings.notifications.desktop.unlimited": "Unlimited",
   "user.settings.notifications.desktopSounds": "Desktop notification sounds",
+  "user.settings.notifications.email.disabled": "Disabled by System Administrator",
+  "user.settings.notifications.email.disabled_long": "Email notifications have been disabled by your System Administrator.",
   "user.settings.notifications.email.everyHour": "Every hour",
   "user.settings.notifications.email.everyXMinutes": "Every {count, plural, one {minute} other {{count, number} minutes}}",
   "user.settings.notifications.email.immediately": "Immediately",


### PR DESCRIPTION
#### Summary
When Email Notifications are turned off server wide, don't allow the
user to configure their email notification preferences.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5879

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file updates
