### PR TITLE
Use host header for successful OAuth redirect (3.6)

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -33,17 +33,18 @@ var allowedMethods []string = []string{
 }
 
 type Context struct {
-	Session      model.Session
-	RequestId    string
-	IpAddress    string
-	Path         string
-	Err          *model.AppError
-	teamURLValid bool
-	teamURL      string
-	siteURL      string
-	T            goi18n.TranslateFunc
-	Locale       string
-	TeamId       string
+	Session       model.Session
+	RequestId     string
+	IpAddress     string
+	Path          string
+	Err           *model.AppError
+	teamURLValid  bool
+	teamURL       string
+	siteURL       string
+	siteURLHeader string
+	T             goi18n.TranslateFunc
+	Locale        string
+	TeamId        string
 }
 
 func ApiAppHandler(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
@@ -154,6 +155,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.SetSiteURL(*utils.Cfg.ServiceSettings.SiteURL)
+	c.SetSiteURLHeader(GetProtocol(r) + "://" + r.Host)
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.RequestId)
 	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v.%v.%v", model.CurrentVersion, model.BuildNumber, utils.ClientCfgHash, utils.IsLicensed))
@@ -442,6 +444,14 @@ func (c *Context) GetTeamURL() string {
 
 func (c *Context) GetSiteURL() string {
 	return c.siteURL
+}
+
+func (c *Context) SetSiteURLHeader(url string) {
+	c.siteURLHeader = strings.TrimRight(url, "/")
+}
+
+func (c *Context) GetSiteURLHeader() string {
+	return c.siteURLHeader
 }
 
 func (c *Context) GetCurrentTeamMember() *model.TeamMember {

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -296,7 +296,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	state := r.URL.Query().Get("state")
 
-	uri := c.GetSiteURL() + "/signup/" + service + "/complete"
+	uri := c.GetSiteURLHeader() + "/signup/" + service + "/complete"
 
 	if body, teamId, props, err := AuthorizeOAuthUser(service, code, state, uri); err != nil {
 		c.Err = err
@@ -322,7 +322,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 			}
 			if c.Err == nil {
 				if val, ok := props["redirect_to"]; ok {
-					http.Redirect(w, r, c.GetSiteURL()+val, http.StatusTemporaryRedirect)
+					http.Redirect(w, r, c.GetSiteURLHeader()+val, http.StatusTemporaryRedirect)
 					return
 				}
 				http.Redirect(w, r, GetProtocol(r)+"://"+r.Host, http.StatusTemporaryRedirect)
@@ -382,7 +382,7 @@ func authorizeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// here we should check if the user is logged in
 	if len(c.Session.UserId) == 0 {
-		http.Redirect(w, r, c.GetSiteURL()+"/login?redirect_to="+url.QueryEscape(r.RequestURI), http.StatusFound)
+		http.Redirect(w, r, c.GetSiteURLHeader()+"/login?redirect_to="+url.QueryEscape(r.RequestURI), http.StatusFound)
 		return
 	}
 
@@ -403,7 +403,7 @@ func authorizeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		doAllow := func() (*http.Response, *model.AppError) {
 			HttpClient := &http.Client{}
-			url := c.GetSiteURL() + "/api/v3/oauth/allow?response_type=" + model.AUTHCODE_RESPONSE_TYPE + "&client_id=" + clientId + "&redirect_uri=" + url.QueryEscape(redirect) + "&scope=" + scope + "&state=" + url.QueryEscape(state)
+			url := c.GetSiteURLHeader() + "/api/v3/oauth/allow?response_type=" + model.AUTHCODE_RESPONSE_TYPE + "&client_id=" + clientId + "&redirect_uri=" + url.QueryEscape(redirect) + "&scope=" + scope + "&state=" + url.QueryEscape(state)
 			rq, _ := http.NewRequest("GET", url, strings.NewReader(""))
 
 			rq.Header.Set(model.HEADER_AUTH, model.HEADER_BEARER+" "+c.Session.Token)
@@ -723,7 +723,7 @@ func GetAuthorizationCode(c *Context, service string, props map[string]string, l
 	props["hash"] = model.HashPassword(clientId)
 	state := b64.StdEncoding.EncodeToString([]byte(model.MapToJson(props)))
 
-	redirectUri := c.GetSiteURL() + "/signup/" + service + "/complete"
+	redirectUri := c.GetSiteURLHeader() + "/signup/" + service + "/complete"
 
 	authUrl := endpoint + "?response_type=code&client_id=" + clientId + "&redirect_uri=" + url.QueryEscape(redirectUri) + "&state=" + url.QueryEscape(state)
 


### PR DESCRIPTION
This is to keep GitLab SSO working when the SiteURL isn't configured

#### Checklist
- Touches critical sections of the codebase (auth, upgrade, etc.)
