### PR TITLE
PLT-6198: Use added to channel system message on default channels.

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -163,7 +163,7 @@ func (me *TestHelper) CreateUser(client *model.Client) *model.User {
 func LinkUserToTeam(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	err := app.JoinUserToTeam(team, user)
+	err := app.JoinUserToTeam(team, user, "")
 	if err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()

--- a/api/team.go
+++ b/api/team.go
@@ -153,7 +153,7 @@ func addUserToTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := app.AddUserToTeam(c.TeamId, userId); err != nil {
+	if _, err := app.AddUserToTeam(c.TeamId, userId, ""); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -362,7 +362,7 @@ func (me *TestHelper) UpdateActiveUser(user *model.User, active bool) {
 func LinkUserToTeam(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	err := app.JoinUserToTeam(team, user)
+	err := app.JoinUserToTeam(team, user, "")
 	if err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()

--- a/api4/team.go
+++ b/api4/team.go
@@ -407,7 +407,7 @@ func addTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	members, err = app.AddTeamMembers(c.Params.TeamId, userIds)
+	members, err = app.AddTeamMembers(c.Params.TeamId, userIds, c.Session.UserId)
 
 	if err != nil {
 		c.Err = err

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -174,7 +174,7 @@ func (me *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 func LinkUserToTeam(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	err := JoinUserToTeam(team, user)
+	err := JoinUserToTeam(team, user, "")
 	if err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()

--- a/app/import.go
+++ b/app/import.go
@@ -865,7 +865,7 @@ func OldImportUser(team *model.Team, user *model.User) *model.User {
 			l4g.Error(utils.T("api.import.import_user.set_email.error"), cresult.Err)
 		}
 
-		if err := JoinUserToTeam(team, user); err != nil {
+		if err := JoinUserToTeam(team, user, ""); err != nil {
 			l4g.Error(utils.T("api.import.import_user.join_team.error"), err)
 		}
 

--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -160,7 +160,7 @@ func SlackAddUsers(teamId string, slackusers []SlackUser, log *bytes.Buffer) map
 		if result := <-Srv.Store.User().GetByEmail(email); result.Err == nil {
 			existingUser := result.Data.(*model.User)
 			addedUsers[sUser.Id] = existingUser
-			if err := JoinUserToTeam(team, addedUsers[sUser.Id]); err != nil {
+			if err := JoinUserToTeam(team, addedUsers[sUser.Id], ""); err != nil {
 				log.WriteString(utils.T("api.slackimport.slack_add_users.merge_existing_failed", map[string]interface{}{"Email": existingUser.Email, "Username": existingUser.Username}))
 			} else {
 				log.WriteString(utils.T("api.slackimport.slack_add_users.merge_existing", map[string]interface{}{"Email": existingUser.Email, "Username": existingUser.Username}))

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -95,7 +95,7 @@ func TestAddUserToTeam(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
 	ruser, _ := CreateUser(&user)
 
-	if _, err := AddUserToTeam(th.BasicTeam.Id, ruser.Id); err != nil {
+	if _, err := AddUserToTeam(th.BasicTeam.Id, ruser.Id, ""); err != nil {
 		t.Log(err)
 		t.Fatal("Should add user to the team")
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -63,7 +63,7 @@ func CreateUserWithHash(user *model.User, hash string, data string) (*model.User
 		return nil, err
 	}
 
-	if err := JoinUserToTeam(team, ruser); err != nil {
+	if err := JoinUserToTeam(team, ruser, ""); err != nil {
 		return nil, err
 	}
 
@@ -92,7 +92,7 @@ func CreateUserWithInviteId(user *model.User, inviteId string) (*model.User, *mo
 		return nil, err
 	}
 
-	if err := JoinUserToTeam(team, ruser); err != nil {
+	if err := JoinUserToTeam(team, ruser, ""); err != nil {
 		return nil, err
 	}
 

--- a/cmd/platform/team.go
+++ b/cmd/platform/team.go
@@ -154,7 +154,7 @@ func addUserToTeam(team *model.Team, user *model.User, userArg string) {
 		CommandPrintErrorln("Can't find user '" + userArg + "'")
 		return
 	}
-	if err := app.JoinUserToTeam(team, user); err != nil {
+	if err := app.JoinUserToTeam(team, user, ""); err != nil {
 		CommandPrintErrorln("Unable to add '" + userArg + "' to " + team.Name)
 	}
 }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -72,7 +72,7 @@ func TestIncomingWebhook(t *testing.T) {
 	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = ApiClient.Must(ApiClient.CreateTeam(team)).Data.(*model.Team)
 
-	app.JoinUserToTeam(team, user)
+	app.JoinUserToTeam(team, user, "")
 
 	app.UpdateUserRoles(user.Id, model.ROLE_SYSTEM_ADMIN.Id)
 	ApiClient.SetTeamId(team.Id)


### PR DESCRIPTION
#### Summary
When a user is added to a team by another user, pass through the adding user so that the system message can say "X added to channel Y by Z" instead of "X joined Y" in the default channels.

#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-6198