### PR TITLE
PLT-5750 Add sequence number to websocket connections and events

### DIFF
--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -94,7 +94,6 @@ func Publish(message *model.WebSocketEvent) {
 		metrics.IncrementWebsocketEvent(message.Event)
 	}
 
-	message.DoPreComputeJson()
 	for _, hub := range hubs {
 		hub.Broadcast(message)
 	}
@@ -105,7 +104,6 @@ func Publish(message *model.WebSocketEvent) {
 }
 
 func PublishSkipClusterSend(message *model.WebSocketEvent) {
-	message.DoPreComputeJson()
 	for _, hub := range hubs {
 		hub.Broadcast(message)
 	}

--- a/app/websocket_router.go
+++ b/app/websocket_router.go
@@ -61,7 +61,6 @@ func (wr *WebSocketRouter) ServeWebSocket(conn *WebConn, r *model.WebSocketReque
 			HubRegister(conn)
 
 			resp := model.NewWebSocketResponse(model.STATUS_OK, r.Seq, nil)
-			resp.DoPreComputeJson()
 			conn.Send <- resp
 		}
 
@@ -91,7 +90,6 @@ func ReturnWebSocketError(conn *WebConn, r *model.WebSocketRequest, err *model.A
 
 	err.DetailedError = ""
 	errorResp := model.NewWebSocketError(r.Seq, err)
-	errorResp.DoPreComputeJson()
 
 	conn.Send <- errorResp
 }

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -36,9 +36,8 @@ const (
 type WebSocketMessage interface {
 	ToJson() string
 	IsValid() bool
-	DoPreComputeJson()
-	GetPreComputeJson() []byte
 	EventType() string
+	SetSequence(seq uint64)
 }
 
 type WebsocketBroadcast struct {
@@ -52,6 +51,7 @@ type WebSocketEvent struct {
 	Event          string                 `json:"event"`
 	Data           map[string]interface{} `json:"data"`
 	Broadcast      *WebsocketBroadcast    `json:"broadcast"`
+	Sequence       uint64                 `json:"seq"`
 	PreComputeJson []byte                 `json:"-"`
 }
 
@@ -72,17 +72,8 @@ func (o *WebSocketEvent) EventType() string {
 	return o.Event
 }
 
-func (o *WebSocketEvent) DoPreComputeJson() {
-	b, err := json.Marshal(o)
-	if err != nil {
-		o.PreComputeJson = []byte("")
-	} else {
-		o.PreComputeJson = b
-	}
-}
-
-func (o *WebSocketEvent) GetPreComputeJson() []byte {
-	return o.PreComputeJson
+func (o *WebSocketEvent) SetSequence(seq uint64) {
+	o.Sequence = seq
 }
 
 func (o *WebSocketEvent) ToJson() string {
@@ -133,6 +124,9 @@ func (o *WebSocketResponse) EventType() string {
 	return ""
 }
 
+func (o *WebSocketResponse) SetSequence(seq uint64) {
+}
+
 func (o *WebSocketResponse) ToJson() string {
 	b, err := json.Marshal(o)
 	if err != nil {
@@ -140,19 +134,6 @@ func (o *WebSocketResponse) ToJson() string {
 	} else {
 		return string(b)
 	}
-}
-
-func (o *WebSocketResponse) DoPreComputeJson() {
-	b, err := json.Marshal(o)
-	if err != nil {
-		o.PreComputeJson = []byte("")
-	} else {
-		o.PreComputeJson = b
-	}
-}
-
-func (o *WebSocketResponse) GetPreComputeJson() []byte {
-	return o.PreComputeJson
 }
 
 func WebSocketResponseFromJson(data io.Reader) *WebSocketResponse {

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -37,7 +37,6 @@ type WebSocketMessage interface {
 	ToJson() string
 	IsValid() bool
 	EventType() string
-	SetSequence(seq uint64)
 }
 
 type WebsocketBroadcast struct {
@@ -48,11 +47,10 @@ type WebsocketBroadcast struct {
 }
 
 type WebSocketEvent struct {
-	Event          string                 `json:"event"`
-	Data           map[string]interface{} `json:"data"`
-	Broadcast      *WebsocketBroadcast    `json:"broadcast"`
-	Sequence       uint64                 `json:"seq"`
-	PreComputeJson []byte                 `json:"-"`
+	Event     string                 `json:"event"`
+	Data      map[string]interface{} `json:"data"`
+	Broadcast *WebsocketBroadcast    `json:"broadcast"`
+	Sequence  int64                  `json:"seq"`
 }
 
 func (m *WebSocketEvent) Add(key string, value interface{}) {
@@ -70,10 +68,6 @@ func (o *WebSocketEvent) IsValid() bool {
 
 func (o *WebSocketEvent) EventType() string {
 	return o.Event
-}
-
-func (o *WebSocketEvent) SetSequence(seq uint64) {
-	o.Sequence = seq
 }
 
 func (o *WebSocketEvent) ToJson() string {
@@ -97,11 +91,10 @@ func WebSocketEventFromJson(data io.Reader) *WebSocketEvent {
 }
 
 type WebSocketResponse struct {
-	Status         string                 `json:"status"`
-	SeqReply       int64                  `json:"seq_reply,omitempty"`
-	Data           map[string]interface{} `json:"data,omitempty"`
-	Error          *AppError              `json:"error,omitempty"`
-	PreComputeJson []byte                 `json:"-"`
+	Status   string                 `json:"status"`
+	SeqReply int64                  `json:"seq_reply,omitempty"`
+	Data     map[string]interface{} `json:"data,omitempty"`
+	Error    *AppError              `json:"error,omitempty"`
 }
 
 func (m *WebSocketResponse) Add(key string, value interface{}) {
@@ -122,9 +115,6 @@ func (o *WebSocketResponse) IsValid() bool {
 
 func (o *WebSocketResponse) EventType() string {
 	return ""
-}
-
-func (o *WebSocketResponse) SetSequence(seq uint64) {
 }
 
 func (o *WebSocketResponse) ToJson() string {

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -61,6 +61,7 @@ export function initialize() {
 
     WebSocketClient.setEventCallback(handleEvent);
     WebSocketClient.setFirstConnectCallback(handleFirstConnect);
+    WebSocketClient.setMissedEventCallback(() => reconnect(false));
     WebSocketClient.setCloseCallback(handleClose);
     WebSocketClient.initialize(connUrl);
 }

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -61,7 +61,13 @@ export function initialize() {
 
     WebSocketClient.setEventCallback(handleEvent);
     WebSocketClient.setFirstConnectCallback(handleFirstConnect);
-    WebSocketClient.setMissedEventCallback(() => reconnect(false));
+    WebSocketClient.setReconnectCallback(() => reconnect(false));
+    WebSocketClient.setMissedEventCallback(() => {
+        if (global.window.mm_config.EnableDeveloper === 'true') {
+            Client.logClientError('missed websocket event seq=' + WebSocketClient.eventSequence);
+        }
+        reconnect(false);
+    });
     WebSocketClient.setCloseCallback(handleClose);
     WebSocketClient.initialize(connUrl);
 }

--- a/webapp/client/websocket_client.jsx
+++ b/webapp/client/websocket_client.jsx
@@ -10,11 +10,13 @@ export default class WebSocketClient {
         this.conn = null;
         this.connectionUrl = null;
         this.sequence = 1;
+        this.eventSequence = 0;
         this.connectFailCount = 0;
         this.eventCallback = null;
         this.responseCallbacks = {};
         this.firstConnectCallback = null;
         this.reconnectCallback = null;
+        this.missedEventCallback = null;
         this.errorCallback = null;
         this.closeCallback = null;
     }
@@ -37,6 +39,8 @@ export default class WebSocketClient {
         this.connectionUrl = connectionUrl;
 
         this.conn.onopen = () => {
+            this.eventSequence = 0;
+
             if (token) {
                 this.sendMessage('authentication_challenge', {token});
             }
@@ -108,6 +112,11 @@ export default class WebSocketClient {
                     Reflect.deleteProperty(this.responseCallbacks, msg.seq_reply);
                 }
             } else if (this.eventCallback) {
+                if (msg.seq !== this.eventSequence && this.missedEventCallback) {
+                    console.log('missed websocket event'); //eslint-disable-line no-console
+                    this.missedEventCallback();
+                }
+                this.eventSequence = msg.seq + 1;
                 this.eventCallback(msg);
             }
         };
@@ -123,6 +132,10 @@ export default class WebSocketClient {
 
     setReconnectCallback(callback) {
         this.reconnectCallback = callback;
+    }
+
+    setMissedEventCallback(callback) {
+        this.missedEventCallback = callback;
     }
 
     setErrorCallback(callback) {

--- a/webapp/client/websocket_client.jsx
+++ b/webapp/client/websocket_client.jsx
@@ -113,7 +113,7 @@ export default class WebSocketClient {
                 }
             } else if (this.eventCallback) {
                 if (msg.seq !== this.eventSequence && this.missedEventCallback) {
-                    console.log('missed websocket event'); //eslint-disable-line no-console
+                    console.log('missed websocket event, act_seq=' + msg.seq + ' exp_seq=' + this.eventSequence); //eslint-disable-line no-console
                     this.missedEventCallback();
                 }
                 this.eventSequence = msg.seq + 1;

--- a/wsapi/websocket_handler.go
+++ b/wsapi/websocket_handler.go
@@ -27,7 +27,6 @@ func (wh webSocketHandler) ServeWebSocket(conn *app.WebConn, r *model.WebSocketR
 		l4g.Error(utils.T("api.web_socket_handler.log.error"), "/api/v3/users/websocket", r.Action, r.Seq, conn.UserId, sessionErr.SystemMessage(utils.T), sessionErr.Error())
 		sessionErr.DetailedError = ""
 		errResp := model.NewWebSocketError(r.Seq, sessionErr)
-		errResp.DoPreComputeJson()
 
 		conn.Send <- errResp
 		return
@@ -44,14 +43,12 @@ func (wh webSocketHandler) ServeWebSocket(conn *app.WebConn, r *model.WebSocketR
 		l4g.Error(utils.T("api.web_socket_handler.log.error"), "/api/v3/users/websocket", r.Action, r.Seq, r.Session.UserId, err.SystemMessage(utils.T), err.DetailedError)
 		err.DetailedError = ""
 		errResp := model.NewWebSocketError(r.Seq, err)
-		errResp.DoPreComputeJson()
 
 		conn.Send <- errResp
 		return
 	}
 
 	resp := model.NewWebSocketResponse(model.STATUS_OK, r.Seq, data)
-	resp.DoPreComputeJson()
 
 	conn.Send <- resp
 }


### PR DESCRIPTION
#### Summary
* Remove the pre computation of websocket event JSON
* Changed WebSocketEvents to be passed as value (to prevent race condition when adding sequence number)
* Add a sequence number to each websocket connection
* Client will run reconnect logic if it gets an out of order sequence

I'm aware some of this may have a significant effect on performance. @crspeller is going to run load tests but in the interest of trying this out in a real environment we're going to merge it now and revert it if we need to.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5750