### PR TITLE
PLT-6200 Fixed file upload button not working on iOS

### DIFF
--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -350,11 +350,16 @@ class FileUpload extends React.Component {
         const channelId = this.props.channelId || ChannelStore.getCurrentId();
 
         const uploadsRemaining = Constants.MAX_UPLOAD_FILES - this.props.getFileCount(channelId);
-        const emojiSpan = (<span
-            className={'fa fa-smile-o icon--emoji-picker emoji-' + this.props.navBarName}
-            onClick={this.emojiClick}
-                           />);
-        const filestyle = {visibility: 'hidden'};
+
+        let emojiSpan;
+        if (this.props.emojiEnabled) {
+            emojiSpan = (
+                <span
+                    className={'fa fa-smile-o icon--emoji-picker emoji-' + this.props.navBarName}
+                    onClick={this.emojiClick}
+                />
+            );
+        }
 
         return (
             <span
@@ -363,20 +368,19 @@ class FileUpload extends React.Component {
             >
                 <div className='icon--attachment'>
                     <span
+                        className='icon'
                         dangerouslySetInnerHTML={{__html: Constants.ATTACHMENT_ICON_SVG}}
-                        onClick={() => this.refs.fileInput.click()}
                     />
                     <input
                         ref='fileInput'
                         type='file'
-                        style={filestyle}
                         onChange={this.handleChange}
                         onClick={uploadsRemaining > 0 ? this.props.onClick : this.handleMaxUploadReached}
                         multiple={multiple}
                         accept={accept}
                     />
                 </div>
-                {this.props.emojiEnabled ? emojiSpan : ''}
+                {emojiSpan}
             </span>
         );
     }

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -33,14 +33,9 @@
         .msg-typing {
             display: none;
         }
-    }
 
-    .post-create__container{
-        .post-create-body {
-            .icon__postcontent_picker {
-                display:none;
-                top: -7px;
-            }
+        .icon--emoji-picker {
+            display: none;
         }
     }
 


### PR DESCRIPTION
This took a while to track down. Some browsers don't allow you to trigger a file input programatically, so I reverted a change that removed the old method of triggering the upload using a transparent file input overlayed with the upload button. I also fixed the button being slightly off-center in mobile view with the emoji picker enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6200

#### Checklist
- Has UI changes