### PR TITLE
PLT-6163 Replace initial load of user's channel members for all teams with a lazy load

### DIFF
--- a/webapp/actions/notification_actions.jsx
+++ b/webapp/actions/notification_actions.jsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import Constants from 'utils/constants.jsx';
+import UserStore from 'stores/user_store.jsx';
+import ChannelStore from 'stores/channel_store.jsx';
+import NotificationStore from 'stores/notification_store.jsx';
+
+import {isSystemMessage} from 'utils/post_utils.jsx';
+import {buildGroupChannelName} from 'utils/channel_utils.jsx';
+import {isWindowsApp, isMacApp, isMobileApp} from 'utils/user_agent.jsx';
+import * as Utils from 'utils/utils.jsx';
+
+export function sendDesktopNotification(post, msgProps) {
+    if ((UserStore.getCurrentId() === post.user_id && post.props.from_webhook !== 'true')) {
+        return;
+    }
+
+    if (isSystemMessage(post)) {
+        return;
+    }
+
+    let mentions = [];
+    if (msgProps.mentions) {
+        mentions = JSON.parse(msgProps.mentions);
+    }
+    const teamId = msgProps.team_id;
+
+    let channel = ChannelStore.get(post.channel_id);
+    const user = UserStore.getCurrentUser();
+    const member = ChannelStore.getMyMember(post.channel_id);
+
+    let notifyLevel = member && member.notify_props ? member.notify_props.desktop : 'default';
+    if (notifyLevel === 'default') {
+        notifyLevel = user.notify_props.desktop;
+    }
+
+    if (notifyLevel === 'none') {
+        return;
+    } else if (notifyLevel === 'mention' && mentions.indexOf(user.id) === -1 && msgProps.channel_type !== Constants.DM_CHANNEL) {
+        return;
+    }
+
+    let username = Utils.localizeMessage('channel_loader.someone', 'Someone');
+    if (post.props.override_username && global.window.mm_config.EnablePostUsernameOverride === 'true') {
+        username = post.props.override_username;
+    } else if (msgProps.sender_name) {
+        username = msgProps.sender_name;
+    } else if (UserStore.hasProfile(post.user_id)) {
+        username = UserStore.getProfile(post.user_id).username;
+    }
+
+    let title = Utils.localizeMessage('channel_loader.posted', 'Posted');
+    if (!channel) {
+        title = msgProps.channel_display_name;
+        channel = {
+            name: msgProps.channel_name,
+            type: msgProps.channel_type
+        };
+    } else if (channel.type === Constants.DM_CHANNEL) {
+        title = Utils.localizeMessage('notification.dm', 'Direct Message');
+    } else if (channel.type === Constants.GM_CHANNEL) {
+        title = buildGroupChannelName(channel.id);
+    } else {
+        title = channel.display_name;
+    }
+
+    if (title === '') {
+        title = msgProps.channel_display_name;
+    }
+
+    let notifyText = post.message.replace(/\n+/g, ' ');
+    if (notifyText.length > 50) {
+        notifyText = notifyText.substring(0, 49) + '...';
+    }
+
+    let body = '';
+    if (notifyText.length === 0) {
+        if (msgProps.image) {
+            body = username + Utils.localizeMessage('channel_loader.uploadedImage', ' uploaded an image');
+        } else if (msgProps.otherFile) {
+            body = username + Utils.localizeMessage('channel_loader.uploadedFile', ' uploaded a file');
+        } else {
+            body = username + Utils.localizeMessage('channel_loader.something', ' did something new');
+        }
+    } else {
+        body = username + Utils.localizeMessage('channel_loader.wrote', ' wrote: ') + notifyText;
+    }
+
+    let duration = Constants.DEFAULT_NOTIFICATION_DURATION;
+    if (user.notify_props && user.notify_props.desktop_duration) {
+        duration = parseInt(user.notify_props.desktop_duration, 10) * 1000;
+    }
+
+    //Play a sound if explicitly set in settings
+    const sound = !user.notify_props || user.notify_props.desktop_sound === 'true';
+
+    // Notify if you're not looking in the right channel or when
+    // the window itself is not active
+    const activeChannel = ChannelStore.getCurrent();
+    const channelId = channel ? channel.id : null;
+    const notify = (activeChannel && activeChannel.id !== channelId) || !NotificationStore.getFocus();
+
+    if (notify) {
+        Utils.notifyMe(title, body, channel, teamId, duration, !sound);
+
+        //Don't add extra sounds on native desktop clients
+        if (sound && !isWindowsApp() && !isMacApp() && !isMobileApp()) {
+            Utils.ding();
+        }
+    }
+}

