### PR TITLE
PLT-6155: Keep pin badges in RHS consistent with that in center

### DIFF
--- a/webapp/stores/search_store.jsx
+++ b/webapp/stores/search_store.jsx
@@ -117,6 +117,20 @@ class SearchStoreClass extends EventEmitter {
             });
         }
     }
+
+    togglePinPost(postId, isPinned) {
+        const results = this.getSearchResults();
+        if (results == null) {
+            return;
+        }
+
+        if (postId in results.posts) {
+            const post = results.posts[postId];
+            results.posts[postId] = Object.assign({}, post, {
+                is_pinned: isPinned
+            });
+        }
+    }
 }
 
 var SearchStore = new SearchStoreClass();
@@ -138,6 +152,14 @@ SearchStore.dispatchToken = AppDispatcher.register((payload) => {
         break;
     case ActionTypes.POST_DELETED:
         SearchStore.deletePost(action.post);
+        SearchStore.emitSearchChange();
+        break;
+    case ActionTypes.RECEIVED_POST_PINNED:
+        SearchStore.togglePinPost(action.reaction, true);
+        SearchStore.emitSearchChange();
+        break;
+    case ActionTypes.RECEIVED_POST_UNPINNED:
+        SearchStore.togglePinPost(action.reaction, false);
         SearchStore.emitSearchChange();
         break;
     default:

--- a/webapp/utils/async_client.jsx
+++ b/webapp/utils/async_client.jsx
@@ -1606,7 +1606,8 @@ export function pinPost(channelId, reaction) {
             // the "post_edited" websocket event take cares of updating the posts
             // the action below is mostly dispatched for the RHS to update
             AppDispatcher.handleServerAction({
-                type: ActionTypes.RECEIVED_POST_PINNED
+                type: ActionTypes.RECEIVED_POST_PINNED,
+                reaction
             });
         },
         (err) => {
@@ -1623,7 +1624,8 @@ export function unpinPost(channelId, reaction) {
             // the "post_edited" websocket event take cares of updating the posts
             // the action below is mostly dispatched for the RHS to update
             AppDispatcher.handleServerAction({
-                type: ActionTypes.RECEIVED_POST_UNPINNED
+                type: ActionTypes.RECEIVED_POST_UNPINNED,
+                reaction
             });
         },
         (err) => {


### PR DESCRIPTION
Sync search store when recieving pin/unpin event to keep pin
badges in RHS consistent with that in center channel.

Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Sync search store when recieving pin/unpin event to keep pin
badges in RHS consistent with that in center channel.

#### Ticket Link
issue:https://github.com/mattermost/platform/issues/5981
jira:https://mattermost.atlassian.net/browse/PLT-6155

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
