### PR TITLE
[PLT-5941] Add Extra Check Before Rendering Reactions

### DIFF
--- a/webapp/components/post_view/components/reaction_list_container.jsx
+++ b/webapp/components/post_view/components/reaction_list_container.jsx
@@ -82,17 +82,17 @@ export default class ReactionListContainer extends React.Component {
     }
 
     render() {
-        if (!this.props.post.has_reactions) {
-            return null;
+        if (this.props.post.has_reactions && this.state.reactions.length > 0) {
+            return (
+                <ReactionListView
+                    post={this.props.post}
+                    currentUserId={this.props.currentUserId}
+                    reactions={this.state.reactions}
+                    emojis={this.state.emojis}
+                />
+            );
         }
 
-        return (
-            <ReactionListView
-                post={this.props.post}
-                currentUserId={this.props.currentUserId}
-                reactions={this.state.reactions}
-                emojis={this.state.emojis}
-            />
-        );
+        return null;
     }
 }


### PR DESCRIPTION
#### Summary
Added an extra check to ensure that `reactions` isn't empty before rendering. This fixes the issue where there's a blank space after removing a reaction.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5941
https://github.com/mattermost/platform/issues/5832
