### PR TITLE
Added SidebarHeaderDropdownButton to stop console warning

### DIFF
--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -11,6 +11,7 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import WebrtcStore from 'stores/webrtc_store.jsx';
 import AboutBuildModal from './about_build_modal.jsx';
+import SidebarHeaderDropdownButton from './sidebar_header_dropdown_button.jsx';
 import TeamMembersModal from './team_members_modal.jsx';
 import UserSettingsModal from './user_settings/user_settings_modal.jsx';
 
@@ -454,17 +455,10 @@ export default class SidebarHeaderDropdown extends React.Component {
                 className='sidebar-header-dropdown'
                 pullRight={true}
             >
-                <a
-                    href='#'
-                    className='sidebar-header-dropdown__toggle'
+                <SidebarHeaderDropdownButton
                     bsRole='toggle'
                     onClick={this.toggleDropdown}
-                >
-                    <span
-                        className='sidebar-header-dropdown__icon'
-                        dangerouslySetInnerHTML={{__html: Constants.MENU_ICON}}
-                    />
-                </a>
+                />
                 <Dropdown.Menu>
                     <li>
                         <a

--- a/webapp/components/sidebar_header_dropdown_button.jsx
+++ b/webapp/components/sidebar_header_dropdown_button.jsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+
+import Constants from 'utils/constants.jsx';
+
+export default class SidebarHeaderDropdownButton extends React.PureComponent {
+    static propTypes = {
+        bsRole: React.PropTypes.oneOf(['toggle']).isRequired, // eslint-disable-line react/no-unused-prop-types
+        onClick: React.PropTypes.func.isRequired
+    };
+
+    render() {
+        return (
+            <a
+                href='#'
+                className='sidebar-header-dropdown__toggle'
+                onClick={this.props.onClick}
+            >
+                <span
+                    className='sidebar-header-dropdown__icon'
+                    dangerouslySetInnerHTML={{__html: Constants.MENU_ICON}}
+                />
+            </a>
+        );
+    }
+}
+


### PR DESCRIPTION
This all works the same, but it doesn't pass a `bsRole` prop into the link since that was generating warnings in dev mode