### PR TITLE
PLT-6368 Changed client to always use window.location.origin over SiteURL (3.6)

### DIFF
--- a/webapp/stores/team_store.jsx
+++ b/webapp/stores/team_store.jsx
@@ -125,7 +125,7 @@ class TeamStoreClass extends EventEmitter {
 
         if (current) {
             // can't call Utils.getSiteURL here because that introduces a circular dependency
-            const origin = window.mm_config.SiteURL || window.location.origin;
+            const origin = window.location.origin;
 
             return origin + '/signup_user_complete/?id=' + current.invite_id;
         }
@@ -141,7 +141,7 @@ class TeamStoreClass extends EventEmitter {
         }
 
         // can't call Utils.getSiteURL here because that introduces a circular dependency
-        const origin = window.mm_config.SiteURL || window.location.origin;
+        const origin = window.location.origin;
 
         return origin + '/' + team.name;
     }

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -1278,10 +1278,6 @@ export function isValidPassword(password) {
 }
 
 export function getSiteURL() {
-    if (global.mm_config.SiteURL) {
-        return global.mm_config.SiteURL;
-    }
-
     if (window.location.origin) {
         return window.location.origin;
     }


### PR DESCRIPTION
This is to fix the various websocket issues that come up when the SiteURL is set. It also makes sure that any URLs displayed in the client match the current URL

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6368

#### Checklist
- Touches critical sections of the codebase (auth, upgrade, etc.)
