### PR TITLE
Implement some channel endpoints for APIv4

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -366,8 +366,8 @@ func searchChannelsForTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToTeam(c.Session, c.Params.TeamId, model.PERMISSION_READ_PUBLIC_CHANNEL) {
-		c.SetPermissionError(model.PERMISSION_READ_PUBLIC_CHANNEL)
+	if !app.SessionHasPermissionToTeam(c.Session, c.Params.TeamId, model.PERMISSION_LIST_TEAM_CHANNELS) {
+		c.SetPermissionError(model.PERMISSION_LIST_TEAM_CHANNELS)
 		return
 	}
 

--- a/app/channel.go
+++ b/app/channel.go
@@ -260,6 +260,11 @@ func UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
 	}
 }
 
+func PatchChannel(channel *model.Channel, patch *model.ChannelPatch) (*model.Channel, *model.AppError) {
+	channel.Patch(patch)
+	return UpdateChannel(channel)
+}
+
 func UpdateChannelMemberRoles(channelId string, userId string, newRoles string) (*model.ChannelMember, *model.AppError) {
 	var member *model.ChannelMember
 	var err *model.AppError

--- a/model/channel.go
+++ b/model/channel.go
@@ -46,7 +46,23 @@ type Channel struct {
 	CreatorId     string `json:"creator_id"`
 }
 
+type ChannelPatch struct {
+	DisplayName *string `json:"display_name"`
+	Name        *string `json:"name"`
+	Header      *string `json:"header"`
+	Purpose     *string `json:"purpose"`
+}
+
 func (o *Channel) ToJson() string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func (o *ChannelPatch) ToJson() string {
 	b, err := json.Marshal(o)
 	if err != nil {
 		return ""
@@ -58,6 +74,17 @@ func (o *Channel) ToJson() string {
 func ChannelFromJson(data io.Reader) *Channel {
 	decoder := json.NewDecoder(data)
 	var o Channel
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
+	} else {
+		return nil
+	}
+}
+
+func ChannelPatchFromJson(data io.Reader) *ChannelPatch {
+	decoder := json.NewDecoder(data)
+	var o ChannelPatch
 	err := decoder.Decode(&o)
 	if err == nil {
 		return &o
@@ -135,6 +162,24 @@ func (o *Channel) ExtraUpdated() {
 
 func (o *Channel) IsGroupOrDirect() bool {
 	return o.Type == CHANNEL_DIRECT || o.Type == CHANNEL_GROUP
+}
+
+func (o *Channel) Patch(patch *ChannelPatch) {
+	if patch.DisplayName != nil {
+		o.DisplayName = *patch.DisplayName
+	}
+
+	if patch.Name != nil {
+		o.Name = *patch.Name
+	}
+
+	if patch.Header != nil {
+		o.Header = *patch.Header
+	}
+
+	if patch.Purpose != nil {
+		o.Purpose = *patch.Purpose
+	}
 }
 
 func GetDMNameFromIds(userId1, userId2 string) string {

--- a/model/channel_test.go
+++ b/model/channel_test.go
@@ -16,6 +16,39 @@ func TestChannelJson(t *testing.T) {
 	if o.Id != ro.Id {
 		t.Fatal("Ids do not match")
 	}
+
+	p := ChannelPatch{Name: new(string)}
+	*p.Name = NewId()
+	json = p.ToJson()
+	rp := ChannelPatchFromJson(strings.NewReader(json))
+
+	if *p.Name != *rp.Name {
+		t.Fatal("names do not match")
+	}
+}
+
+func TestChannelPatch(t *testing.T) {
+	p := &ChannelPatch{Name: new(string), DisplayName: new(string), Header: new(string), Purpose: new(string)}
+	*p.Name = NewId()
+	*p.DisplayName = NewId()
+	*p.Header = NewId()
+	*p.Purpose = NewId()
+
+	o := Channel{Id: NewId(), Name: NewId()}
+	o.Patch(p)
+
+	if *p.Name != o.Name {
+		t.Fatal("do not match")
+	}
+	if *p.DisplayName != o.DisplayName {
+		t.Fatal("do not match")
+	}
+	if *p.Header != o.Header {
+		t.Fatal("do not match")
+	}
+	if *p.Purpose != o.Purpose {
+		t.Fatal("do not match")
+	}
 }
 
 func TestChannelIsValid(t *testing.T) {

--- a/model/client4.go
+++ b/model/client4.go
@@ -834,6 +834,16 @@ func (c *Client4) UpdateChannel(channel *Channel) (*Channel, *Response) {
 	}
 }
 
+// PatchChannel partially updates a channel. Any missing fields are not updated.
+func (c *Client4) PatchChannel(channelId string, patch *ChannelPatch) (*Channel, *Response) {
+	if r, err := c.DoApiPut(c.GetChannelRoute(channelId)+"/patch", patch.ToJson()); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return ChannelFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // CreateDirectChannel creates a direct message channel based on the two user
 // ids provided.
 func (c *Client4) CreateDirectChannel(userId1, userId2 string) (*Channel, *Response) {

--- a/model/client4.go
+++ b/model/client4.go
@@ -866,10 +866,20 @@ func (c *Client4) GetChannelStats(channelId string, etag string) (*ChannelStats,
 	}
 }
 
-// GetPublicChannelsForTeam returns a channel based on the provided team id string.
+// GetPublicChannelsForTeam returns a list of public channels based on the provided team id string.
 func (c *Client4) GetPublicChannelsForTeam(teamId string, page int, perPage int, etag string) (*ChannelList, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
 	if r, err := c.DoApiGet(c.GetPublicChannelsForTeamRoute(teamId)+query, etag); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return ChannelListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// GetChannelsForTeamForUser returns a list channels of on a team for a user.
+func (c *Client4) GetChannelsForTeamForUser(teamId, userId, etag string) (*ChannelList, *Response) {
+	if r, err := c.DoApiGet(c.GetUserRoute(userId)+c.GetTeamRoute(teamId)+"/channels", etag); err != nil {
 		return nil, &Response{StatusCode: r.StatusCode, Error: err}
 	} else {
 		defer closeBody(r)

--- a/model/client4.go
+++ b/model/client4.go
@@ -897,6 +897,16 @@ func (c *Client4) GetChannelsForTeamForUser(teamId, userId, etag string) (*Chann
 	}
 }
 
+// SearchChannels returns the channels on a team matching the provided search term.
+func (c *Client4) SearchChannels(teamId string, search *ChannelSearch) (*ChannelList, *Response) {
+	if r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/channels/search", search.ToJson()); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return ChannelListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // DeleteChannel deletes channel based on the provided channel id string.
 func (c *Client4) DeleteChannel(channelId string) (bool, *Response) {
 	if r, err := c.DoApiDelete(c.GetChannelRoute(channelId)); err != nil {


### PR DESCRIPTION
#### Summary
* Add v4 endpoint for getting the channels on a team for a user
* Implement PUT /channels/{channel_id}/patch endpoint for APIv4
* Implement POST /teams/{team_id}/channels/search endpoint for APIv4

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#174)
- [x] All new/modified APIs include changes to the drivers