### PR TITLE
[PLT-5585] Save Recently Used Emojis After Logout

### DIFF
--- a/webapp/stores/browser_store.jsx
+++ b/webapp/stores/browser_store.jsx
@@ -3,6 +3,7 @@
 
 import {browserHistory} from 'react-router/es6';
 import * as Utils from 'utils/utils.jsx';
+import Constants from 'utils/constants.jsx';
 
 const notSupportedParams = {
     title: Utils.localizeMessage('error.not_supported.title', 'Browser not supported'),
@@ -151,9 +152,14 @@ class BrowserStoreClass {
         const serverVersion = this.getLastServerVersion();
         const landingPageSeen = this.hasSeenLandingPage();
         const selectedTeams = this.getItem('selected_teams');
+        const recentEmojis = localStorage.getItem(Constants.RECENT_EMOJI_KEY);
 
         sessionStorage.clear();
         localStorage.clear();
+
+        if (recentEmojis) {
+            localStorage.setItem(Constants.RECENT_EMOJI_KEY, recentEmojis);
+        }
 
         if (logoutId) {
             sessionStorage.setItem('__logout__', logoutId);

--- a/webapp/stores/emoji_store.jsx
+++ b/webapp/stores/emoji_store.jsx
@@ -10,7 +10,6 @@ import * as Emoji from 'utils/emoji.jsx';
 const ActionTypes = Constants.ActionTypes;
 
 const CHANGE_EVENT = 'changed';
-const RECENT_EMOJI_KEY = 'recentEmojis';
 const MAXIMUM_RECENT_EMOJI = 27;
 
 // Wrap the contents of the store so that we don't need to construct an ES6 map where most of the content
@@ -171,11 +170,11 @@ class EmojiStore extends EventEmitter {
         if (recentEmojis.length > MAXIMUM_RECENT_EMOJI) {
             recentEmojis.splice(0, recentEmojis.length - MAXIMUM_RECENT_EMOJI);
         }
-        localStorage.setItem(RECENT_EMOJI_KEY, JSON.stringify(recentEmojis));
+        localStorage.setItem(Constants.RECENT_EMOJI_KEY, JSON.stringify(recentEmojis));
     }
 
     getRecentEmojis() {
-        const result = JSON.parse(localStorage.getItem(RECENT_EMOJI_KEY));
+        const result = JSON.parse(localStorage.getItem(Constants.RECENT_EMOJI_KEY));
         if (!result) {
             return [];
         }

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -894,6 +894,7 @@ export const Constants = {
     MIN_HASHTAG_LINK_LENGTH: 3,
     CHANNEL_SCROLL_ADJUSTMENT: 100,
     EMOJI_PATH: '/static/emoji',
+    RECENT_EMOJI_KEY: 'recentEmojis',
     DEFAULT_WEBHOOK_LOGO: logoWebhook,
     MHPNS: 'https://push.mattermost.com',
     MTPNS: 'http://push-test.mattermost.com',


### PR DESCRIPTION
#### Summary
The `Recently Used` emojis will now persist after the user logs out and back in.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5585
