### PR TITLE
PLT-5267: Remove fake img preview before loaded

### DIFF
--- a/webapp/components/post_view/components/post_body_additional_content.jsx
+++ b/webapp/components/post_view/components/post_body_additional_content.jsx
@@ -21,11 +21,13 @@ export default class PostBodyAdditionalContent extends React.Component {
         this.toggleEmbedVisibility = this.toggleEmbedVisibility.bind(this);
         this.isLinkToggleable = this.isLinkToggleable.bind(this);
         this.handleLinkLoadError = this.handleLinkLoadError.bind(this);
+        this.handleLinkLoaded = this.handleLinkLoaded.bind(this);
 
         this.state = {
             embedVisible: props.previewCollapsed.startsWith('false'),
             link: Utils.extractFirstLink(props.post.message),
-            linkLoadError: false
+            linkLoadError: false,
+            linkLoaded: false
         };
     }
 
@@ -33,7 +35,8 @@ export default class PostBodyAdditionalContent extends React.Component {
         this.setState({
             embedVisible: nextProps.previewCollapsed.startsWith('false'),
             link: Utils.extractFirstLink(nextProps.post.message),
-            linkLoadError: false
+            linkLoadError: false,
+            linkLoaded: false
         });
     }
 
@@ -48,6 +51,9 @@ export default class PostBodyAdditionalContent extends React.Component {
             return true;
         }
         if (nextState.linkLoadError !== this.state.linkLoadError) {
+            return true;
+        }
+        if (nextState.linkLoaded !== this.state.linkLoaded) {
             return true;
         }
         return false;
@@ -103,6 +109,12 @@ export default class PostBodyAdditionalContent extends React.Component {
         });
     }
 
