### PR TITLE
Don't sanitize returned user when updating a user

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -745,6 +745,8 @@ func TestPatchUser(t *testing.T) {
 	patch.LastName = new(string)
 	*patch.LastName = "Wilander"
 	patch.Position = new(string)
+	patch.NotifyProps = model.StringMap{}
+	patch.NotifyProps["comment"] = "somethingrandom"
 
 	ruser, resp := Client.PatchUser(user.Id, patch)
 	CheckNoError(t, resp)
@@ -764,6 +766,9 @@ func TestPatchUser(t *testing.T) {
 	}
 	if ruser.Username != user.Username {
 		t.Fatal("Username should not have updated")
+	}
+	if ruser.NotifyProps["comment"] != "somethingrandom" {
+		t.Fatal("NotifyProps did not update properly")
 	}
 
 	_, resp = Client.PatchUser("junk", patch)

--- a/app/user.go
+++ b/app/user.go
@@ -940,9 +940,7 @@ func UpdateUserAsUser(user *model.User, asAdmin bool) (*model.User, *model.AppEr
 		return nil, err
 	}
 
-	SanitizeProfile(updatedUser, asAdmin)
-
-	sendUpdatedUserEvent(updatedUser)
+	sendUpdatedUserEvent(*updatedUser, asAdmin)
 
 	return updatedUser, nil
 }
@@ -960,14 +958,14 @@ func PatchUser(userId string, patch *model.UserPatch, asAdmin bool) (*model.User
 		return nil, err
 	}
 
-	SanitizeProfile(updatedUser, asAdmin)
-
-	sendUpdatedUserEvent(updatedUser)
+	sendUpdatedUserEvent(*updatedUser, asAdmin)
 
 	return updatedUser, nil
 }
 
-func sendUpdatedUserEvent(user *model.User) {
+func sendUpdatedUserEvent(user model.User, asAdmin bool) {
+	SanitizeProfile(&user, asAdmin)
+
 	omitUsers := make(map[string]bool, 1)
 	omitUsers[user.Id] = true
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", omitUsers)

--- a/model/user.go
+++ b/model/user.go
@@ -69,15 +69,15 @@ type User struct {
 }
 
 type UserPatch struct {
-	Username    *string    `json:"username"`
-	Nickname    *string    `json:"nickname"`
-	FirstName   *string    `json:"first_name"`
-	LastName    *string    `json:"last_name"`
-	Position    *string    `json:"position"`
-	Email       *string    `json:"email"`
-	Props       *StringMap `json:"props,omitempty"`
-	NotifyProps *StringMap `json:"notify_props,omitempty"`
-	Locale      *string    `json:"locale"`
+	Username    *string   `json:"username"`
+	Nickname    *string   `json:"nickname"`
+	FirstName   *string   `json:"first_name"`
+	LastName    *string   `json:"last_name"`
+	Position    *string   `json:"position"`
+	Email       *string   `json:"email"`
+	Props       StringMap `json:"props,omitempty"`
+	NotifyProps StringMap `json:"notify_props,omitempty"`
+	Locale      *string   `json:"locale"`
 }
 
 // IsValid validates the user and returns an error if it isn't configured
@@ -260,11 +260,11 @@ func (u *User) Patch(patch *UserPatch) {
 	}
 
 	if patch.Props != nil {
-		u.Props = *patch.Props
+		u.Props = patch.Props
 	}
 
 	if patch.NotifyProps != nil {
-		u.NotifyProps = *patch.NotifyProps
+		u.NotifyProps = patch.NotifyProps
 	}
 
 	if patch.Locale != nil {

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -192,14 +192,8 @@ func (us SqlUserStore) Update(user *model.User, trustedUpdateData bool) StoreCha
 			} else if count != 1 {
 				result.Err = model.NewLocAppError("SqlUserStore.Update", "store.sql_user.update.app_error", nil, fmt.Sprintf("user_id=%v, count=%v", user.Id, count))
 			} else {
-				user.Password = ""
-				user.AuthData = new(string)
-				*user.AuthData = ""
-				user.MfaSecret = ""
-				oldUser.Password = ""
-				oldUser.AuthData = new(string)
-				*oldUser.AuthData = ""
-				oldUser.MfaSecret = ""
+				user.Sanitize(map[string]bool{})
+				oldUser.Sanitize(map[string]bool{})
 				result.Data = [2]*model.User{user, oldUser}
 			}
 		}
@@ -466,9 +460,7 @@ func (us SqlUserStore) GetAllProfiles(offset int, limit int) StoreChannel {
 		} else {
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 			}
 
 			result.Data = users
@@ -515,9 +507,7 @@ func (us SqlUserStore) GetProfiles(teamId string, offset int, limit int) StoreCh
 		} else {
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 			}
 
 			result.Data = users
