### PR TITLE
PLT-6018: Add APIv4 Endpoint for fetching deleted Channels

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -21,6 +21,7 @@ func InitChannel() {
 	BaseRoutes.Channels.Handle("/members/{user_id:[A-Za-z0-9]+}/view", ApiSessionRequired(viewChannel)).Methods("POST")
 
 	BaseRoutes.ChannelsForTeam.Handle("", ApiSessionRequired(getPublicChannelsForTeam)).Methods("GET")
+	BaseRoutes.ChannelsForTeam.Handle("/deleted", ApiSessionRequired(getDeletedChannelsForTeam)).Methods("GET")
 	BaseRoutes.ChannelsForTeam.Handle("/ids", ApiSessionRequired(getPublicChannelsByIdsForTeam)).Methods("POST")
 	BaseRoutes.ChannelsForTeam.Handle("/search", ApiSessionRequired(searchChannelsForTeam)).Methods("POST")
 	BaseRoutes.User.Handle("/teams/{team_id:[A-Za-z0-9]+}/channels", ApiSessionRequired(getChannelsForTeamForUser)).Methods("GET")
@@ -377,6 +378,26 @@ func getPublicChannelsForTeam(c *Context, w http.ResponseWriter, r *http.Request
 	}
 
 	if channels, err := app.GetPublicChannelsForTeam(c.Params.TeamId, c.Params.Page, c.Params.PerPage); err != nil {
+		c.Err = err
+		return
+	} else {
+		w.Write([]byte(channels.ToJson()))
+		return
+	}
+}
+
+func getDeletedChannelsForTeam(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireTeamId()
+	if c.Err != nil {
+		return
+	}
+
+	if !app.SessionHasPermissionToTeam(c.Session, c.Params.TeamId, model.PERMISSION_MANAGE_TEAM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_TEAM)
+		return
+	}
+
+	if channels, err := app.GetDeletedChannels(c.Params.TeamId, c.Params.Page * c.Params.PerPage, c.Params.PerPage); err != nil {
 		c.Err = err
 		return
 	} else {

--- a/app/channel.go
+++ b/app/channel.go
@@ -689,6 +689,14 @@ func GetChannelsForUser(teamId string, userId string) (*model.ChannelList, *mode
 	}
 }
 
