### PR TITLE
PLT-6240: Remove own pinned post from RHS when removed from channel

### DIFF
--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -11,6 +11,7 @@ import {loadStatusesForChannel} from 'actions/status_actions.jsx';
 import {loadNewDMIfNeeded, loadNewGMIfNeeded} from 'actions/user_actions.jsx';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 import {sendDesktopNotification} from 'actions/notification_actions.jsx';
+import * as GlobalActions from 'actions/global_actions.jsx';
 
 import Client from 'client/web_client.jsx';
 import * as AsyncClient from 'utils/async_client.jsx';
@@ -426,11 +427,6 @@ export function updatePost(post, success, isPost) {
         });
 }
 
-export function removePostFromStore(post) {
-    PostStore.removePost(post);
-    PostStore.emitChange();
-}
-
 export function emitEmojiPosted(emoji) {
     AppDispatcher.handleServerAction({
         type: ActionTypes.EMOJI_POSTED,
@@ -443,7 +439,7 @@ export function deletePost(channelId, post, success, error) {
         channelId,
         post.id,
         () => {
-            removePostFromStore(post);
+            GlobalActions.emitRemovePost(post);
             if (post.id === PostStore.getSelectedPostId()) {
                 AppDispatcher.handleServerAction({
                     type: ActionTypes.RECEIVED_POST_SELECTED,

--- a/webapp/stores/search_store.jsx
+++ b/webapp/stores/search_store.jsx
@@ -133,6 +133,19 @@ class SearchStoreClass extends EventEmitter {
             });
         }
     }
+
+    removePost(post) {
+        const results = this.getSearchResults();
+        if (results == null) {
+            return;
+        }
+
+        const index = results.order.indexOf(post.id);
+        if (index > -1) {
+            delete results.posts[post.id];
+            results.order.splice(index, 1);
+        }
+    }
 }
 
 var SearchStore = new SearchStoreClass();
@@ -169,6 +182,10 @@ SearchStore.dispatchToken = AppDispatcher.register((payload) => {
         break;
     case ActionTypes.RECEIVED_POST_UNPINNED:
         SearchStore.togglePinPost(action.reaction, false);
+        SearchStore.emitSearchChange();
+        break;
+    case ActionTypes.REMOVE_POST:
+        SearchStore.removePost(action.post);
         SearchStore.emitSearchChange();
         break;
     default:


### PR DESCRIPTION


#### Summary
Dispatch REMOVE_POST event after successfully initiating delete post,
others get informed by websocket event and will mark the msg as deleted
but not delete from RHS.

#### Ticket Link
jira: https://mattermost.atlassian.net/browse/PLT-6240

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
