### PR TITLE
Update markdown test for lists

### DIFF
--- a/tests/test-markdown-lists.md
+++ b/tests/test-markdown-lists.md
@@ -71,23 +71,22 @@ Verify that all list types render as expected.
 - Two
 + Three
 
-### Multi-Item Unordered List with Line Break
+### Multi-Item Unordered List with Line Break (Break should not render)
 
 **Expected:**
 ```
 • Item A
 • Item B
-
 • Item C
 • Item D
 ```
 
 **Actual:**
-• Item A
-• Item B
+* Item A
++ Item B
 
-• Item C
-• Item D
+- Item C
+- Item D
 
 ### Nested Unordered List
 

--- a/tests/test-markdown-lists.md
+++ b/tests/test-markdown-lists.md
@@ -183,7 +183,6 @@ Verify that all list types render as expected.
 ```
 1. One
   • Two
-
 2. Two
 3. Three
 ```
@@ -191,7 +190,7 @@ Verify that all list types render as expected.
 **Actual:**
 
 1. One
-  - Two
+    - Two
 
 2. Two
 3. Three
@@ -202,6 +201,7 @@ Verify that all list types render as expected.
 ```
 1. One
 2. Two
+
 This text should be on a new line.
 ```
 
@@ -250,14 +250,20 @@ This text should be on a new line.
 **Expected:**
 ```
 List A:
+
 1. One
+
 List B:
+
 2. Two
 ```
 
 List A:
+
 1. One
+
 List B:
+
 2. Two
 
 ### Lists with blank lines before and after 


### PR DESCRIPTION
#### Summary
Updating the markdown lists test for changed expectations for line breaks in lists.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6251
https://mattermost.atlassian.net/browse/PLT-6250

Per Harrison:
Multi-Item Unordered List with Line Break is incorrect. The "actual" text should be
```
- Item A
- Item B

- Item C
- Item D
```
and the expected text shouldn't have a blank line between the list items. 

Ordered Lists Separated by Carriage Returns is also incorrect. The actual text should have two more spaces before the second line `- Two` and the expected text shouldn't have a blank line between the two parts of the list.
	
The expected text for New Line After a List should have a blank line between the list and the line of text following it.

The expected text for the Multiple Lists one should have blank lines between each of the lines as in the actual text.