### PR TITLE
[PLT-6164] Update Profile Picture Format Message

### DIFF
--- a/webapp/components/setting_picture.jsx
+++ b/webapp/components/setting_picture.jsx
@@ -112,7 +112,7 @@ export default class SettingPicture extends React.Component {
         var helpText = (
             <FormattedMessage
                 id='setting_picture.help'
-                defaultMessage='Upload a profile picture in either JPG or PNG format, at least {width}px in width and {height}px height.'
+                defaultMessage='Upload a profile picture in BMP, JPG, JPEG or PNG format, at least {width}px in width and {height}px height.'
                 values={{
                     width: global.window.mm_config.ProfileWidth,
                     height: global.window.mm_config.ProfileHeight

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1887,7 +1887,7 @@
   "setting_item_max.save": "Save",
   "setting_item_min.edit": "Edit",
   "setting_picture.cancel": "Cancel",
-  "setting_picture.help": "Upload a profile picture in either JPG or PNG format, at least {width}px in width and {height}px height.",
+  "setting_picture.help": "Upload a profile picture in BMP, JPG, JPEG or PNG format, at least {width}px in width and {height}px height.",
   "setting_picture.save": "Save",
   "setting_picture.select": "Select",
   "setting_upload.import": "Import",


### PR DESCRIPTION
#### Summary
Upon investigation of supported profile picture formats, it was found that `BMP` and `JPEG` work are supported, while the message says they aren't. Discussed with @jasonblais, and it was decided to update the message to: `Upload a profile picture in BMP, JPG, JPEG or PNG format, at least 128px in width and 128px height.`

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6164
https://github.com/mattermost/platform/issues/5980

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
