### PR TITLE
APIv4 POST /posts/{post_id/pin & unpin

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -35,6 +35,7 @@ type TestHelper struct {
 	BasicPrivateChannel *model.Channel
 	BasicChannel2       *model.Channel
 	BasicPost           *model.Post
+	PinnedPost          *model.Post
 
 	SystemAdminClient *model.Client4
 	SystemAdminUser   *model.User
@@ -144,6 +145,7 @@ func (me *TestHelper) InitBasic() *TestHelper {
 	me.BasicPrivateChannel = me.CreatePrivateChannel()
 	me.BasicChannel2 = me.CreatePublicChannel()
 	me.BasicPost = me.CreatePost()
+	me.PinnedPost = me.CreatePinnedPost()
 	me.BasicUser = me.CreateUser()
 	LinkUserToTeam(me.BasicUser, me.BasicTeam)
 	me.BasicUser2 = me.CreateUser()

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -35,7 +35,6 @@ type TestHelper struct {
 	BasicPrivateChannel *model.Channel
 	BasicChannel2       *model.Channel
 	BasicPost           *model.Post
-	PinnedPost          *model.Post
 
 	SystemAdminClient *model.Client4
 	SystemAdminUser   *model.User
@@ -145,7 +144,6 @@ func (me *TestHelper) InitBasic() *TestHelper {
 	me.BasicPrivateChannel = me.CreatePrivateChannel()
 	me.BasicChannel2 = me.CreatePublicChannel()
 	me.BasicPost = me.CreatePost()
-	me.PinnedPost = me.CreatePinnedPost()
 	me.BasicUser = me.CreateUser()
 	LinkUserToTeam(me.BasicUser, me.BasicTeam)
 	me.BasicUser2 = me.CreateUser()

--- a/api4/post.go
+++ b/api4/post.go
@@ -26,6 +26,8 @@ func InitPost() {
 	BaseRoutes.Team.Handle("/posts/search", ApiSessionRequired(searchPosts)).Methods("POST")
 	BaseRoutes.Post.Handle("", ApiSessionRequired(updatePost)).Methods("PUT")
 	BaseRoutes.Post.Handle("/patch", ApiSessionRequired(patchPost)).Methods("PUT")
+	BaseRoutes.Post.Handle("/pin", ApiSessionRequired(pinPost)).Methods("POST")
+	BaseRoutes.Post.Handle("/unpin", ApiSessionRequired(unpinPost)).Methods("POST")
 }
 
 func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -271,6 +273,38 @@ func patchPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write([]byte(patchedPost.ToJson()))
+}
+
+func saveIsPinnedPost(c *Context, w http.ResponseWriter, r *http.Request, isPinned bool) {
+	c.RequirePostId()
+	if c.Err != nil {
+		return
+	}
+
+	if !app.SessionHasPermissionToChannelByPost(c.Session, c.Params.PostId, model.PERMISSION_READ_CHANNEL) {
+		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
+		return
+	}
+
+	patch := &model.PostPatch{}
+	patch.IsPinned = new(bool)
+	*patch.IsPinned = isPinned
+
+	_, err := app.PatchPost(c.Params.PostId, patch)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	ReturnStatusOK(w)
+}
+
+func pinPost(c *Context, w http.ResponseWriter, r *http.Request) {
+	saveIsPinnedPost(c, w, r, true)
+}
+
+func unpinPost(c *Context, w http.ResponseWriter, r *http.Request) {
+	saveIsPinnedPost(c, w, r, false)
 }
 
 func getFileInfosForPost(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -309,7 +309,7 @@ func TestUnpinPost(t *testing.T) {
 	defer TearDown()
 	Client := th.Client
 
-	pinnedPost := th.PinnedPost
+	pinnedPost := th.CreatePinnedPost()
 	pass, resp := Client.UnpinPost(pinnedPost.Id)
 	CheckNoError(t, resp)
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -269,6 +269,76 @@ func TestPatchPost(t *testing.T) {
 	CheckNoError(t, resp)
 }
 
+func TestPinPost(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	post := th.BasicPost
+	pass, resp := Client.PinPost(post.Id)
+	CheckNoError(t, resp)
+
+	if !pass {
+		t.Fatal("should have passed")
+	}
+
+	if rpost, err := app.GetSinglePost(post.Id); err != nil && rpost.IsPinned != true {
+		t.Fatal("failed to pin post")
+	}
+
+	pass, resp = Client.PinPost("junk")
+	CheckBadRequestStatus(t, resp)
+
+	if pass {
+		t.Fatal("should have failed")
+	}
+
+	_, resp = Client.PinPost(GenerateTestId())
+	CheckForbiddenStatus(t, resp)
+
+	Client.Logout()
+	_, resp = Client.PinPost(post.Id)
+	CheckUnauthorizedStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.PinPost(post.Id)
+	CheckNoError(t, resp)
+}
+
+func TestUnpinPost(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	pinnedPost := th.PinnedPost
+	pass, resp := Client.UnpinPost(pinnedPost.Id)
+	CheckNoError(t, resp)
+
+	if !pass {
+		t.Fatal("should have passed")
+	}
+
+	if rpost, err := app.GetSinglePost(pinnedPost.Id); err != nil && rpost.IsPinned != false {
+		t.Fatal("failed to pin post")
+	}
+
+	pass, resp = Client.UnpinPost("junk")
+	CheckBadRequestStatus(t, resp)
+
+	if pass {
+		t.Fatal("should have failed")
+	}
+
+	_, resp = Client.UnpinPost(GenerateTestId())
+	CheckForbiddenStatus(t, resp)
+
+	Client.Logout()
+	_, resp = Client.UnpinPost(pinnedPost.Id)
+	CheckUnauthorizedStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.UnpinPost(pinnedPost.Id)
+	CheckNoError(t, resp)
+}
+
 func TestGetPostsForChannel(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer TearDown()

--- a/model/client4.go
+++ b/model/client4.go
@@ -1239,6 +1239,26 @@ func (c *Client4) PatchPost(postId string, patch *PostPatch) (*Post, *Response) 
 	}
 }
 
+// PinPost pin a post based on provided post id string.
+func (c *Client4) PinPost(postId string) (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetPostRoute(postId)+"/pin", ""); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
+// UnpinPost unpin a post based on provided post id string.
+func (c *Client4) UnpinPost(postId string) (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetPostRoute(postId)+"/unpin", ""); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // GetPost gets a single post.
 func (c *Client4) GetPost(postId string, etag string) (*Post, *Response) {
 	if r, err := c.DoApiGet(c.GetPostRoute(postId), etag); err != nil {


### PR DESCRIPTION
#### Summary
This is implementation endpoints for APIv4:
- `POST /posts/{post_id/pin`
- `POST /posts/{post_id/unpin`

Note that this PR is implemented on top of PR#[5883][5883] as I find it necessary and simple. I'll just fix conflict later once accepted.

#### Ticket Link
Jira ticket: [PLT-5246][5246]

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs) [mattermost-api-reference #194][194]
- [x] All new/modified APIs include changes to the drivers

[5246]: https://mattermost.atlassian.net/browse/PLT-5246
[194]: https://github.com/mattermost/mattermost-api-reference/pull/194
[5883]: https://github.com/mattermost/platform/pull/5883