### PR TITLE
PLT-6368 Changed client to always use window.location.origin over SiteURL (3.8)

### DIFF
--- a/webapp/utils/url.jsx
+++ b/webapp/utils/url.jsx
@@ -18,10 +18,6 @@ export function getShortenedURL(url = '', getLength = 27) {
 }
 
 export function getSiteURL() {
-    if (global.mm_config.SiteURL) {
-        return global.mm_config.SiteURL;
-    }
-
     if (window.location.origin) {
         return window.location.origin;
     }


### PR DESCRIPTION
This is to fix the various websocket issues that come up when the SiteURL is set. It also makes sure that any URLs displayed in the client match the current URL

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6368

#### Checklist
- Touches critical sections of the codebase (auth, upgrade, etc.)
