### PR TITLE
Implement GET /webrtc/token endpoint for APIv4

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -178,6 +178,7 @@ func InitApi(full bool) {
 	InitWebSocket()
 	InitEmoji()
 	InitReaction()
+	InitWebrtc()
 
 	app.Srv.Router.Handle("/api/v4/{anything:.*}", http.HandlerFunc(Handle404))
 

--- a/api4/webrtc.go
+++ b/api4/webrtc.go
@@ -1,7 +1,7 @@
-// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-package api
+package api4
 
 import (
 	"net/http"
@@ -14,7 +14,7 @@ import (
 func InitWebrtc() {
 	l4g.Debug(utils.T("api.webrtc.init.debug"))
 
-	BaseRoutes.Webrtc.Handle("/token", ApiUserRequired(webrtcToken)).Methods("POST")
+	BaseRoutes.Webrtc.Handle("/token", ApiSessionRequired(webrtcToken)).Methods("GET")
 }
 
 func webrtcToken(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/webrtc_test.go
+++ b/api4/webrtc_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"testing"
+
+	"github.com/mattermost/platform/utils"
+)
+
+func TestGetWebrtcToken(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	enableWebrtc := *utils.Cfg.WebrtcSettings.Enable
+	defer func() {
+		*utils.Cfg.WebrtcSettings.Enable = enableWebrtc
+	}()
+	*utils.Cfg.WebrtcSettings.Enable = false
+
+	_, resp := Client.GetWebrtcToken()
+	CheckNotImplementedStatus(t, resp)
+
+	Client.Logout()
+	_, resp = Client.GetWebrtcToken()
+	CheckUnauthorizedStatus(t, resp)
+}

--- a/app/webrtc.go
+++ b/app/webrtc.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/tls"
+	"encoding/base64"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+func GetWebrtcInfoForSession(sessionId string) (*model.WebrtcInfoResponse, *model.AppError) {
+	token, err := GetWebrtcToken(sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &model.WebrtcInfoResponse{
+		Token:      token,
+		GatewayUrl: *utils.Cfg.WebrtcSettings.GatewayWebsocketUrl,
+	}
+
+	if len(*utils.Cfg.WebrtcSettings.StunURI) > 0 {
+		result.StunUri = *utils.Cfg.WebrtcSettings.StunURI
+	}
+
+	if len(*utils.Cfg.WebrtcSettings.TurnURI) > 0 {
+		timestamp := strconv.FormatInt(utils.EndOfDay(time.Now().AddDate(0, 0, 1)).Unix(), 10)
+		username := timestamp + ":" + *utils.Cfg.WebrtcSettings.TurnUsername
+
+		result.TurnUri = *utils.Cfg.WebrtcSettings.TurnURI
+		result.TurnPassword = GenerateTurnPassword(username, *utils.Cfg.WebrtcSettings.TurnSharedKey)
+		result.TurnUsername = username
+	}
+
+	return result, nil
+}
+
+func GetWebrtcToken(sessionId string) (string, *model.AppError) {
+	if !*utils.Cfg.WebrtcSettings.Enable {
+		return "", model.NewAppError("WebRTC.getWebrtcToken", "api.webrtc.disabled.app_error", nil, "", http.StatusNotImplemented)
+	}
+
+	token := base64.StdEncoding.EncodeToString([]byte(sessionId))
+
+	data := make(map[string]string)
+	data["janus"] = "add_token"
+	data["token"] = token
+	data["transaction"] = model.NewId()
+	data["admin_secret"] = *utils.Cfg.WebrtcSettings.GatewayAdminSecret
+
+	rq, _ := http.NewRequest("POST", *utils.Cfg.WebrtcSettings.GatewayAdminUrl, strings.NewReader(model.MapToJson(data)))
+	rq.Header.Set("Content-Type", "application/json")
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: *utils.Cfg.ServiceSettings.EnableInsecureOutgoingConnections},
+	}
+	httpClient := &http.Client{Transport: tr}
+	if rp, err := httpClient.Do(rq); err != nil {
+		return "", model.NewAppError("WebRTC.Token", "model.client.connecting.app_error", nil, err.Error(), http.StatusInternalServerError)
+	} else if rp.StatusCode >= 300 {
+		defer CloseBody(rp)
+		return "", model.AppErrorFromJson(rp.Body)
+	} else {
+		janusResponse := model.GatewayResponseFromJson(rp.Body)
+		if janusResponse.Status != "success" {
+			return "", model.NewAppError("getWebrtcToken", "api.webrtc.register_token.app_error", nil, "", http.StatusInternalServerError)
+		}
+	}
+
+	return token, nil
+}
+
+func GenerateTurnPassword(username string, secret string) string {
+	key := []byte(secret)
+	h := hmac.New(sha1.New, key)
+	h.Write([]byte(username))
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}

--- a/model/client4.go
+++ b/model/client4.go
@@ -2286,6 +2286,19 @@ func (c *Client4) UpdateUserStatus(userId string, userStatus *Status) (*Status, 
 	}
 }
 
+// Webrtc Section
+
+// GetWebrtcToken returns a valid token, stun server and turn server with credentials to
+// use with the Mattermost WebRTC service.
+func (c *Client4) GetWebrtcToken() (*WebrtcInfoResponse, *Response) {
+	if r, err := c.DoApiGet("/webrtc/token", ""); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return WebrtcInfoResponseFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // Emoji Section
 
 // CreateEmoji will save an emoji to the server if the current user has permission

--- a/model/webrtc.go
+++ b/model/webrtc.go
@@ -1,9 +1,21 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package model
 
 import (
 	"encoding/json"
 	"io"
 )
+
+type WebrtcInfoResponse struct {
+	Token        string `json:"token"`
+	GatewayUrl   string `json:"gateway_url"`
+	StunUri      string `json:"stun_uri,omitempty"`
+	TurnUri      string `json:"turn_uri,omitempty"`
+	TurnPassword string `json:"turn_password,omitempty"`
+	TurnUsername string `json:"turn_username,omitempty"`
+}
 
 type GatewayResponse struct {
 	Status string `json:"janus"`
@@ -12,6 +24,26 @@ type GatewayResponse struct {
 func GatewayResponseFromJson(data io.Reader) *GatewayResponse {
 	decoder := json.NewDecoder(data)
 	var o GatewayResponse
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
+	} else {
+		return nil
+	}
+}
+
+func (o *WebrtcInfoResponse) ToJson() string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func WebrtcInfoResponseFromJson(data io.Reader) *WebrtcInfoResponse {
+	decoder := json.NewDecoder(data)
+	var o WebrtcInfoResponse
 	err := decoder.Decode(&o)
 	if err == nil {
 		return &o

--- a/model/webrtc_test.go
+++ b/model/webrtc_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWebrtcJson(t *testing.T) {
+	o := WebrtcInfoResponse{Token: NewId(), GatewayUrl: NewId()}
+	json := o.ToJson()
+	ro := WebrtcInfoResponseFromJson(strings.NewReader(json))
+
+	if o.Token != ro.Token {
+		t.Fatal("Tokens do not match")
+	}
+}


### PR DESCRIPTION
#### Summary
Implement GET /webrtc/token endpoint for APIv4.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#212)
- [x] All new/modified APIs include changes to the drivers