### PR TITLE
PLT 6125 Allow system admins to create users on closed servers

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -67,6 +67,8 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		ruser, err = app.CreateUserWithHash(user, hash, r.URL.Query().Get("d"), c.GetSiteURL())
 	} else if len(inviteId) > 0 {
 		ruser, err = app.CreateUserWithInviteId(user, inviteId, c.GetSiteURL())
+	} else if c.IsSystemAdmin() {
+		ruser, err = app.CreateUserAsAdmin(user, c.GetSiteURL())
 	} else {
 		ruser, err = app.CreateUserFromSignup(user, c.GetSiteURL())
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -104,6 +104,19 @@ func CreateUserWithInviteId(user *model.User, inviteId string, siteURL string) (
 	return ruser, nil
 }
 
+func CreateUserAsAdmin(user *model.User, siteURL string) (*model.User, *model.AppError) {
+	ruser, err := CreateUser(user)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := SendWelcomeEmail(ruser.Id, ruser.Email, ruser.EmailVerified, ruser.Locale, siteURL); err != nil {
+		l4g.Error(err.Error())
+	}
+
+	return ruser, nil
+}
+
 func CreateUserFromSignup(user *model.User, siteURL string) (*model.User, *model.AppError) {
 	if err := IsUserSignUpAllowed(); err != nil {
 		return nil, err


### PR DESCRIPTION
#### Summary
Allow system admins to create users on closed servers
Test Case credits goes to @jwilander for showing me the way to deal with it...

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6125

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
