### PR TITLE
PLT-4176: Remain RHS pin post unchanged after channel switching

### DIFF
--- a/webapp/stores/search_store.jsx
+++ b/webapp/stores/search_store.jsx
@@ -5,6 +5,8 @@ import AppDispatcher from '../dispatcher/app_dispatcher.jsx';
 import EventEmitter from 'events';
 
 import Constants from 'utils/constants.jsx';
+import ChannelStore from 'stores/channel_store.jsx';
+
 var ActionTypes = Constants.ActionTypes;
 
 var CHANGE_EVENT = 'change';
@@ -126,6 +128,13 @@ SearchStore.dispatchToken = AppDispatcher.register((payload) => {
 
     switch (action.type) {
     case ActionTypes.RECEIVED_SEARCH:
+        if (SearchStore.getIsPinnedPosts() === action.is_pinned_posts &&
+            action.is_pinned_posts === true &&
+            SearchStore.getSearchResults().posts &&
+            ChannelStore.getCurrentId() !== Object.values(SearchStore.getSearchResults().posts)[0].channel_id) {
+            // ignore pin posts update after switch to a new channel
+            return;
+        }
         SearchStore.storeSearchResults(action.results, action.is_mention_search, action.is_flagged_posts, action.is_pinned_posts);
         SearchStore.emitSearchChange();
         break;


### PR DESCRIPTION
Prevent changes to search_store after switched channel so that
RHS pin posts can continue to display previous content.

Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Prevent changes to search_store after switched channel so that
RHS pin posts can continue to display previous content.

#### Ticket Link
issue:https://github.com/mattermost/platform/issues/5996

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes