### PR TITLE
PLT-5904 (WebApp): Config for skip email server cert verification.

### DIFF
--- a/webapp/components/admin_console/email_settings.jsx
+++ b/webapp/components/admin_console/email_settings.jsx
@@ -34,6 +34,7 @@ export default class EmailSettings extends AdminSettings {
         config.EmailSettings.ConnectionSecurity = this.state.connectionSecurity;
         config.EmailSettings.EnableEmailBatching = this.state.enableEmailBatching;
         config.ServiceSettings.EnableSecurityFixAlert = this.state.enableSecurityFixAlert;
+        config.EmailSettings.SkipServerCertificateVerification = this.state.skipServerCertificateVerification;
 
         return config;
     }
@@ -50,6 +51,7 @@ export default class EmailSettings extends AdminSettings {
             smtpPort: config.EmailSettings.SMTPPort,
             connectionSecurity: config.EmailSettings.ConnectionSecurity,
             enableEmailBatching: config.EmailSettings.EnableEmailBatching,
+            skipServerCertificateVerification: config.EmailSettings.SkipServerCertificateVerification,
             enableSecurityFixAlert: config.ServiceSettings.EnableSecurityFixAlert
         };
     }
@@ -273,6 +275,23 @@ export default class EmailSettings extends AdminSettings {
                     config={this.props.config}
                     getConfigFromState={this.getConfigFromState}
                     disabled={!this.state.sendEmailNotifications}
+                />
+                <BooleanSetting
+                    id='skipServerCertificateVerification'
+                    label={
+                        <FormattedMessage
+                            id='admin.email.skipServerCertificateVerification.title'
+                            defaultMessage='Skip Server Certificate Verification: '
+                        />
+                    }
+                    helpText={
+                        <FormattedMessage
+                            id='admin.email.skipServerCertificateVerification.description'
+                            defaultMessage='When true, Mattermost will not verify the email server certificate.'
+                        />
+                    }
+                    value={this.state.skipServerCertificateVerification}
+                    onChange={this.handleChange}
                 />
                 <BooleanSetting
                     id='enableSecurityFixAlert'

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -283,6 +283,8 @@
   "admin.email.requireVerificationDescription": "Typically set to true in production. When true, Mattermost requires email verification after account creation prior to allowing login. Developers may set this field to false so skip sending verification emails for faster development.",
   "admin.email.requireVerificationTitle": "Require Email Verification: ",
   "admin.email.selfPush": "Manually enter Push Notification Service location",
+  "admin.email.skipServerCertificateVerification.description": "When true, Mattermost will not verify the email server certificate.",
+  "admin.email.skipServerCertificateVerification.title": "Skip Server Certificate Verification: ",
   "admin.email.smtpPasswordDescription": " Obtain this credential from administrator setting up your email server.",
   "admin.email.smtpPasswordExample": "E.g.: \"yourpassword\", \"jcuS8PuvcpGhpgHhlcpT1Mx42pnqMxQY\"",
   "admin.email.smtpPasswordTitle": "SMTP Server Password:",


### PR DESCRIPTION
#### Summary
System console configuration for config for skip email server cert verification. This got missed a while ago, but should have followed soon after the [server-side PR for this change](https://github.com/mattermost/platform/pull/5857) was merged.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5904

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file updates
