### PR TITLE
API4 DELETE /commands/{command_id}

### DIFF
--- a/model/client4.go
+++ b/model/client4.go
@@ -2202,6 +2202,16 @@ func (c *Client4) UpdateCommand(cmd *Command) (*Command, *Response) {
 	}
 }
 
+// DeleteCommand deletes a command based on the provided command id string
+func (c *Client4) DeleteCommand(commandId string) (bool, *Response) {
+	if r, err := c.DoApiDelete(c.GetCommandRoute(commandId)); err != nil {
+		return false, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // ListCommands will retrieve a list of commands available in the team.
 func (c *Client4) ListCommands(teamId string, customOnly bool) ([]*Command, *Response) {
 	query := fmt.Sprintf("?team_id=%v&custom_only=%v", teamId, customOnly)


### PR DESCRIPTION
#### Summary
This is endpoint for `API4 DELETE /commands/{command_id}`.
This PR is on top of [PR#5999][5999]. I'll just rebase once it's merged.

#### Ticket Link
n/a

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs) [mattermost-api-reference #207][207]
- [x] All new/modified APIs include changes to the drivers

[207]: https://github.com/mattermost/mattermost-api-reference/pull/207
[5999]: https://github.com/mattermost/platform/pull/5999