### PR TITLE
Fix possible MFA enforcement redirect loop

### DIFF
--- a/webapp/root.jsx
+++ b/webapp/root.jsx
@@ -60,6 +60,8 @@ function preRenderSetup(callwhendone) {
     // Make sure the websockets close and reset version
     $(window).on('beforeunload',
          () => {
+             // Turn off to prevent getting stuck in a loop
+             $(window).off('beforeunload');
              BrowserStore.setLastServerVersion('');
              if (UserStore.getCurrentUser()) {
                  AsyncClient.viewChannel('', ChannelStore.getCurrentId() || '');


### PR DESCRIPTION
#### Summary
In rare cases the app could get into a state where it's trying to make an API request when unloading the page, but it would fail because MFA isn't enabled and then try to unload again getting stuck in a loop. This fixes it by turning off the unload event after it's fired once.