### PR TITLE
PLT-6098 Added Manage Teams modal to System Console users list

### DIFF
--- a/webapp/actions/team_actions.jsx
+++ b/webapp/actions/team_actions.jsx
@@ -150,3 +150,11 @@ export function switchTeams(url) {
     AsyncClient.viewChannel();
     browserHistory.push(url);
 }
+
+export function getTeamsForUser(userId, success, error) {
+    Client.getTeamsForUser(userId, success, error);
+}
+
+export function getTeamMembersForUser(userId, success, error) {
+    Client.getTeamMembersForUser(userId, success, error);
+}

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -244,7 +244,10 @@ function handleLeaveTeamEvent(msg) {
             Client.setTeamId('');
             BrowserStore.removeGlobalItem('team');
             BrowserStore.removeGlobalItem(msg.data.team_id);
-            GlobalActions.redirectUserToDefaultTeam();
+
+            if (!global.location.pathname.startsWith('/admin_console')) {
+                GlobalActions.redirectUserToDefaultTeam();
+            }
         }
     } else {
         UserStore.removeProfileFromTeam(msg.data.team_id, msg.data.user_id);

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -550,6 +550,16 @@ export default class Client {
             end(this.handleResponse.bind(this, 'getAllTeamListings', success, error));
     }
 
+    getTeamsForUser(userId, success, error) {
+        // Call out to API v4 since this call doesn't exist in v3
+        request.
+            get(`${this.url}/api/v4/users/${userId}/teams`).
+            set(this.defaultHeaders).
+            type('application/json').
+            accept('application/json').
+            end(this.handleResponse.bind(this, 'getTeamsForUser', success, error));
+    }
+
     getMyTeam(success, error) {
         request.
             get(`${this.getTeamNeededRoute()}/me`).
@@ -584,6 +594,16 @@ export default class Client {
         type('application/json').
         accept('application/json').
         end(this.handleResponse.bind(this, 'getMyTeamMembers', success, error));
+    }
+
+    getTeamMembersForUser(userId, success, error) {
+        // Call out to API v4 since this call doesn't exist in v3
+        request.
+            get(`${this.url}/api/v4/users/${userId}/teams/members`).
+            set(this.defaultHeaders).
+            type('application/json').
+            accept('application/json').
+            end(this.handleResponse.bind(this, 'getTeamsForUser', success, error));
     }
 
     getMyTeamsUnread(teamId, success, error) {
@@ -1273,6 +1293,16 @@ export default class Client {
             end(this.handleResponse.bind(this, 'uploadProfileImage', success, error));
 
         this.trackEvent('api', 'api_users_update_profile_picture');
+    }
+
+    getProfilePictureUrl(id, lastPictureUpdate) {
+        let url = `${this.getUsersRoute()}/${id}/image`;
+
+        if (lastPictureUpdate) {
+            url += `?time=${lastPictureUpdate}`;
+        }
+
+        return url;
     }
 
     // Channel Routes Section

--- a/webapp/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
+++ b/webapp/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 
 import React from 'react';
-import {DropdownButton, MenuItem} from 'react-bootstrap';
+import {Dropdown, MenuItem} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import {updateTeamMemberRoles, removeUserFromTeam} from 'actions/team_actions.jsx';
@@ -113,21 +113,25 @@ export default class ManageTeamsDropdown extends React.Component {
         }
 
         return (
-            <DropdownButton
+            <Dropdown
                 id={`manage-teams-${this.props.user.id}-${this.props.teamMember.team_id}`}
                 open={this.state.show}
                 onToggle={this.toggleDropdown}
-                title={title}
             >
-                {makeTeamAdmin}
-                {makeMember}
-                <MenuItem onSelect={this.removeFromTeam}>
-                    <FormattedMessage
-                        id='team_members_dropdown.leave_team'
-                        defaultMessage='Remove from Team'
-                    />
-                </MenuItem>
-            </DropdownButton>
+                <Dropdown.Toggle useAnchor={true}>
+                    {title}
+                </Dropdown.Toggle>
+                <Dropdown.Menu>
+                    {makeTeamAdmin}
+                    {makeMember}
+                    <MenuItem onSelect={this.removeFromTeam}>
+                        <FormattedMessage
+                            id='team_members_dropdown.leave_team'
+                            defaultMessage='Remove from Team'
+                        />
+                    </MenuItem>
+                </Dropdown.Menu>
+            </Dropdown>
         );
     }
 }

--- a/webapp/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
+++ b/webapp/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
@@ -1,0 +1,113 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {DropdownButton, MenuItem} from 'react-bootstrap';
+
+import {updateTeamMemberRoles, removeUserFromTeam} from 'actions/team_actions.jsx';
+
+import * as Utils from 'utils/utils.jsx';
+
+export default class ManageTeamsDropdown extends React.Component {
+    static propTypes = {
+        user: React.PropTypes.object.isRequired,
+        teamMember: React.PropTypes.object.isRequired,
+        onError: React.PropTypes.func.isRequired,
+        onMemberChange: React.PropTypes.func.isRequired,
+        onMemberRemove: React.PropTypes.func.isRequired
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.toggleDropdown = this.toggleDropdown.bind(this);
+
+        this.makeTeamAdmin = this.makeTeamAdmin.bind(this);
+        this.makeMember = this.makeMember.bind(this);
+        this.removeFromTeam = this.removeFromTeam.bind(this);
+
+        this.handleMemberChange = this.handleMemberChange.bind(this);
+        this.handleMemberRemove = this.handleMemberRemove.bind(this);
+
+        this.state = {
+            show: false
+        };
+    }
+
+    toggleDropdown() {
+        this.setState({
+            show: !this.state.show
+        });
+    }
+
+    makeTeamAdmin() {
+        updateTeamMemberRoles(
+            this.props.teamMember.team_id,
+            this.props.user.id,
+            'team_user team_admin',
+            this.handleMemberChange,
+            this.props.onError
+        );
+    }
+
+    makeMember() {
+        updateTeamMemberRoles(
+            this.props.teamMember.team_id,
+            this.props.user.id,
+            'team_user',
+            this.handleMemberChange,
+            this.props.onError
+        );
+    }
+
+    removeFromTeam() {
+        removeUserFromTeam(
+            this.props.teamMember.team_id,
+            this.props.user.id,
+            this.handleMemberRemove,
+            this.props.onError
+        );
+    }
+
+    handleMemberChange() {
+        this.props.onMemberChange(this.props.teamMember.team_id);
+    }
+
+    handleMemberRemove() {
+        this.props.onMemberRemove(this.props.teamMember.team_id);
+    }
+
+    render() {
+        const isTeamAdmin = Utils.isAdmin(this.props.teamMember.roles);
+
+        let title;
+        if (isTeamAdmin) {
+            title = 'Team Admin';
+        } else {
+            title = 'Team Member';
+        }
+
+        let makeTeamAdmin = null;
+        if (!isTeamAdmin) {
+            makeTeamAdmin = <MenuItem onSelect={this.makeTeamAdmin}>{'Make Team Admin'}</MenuItem>;
+        }
+
+        let makeMember = null;
+        if (isTeamAdmin) {
+            makeMember = <MenuItem onSelect={this.makeMember}>{'Make Member'}</MenuItem>;
+        }
+
+        return (
+            <DropdownButton
+                id={`manage-teams-${this.props.user.id}-${this.props.teamMember.team_id}`}
+                open={this.state.show}
+                onToggle={this.toggleDropdown}
+                title={title}
+            >
+                {makeTeamAdmin}
+                {makeMember}
+                <MenuItem onSelect={this.removeFromTeam}>{'Remove from Team'}</MenuItem>
+            </DropdownButton>
+        );
+    }
+}

--- a/webapp/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
+++ b/webapp/components/admin_console/manage_teams_modal/manage_teams_dropdown.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import {DropdownButton, MenuItem} from 'react-bootstrap';
+import {FormattedMessage} from 'react-intl';
 
 import {updateTeamMemberRoles, removeUserFromTeam} from 'actions/team_actions.jsx';
 
@@ -82,19 +83,33 @@ export default class ManageTeamsDropdown extends React.Component {
 
         let title;
         if (isTeamAdmin) {
-            title = 'Team Admin';
+            title = Utils.localizeMessage('admin.user_item.teamAdmin', 'Team Admin');
         } else {
-            title = 'Team Member';
+            title = Utils.localizeMessage('admin.user_item.teamMember', 'Team Member');
         }
 
         let makeTeamAdmin = null;
         if (!isTeamAdmin) {
-            makeTeamAdmin = <MenuItem onSelect={this.makeTeamAdmin}>{'Make Team Admin'}</MenuItem>;
+            makeTeamAdmin = (
+                <MenuItem onSelect={this.makeTeamAdmin}>
+                    <FormattedMessage
+                        id='admin.user_item.makeTeamAdmin'
+                        defaultMessage='Make Team Admin'
+                    />
+                </MenuItem>
+            );
         }
 
         let makeMember = null;
         if (isTeamAdmin) {
-            makeMember = <MenuItem onSelect={this.makeMember}>{'Make Member'}</MenuItem>;
+            makeMember = (
+                <MenuItem onSelect={this.makeMember}>
+                    <FormattedMessage
+                        id='admin.user_item.makeMember'
+                        defaultMessage='Make Member'
+                    />
+                </MenuItem>
+            );
         }
 
         return (
@@ -106,7 +121,12 @@ export default class ManageTeamsDropdown extends React.Component {
             >
                 {makeTeamAdmin}
                 {makeMember}
-                <MenuItem onSelect={this.removeFromTeam}>{'Remove from Team'}</MenuItem>
+                <MenuItem onSelect={this.removeFromTeam}>
+                    <FormattedMessage
+                        id='team_members_dropdown.leave_team'
+                        defaultMessage='Remove from Team'
+                    />
+                </MenuItem>
             </DropdownButton>
         );
     }

--- a/webapp/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
+++ b/webapp/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import {Modal} from 'react-bootstrap';
+import {FormattedMessage} from 'react-intl';
 
 import * as TeamActions from 'actions/team_actions.jsx';
 
@@ -176,7 +177,10 @@ export default class ManageTeamsModal extends React.Component {
             >
                 <Modal.Header closeButton={true}>
                     <Modal.Title>
-                        {'Manage Teams'}
+                        <FormattedMessage
+                            id='admin.user_item.manageTeams'
+                            defaultMessage='Manage Teams'
+                        />
                     </Modal.Title>
                 </Modal.Header>
                 <Modal.Body>

--- a/webapp/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
+++ b/webapp/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
@@ -11,6 +11,7 @@ import Client from 'client/web_client.jsx';
 
 import LoadingScreen from 'components/loading_screen.jsx';
 
+import {sortTeamsByDisplayName} from 'utils/team_utils.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import ManageTeamsDropdown from './manage_teams_dropdown.jsx';
@@ -66,7 +67,7 @@ export default class ManageTeamsModal extends React.Component {
     loadTeamsAndTeamMembers(user = this.props.user) {
         TeamActions.getTeamsForUser(user.id, (teams) => {
             this.setState({
-                teams
+                teams: teams.sort(sortTeamsByDisplayName)
             });
         });
 

--- a/webapp/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
+++ b/webapp/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
@@ -14,6 +14,7 @@ import LoadingScreen from 'components/loading_screen.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import ManageTeamsDropdown from './manage_teams_dropdown.jsx';
+import RemoveFromTeamButton from './remove_from_team_button.jsx';
 
 export default class ManageTeamsModal extends React.Component {
     static propTypes = {
@@ -105,6 +106,8 @@ export default class ManageTeamsModal extends React.Component {
             return <LoadingScreen/>;
         }
 
+        const isSystemAdmin = Utils.isAdmin(user.roles);
+
         let name = Utils.getFullName(user);
         if (name) {
             name += ` (@${user.username})`;
@@ -120,6 +123,29 @@ export default class ManageTeamsModal extends React.Component {
                     return null;
                 }
 
+                let action;
+                if (isSystemAdmin) {
+                    action = (
+                        <RemoveFromTeamButton
+                            user={user}
+                            team={team}
+                            onError={this.handleError}
+                            onMemberRemove={this.handleMemberRemove}
+                        />
+                    );
+                } else {
+                    action = (
+                        <ManageTeamsDropdown
+                            user={user}
+                            team={team}
+                            teamMember={teamMember}
+                            onError={this.handleError}
+                            onMemberChange={this.handleMemberChange}
+                            onMemberRemove={this.handleMemberRemove}
+                        />
+                    );
+                }
+
                 return (
                     <div
                         key={team.id}
@@ -129,20 +155,25 @@ export default class ManageTeamsModal extends React.Component {
                             {team.display_name}
                         </div>
                         <div className='manage-teams__team-actions'>
-                            <ManageTeamsDropdown
-                                user={user}
-                                team={team}
-                                teamMember={teamMember}
-                                onError={this.handleError}
-                                onMemberChange={this.handleMemberChange}
-                                onMemberRemove={this.handleMemberRemove}
-                            />
+                            {action}
                         </div>
                     </div>
                 );
             });
         } else {
             teamList = <LoadingScreen/>;
+        }
+
+        let systemAdminIndicator = null;
+        if (isSystemAdmin) {
+            systemAdminIndicator = (
+                <div className='manage-teams__system-admin'>
+                    <FormattedMessage
+                        id='admin.user_item.sysAdmin'
+                        defaultMessage='System Admin'
+                    />
+                </div>
+            );
         }
 
         return (
@@ -160,6 +191,7 @@ export default class ManageTeamsModal extends React.Component {
                             {user.email}
                         </div>
                     </div>
+                    {systemAdminIndicator}
                 </div>
                 <div className='manage-teams__teams'>
                     {teamList}

--- a/webapp/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
+++ b/webapp/components/admin_console/manage_teams_modal/manage_teams_modal.jsx
@@ -1,0 +1,188 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {Modal} from 'react-bootstrap';
+
+import * as TeamActions from 'actions/team_actions.jsx';
+
+import Client from 'client/web_client.jsx';
+
+import LoadingScreen from 'components/loading_screen.jsx';
+
+import * as Utils from 'utils/utils.jsx';
+
+import ManageTeamsDropdown from './manage_teams_dropdown.jsx';
+
+export default class ManageTeamsModal extends React.Component {
+    static propTypes = {
+        onModalDismissed: React.PropTypes.func.isRequired,
+        show: React.PropTypes.bool.isRequired,
+        user: React.PropTypes.object
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.loadTeamsAndTeamMembers = this.loadTeamsAndTeamMembers.bind(this);
+
+        this.handleError = this.handleError.bind(this);
+        this.handleMemberChange = this.handleMemberChange.bind(this);
+        this.handleMemberRemove = this.handleMemberRemove.bind(this);
+
+        this.renderContents = this.renderContents.bind(this);
+
+        this.state = {
+            error: null,
+            teams: null,
+            teamMembers: null
+        };
+    }
+
+    componentDidMount() {
+        if (this.props.user) {
+            this.loadTeamsAndTeamMembers();
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        const userId = this.props.user ? this.props.user.id : '';
+        const nextUserId = nextProps.user ? nextProps.user.id : '';
+
+        if (userId !== nextUserId) {
+            this.setState({
+                teams: null,
+                teamMembers: null
+            });
+
+            if (nextProps.user) {
+                this.loadTeamsAndTeamMembers(nextProps.user);
+            }
+        }
+    }
+
+    loadTeamsAndTeamMembers(user = this.props.user) {
+        TeamActions.getTeamsForUser(user.id, (teams) => {
+            this.setState({
+                teams
+            });
+        });
+
+        TeamActions.getTeamMembersForUser(user.id, (teamMembers) => {
+            this.setState({
+                teamMembers
+            });
+        });
+    }
+
+    handleError(error) {
+        this.setState({
+            error
+        });
+    }
+
+    handleMemberChange() {
+        TeamActions.getTeamMembersForUser(this.props.user.id, (teamMembers) => {
+            this.setState({
+                teamMembers
+            });
+        });
+    }
+
+    handleMemberRemove(teamId) {
+        this.setState({
+            teams: this.state.teams.filter((team) => team.id !== teamId),
+            teamMembers: this.state.teamMembers.filter((teamMember) => teamMember.team_id !== teamId)
+        });
+    }
+
+    renderContents() {
+        const {user} = this.props;
+        const {teams, teamMembers} = this.state;
+
+        if (!user) {
+            return <LoadingScreen/>;
+        }
+
+        let name = Utils.getFullName(user);
+        if (name) {
+            name += ` (@${user.username})`;
+        } else {
+            name = `@${user.username}`;
+        }
+
+        let teamList;
+        if (teams && teamMembers) {
+            teamList = teams.map((team) => {
+                const teamMember = teamMembers.find((member) => member.team_id === team.id);
+                if (!teamMember) {
+                    return null;
+                }
+
+                return (
+                    <div
+                        key={team.id}
+                        className='manage-teams__team'
+                    >
+                        <div className='manage-teams__team-name'>
+                            {team.display_name}
+                        </div>
+                        <div className='manage-teams__team-actions'>
+                            <ManageTeamsDropdown
+                                user={user}
+                                team={team}
+                                teamMember={teamMember}
+                                onError={this.handleError}
+                                onMemberChange={this.handleMemberChange}
+                                onMemberRemove={this.handleMemberRemove}
+                            />
+                        </div>
+                    </div>
+                );
+            });
+        } else {
+            teamList = <LoadingScreen/>;
+        }
+
+        return (
+            <div>
+                <div className='manage-teams__user'>
+                    <img
+                        className='manage-teams__profile-picture'
+                        src={Client.getProfilePictureUrl(user.id, user.last_picture_update)}
+                    />
+                    <div className='manage-teams__info'>
+                        <div className='manage-teams__name'>
+                            {name}
+                        </div>
+                        <div className='manage-teams__email'>
+                            {user.email}
+                        </div>
+                    </div>
+                </div>
+                <div className='manage-teams__teams'>
+                    {teamList}
+                </div>
+            </div>
+        );
+    }
+
+    render() {
+        return (
+            <Modal
+                show={this.props.show}
+                onHide={this.props.onModalDismissed}
+                dialogClassName='manage-teams'
+            >
+                <Modal.Header closeButton={true}>
+                    <Modal.Title>
+                        {'Manage Teams'}
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {this.renderContents()}
+                </Modal.Body>
+            </Modal>
+        );
+    }
+}

--- a/webapp/components/admin_console/manage_teams_modal/remove_from_team_button.jsx
+++ b/webapp/components/admin_console/manage_teams_modal/remove_from_team_button.jsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import {removeUserFromTeam} from 'actions/team_actions.jsx';
+
+export default class RemoveFromTeamButton extends React.PureComponent {
+    static propTypes = {
+        onError: React.PropTypes.func.isRequired,
+        onMemberRemove: React.PropTypes.func.isRequired,
+        team: React.PropTypes.object.isRequired,
+        user: React.PropTypes.object.isRequired
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.handleClick = this.handleClick.bind(this);
+        this.handleMemberRemove = this.handleMemberRemove.bind(this);
+    }
+
+    handleClick(e) {
+        e.preventDefault();
+
+        removeUserFromTeam(
+            this.props.team.id,
+            this.props.user.id,
+            this.handleMemberRemove,
+            this.props.onError
+        );
+    }
+
+    handleMemberRemove() {
+        this.props.onMemberRemove(this.props.team.id);
+    }
+
+    render() {
+        return (
+            <button
+                className='btn btn-default'
+                onClick={this.handleClick}
+            >
+                <FormattedMessage
+                    id='team_members_dropdown.leave_team'
+                    defaultMessage='Remove from Team'
+                />
+            </button>
+        );
+    }
+}

--- a/webapp/components/admin_console/system_users/system_users_dropdown.jsx
+++ b/webapp/components/admin_console/system_users/system_users_dropdown.jsx
@@ -300,7 +300,10 @@ export default class SystemUsersDropdown extends React.Component {
                         href='#'
                         onClick={this.handleManageTeams}
                     >
-                        {'Manage Teams'}
+                        <FormattedMessage
+                            id='admin.user_item.manageTeams'
+                            defaultMessage='Manage Teams'
+                        />
                     </a>
                 </li>
             );

--- a/webapp/components/admin_console/system_users/system_users_dropdown.jsx
+++ b/webapp/components/admin_console/system_users/system_users_dropdown.jsx
@@ -18,7 +18,8 @@ import React from 'react';
 export default class SystemUsersDropdown extends React.Component {
     static propTypes = {
         user: React.PropTypes.object.isRequired,
-        doPasswordReset: React.PropTypes.func.isRequired
+        doPasswordReset: React.PropTypes.func.isRequired,
+        doManageTeams: React.PropTypes.func.isRequired
     };
 
     constructor(props) {
@@ -28,6 +29,7 @@ export default class SystemUsersDropdown extends React.Component {
         this.handleMakeActive = this.handleMakeActive.bind(this);
         this.handleMakeNotActive = this.handleMakeNotActive.bind(this);
         this.handleMakeSystemAdmin = this.handleMakeSystemAdmin.bind(this);
+        this.handleManageTeams = this.handleManageTeams.bind(this);
         this.handleResetPassword = this.handleResetPassword.bind(this);
         this.handleResetMfa = this.handleResetMfa.bind(this);
         this.handleDemoteSystemAdmin = this.handleDemoteSystemAdmin.bind(this);
@@ -92,6 +94,12 @@ export default class SystemUsersDropdown extends React.Component {
                 this.setState({serverError: err.message});
             }
         );
+    }
+
+    handleManageTeams(e) {
+        e.preventDefault();
+
+        this.props.doManageTeams(this.props.user);
     }
 
     handleResetPassword(e) {
@@ -177,6 +185,7 @@ export default class SystemUsersDropdown extends React.Component {
         let showMakeSystemAdmin = !Utils.isSystemAdmin(user.roles);
         let showMakeActive = false;
         let showMakeNotActive = !Utils.isSystemAdmin(user.roles);
+        let showManageTeams = true;
         const mfaEnabled = global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.MFA === 'true' && global.window.mm_config.EnableMultifactorAuthentication === 'true';
         const showMfaReset = mfaEnabled && user.mfa_active;
 
@@ -191,6 +200,7 @@ export default class SystemUsersDropdown extends React.Component {
             showMakeSystemAdmin = false;
             showMakeActive = true;
             showMakeNotActive = false;
+            showManageTeams = false;
         }
 
         let disableActivationToggle = false;
@@ -276,6 +286,21 @@ export default class SystemUsersDropdown extends React.Component {
                             id='admin.user_item.makeInactive'
                             defaultMessage='Make Inactive'
                         />
+                    </a>
+                </li>
+            );
+        }
+
+        let manageTeams = null;
+        if (showManageTeams) {
+            manageTeams = (
+                <li role='presentation'>
+                    <a
+                        role='menuitem'
+                        href='#'
+                        onClick={this.handleManageTeams}
+                    >
+                        {'Manage Teams'}
                     </a>
                 </li>
             );
@@ -404,6 +429,7 @@ export default class SystemUsersDropdown extends React.Component {
                     {makeActive}
                     {makeNotActive}
                     {makeSystemAdmin}
+                    {manageTeams}
                     {mfaReset}
                     {passwordReset}
                 </ul>

--- a/webapp/components/admin_console/system_users/system_users_list.jsx
+++ b/webapp/components/admin_console/system_users/system_users_list.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
 
+import ManageTeamsModal from 'components/admin_console/manage_teams_modal/manage_teams_modal.jsx';
 import ResetPasswordModal from 'components/admin_console/reset_password_modal.jsx';
 import SearchableUserList from 'components/searchable_user_list/searchable_user_list.jsx';
 
@@ -35,6 +36,9 @@ export default class SystemUsersList extends React.Component {
         this.previousPage = this.previousPage.bind(this);
         this.search = this.search.bind(this);
 
+        this.doManageTeams = this.doManageTeams.bind(this);
+        this.doManageTeamsDismiss = this.doManageTeamsDismiss.bind(this);
+
         this.doPasswordReset = this.doPasswordReset.bind(this);
         this.doPasswordResetDismiss = this.doPasswordResetDismiss.bind(this);
         this.doPasswordResetSubmit = this.doPasswordResetSubmit.bind(this);
@@ -42,6 +46,7 @@ export default class SystemUsersList extends React.Component {
         this.state = {
             page: 0,
 
+            showManageTeamsModal: false,
             showPasswordModal: false,
             user: null
         };
@@ -69,6 +74,20 @@ export default class SystemUsersList extends React.Component {
         if (term !== '') {
             this.setState({page: 0});
         }
+    }
+
+    doManageTeams(user) {
+        this.setState({
+            showManageTeamsModal: true,
+            user
+        });
+    }
+
+    doManageTeamsDismiss() {
+        this.setState({
+            showManageTeamsModal: false,
+            user: null
+        });
     }
 
     doPasswordReset(user) {
@@ -211,7 +230,8 @@ export default class SystemUsersList extends React.Component {
                     extraInfo={extraInfo}
                     actions={[SystemUsersDropdown]}
                     actionProps={{
-                        doPasswordReset: this.doPasswordReset
+                        doPasswordReset: this.doPasswordReset,
+                        doManageTeams: this.doManageTeams
                     }}
                     nextPage={this.nextPage}
                     previousPage={this.previousPage}
@@ -219,6 +239,11 @@ export default class SystemUsersList extends React.Component {
                     page={this.state.page}
                     term={this.props.term}
                     onTermChange={this.props.onTermChange}
+                />
+                <ManageTeamsModal
+                    user={this.state.user}
+                    show={this.state.showManageTeamsModal}
+                    onModalDismissed={this.doManageTeamsDismiss}
                 />
                 <ResetPasswordModal
                     user={this.state.user}

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -904,6 +904,7 @@
   "admin.user_item.resetPwd": "Reset Password",
   "admin.user_item.switchToEmail": "Switch to Email/Password",
   "admin.user_item.teamAdmin": "Team Admin",
+  "admin.user_item.sysAdmin": "System Admin",
   "admin.webrtc.enableDescription": "When true, Mattermost allows making <strong>one-on-one</strong> video calls. WebRTC calls are available on Chrome, Firefox and Mattermost Desktop Apps.",
   "admin.webrtc.enableTitle": "Enable Mattermost WebRTC: ",
   "admin.webrtc.gatewayAdminSecretDescription": "Enter your admin secret password to access the Gateway Admin URL.",

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -896,6 +896,7 @@
   "admin.user_item.makeMember": "Make Member",
   "admin.user_item.makeSysAdmin": "Make System Admin",
   "admin.user_item.makeTeamAdmin": "Make Team Admin",
+  "admin.user_item.manageTeams": "Manage Teams",
   "admin.user_item.member": "Member",
   "admin.user_item.mfaNo": "<strong>MFA</strong>: No",
   "admin.user_item.mfaYes": "<strong>MFA</strong>: Yes",

--- a/webapp/sass/routes/_admin-console.scss
+++ b/webapp/sass/routes/_admin-console.scss
@@ -540,12 +540,12 @@
     .manage-teams__system-admin {
         margin-left: 10px;
         opacity: 0.5;
+        padding-right: 10px;
     }
 
     .manage-teams__team {
         align-items: center;
         display: flex;
-        font-weight: bold;
         padding: 10px;
     }
 
@@ -557,6 +557,7 @@
 
     .manage-teams__team-name {
         flex: 1;
+        font-weight: bold;
         overflow: hidden;
         text-overflow: ellipsis;
     }

--- a/webapp/sass/routes/_admin-console.scss
+++ b/webapp/sass/routes/_admin-console.scss
@@ -504,34 +504,48 @@
 
 .manage-teams {
     .manage-teams__user {
+        align-items: center;
         border-bottom-color: lightgray;
         border-bottom-style: solid;
         border-bottom-width: 1px;
+        display: flex;
         padding-bottom: 15px;
     }
 
     .manage-teams__profile-picture {
         border-radius: 20px;
+        height: 40px;
         width: 40px;
     }
 
     .manage-teams__info {
-        display: inline-block;
+        flex: 1;
         margin-left: 10px;
-        vertical-align: middle;
+        overflow: hidden;
+        white-space: nowrap;
 
         .manage-teams__name {
             font-weight: bold;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .manage-teams__email {
             opacity: 0.5;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
+    }
+
+    .manage-teams__system-admin {
+        margin-left: 10px;
+        opacity: 0.5;
     }
 
     .manage-teams__team {
         align-items: center;
         display: flex;
+        font-weight: bold;
         padding: 10px;
     }
 
@@ -543,5 +557,16 @@
 
     .manage-teams__team-name {
         flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .manage-teams__team-actions {
+        margin-left: 10px;
+
+        // Override default react-bootstrap style
+        .dropdown-toggle {
+            @include box-shadow(none);
+        }
     }
 }

--- a/webapp/sass/routes/_admin-console.scss
+++ b/webapp/sass/routes/_admin-console.scss
@@ -501,3 +501,47 @@
         width: 200px
     }
 }
+
+.manage-teams {
+    .manage-teams__user {
+        border-bottom-color: lightgray;
+        border-bottom-style: solid;
+        border-bottom-width: 1px;
+        padding-bottom: 15px;
+    }
+
+    .manage-teams__profile-picture {
+        border-radius: 20px;
+        width: 40px;
+    }
+
+    .manage-teams__info {
+        display: inline-block;
+        margin-left: 10px;
+        vertical-align: middle;
+
+        .manage-teams__name {
+            font-weight: bold;
+        }
+
+        .manage-teams__email {
+            opacity: 0.5;
+        }
+    }
+
+    .manage-teams__team {
+        align-items: center;
+        display: flex;
+        padding: 10px;
+
+        & + & {
+            border-top-color: lightgray;
+            border-top-style: solid;
+            border-top-width: 1px;
+        }
+    }
+
+    .manage-teams__team-name {
+        flex: 1;
+    }
+}

--- a/webapp/sass/routes/_admin-console.scss
+++ b/webapp/sass/routes/_admin-console.scss
@@ -533,12 +533,12 @@
         align-items: center;
         display: flex;
         padding: 10px;
+    }
 
-        & + & {
-            border-top-color: lightgray;
-            border-top-style: solid;
-            border-top-width: 1px;
-        }
+    .manage-teams__team + .manage-teams__team {
+        border-top-color: lightgray;
+        border-top-style: solid;
+        border-top-width: 1px;
     }
 
     .manage-teams__team-name {


### PR DESCRIPTION
The Manage Teams modal is needed for 3.8 since we'd be losing some functionality without it (specifically, the ability for System Admins to promote/demote Team Admins and remove users from teams).

This is based upon #5882 so changes specific to this one are here: https://github.com/mattermost/platform/compare/PLT-2713c...PLT-6098

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6098

#### Checklist
- Has UI changes
- Includes text changes and localization file ([.../i18n/en.json]

![image](https://cloud.githubusercontent.com/assets/3277310/24478562/41dc01e4-14a9-11e7-8481-50be33efab48.png)
