### PR TITLE
PLT-6369/PLT-5926/PLT-6357 Fix OAuth SSO first account creation, add mobile support, and fix refresh tokens

### DIFF
--- a/api4/oauth.go
+++ b/api4/oauth.go
@@ -417,6 +417,9 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else if action == model.OAUTH_ACTION_SSO_TO_EMAIL {
 
 		redirectUrl = app.GetProtocol(r) + "://" + r.Host + "/claim?email=" + url.QueryEscape(props["email"])
+	} else if action == model.OAUTH_ACTION_MOBILE {
+		ReturnStatusOK(w)
+		return
 	} else {
 		session, err := app.DoLogin(w, r, user, "")
 		if err != nil {

--- a/api4/params.go
+++ b/api4/params.go
@@ -104,7 +104,7 @@ func ApiParamsFromRequest(r *http.Request) *ApiParams {
 	}
 
 	if val, ok := props["service"]; ok {
-		params.Category = val
+		params.Service = val
 	}
 
 	if val, ok := props["preference_name"]; ok {

--- a/model/oauth.go
+++ b/model/oauth.go
@@ -16,6 +16,7 @@ const (
 	OAUTH_ACTION_LOGIN        = "login"
 	OAUTH_ACTION_EMAIL_TO_SSO = "email_to_sso"
 	OAUTH_ACTION_SSO_TO_EMAIL = "sso_to_email"
+	OAUTH_ACTION_MOBILE       = "mobile"
 )
 
 type OAuthApp struct {


### PR DESCRIPTION
#### Summary
* Fix OAuth first account creation and service parameter bug
* Add mobile support with mobile action that just returns 200
* Always return refresh token with access token
* Regenerate refresh token after it gets used

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6369
https://mattermost.atlassian.net/browse/PLT-5826
https://mattermost.atlassian.net/browse/PLT-6357

#### Checklist
- [x] Added or updated unit tests (required for all new features)