### PR TITLE
PLT-3915/PLT-5550 Improve handling of Markdown while parsing mentions

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/platform/einterfaces"
@@ -649,7 +650,10 @@ func GetExplicitMentions(message string, keywords map[string][]string) (map[stri
 
 	message = removeCodeFromMessage(message)
 
-	for _, word := range strings.Fields(message) {
+	for _, word := range strings.FieldsFunc(message, func(c rune) bool {
+		// Split on whitespace (as strings.Fields normally does) or on Markdown characters
+		return unicode.IsSpace(c) || c == '*' || c == '~'
+	}) {
 		isMention := false
 
 		if word == "@here" {

--- a/app/notification.go
+++ b/app/notification.go
@@ -724,10 +724,14 @@ var inlineCodePattern = regexp.MustCompile("(?m)\\`(?:.+?|.*?\n(.*?\\S.*?\n)*.*?
 
 // Strips pre-formatted text and code blocks from a Markdown string by replacing them with whitespace
 func removeCodeFromMessage(message string) string {
-	message = codeBlockPattern.ReplaceAllString(message, "")
+	if strings.Contains(message, "```") {
+		message = codeBlockPattern.ReplaceAllString(message, "")
+	}
 
 	// Replace with a space to prevent cases like "user`code`name" from turning into "username"
-	message = inlineCodePattern.ReplaceAllString(message, " ")
+	if strings.Contains(message, "`") {
+		message = inlineCodePattern.ReplaceAllString(message, " ")
+	}
 
 	return message
 }

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -39,6 +39,7 @@ func TestSendNotifications(t *testing.T) {
 func TestGetExplicitMentions(t *testing.T) {
 	id1 := model.NewId()
 	id2 := model.NewId()
+	id3 := model.NewId()
 
 	// not mentioning anybody
 	message := "this is a message"
@@ -126,6 +127,37 @@ func TestGetExplicitMentions(t *testing.T) {
 	keywords = map[string][]string{}
 	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 0 {
 		t.Fatal("@channel in code block shouldn't cause a mention")
+	}
+
+	// Markdown-formatted text that isn't code should trigger mentions
+	message = "*@aaa @bbb @ccc*"
+	keywords = map[string][]string{"@aaa": {id1}, "@bbb": {id2}, "@ccc": {id3}}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 3 || !mentions[id1] || !mentions[id2] || !mentions[id3] {
+		t.Fatal("should've mentioned all 3 users", mentions)
+	}
+
+	message = "**@aaa @bbb @ccc**"
+	keywords = map[string][]string{"@aaa": {id1}, "@bbb": {id2}, "@ccc": {id3}}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 3 || !mentions[id1] || !mentions[id2] || !mentions[id3] {
+		t.Fatal("should've mentioned all 3 users")
+	}
+
+	message = "~~@aaa @bbb @ccc~~"
+	keywords = map[string][]string{"@aaa": {id1}, "@bbb": {id2}, "@ccc": {id3}}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 3 || !mentions[id1] || !mentions[id2] || !mentions[id3] {
+		t.Fatal("should've mentioned all 3 users")
+	}
+
+	message = "### @aaa"
+	keywords = map[string][]string{"@aaa": {id1}, "@bbb": {id2}, "@ccc": {id3}}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 1 || !mentions[id1] || mentions[id2] || mentions[id3] {
+		t.Fatal("should've only mentioned aaa")
+	}
+
+	message = "> @aaa"
+	keywords = map[string][]string{"@aaa": {id1}, "@bbb": {id2}, "@ccc": {id3}}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 1 || !mentions[id1] || mentions[id2] || mentions[id3] {
+		t.Fatal("should've only mentioned aaa")
 	}
 }
 

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -113,6 +113,20 @@ func TestGetExplicitMentions(t *testing.T) {
 	if mentions, potential, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 1 || !mentions[id1] || len(potential) != 1 {
 		t.Fatal("should've mentioned user and have a potential not in channel")
 	}
+
+	// words in inline code shouldn't trigger mentions
+	message = "`this shouldn't mention @channel at all`"
+	keywords = map[string][]string{}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 0 {
+		t.Fatal("@channel in inline code shouldn't cause a mention")
+	}
+
+	// words in code blocks shouldn't trigger mentions
+	message = "```\nthis shouldn't mention @channel at all\n```"
+	keywords = map[string][]string{}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 0 {
+		t.Fatal("@channel in code block shouldn't cause a mention")
+	}
 }
 
 func TestGetExplicitMentionsAtHere(t *testing.T) {
@@ -174,6 +188,140 @@ func TestGetExplicitMentionsAtHere(t *testing.T) {
 		t.Fatal("should've mentioned @user with \"@here @user\"")
 	} else if len(potential) > 1 {
 		t.Fatal("should've potential mentions for @potential")
+	}
+}
+
+func TestRemoveCodeFromMessage(t *testing.T) {
+	input := "this is regular text"
+	expected := input
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is text with\n```\na code block\n```\nin it"
+	expected = "this is text with\n\nin it"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is text with\n```javascript\na JS code block\n```\nin it"
+	expected = "this is text with\n\nin it"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is text with\n```java script?\na JS code block\n```\nin it"
+	expected = "this is text with\n\nin it"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is text with an empty\n```\n\n\n\n```\nin it"
+	expected = "this is text with an empty\n\nin it"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is text with\n```\ntwo\n```\ncode\n```\nblocks\n```\nin it"
+	expected = "this is text with\n\ncode\n\nin it"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is text with indented\n  ```\ncode\n  ```\nin it"
+	expected = "this is text with indented\n\nin it"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is text ending with\n```\nan unfinished code block"
+	expected = "this is text ending with\n"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `code` in a sentence"
+	expected = "this is   in a sentence"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `two` things of `code` in a sentence"
+	expected = "this is   things of   in a sentence"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `code with spaces` in a sentence"
+	expected = "this is   in a sentence"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `code\nacross multiple` lines"
+	expected = "this is   lines"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `code\non\nmany\ndifferent` lines"
+	expected = "this is   lines"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `\ncode on its own line\n` across multiple lines"
+	expected = "this is   across multiple lines"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `\n    some more code    \n` across multiple lines"
+	expected = "this is   across multiple lines"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `\ncode` on its own line"
+	expected = "this is   on its own line"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `code\n` on its own line"
+	expected = "this is   on its own line"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is *italics mixed with `code in a way that has the code` take precedence*"
+	expected = "this is *italics mixed with   take precedence*"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is code within a wo` `rd for some reason"
+	expected = "this is code within a wo rd for some reason"
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `not\n\ncode` because it has a blank line"
+	expected = input
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is `not\n    \ncode` because it has line with only whitespace"
+	expected = input
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "this is just `` two backquotes"
+	expected = input
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
 	}
 }
 


### PR DESCRIPTION
There's two main changes here:
1. Ensure that mentions never occur inside of code blocks. This is done by stripping all code blocks from the message text before actually looking for mentions
2. Strip `*` and `~` characters while doing the initial word splitting so that markdown-formatted words are treated exactly the same as non-markdown-formatted words.

I've added unit tests for both cases as well as some extensive ones for all the weird cases that may be encountered with code blocks

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3915
https://mattermost.atlassian.net/browse/PLT-5550

#### Checklist
- Added or updated unit tests (required for all new features)
- Touches critical sections of the codebase (auth, upgrade, etc.)
