### PR TITLE
PLT-6260: Allow empty legal/support links.

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -698,7 +698,7 @@ func (o *Config) SetDefaults() {
 	}
 
 	if !IsSafeLink(o.SupportSettings.TermsOfServiceLink) {
-		o.SupportSettings.TermsOfServiceLink = nil
+		*o.SupportSettings.TermsOfServiceLink = ""
 	}
 
 	if o.SupportSettings.TermsOfServiceLink == nil {
@@ -707,7 +707,7 @@ func (o *Config) SetDefaults() {
 	}
 
 	if !IsSafeLink(o.SupportSettings.PrivacyPolicyLink) {
-		o.SupportSettings.PrivacyPolicyLink = nil
+		*o.SupportSettings.PrivacyPolicyLink = ""
 	}
 
 	if o.SupportSettings.PrivacyPolicyLink == nil {
@@ -716,7 +716,7 @@ func (o *Config) SetDefaults() {
 	}
 
 	if !IsSafeLink(o.SupportSettings.AboutLink) {
-		o.SupportSettings.AboutLink = nil
+		*o.SupportSettings.AboutLink = ""
 	}
 
 	if o.SupportSettings.AboutLink == nil {
@@ -725,7 +725,7 @@ func (o *Config) SetDefaults() {
 	}
 
 	if !IsSafeLink(o.SupportSettings.HelpLink) {
-		o.SupportSettings.HelpLink = nil
+		*o.SupportSettings.HelpLink = ""
 	}
 
 	if o.SupportSettings.HelpLink == nil {
@@ -734,7 +734,7 @@ func (o *Config) SetDefaults() {
 	}
 
 	if !IsSafeLink(o.SupportSettings.ReportAProblemLink) {
-		o.SupportSettings.ReportAProblemLink = nil
+		*o.SupportSettings.ReportAProblemLink = ""
 	}
 
 	if o.SupportSettings.ReportAProblemLink == nil {


### PR DESCRIPTION
#### Summary
Allow legal/support URLs to be empty (meaning they get hidden from the UI in various places).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6260