### PR TITLE
[PLT-6154] Clicking @ should append @[username] to the search

### DIFF
--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -522,7 +522,7 @@ export function clientLogout(redirectTo = '/') {
 
 export function emitSearchMentionsEvent(user) {
     let terms = '';
-    if (user.notify_props && user.notify_props.mention_keys) {
+    if (user.notify_props) {
         const termKeys = UserStore.getMentionKeys(user.id);
 
         if (termKeys.indexOf('@channel') !== -1) {


### PR DESCRIPTION
#### Summary
Fix the issue where clicking the `@` was not passing the default `@[username]` into the search box + opening the results.

More specifically this issue happens when you have nothing selected on the below settings:
![notification settings](https://cloud.githubusercontent.com/assets/13369829/24526172/8f607268-1573-11e7-8a71-09d39f4000c0.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6154

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