@@ -563,9 +553,7 @@ func (us SqlUserStore) GetProfilesInChannel(channelId string, offset int, limit 
 		} else {
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 			}
 
 			result.Data = users
@@ -617,9 +605,7 @@ func (us SqlUserStore) GetAllProfilesInChannel(channelId string, allowFromCache 
 			userMap := make(map[string]*model.User)
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 				userMap[u.Id] = u
 			}
 
@@ -665,9 +651,7 @@ func (us SqlUserStore) GetProfilesNotInChannel(teamId string, channelId string, 
 		} else {
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 			}
 
 			result.Data = users
@@ -713,9 +697,7 @@ func (us SqlUserStore) GetProfilesWithoutTeam(offset int, limit int) StoreChanne
 		} else {
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 			}
 
 			result.Data = users
@@ -756,9 +738,7 @@ func (us SqlUserStore) GetProfilesByUsernames(usernames []string, teamId string)
 			userMap := make(map[string]*model.User)
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 				userMap[u.Id] = u
 			}
 
@@ -804,9 +784,7 @@ func (us SqlUserStore) GetRecentlyActiveUsersForTeam(teamId string) StoreChannel
 
 			for _, userWithLastActivityAt := range users {
 				u := userWithLastActivityAt.User
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 				u.LastActivityAt = userWithLastActivityAt.LastActivityAt
 				userMap[u.Id] = &u
 			}
@@ -876,9 +854,8 @@ func (us SqlUserStore) GetProfileByIds(userIds []string, allowFromCache bool) St
 		} else {
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
+
 				profileByIdsCache.AddWithExpiresInSecs(u.Id, u, PROFILE_BY_IDS_CACHE_SEC)
 			}
 
@@ -908,9 +885,7 @@ func (us SqlUserStore) GetSystemAdminProfiles() StoreChannel {
 			userMap := make(map[string]*model.User)
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 				userMap[u.Id] = u
 			}
 
@@ -1493,9 +1468,7 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 		result.Err = model.NewLocAppError("SqlUserStore.Search", "store.sql_user.search.app_error", nil, "term="+term+", "+"search_type="+searchType+", "+err.Error())
 	} else {
 		for _, u := range users {
-			u.Password = ""
-			u.AuthData = new(string)
-			*u.AuthData = ""
+			u.Sanitize(map[string]bool{})
 		}
 
 		result.Data = users
@@ -1568,9 +1541,7 @@ func (us SqlUserStore) GetProfilesNotInTeam(teamId string, offset int, limit int
 		} else {
 
 			for _, u := range users {
-				u.Password = ""
-				u.AuthData = new(string)
-				*u.AuthData = ""
+				u.Sanitize(map[string]bool{})
 			}
 
 			result.Data = users

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -192,6 +192,14 @@ func (us SqlUserStore) Update(user *model.User, trustedUpdateData bool) StoreCha
 			} else if count != 1 {
 				result.Err = model.NewLocAppError("SqlUserStore.Update", "store.sql_user.update.app_error", nil, fmt.Sprintf("user_id=%v, count=%v", user.Id, count))
 			} else {
+				user.Password = ""
+				user.AuthData = new(string)
+				*user.AuthData = ""
+				user.MfaSecret = ""
+				oldUser.Password = ""
+				oldUser.AuthData = new(string)
+				*oldUser.AuthData = ""
+				oldUser.MfaSecret = ""
 				result.Data = [2]*model.User{user, oldUser}
 			}
 		}


### PR DESCRIPTION
#### Summary
Don't sanitize returned user when updating a user, only sanitize for websocket events. This makes the assumption that if you have permission to edit a user, you should be able to see all the user's fields (obviously excluding password, auth data, mfa secret fields).

Also fixed the string maps on the user patch model.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (user sanitization)
