### PR TITLE
PLT-6227/PLT-5347 Copy users in/out of profileByIds cache to prevent data race

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -815,7 +815,8 @@ func (us SqlUserStore) GetProfileByIds(userIds []string, allowFromCache bool) St
 		if allowFromCache {
 			for _, userId := range userIds {
 				if cacheItem, ok := profileByIdsCache.Get(userId); ok {
-					u := cacheItem.(*model.User)
+					u := &model.User{}
+					*u = *cacheItem.(*model.User)
 					users = append(users, u)
 				} else {
 					remainingUserIds = append(remainingUserIds, userId)
@@ -856,7 +857,9 @@ func (us SqlUserStore) GetProfileByIds(userIds []string, allowFromCache bool) St
 			for _, u := range users {
 				u.Sanitize(map[string]bool{})
 
-				profileByIdsCache.AddWithExpiresInSecs(u.Id, u, PROFILE_BY_IDS_CACHE_SEC)
+				cpy := &model.User{}
+				*cpy = *u
+				profileByIdsCache.AddWithExpiresInSecs(cpy.Id, cpy, PROFILE_BY_IDS_CACHE_SEC)
 			}
 
 			result.Data = users


### PR DESCRIPTION
#### Summary
Copy users in/out out profileByIds cache to prevent data race. I wasn't able to reliably reproduce the race (did see it once or twice) but this should fix it.

@coreyhulen not sure if you want to try reproducing again once this goes in to confirm that this fixes the issue

@crspeller we'll probably want to load test this to make sure it doesn't negatively affect performance. Not sure if you want to merge first/revert if necessary or just test this branch 0/5

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6227
https://mattermost.atlassian.net/browse/PLT-5347