--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -10,6 +10,7 @@ import UserStore from 'stores/user_store.jsx';
 import {loadStatusesForChannel} from 'actions/status_actions.jsx';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded} from 'actions/user_actions.jsx';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
+import {sendDesktopNotification} from 'actions/notification_actions.jsx';
 
 import Client from 'client/web_client.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
@@ -32,6 +33,14 @@ export function handleNewPost(post, msg) {
         }
     }
 
+    if (ChannelStore.getMyMember(post.channel_id)) {
+        completePostReceive(post, websocketMessageProps);
+    } else {
+        AsyncClient.getChannelMember(post.channel_id, UserStore.getCurrentId()).then(() => completePostReceive(post, websocketMessageProps));
+    }
+}
+
+function completePostReceive(post, websocketMessageProps) {
     if (post.root_id && PostStore.getPost(post.channel_id, post.root_id) == null) {
         Client.getPost(
             post.channel_id,
@@ -51,6 +60,8 @@ export function handleNewPost(post, msg) {
                     websocketMessageProps
                 });
 
+                sendDesktopNotification(post, websocketMessageProps);
+
                 loadProfilesForPosts(data.posts);
             },
             (err) => {
@@ -66,6 +77,8 @@ export function handleNewPost(post, msg) {
         post,
         websocketMessageProps
     });
+
+    sendDesktopNotification(post, websocketMessageProps);
 }
 
 export function pinPost(channelId, postId) {

--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -108,8 +108,7 @@ function preNeedsTeam(nextState, replace, callback) {
     if (nextState.location.pathname.indexOf('/channels/') > -1 ||
         nextState.location.pathname.indexOf('/pl/') > -1) {
         AsyncClient.getMyTeamsUnread();
-        const members = TeamStore.getMyTeamMembers();
-        members.forEach((m) => AsyncClient.getMyChannelMembersForTeam(m.team_id));
+        AsyncClient.getMyChannelMembersForTeam(team.id);
     }
 
     const d1 = $.Deferred(); //eslint-disable-line new-cap

--- a/webapp/stores/notification_store.jsx
+++ b/webapp/stores/notification_store.jsx
@@ -4,12 +4,6 @@
 import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import EventEmitter from 'events';
 import Constants from 'utils/constants.jsx';
-import UserStore from './user_store.jsx';
-import ChannelStore from './channel_store.jsx';
-import * as UserAgent from 'utils/user_agent.jsx';
-import * as Utils from 'utils/utils.jsx';
-import {buildGroupChannelName} from 'utils/channel_utils.jsx';
-import * as PostUtils from 'utils/post_utils.jsx';
 const ActionTypes = Constants.ActionTypes;
 
 const CHANGE_EVENT = 'change';
@@ -26,107 +20,13 @@ class NotificationStoreClass extends EventEmitter {
     removeChangeListener(callback) {
         this.removeListener(CHANGE_EVENT, callback);
     }
+
     setFocus(focus) {
         this.inFocus = focus;
     }
 
-    handleReceivedPost(post, msgProps) {
-        // Send desktop notification
-        if ((UserStore.getCurrentId() !== post.user_id || post.props.from_webhook === 'true')) {
-            if (PostUtils.isSystemMessage(post)) {
-                return;
-            }
-
-            let mentions = [];
-            if (msgProps.mentions) {
-                mentions = JSON.parse(msgProps.mentions);
-            }
-            const teamId = msgProps.team_id;
-
-            let channel = ChannelStore.get(post.channel_id);
-            const user = UserStore.getCurrentUser();
-            const member = ChannelStore.getMyMember(post.channel_id);
-
-            let notifyLevel = member && member.notify_props ? member.notify_props.desktop : 'default';
-            if (notifyLevel === 'default') {
-                notifyLevel = user.notify_props.desktop;
-            }
-
-            if (notifyLevel === 'none') {
-                return;
-            } else if (notifyLevel === 'mention' && mentions.indexOf(user.id) === -1 && msgProps.channel_type !== Constants.DM_CHANNEL) {
-                return;
-            }
-
-            let username = Utils.localizeMessage('channel_loader.someone', 'Someone');
-            if (post.props.override_username && global.window.mm_config.EnablePostUsernameOverride === 'true') {
-                username = post.props.override_username;
-            } else if (msgProps.sender_name) {
-                username = msgProps.sender_name;
-            } else if (UserStore.hasProfile(post.user_id)) {
-                username = UserStore.getProfile(post.user_id).username;
-            }
-
-            let title = Utils.localizeMessage('channel_loader.posted', 'Posted');
-            if (!channel) {
-                title = msgProps.channel_display_name;
-                channel = {
-                    name: msgProps.channel_name,
-                    type: msgProps.channel_type
-                };
-            } else if (channel.type === Constants.DM_CHANNEL) {
-                title = Utils.localizeMessage('notification.dm', 'Direct Message');
-            } else if (channel.type === Constants.GM_CHANNEL) {
-                title = buildGroupChannelName(channel.id);
-            } else {
-                title = channel.display_name;
-            }
-
-            if (title === '') {
-                title = msgProps.channel_display_name;
-            }
-
-            let notifyText = post.message.replace(/\n+/g, ' ');
-            if (notifyText.length > 50) {
-                notifyText = notifyText.substring(0, 49) + '...';
-            }
-
-            let body = '';
-            if (notifyText.length === 0) {
-                if (msgProps.image) {
-                    body = username + Utils.localizeMessage('channel_loader.uploadedImage', ' uploaded an image');
-                } else if (msgProps.otherFile) {
-                    body = username + Utils.localizeMessage('channel_loader.uploadedFile', ' uploaded a file');
-                } else {
-                    body = username + Utils.localizeMessage('channel_loader.something', ' did something new');
-                }
-            } else {
-                body = username + Utils.localizeMessage('channel_loader.wrote', ' wrote: ') + notifyText;
-            }
-
-            let duration = Constants.DEFAULT_NOTIFICATION_DURATION;
-            if (user.notify_props && user.notify_props.desktop_duration) {
-                duration = parseInt(user.notify_props.desktop_duration, 10) * 1000;
-            }
-
-            //Play a sound if explicitly set in settings
-            const sound = !user.notify_props || user.notify_props.desktop_sound === 'true';
-
-            // Notify if you're not looking in the right channel or when
-            // the window itself is not active
-            const activeChannel = ChannelStore.getCurrent();
-            const channelId = channel ? channel.id : null;
-            const notify = (activeChannel && activeChannel.id !== channelId) || !this.inFocus;
-
-            if (notify) {
-                Utils.notifyMe(title, body, channel, teamId, duration, !sound);
-
-                //Don't add extra sounds on native desktop clients
-                if (sound && !UserAgent.isWindowsApp() && !UserAgent.isMacApp() && !UserAgent.isMobileApp()) {
-                    Utils.ding();
-                }
-            }
-        }
+    getFocus() {
+        return this.inFocus;
     }
 }
 
@@ -136,10 +36,6 @@ NotificationStore.dispatchToken = AppDispatcher.register((payload) => {
     const action = payload.action;
 
     switch (action.type) {
-    case ActionTypes.RECEIVED_POST:
-        NotificationStore.handleReceivedPost(action.post, action.websocketMessageProps);
-        NotificationStore.emitChange();
-        break;
     case ActionTypes.BROWSER_CHANGE_FOCUS:
         NotificationStore.setFocus(action.focus);
         break;


### PR DESCRIPTION
#### Summary
* Replace initial load of user's channel members for all teams with a lazy load when receiving a post in a channel the client doesn't have a channel member for
* Move desktop notification code to an action

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6163