### PR TITLE
PLT-6311 - Link text wrapping fix

### DIFF
--- a/webapp/sass/layout/_markdown.scss
+++ b/webapp/sass/layout/_markdown.scss
@@ -1,7 +1,6 @@
 @charset 'UTF-8';
 
 .markdown__link {
-    word-break: break-all;
 }
 
 .markdown__heading {


### PR DESCRIPTION
#### Summary
PLT-6311 - Link text wrapping fix

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6311

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
