### PR TITLE
Implement client config/license endpoints for APIv4

### DIFF
--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -1,6 +1,7 @@
 package api4
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 
@@ -126,6 +127,58 @@ func TestUpdateConfig(t *testing.T) {
 			t.Log("It should update the SiteName")
 			t.Fatal()
 		}
+	}
+}
+
+func TestGetOldClientConfig(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	config, resp := Client.GetOldClientConfig("")
+	CheckNoError(t, resp)
+
+	if len(config["Version"]) == 0 {
+		t.Fatal("config not returned correctly")
+	}
+
+	Client.Logout()
+
+	_, resp = Client.GetOldClientConfig("")
+	CheckNoError(t, resp)
+
+	if _, err := Client.DoApiGet("/config/client", ""); err == nil || err.StatusCode != http.StatusNotImplemented {
+		t.Fatal("should have errored with 501")
+	}
+
+	if _, err := Client.DoApiGet("/config/client?format=junk", ""); err == nil || err.StatusCode != http.StatusBadRequest {
+		t.Fatal("should have errored with 400")
+	}
+}
+
+func TestGetOldClientLicense(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	license, resp := Client.GetOldClientLicense("")
+	CheckNoError(t, resp)
+
+	if len(license["IsLicensed"]) == 0 {
+		t.Fatal("license not returned correctly")
+	}
+
+	Client.Logout()
+
+	_, resp = Client.GetOldClientLicense("")
+	CheckNoError(t, resp)
+
+	if _, err := Client.DoApiGet("/license/client", ""); err == nil || err.StatusCode != http.StatusNotImplemented {
+		t.Fatal("should have errored with 501")
+	}
+
+	if _, err := Client.DoApiGet("/license/client?format=junk", ""); err == nil || err.StatusCode != http.StatusBadRequest {
+		t.Fatal("should have errored with 400")
 	}
 }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -48,6 +48,14 @@
     "translation": "September"
   },
   {
+    "id": "api.config.client.old_format.app_error",
+    "translation": "New format for the client configuration is not supported yet. Please specify format=old in the query string."
+  },
+  {
+    "id": "api.license.client.old_format.app_error",
+    "translation": "New format for the client license is not supported yet. Please specify format=old in the query string."
+  },
+  {
     "id": "api.admin.add_certificate.no_file.app_error",
     "translation": "No file under 'certificate' in request"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -130,6 +130,10 @@ func (c *Client4) GetConfigRoute() string {
 	return fmt.Sprintf("/config")
 }
 
+func (c *Client4) GetLicenseRoute() string {
+	return fmt.Sprintf("/license")
+}
+
 func (c *Client4) GetPostRoute(postId string) string {
 	return fmt.Sprintf(c.GetPostsRoute()+"/%v", postId)
 }
@@ -1223,6 +1227,7 @@ func (c *Client4) GetPing() (bool, *Response) {
 	}
 }
 
+// TestEmail will attempt to connect to the configured SMTP server.
 func (c *Client4) TestEmail() (bool, *Response) {
 	if r, err := c.DoApiPost(c.GetTestEmailRoute(), ""); err != nil {
 		return false, &Response{StatusCode: r.StatusCode, Error: err}
@@ -1249,6 +1254,28 @@ func (c *Client4) ReloadConfig() (bool, *Response) {
 	} else {
 		defer closeBody(r)
 		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
+// GetOldClientConfig will retrieve the parts of the server configuration needed by the
+// client, formatted in the old format.
+func (c *Client4) GetOldClientConfig(etag string) (map[string]string, *Response) {
+	if r, err := c.DoApiGet(c.GetConfigRoute()+"/client?format=old", etag); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return MapFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// GetOldClientLicense will retrieve the parts of the server license needed by the
+// client, formatted in the old format.
+func (c *Client4) GetOldClientLicense(etag string) (map[string]string, *Response) {
+	if r, err := c.DoApiGet(c.GetLicenseRoute()+"/client?format=old", etag); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return MapFromJson(r.Body), BuildResponse(r)
 	}
 }
 


### PR DESCRIPTION
#### Summary
Implement client config/license endpoints for APIv4. Since we haven't switched these over to be interface maps or structs yet, I added a format query parameter that requires "old" right now. When we move to structs then we can implement the other bit of these endpoints without breaking backwards compatibility. 

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#181)
- [x] All new/modified APIs include changes to the drivers