### PR TITLE
PLT-6146 Fix blanking out of FileIds and backwards compatibility issue with v3

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -84,7 +84,7 @@ func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	post.UserId = c.Session.UserId
 
-	rpost, err := app.UpdatePost(post)
+	rpost, err := app.UpdatePost(post, true)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/post.go
+++ b/api4/post.go
@@ -238,9 +238,14 @@ func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	post.UserId = c.Session.UserId
+	if !app.SessionHasPermissionToPost(c.Session, c.Params.PostId, model.PERMISSION_EDIT_OTHERS_POSTS) {
+		c.SetPermissionError(model.PERMISSION_EDIT_OTHERS_POSTS)
+		return
+	}
 
-	rpost, err := app.UpdatePost(post)
+	post.Id = c.Params.PostId
+
+	rpost, err := app.UpdatePost(post, false)
 	if err != nil {
 		c.Err = err
 		return
@@ -259,6 +264,11 @@ func patchPost(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if post == nil {
 		c.SetInvalidParam("post")
+		return
+	}
+
+	if !app.SessionHasPermissionToChannelByPost(c.Session, c.Params.PostId, model.PERMISSION_EDIT_POST) {
+		c.SetPermissionError(model.PERMISSION_EDIT_POST)
 		return
 	}
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -167,6 +167,15 @@ func TestUpdatePost(t *testing.T) {
 	Client.Logout()
 	_, resp = Client.UpdatePost(rpost.Id, rpost)
 	CheckUnauthorizedStatus(t, resp)
+
+	th.LoginBasic2()
+	_, resp = Client.UpdatePost(rpost.Id, rpost)
+	CheckForbiddenStatus(t, resp)
+
+	Client.Logout()
+
+	_, resp = th.SystemAdminClient.UpdatePost(rpost.Id, rpost)
+	CheckNoError(t, resp)
 }
 
 func TestPatchPost(t *testing.T) {
@@ -261,6 +270,10 @@ func TestPatchPost(t *testing.T) {
 	Client.Logout()
 	_, resp = Client.PatchPost(post.Id, patch)
 	CheckUnauthorizedStatus(t, resp)
+
+	th.LoginBasic2()
+	_, resp = Client.PatchPost(post.Id, patch)
+	CheckForbiddenStatus(t, resp)
 
 	th.LoginTeamAdmin()
 	_, resp = Client.PatchPost(post.Id, patch)


### PR DESCRIPTION
#### Summary
The issue was the new v4 endpoints for updating/patching posts exposed update access to the FileIds field (and some others). This caused a backwards compatibility issue with the v3 endpoint which I fixed. I also cleaned up the permission checks a bit.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6146

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#203)