### PR TITLE
PLT-1384 Synced preferences over the websocket

### DIFF
--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -403,9 +403,31 @@ export function emitPreferenceChangedEvent(preference) {
         preference
     });
 
-    if (preference.category === Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW) {
+    if (addedNewDmUser(preference)) {
         loadProfilesForSidebar();
     }
+}
+
+export function emitPreferencesChangedEvent(preferences) {
+    AppDispatcher.handleServerAction({
+        type: Constants.ActionTypes.RECEIVED_PREFERENCES,
+        preferences
+    });
+
+    if (preferences.findIndex(addedNewDmUser) !== -1) {
+        loadProfilesForSidebar();
+    }
+}
+
+function addedNewDmUser(preference) {
+    return preference.category === Constants.Preferences.CATEGORY_DIRECT_CHANNEL_SHOW && preference.value === 'true';
+}
+
+export function emitPreferencesDeletedEvent(preferences) {
+    AppDispatcher.handleServerAction({
+        type: Constants.ActionTypes.DELETED_PREFERENCES,
+        preferences
+    });
 }
 
 export function emitRemovePost(post) {

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -185,6 +185,14 @@ function handleEvent(msg) {
         handlePreferenceChangedEvent(msg);
         break;
 
+    case SocketEvents.PREFERENCES_CHANGED:
+        handlePreferencesChangedEvent(msg);
+        break;
+
+    case SocketEvents.PREFERENCES_DELETED:
+        handlePreferencesDeletedEvent(msg);
+        break;
+
     case SocketEvents.TYPING:
         handleUserTypingEvent(msg);
         break;
@@ -354,6 +362,16 @@ function handleChannelDeletedEvent(msg) {
 function handlePreferenceChangedEvent(msg) {
     const preference = JSON.parse(msg.data.preference);
     GlobalActions.emitPreferenceChangedEvent(preference);
+}
+
+function handlePreferencesChangedEvent(msg) {
+    const preferences = JSON.parse(msg.data.preferences);
+    GlobalActions.emitPreferencesChangedEvent(preferences);
+}
+
+function handlePreferencesDeletedEvent(msg) {
+    const preferences = JSON.parse(msg.data.preferences);
+    GlobalActions.emitPreferencesDeletedEvent(preferences);
 }
 
 function handleUserTypingEvent(msg) {

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -229,6 +229,8 @@ export const SocketEvents = {
     USER_UPDATED: 'user_updated',
     TYPING: 'typing',
     PREFERENCE_CHANGED: 'preference_changed',
+    PREFERENCES_CHANGED: 'preferences_changed',
+    PREFERENCES_DELETED: 'preferences_deleted',
     EPHEMERAL_MESSAGE: 'ephemeral_message',
     STATUS_CHANGED: 'status_change',
     HELLO: 'hello',


### PR DESCRIPTION
These are the client side changes for syncing preferences between browser tabs. It adds handling for the new websocket event added in https://github.com/mattermost/platform/pull/6107

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-1384