### PR TITLE
PLT-2713 Added 'without_team' option when searching users

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -1535,22 +1535,12 @@ func searchUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var profiles []*model.User
-	var err *model.AppError
-	if props.InChannelId != "" {
-		profiles, err = app.SearchUsersInChannel(props.InChannelId, props.Term, searchOptions, c.IsSystemAdmin())
-	} else if props.NotInChannelId != "" {
-		profiles, err = app.SearchUsersNotInChannel(props.TeamId, props.NotInChannelId, props.Term, searchOptions, c.IsSystemAdmin())
-	} else {
-		profiles, err = app.SearchUsersInTeam(props.TeamId, props.Term, searchOptions, c.IsSystemAdmin())
-	}
-
-	if err != nil {
+	if profiles, err := app.SearchUsers(props, searchOptions, c.IsSystemAdmin()); err != nil {
 		c.Err = err
 		return
+	} else {
+		w.Write([]byte(model.UserListToJson(profiles)))
 	}
-
-	w.Write([]byte(model.UserListToJson(profiles)))
 }
 
 func getProfilesByIds(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -2440,6 +2440,59 @@ func TestSearchUsers(t *testing.T) {
 	}
 
 	if _, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser.Username, NotInChannelId: th.BasicChannel.Id}); err == nil {
+		t.Fatal("should not have access")
+	}
+
+	userWithoutTeam := th.CreateUser(Client)
+	if result, err := Client.SearchUsers(model.UserSearch{Term: userWithoutTeam.Username}); err != nil {
+		t.Fatal(err)
+	} else {
+		users := result.Data.([]*model.User)
+
+		found := false
+		for _, user := range users {
+			if user.Id == userWithoutTeam.Id {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Fatal("should have found user without team")
+		}
+	}
+
+	if result, err := Client.SearchUsers(model.UserSearch{Term: userWithoutTeam.Username, WithoutTeam: true}); err != nil {
+		t.Fatal(err)
+	} else {
+		users := result.Data.([]*model.User)
+
+		found := false
+		for _, user := range users {
+			if user.Id == userWithoutTeam.Id {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Fatal("should have found user without team")
+		}
+	}
+
+	if result, err := Client.SearchUsers(model.UserSearch{Term: th.BasicUser.Username, WithoutTeam: true}); err != nil {
+		t.Fatal(err)
+	} else {
+		users := result.Data.([]*model.User)
+
+		found := false
+		for _, user := range users {
+			if user.Id == th.BasicUser.Id {
+				found = true
+			}
+		}
+
+		if found {
+			t.Fatal("should not have found user with team")
+		}
 	}
 }
 

--- a/model/user_search.go
+++ b/model/user_search.go
@@ -14,6 +14,7 @@ type UserSearch struct {
 	InChannelId    string `json:"in_channel_id"`
 	NotInChannelId string `json:"not_in_channel_id"`
 	AllowInactive  bool   `json:"allow_inactive"`
+	WithoutTeam    bool   `json:"without_team"`
 }
 
 // ToJson convert a User to a json string

--- a/store/store.go
+++ b/store/store.go
@@ -201,6 +201,7 @@ type UserStore interface {
 	Search(teamId string, term string, options map[string]bool) StoreChannel
 	SearchInChannel(channelId string, term string, options map[string]bool) StoreChannel
 	SearchNotInChannel(teamId string, channelId string, term string, options map[string]bool) StoreChannel
+	SearchWithoutTeam(term string, options map[string]bool) StoreChannel
 	AnalyticsGetInactiveUsersCount() StoreChannel
 	AnalyticsGetSystemAdminCount() StoreChannel
 }


### PR DESCRIPTION
I need the ability to search for users without teams for the system console user list. These are the server side changes for that feature

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-2713

#### Checklist
- Added or updated unit tests (required for all new features)
- Added API documentation (https://github.com/mattermost/mattermost-api-reference/pull/171)