+func GetDeletedChannels(teamId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
+	if result := <-Srv.Store.Channel().GetDeleted(teamId, offset, limit); result.Err != nil {
+		return nil, result.Err
+	} else {
+		return result.Data.(*model.ChannelList), nil
+	}
+}
+
 func GetChannelsUserNotIn(teamId string, userId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
 	if result := <-Srv.Store.Channel().GetMoreChannels(teamId, userId, offset, limit); result.Err != nil {
 		return nil, result.Err

--- a/model/client4.go
+++ b/model/client4.go
@@ -1232,6 +1232,17 @@ func (c *Client4) GetPublicChannelsForTeam(teamId string, page int, perPage int,
 	}
 }
 
+// GetDeletedChannelsForTeam returns a list of public channels based on the provided team id string.
+func (c *Client4) GetDeletedChannelsForTeam(teamId string, page int, perPage int, etag string) (*ChannelList, *Response) {
+	query := fmt.Sprintf("/deleted?page=%v&per_page=%v", page, perPage)
+	if r, err := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+query, etag); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return ChannelListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // GetPublicChannelsByIdsForTeam returns a list of public channels based on provided team id string
 func (c *Client4) GetPublicChannelsByIdsForTeam(teamId string, channelIds []string) (*ChannelList, *Response) {
 	if r, err := c.DoApiPost(c.GetChannelsForTeamRoute(teamId)+"/ids", ArrayToJson(channelIds)); err != nil {

--- a/store/sql_channel_store_test.go
+++ b/store/sql_channel_store_test.go
@@ -512,6 +512,88 @@ func TestChannelStoreGetDeletedByName(t *testing.T) {
 	}
 }
 
+func TestChannelStoreGetDeleted(t *testing.T) {
+	Setup()
+
+	o1 := model.Channel{}
+	o1.TeamId = model.NewId()
+	o1.DisplayName = "Channel1"
+	o1.Name = "a" + model.NewId() + "b"
+	o1.Type = model.CHANNEL_OPEN
+	o1.DeleteAt = model.GetMillis()
+	Must(store.Channel().Save(&o1))
+
+	cresult := <-store.Channel().GetDeleted(o1.TeamId, 0, 100)
+	if cresult.Err != nil {
+		t.Fatal(cresult.Err)
+	}
+	list := cresult.Data.(*model.ChannelList)
+
+	if len(*list) != 1 {
+		t.Fatal("wrong list")
+	}
+
+	if (*list)[0].Name != o1.Name {
+		t.Fatal("missing channel")
+	}
+
+	o2 := model.Channel{}
+	o2.TeamId = o1.TeamId
+	o2.DisplayName = "Channel2"
+	o2.Name = "a" + model.NewId() + "b"
+	o2.Type = model.CHANNEL_OPEN
+	Must(store.Channel().Save(&o2))
+
+	cresult = <-store.Channel().GetDeleted(o1.TeamId, 0, 100)
+	if cresult.Err != nil {
+		t.Fatal(cresult.Err)
+	}
+	list = cresult.Data.(*model.ChannelList)
+
+	if len(*list) != 1 {
+		t.Fatal("wrong list")
+	}
+
+	o3 := model.Channel{}
+	o3.TeamId = o1.TeamId
+	o3.DisplayName = "Channel3"
+	o3.Name = "a" + model.NewId() + "b"
+	o3.Type = model.CHANNEL_OPEN
+	o3.DeleteAt = model.GetMillis()
+	Must(store.Channel().Save(&o3))
+
+	cresult = <-store.Channel().GetDeleted(o1.TeamId, 0, 100)
+	if cresult.Err != nil {
+		t.Fatal(cresult.Err)
+	}
+	list = cresult.Data.(*model.ChannelList)
+
+	if len(*list) != 2 {
+		t.Fatal("wrong list length")
+	}
+
+	cresult = <-store.Channel().GetDeleted(o1.TeamId, 0, 1)
+	if cresult.Err != nil {
+		t.Fatal(cresult.Err)
+	}
+	list = cresult.Data.(*model.ChannelList)
+
+	if len(*list) != 1 {
+		t.Fatal("wrong list length")
+	}
+
+	cresult = <-store.Channel().GetDeleted(o1.TeamId, 1, 1)
+	if cresult.Err != nil {
+		t.Fatal(cresult.Err)
+	}
+	list = cresult.Data.(*model.ChannelList)
+
+	if len(*list) != 1 {
+		t.Fatal("wrong list length")
+	}
+
+}
+
 func TestChannelMemberStore(t *testing.T) {
 	Setup()
 

--- a/store/store.go
+++ b/store/store.go
@@ -102,6 +102,7 @@ type ChannelStore interface {
 	GetByName(team_id string, name string, allowFromCache bool) StoreChannel
 	GetByNameIncludeDeleted(team_id string, name string, allowFromCache bool) StoreChannel
 	GetDeletedByName(team_id string, name string) StoreChannel
+	GetDeleted(team_id string, offset int, limit int) StoreChannel
 	GetChannels(teamId string, userId string) StoreChannel
 	GetMoreChannels(teamId string, userId string, offset int, limit int) StoreChannel
 	GetPublicChannelsForTeam(teamId string, offset int, limit int) StoreChannel


### PR DESCRIPTION
#### Summary
Adds APIv4 Endpoint to get deleted Channels
#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6018
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs) https://github.com/mattermost/mattermost-api-reference/pull/190
- [x] All new/modified APIs include changes to the drivers