+    handleLinkLoaded() {
+        this.setState({
+            linkLoaded: true
+        });
+    }
+
     generateToggleableEmbed() {
         const link = this.state.link;
         if (!link) {
@@ -125,6 +137,8 @@ export default class PostBodyAdditionalContent extends React.Component {
                     channelId={this.props.post.channel_id}
                     link={link}
                     onLinkLoadError={this.handleLinkLoadError}
+                    onLinkLoaded={this.handleLinkLoaded}
+                    childComponentDidUpdateFunction={this.props.childComponentDidUpdateFunction}
                 />
             );
         }
@@ -158,14 +172,16 @@ export default class PostBodyAdditionalContent extends React.Component {
             // if message has only one line and starts with a link place toggle in this only line
             // else - place it in new line between message and embed
             const prependToggle = (/^\s*https?:\/\/.*$/).test(this.props.post.message);
-            messageWithToggle.push(
-                <a
-                    className={`post__embed-visibility ${prependToggle ? 'pull-left' : ''}`}
-                    data-expanded={this.state.embedVisible}
-                    aria-label='Toggle Embed Visibility'
-                    onClick={this.toggleEmbedVisibility}
-                />
-            );
+            if (this.state.linkLoaded) {
+                messageWithToggle.push(
+                    <a
+                        className={`post__embed-visibility ${prependToggle ? 'pull-left' : ''}`}
+                        data-expanded={this.state.embedVisible}
+                        aria-label='Toggle Embed Visibility'
+                        onClick={this.toggleEmbedVisibility}
+                    />
+                );
+            }
 
             if (prependToggle) {
                 messageWithToggle.push(this.props.message);

--- a/webapp/components/post_view/components/post_image.jsx
+++ b/webapp/components/post_view/components/post_image.jsx
@@ -30,6 +30,9 @@ export default class PostImageEmbed extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
+        if (this.state.loaded && this.props.childComponentDidUpdateFunction) {
+            this.props.childComponentDidUpdateFunction();
+        }
         if (!this.state.loaded && prevProps.link !== this.props.link) {
             this.loadImg(this.props.link);
         }
@@ -44,8 +47,12 @@ export default class PostImageEmbed extends React.Component {
 
     handleLoadComplete() {
         this.setState({
-            loaded: true
+            loaded: true,
+            errored: false
         });
+        if (this.props.onLinkLoaded) {
+            this.props.onLinkLoaded();
+        }
     }
 
     handleLoadError() {
@@ -59,17 +66,8 @@ export default class PostImageEmbed extends React.Component {
     }
 
     render() {
-        if (this.state.errored) {
+        if (this.state.errored || !this.state.loaded) {
             return null;
-        }
-
-        if (!this.state.loaded) {
-            return (
-                <img
-                    className='img-div placeholder'
-                    height='500px'
-                />
-            );
         }
 
         return (
@@ -83,5 +81,7 @@ export default class PostImageEmbed extends React.Component {
 
 PostImageEmbed.propTypes = {
     link: React.PropTypes.string.isRequired,
-    onLinkLoadError: React.PropTypes.func
+    onLinkLoadError: React.PropTypes.func,
+    onLinkLoaded: React.PropTypes.func,
+    childComponentDidUpdateFunction: React.PropTypes.func
 };

--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -22,7 +22,7 @@ import Constants from 'utils/constants.jsx';
 const ScrollTypes = Constants.ScrollTypes;
 
 import PreferenceStore from 'stores/preference_store.jsx';
-
+import PostStore from 'stores/post_store.jsx';
 import {FormattedDate, FormattedMessage} from 'react-intl';
 
 import React from 'react';
@@ -46,6 +46,7 @@ export default class PostList extends React.Component {
         this.scrollToBottomAnimated = this.scrollToBottomAnimated.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
         this.childComponentDidUpdate = this.childComponentDidUpdate.bind(this);
+        this.checkAndUpdateScrolling = this.checkAndUpdateScrolling.bind(this);
 
         this.jumpToPostNode = null;
         this.wasAtBottom = true;
@@ -510,12 +511,14 @@ export default class PostList extends React.Component {
 
         window.addEventListener('resize', this.handleResize);
         window.addEventListener('keydown', this.handleKeyDown);
+        PostStore.addPostScrollListener(this.checkAndUpdateScrolling);
     }
 
     componentWillUnmount() {
         window.cancelAnimationFrame(this.animationFrameId);
         window.removeEventListener('resize', this.handleResize);
         window.removeEventListener('keydown', this.handleKeyDown);
+        PostStore.removePostScrollListener(this.checkAndUpdateScrolling);
         this.scrollStopAction.cancel();
     }
 

--- a/webapp/sass/layout/_markdown.scss
+++ b/webapp/sass/layout/_markdown.scss
@@ -16,7 +16,6 @@
 #post-list {
     .markdown-inline-img {
         -moz-force-broken-image-icon: 1;
-        height: 500px;
         max-height: 500px;
     }
 }

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -17,6 +17,7 @@ const EDIT_POST_EVENT = 'edit_post';
 const POSTS_VIEW_JUMP_EVENT = 'post_list_jump';
 const SELECTED_POST_CHANGE_EVENT = 'selected_post_change';
 const POST_PINNED_CHANGE_EVENT = 'post_pinned_change';
+const UPDATE_POST_SCROLL_EVENT = 'update_post_scroll';
 
 class PostStoreClass extends EventEmitter {
     constructor() {
@@ -49,6 +50,18 @@ class PostStoreClass extends EventEmitter {
 
     removePostFocusedListener(callback) {
         this.removeListener(FOCUSED_POST_CHANGE, callback);
+    }
+
+    emitPostScroll() {
+        this.emit(UPDATE_POST_SCROLL_EVENT);
+    }
+
+    addPostScrollListener(callback) {
+        this.on(UPDATE_POST_SCROLL_EVENT, callback);
+    }
+
+    removePostScrollLisener(callback) {
+        this.removeListener(UPDATE_POST_SCROLL_EVENT, callback);
     }
 
     emitEditPost(post) {

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -7,6 +7,8 @@ import * as SyntaxHighlighting from './syntax_highlighting.jsx';
 import marked from 'marked';
 import katex from 'katex';
 
+import PostStore from 'stores/post_store.jsx';
+
 function markdownImageLoaded(image) {
     if (image.hasAttribute('height') && image.attributes.height.value !== 'auto') {
         const maxHeight = parseInt(global.getComputedStyle(image).maxHeight, 10);
@@ -20,6 +22,7 @@ function markdownImageLoaded(image) {
     } else {
         image.style.height = 'auto';
     }
+    PostStore.emitPostScroll();
 }
 global.markdownImageLoaded = markdownImageLoaded;
 


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Remove fake img preview and collapse toggle before it is loaded,
only show img and toggle after it is fully loaded.
Fix markdown img size and add scroll down behaviour.

#### Ticket Link
Issue: https://github.com/mattermost/platform/issues/5368
Jira: https://mattermost.atlassian.net/browse/PLT-5267

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
