### PR TITLE
PLT-6328 Check for HTTPS protocol if not coming from proxy

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -702,7 +702,7 @@ func GetAuthorizationCode(c *Context, service string, props map[string]string, l
 	props["hash"] = model.HashPassword(clientId)
 	state := b64.StdEncoding.EncodeToString([]byte(model.MapToJson(props)))
 
-	redirectUri := utils.GetSiteURL() + "/signup/" + service + "/complete"
+	redirectUri := c.GetSiteURLHeader() + "/signup/" + service + "/complete"
 
 	authUrl := endpoint + "?response_type=code&client_id=" + clientId + "&redirect_uri=" + url.QueryEscape(redirectUri) + "&state=" + url.QueryEscape(state)
 

--- a/app/login.go
+++ b/app/login.go
@@ -128,7 +128,7 @@ func DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, deviceId 
 }
 
 func GetProtocol(r *http.Request) string {
-	if r.Header.Get(model.HEADER_FORWARDED_PROTO) == "https" {
+	if r.Header.Get(model.HEADER_FORWARDED_PROTO) == "https" || r.TLS != nil {
 		return "https"
 	} else {
 		return "http"


### PR DESCRIPTION
#### Summary
We weren't checking the protocol correctly for direct HTTPS connections, not connections coming from the proxy. This caused us to build the site URL using the wrong protocol and was breaking the OAuth2 login flow. I also switched back to using the `c.GetSiteURLHeader()` for all of the OAuth login flow to ensure we don't break any existing systems.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6328