### PR TITLE
[APIV4] Implement GET /teams/{team_id}/commands/autocomplete

### DIFF
--- a/api4/command.go
+++ b/api4/command.go
@@ -18,6 +18,8 @@ func InitCommand() {
 
 	BaseRoutes.Commands.Handle("", ApiSessionRequired(createCommand)).Methods("POST")
 	BaseRoutes.Commands.Handle("", ApiSessionRequired(listCommands)).Methods("GET")
+
+	BaseRoutes.Team.Handle("/commands/autocomplete", ApiSessionRequired(listAutocompleteCommands)).Methods("GET")
 }
 
 func createCommand(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -87,6 +89,26 @@ func listCommands(c *Context, w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+	}
+
+	w.Write([]byte(model.CommandListToJson(commands)))
+}
+
+func listAutocompleteCommands(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireTeamId()
+	if c.Err != nil {
+		return
+	}
+
+	if !app.SessionHasPermissionToTeam(c.Session, c.Params.TeamId, model.PERMISSION_VIEW_TEAM) {
+		c.SetPermissionError(model.PERMISSION_VIEW_TEAM)
+		return
+	}
+
+	commands, err := app.ListAutocompleteCommands(c.Params.TeamId, c.T)
+	if err != nil {
+		c.Err = err
+		return
 	}
 
 	w.Write([]byte(model.CommandListToJson(commands)))

--- a/model/client4.go
+++ b/model/client4.go
@@ -78,6 +78,10 @@ func (c *Client4) GetTeamRoute(teamId string) string {
 	return fmt.Sprintf(c.GetTeamsRoute()+"/%v", teamId)
 }
 
+func (c *Client4) GetTeamAutoCompleteCommandsRoute(teamId string) string {
+	return fmt.Sprintf(c.GetTeamsRoute()+"/%v/commands/autocomplete", teamId)
+}
+
 func (c *Client4) GetTeamByNameRoute(teamName string) string {
 	return fmt.Sprintf(c.GetTeamsRoute()+"/name/%v", teamName)
 }
@@ -2023,6 +2027,16 @@ func (c *Client4) CreateCommand(cmd *Command) (*Command, *Response) {
 func (c *Client4) ListCommands(teamId string, customOnly bool) ([]*Command, *Response) {
 	query := fmt.Sprintf("?team_id=%v&custom_only=%v", teamId, customOnly)
 	if r, err := c.DoApiGet(c.GetCommandsRoute()+query, ""); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CommandListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// ListCommands will retrieve a list of commands available in the team.
+func (c *Client4) ListAutocompleteCommands(teamId string) ([]*Command, *Response) {
+	if r, err := c.DoApiGet(c.GetTeamAutoCompleteCommandsRoute(teamId), ""); err != nil {
 		return nil, &Response{StatusCode: r.StatusCode, Error: err}
 	} else {
 		defer closeBody(r)


### PR DESCRIPTION
#### Summary
This PR implements the GET /teams/{team_id}/commands/autocomplete for apiV4

#### Ticket Link
n/a

#### Checklist
- [x] Added or updated unit tests
- [x] Added API documentation - PR: https://github.com/mattermost/mattermost-api-reference/pull/204
- [x] All new/modified APIs include changes to the drivers
