### PR TITLE
[PLT-4118] Help text on "Private Channel --> Set Channel Purpose" is incorrect

### DIFF
--- a/webapp/components/edit_channel_purpose_modal.jsx
+++ b/webapp/components/edit_channel_purpose_modal.jsx
@@ -110,6 +110,21 @@ export default class EditChannelPurposeModal extends React.Component {
             );
         }
 
+        let channelPurposeModal = (
+            <FormattedMessage
+                id='edit_channel_purpose_modal.body'
+                defaultMessage='Describe how this channel should be used. This text appears in the channel list in the "More..." menu and helps others decide whether to join.'
+            />
+        );
+        if (this.props.channel.type === 'P') {
+            channelPurposeModal = (
+                <FormattedMessage
+                    id='edit_channel_private_purpose_modal.body'
+                    defaultMessage='This text appears in the \"View Info\" modal of the private channel.'
+                />
+            );
+        }
+
         return (
             <Modal
                 className='modal-edit-channel-purpose'
@@ -125,10 +140,7 @@ export default class EditChannelPurposeModal extends React.Component {
                 </Modal.Header>
                 <Modal.Body>
                     <p>
-                        <FormattedMessage
-                            id='edit_channel_purpose_modal.body'
-                            defaultMessage='Describe how this channel should be used. This text appears in the channel list in the "More..." menu and helps others decide whether to join.'
-                        />
+                        {channelPurposeModal}
                     </p>
                     <textarea
                         ref='purpose'

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1250,6 +1250,7 @@
   "edit_channel_header_modal.title": "Edit Header for {channel}",
   "edit_channel_header_modal.title_dm": "Edit Header",
   "edit_channel_purpose_modal.body": "Describe how this channel should be used. This text appears in the channel list in the \"More...\" menu and helps others decide whether to join.",
+  "edit_channel_private_purpose_modal.body": "This text appears in the \"View Info\" modal of the private channel.",
   "edit_channel_purpose_modal.cancel": "Cancel",
   "edit_channel_purpose_modal.error": "This channel purpose is too long, please enter a shorter one",
   "edit_channel_purpose_modal.save": "Save",


### PR DESCRIPTION
#### Summary
[PLT-4118] Help text on "Private Channel --> Set Channel Purpose" is incorrect

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/PLT-4118
GitHub: https://github.com/mattermost/platform/issues/6128

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
