### PR TITLE
PLT-6257 Use SiteURL for OAuth login

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -702,7 +702,7 @@ func GetAuthorizationCode(c *Context, service string, props map[string]string, l
 	props["hash"] = model.HashPassword(clientId)
 	state := b64.StdEncoding.EncodeToString([]byte(model.MapToJson(props)))
 
-	redirectUri := c.GetSiteURLHeader() + "/signup/" + service + "/complete"
+	redirectUri := utils.GetSiteURL() + "/signup/" + service + "/complete"
 
 	authUrl := endpoint + "?response_type=code&client_id=" + clientId + "&redirect_uri=" + url.QueryEscape(redirectUri) + "&state=" + url.QueryEscape(state)
 


### PR DESCRIPTION
#### Summary
Use SiteURL for OAuth login to make sure correct URL is used. Should fix Office365 issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6257