### PR TITLE
Support Slack attachments in response to outgoing webhooks

### DIFF
--- a/model/outgoing_webhook.go
+++ b/model/outgoing_webhook.go
@@ -43,6 +43,14 @@ type OutgoingWebhookPayload struct {
 	TriggerWord string `json:"trigger_word"`
 }
 
+type OutgoingWebhookResponse struct {
+	ResponseType string             `json:"response_type"`
+	Text         string             `json:"text"`
+	Username     string             `json:"username"`
+	IconURL      string             `json:"icon_url"`
+	Attachments  []*SlackAttachment `json:"attachments"`
+}
+
 func (o *OutgoingWebhookPayload) ToJSON() string {
 	b, err := json.Marshal(o)
 	if err != nil {
@@ -223,4 +231,24 @@ func (o *OutgoingWebhook) TriggerWordStartsWith(word string) bool {
 	}
 
 	return false
+}
+
+func OutgoingWebhookResponseFromJson(data io.Reader) *OutgoingWebhookResponse {
+	decoder := json.NewDecoder(data)
+	var o OutgoingWebhookResponse
+
+	if err := decoder.Decode(&o); err != nil {
+		return nil
+	}
+
+	// Ensure attachment fields are stored as strings
+	for _, attachment := range o.Attachments {
+		for _, field := range attachment.Fields {
+			if field.Value != nil {
+				field.Value = fmt.Sprintf("%v", field.Value)
+			}
+		}
+	}
+
+	return &o
 }


### PR DESCRIPTION
#### Summary
Support standard Slack messages with or without attachments and with in_channel or ephemeral type in response to outgoing webhooks.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3658
#4237

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Includes text changes and localization file ([.../i18n/en.json]