### PR TITLE
PLT-4113 Added default for FileSettings.Directory

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -487,6 +487,10 @@ func (o *Config) SetDefaults() {
 		o.FileSettings.InitialFont = "luximbi.ttf"
 	}
 
+	if o.FileSettings.Directory == "" {
+		o.FileSettings.Directory = "./data/"
+	}
+
 	if len(o.EmailSettings.InviteSalt) == 0 {
 		o.EmailSettings.InviteSalt = NewRandomString(32)
 	}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"testing"
+)
+
+func TestConfigDefaultFileSettingsDirectory(t *testing.T) {
+	c1 := Config{}
+	c1.SetDefaults()
+
+	if c1.FileSettings.Directory != "./data/" {
+		t.Fatal("FileSettings.Directory should default to './data/'")
+	}
+}


### PR DESCRIPTION
#### Summary
Defaults the FileSettings.Directory config to './data/' the System Console worked without any client changes. I also added a test for the server change.

#### Ticket Link
https://github.com/mattermost/platform/issues/6173

#### Checklist
- [x] Added or updated unit tests (required for all new features)