### PR TITLE
PLT-6063: AddUserToTeam permission depends on policy.

### DIFF
--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 )
@@ -510,12 +511,25 @@ func TestAddTeamMember(t *testing.T) {
 	team := th.BasicTeam
 	otherUser := th.CreateUser()
 
-	// by user_id
-	th.LoginTeamAdmin()
+	if err := app.RemoveUserFromTeam(th.BasicTeam.Id, th.BasicUser2.Id); err != nil {
+		t.Fatalf(err.Error())
+	}
 
+	// Regular user can't add a member to a team they don't belong to.
+	th.LoginBasic2()
 	tm, resp := Client.AddTeamMember(team.Id, otherUser.Id, "", "", "")
+	CheckForbiddenStatus(t, resp)
+	if resp.Error == nil {
+		t.Fatalf("ERror is nhul")
+	}
+	Client.Logout()
+
+	// Regular user can add a member to a team they belong to.
+	th.LoginBasic()
+	tm, resp = Client.AddTeamMember(team.Id, otherUser.Id, "", "", "")
 	CheckNoError(t, resp)
 
+	// Check all the returned data.
 	if tm == nil {
 		t.Fatal("should have returned team member")
 	}
@@ -528,6 +542,7 @@ func TestAddTeamMember(t *testing.T) {
 		t.Fatal("team ids should have matched")
 	}
 
+	// Check with various invalid requests.
 	tm, resp = Client.AddTeamMember(team.Id, "junk", "", "", "")
 	CheckBadRequestStatus(t, resp)
 
@@ -544,18 +559,85 @@ func TestAddTeamMember(t *testing.T) {
 	_, resp = Client.AddTeamMember(team.Id, GenerateTestId(), "", "", "")
 	CheckNotFoundStatus(t, resp)
 
+	Client.Logout()
+
+	// Check effects of config and license changes.
+	restrictTeamInvite := *utils.Cfg.TeamSettings.RestrictTeamInvite
+	isLicensed := utils.IsLicensed
+	license := utils.License
+	defer func() {
+		*utils.Cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite
+		utils.IsLicensed = isLicensed
+		utils.License = license
+		utils.SetDefaultRolesBasedOnConfig()
+	}()
+
+	// Set the config so that only team admins can add a user to a team.
+	*utils.Cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN
+	utils.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
+	// Test without the EE license to see that the permission restriction is ignored.
+	_, resp = Client.AddTeamMember(team.Id, otherUser.Id, "", "", "")
+	CheckNoError(t, resp)
+
+	// Add an EE license.
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
+	utils.SetDefaultRolesBasedOnConfig()
+	th.LoginBasic()
+
+	// Check that a regular user can't add someone to the team.
 	_, resp = Client.AddTeamMember(team.Id, otherUser.Id, "", "", "")
 	CheckForbiddenStatus(t, resp)
 
-	Client.Logout()
+	// Update user to team admin
+	UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
+	app.InvalidateAllCaches()
+	*utils.Cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
+	utils.SetDefaultRolesBasedOnConfig()
+	th.LoginBasic()
 
+	// Should work as a team admin.
 	_, resp = Client.AddTeamMember(team.Id, otherUser.Id, "", "", "")
-	CheckUnauthorizedStatus(t, resp)
+	CheckNoError(t, resp)
 
+	// Change permission level to System Admin
+	*utils.Cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_SYSTEM_ADMIN
+	utils.SetDefaultRolesBasedOnConfig()
+
+	// Should not work as team admin.
+	_, resp = Client.AddTeamMember(team.Id, otherUser.Id, "", "", "")
+	CheckForbiddenStatus(t, resp)
+
+	// Should work as system admin.
 	_, resp = th.SystemAdminClient.AddTeamMember(team.Id, otherUser.Id, "", "", "")
 	CheckNoError(t, resp)
+
+	// Change permission level to All
+	UpdateUserToNonTeamAdmin(th.BasicUser, th.BasicTeam)
+	app.InvalidateAllCaches()
+	*utils.Cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_ALL
+	utils.IsLicensed = true
+	utils.License = &model.License{Features: &model.Features{}}
+	utils.License.Features.SetDefaults()
+	utils.SetDefaultRolesBasedOnConfig()
+	th.LoginBasic()
+
+	// Should work as a regular user.
+	_, resp = Client.AddTeamMember(team.Id, otherUser.Id, "", "", "")
+	CheckNoError(t, resp)
+
+	// Reset config and license.
+	*utils.Cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite
+	utils.IsLicensed = isLicensed
+	utils.License = license
+	utils.SetDefaultRolesBasedOnConfig()
+	th.LoginBasic()
 
 	// by hash and data
 	Client.Login(otherUser.Email, otherUser.Password)

--- a/model/authorization.go
+++ b/model/authorization.go
@@ -343,7 +343,6 @@ func InitalizeRoles() {
 		"authentication.roles.team_admin.description",
 		[]string{
 			PERMISSION_EDIT_OTHERS_POSTS.Id,
-			PERMISSION_ADD_USER_TO_TEAM.Id,
 			PERMISSION_REMOVE_USER_FROM_TEAM.Id,
 			PERMISSION_MANAGE_TEAM.Id,
 			PERMISSION_IMPORT_TEAM.Id,
@@ -400,6 +399,7 @@ func InitalizeRoles() {
 							PERMISSION_DELETE_POST.Id,
 							PERMISSION_DELETE_OTHERS_POSTS.Id,
 							PERMISSION_CREATE_TEAM.Id,
+							PERMISSION_ADD_USER_TO_TEAM.Id,
 						},
 						ROLE_TEAM_USER.Permissions...,
 					),

--- a/utils/authorization.go
+++ b/utils/authorization.go
@@ -195,17 +195,26 @@ func SetDefaultRolesBasedOnConfig() {
 		)
 	}
 
-	// If team admins are given permission
-	if *Cfg.TeamSettings.RestrictTeamInvite == model.PERMISSIONS_TEAM_ADMIN {
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
+	// Grant permissions for inviting and adding users to a team.
+	if IsLicensed {
+		if *Cfg.TeamSettings.RestrictTeamInvite == model.PERMISSIONS_TEAM_ADMIN {
+			model.ROLE_TEAM_ADMIN.Permissions = append(
+				model.ROLE_TEAM_ADMIN.Permissions,
+				model.PERMISSION_INVITE_USER.Id,
+				model.PERMISSION_ADD_USER_TO_TEAM.Id,
+			)
+		} else if *Cfg.TeamSettings.RestrictTeamInvite == model.PERMISSIONS_ALL {
+			model.ROLE_SYSTEM_USER.Permissions = append(
+				model.ROLE_SYSTEM_USER.Permissions,
+				model.PERMISSION_INVITE_USER.Id,
+				model.PERMISSION_ADD_USER_TO_TEAM.Id,
+			)
+		}
+	} else {
+		model.ROLE_TEAM_USER.Permissions = append(
+			model.ROLE_TEAM_USER.Permissions,
 			model.PERMISSION_INVITE_USER.Id,
-		)
-		// If it's not restricted to system admin or team admin, then give all users permission
-	} else if *Cfg.TeamSettings.RestrictTeamInvite != model.PERMISSIONS_SYSTEM_ADMIN {
-		model.ROLE_SYSTEM_USER.Permissions = append(
-			model.ROLE_SYSTEM_USER.Permissions,
-			model.PERMISSION_INVITE_USER.Id,
+			model.PERMISSION_ADD_USER_TO_TEAM.Id,
 		)
 	}
 


### PR DESCRIPTION
#### Summary
AddUserToTeam permission depends on policy.

Uses same policy setting as InviteUserToTeam.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6063

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (permissions).
