### PR TITLE
PLT-6283 Hide Preview Mode error bar after enabling email notifications

### DIFF
--- a/webapp/components/admin_console/configuration_settings.jsx
+++ b/webapp/components/admin_console/configuration_settings.jsx
@@ -6,6 +6,7 @@ import {FormattedMessage} from 'react-intl';
 
 import ErrorStore from 'stores/error_store.jsx';
 
+import {ErrorBarTypes} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import AdminSettings from './admin_settings.jsx';
@@ -67,10 +68,8 @@ export default class ConfigurationSettings extends AdminSettings {
     }
 
     handleSaved(newConfig) {
-        const lastError = ErrorStore.getLastError();
-
-        if (lastError && lastError.message === 'error_bar.site_url' && newConfig.ServiceSettings.SiteURL) {
-            ErrorStore.clearLastError(true);
+        if (newConfig.ServiceSettings.SiteURL) {
+            ErrorStore.clearError(ErrorBarTypes.SITE_URL);
         }
     }
 

--- a/webapp/components/admin_console/email_settings.jsx
+++ b/webapp/components/admin_console/email_settings.jsx
@@ -3,6 +3,9 @@
 
 import React from 'react';
 
+import ErrorStore from 'stores/error_store.jsx';
+
+import {ErrorBarTypes} from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import AdminSettings from './admin_settings.jsx';
@@ -18,6 +21,8 @@ export default class EmailSettings extends AdminSettings {
         super(props);
 
         this.getConfigFromState = this.getConfigFromState.bind(this);
+
+        this.handleSaved = this.handleSaved.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
     }
@@ -37,6 +42,12 @@ export default class EmailSettings extends AdminSettings {
         config.EmailSettings.SkipServerCertificateVerification = this.state.skipServerCertificateVerification;
 
         return config;
+    }
+
+    handleSaved(newConfig) {
+        if (newConfig.EmailSettings.SendEmailNotifications) {
+            ErrorStore.clearError(ErrorBarTypes.PREVIEW_MODE);
+        }
     }
 
     getStateFromConfig(config) {

--- a/webapp/stores/error_store.jsx
+++ b/webapp/stores/error_store.jsx
@@ -62,6 +62,14 @@ class ErrorStoreClass extends EventEmitter {
         BrowserStore.setGlobalItem('last_error_conn', count);
     }
 
+    clearError(message) {
+        const lastError = this.getLastError();
+
+        if (lastError && lastError.message === message) {
+            this.clearLastError(true);
+        }
+    }
+
     clearLastError(force) {
         var lastError = this.getLastError();
 

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -287,6 +287,14 @@ export const ErrorPageTypes = {
     LOCAL_STORAGE: 'local_storage'
 };
 
+export const ErrorBarTypes = {
+    LICENSE_EXPIRING: 'error_bar.license_expiring',
+    LICENSE_EXPIRED: 'error_bar.license_expired',
+    LICENSE_PAST_GRACE: 'error_bar.past_grace',
+    PREVIEW_MODE: 'error_bar.preview_mode',
+    SITE_URL: 'error_bar.site_url'
+};
+
 export const Constants = {
     Preferences,
     SocketEvents,
@@ -297,6 +305,7 @@ export const Constants = {
     TutorialSteps,
     PostTypes,
     ErrorPageTypes,
+    ErrorBarTypes,
 
     IGNORE_POST_TYPES: [PostTypes.JOIN_LEAVE, PostTypes.JOIN_CHANNEL, PostTypes.LEAVE_CHANNEL, PostTypes.REMOVE_FROM_CHANNEL, PostTypes.ADD_TO_CHANNEL, PostTypes.ADD_REMOVE],
 


### PR DESCRIPTION
I moved the *_ERROR constants out of error_bar.jsx and into ErrorBarTypes in constants.jsx and then used those for a new ErrorStore.clearError method that clears the error bar if it's the provided type of error.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6283

#### Checklist
- Has UI changes