### PR TITLE
[PLT-4303] svg preview

### DIFF
--- a/webapp/components/file_preview.jsx
+++ b/webapp/components/file_preview.jsx
@@ -33,7 +33,7 @@ export default class FilePreview extends React.Component {
 
             let className = 'file-preview';
             let previewImage;
-            if (type === 'image') {
+            if (type === 'image' || type === 'svg') {
                 previewImage = (
                     <img
                         className='file-preview__image'

--- a/webapp/components/view_image.jsx
+++ b/webapp/components/view_image.jsx
@@ -180,7 +180,7 @@ export default class ViewImageModal extends React.Component {
         if (this.state.loaded[this.state.imgId]) {
             const fileType = Utils.getFileType(fileInfo.extension);
 
-            if (fileType === 'image') {
+            if (fileType === 'image' || fileType === 'svg') {
                 content = (
                     <ImagePreview
                         fileInfo={fileInfo}

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -335,6 +335,7 @@ export const Constants = {
     CODE_TYPES: ['as', 'applescript', 'osascript', 'scpt', 'bash', 'sh', 'zsh', 'clj', 'boot', 'cl2', 'cljc', 'cljs', 'cljs.hl', 'cljscm', 'cljx', 'hic', 'coffee', '_coffee', 'cake', 'cjsx', 'cson', 'iced', 'cpp', 'c', 'cc', 'h', 'c++', 'h++', 'hpp', 'cs', 'csharp', 'css', 'd', 'di', 'dart', 'delphi', 'dpr', 'dfm', 'pas', 'pascal', 'freepascal', 'lazarus', 'lpr', 'lfm', 'diff', 'django', 'jinja', 'dockerfile', 'docker', 'erl', 'f90', 'f95', 'fsharp', 'fs', 'gcode', 'nc', 'go', 'groovy', 'handlebars', 'hbs', 'html.hbs', 'html.handlebars', 'hs', 'hx', 'java', 'jsp', 'js', 'jsx', 'json', 'jl', 'kt', 'ktm', 'kts', 'less', 'lisp', 'lua', 'mk', 'mak', 'md', 'mkdown', 'mkd', 'matlab', 'm', 'mm', 'objc', 'obj-c', 'ml', 'perl', 'pl', 'php', 'php3', 'php4', 'php5', 'php6', 'ps', 'ps1', 'pp', 'py', 'gyp', 'r', 'ruby', 'rb', 'gemspec', 'podspec', 'thor', 'irb', 'rs', 'scala', 'scm', 'sld', 'scss', 'st', 'sql', 'swift', 'tex', 'txt', 'vbnet', 'vb', 'bas', 'vbs', 'v', 'veo', 'xml', 'html', 'xhtml', 'rss', 'atom', 'xsl', 'plist', 'yaml'],
     PDF_TYPES: ['pdf'],
     PATCH_TYPES: ['patch'],
+    SVG_TYPES: ['svg'],
     ICON_FROM_TYPE: {
         audio: audioIcon,
         video: videoIcon,

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -426,6 +426,10 @@ export function getFileType(extin) {
         return 'patch';
     }
 
+    if (Constants.SVG_TYPES.indexOf(ext) > -1) {
+        return 'svg';
+    }
+
     return 'other';
 }
 
@@ -449,7 +453,7 @@ export function getIconClassName(fileTypeIn) {
         return Constants.ICON_NAME_FROM_TYPE[fileType];
     }
 
-    return 'glyphicon-file';
+    return 'generic';
 }
 
 export function splitFileLocation(fileLocation) {


### PR DESCRIPTION
#### Summary
Render SVG file preview.

> The thumbnail would still be a file icon (even better if we could find a better one), but the preview dialog could show the actual svg.

https://pre-release.mattermost.com/core/pl/3kion9ru63gafqymeknumus39e

I implemented this way.

#### Ticket Link
[PLT-4303](https://mattermost.atlassian.net/browse/PLT-4303)
#4186

#### Checklist
N/A