### PR TITLE
[PLT-6387] fix regression with unable to react with :+1:

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -90,7 +90,7 @@ type Routes struct {
 	Emojis *mux.Router // 'api/v4/emoji'
 	Emoji  *mux.Router // 'api/v4/emoji/{emoji_id:[A-Za-z0-9]+}'
 
-	ReactionByNameForPostForUser *mux.Router // 'api/v4/users/{user_id:[A-Za-z0-9]+}/posts/{post_id:[A-Za-z0-9]+}/reactions/{emoji_name:[A-Za-z0-9_-]+}'
+	ReactionByNameForPostForUser *mux.Router // 'api/v4/users/{user_id:[A-Za-z0-9]+}/posts/{post_id:[A-Za-z0-9]+}/reactions/{emoji_name:[A-Za-z0-9_-+]+}'
 
 	Webrtc *mux.Router // 'api/v4/webrtc'
 }
@@ -170,7 +170,7 @@ func InitApi(full bool) {
 	BaseRoutes.Emojis = BaseRoutes.ApiRoot.PathPrefix("/emoji").Subrouter()
 	BaseRoutes.Emoji = BaseRoutes.Emojis.PathPrefix("/{emoji_id:[A-Za-z0-9]+}").Subrouter()
 
-	BaseRoutes.ReactionByNameForPostForUser = BaseRoutes.PostForUser.PathPrefix("/reactions/{emoji_name:[A-Za-z0-9_-]+}").Subrouter()
+	BaseRoutes.ReactionByNameForPostForUser = BaseRoutes.PostForUser.PathPrefix("/reactions/{emoji_name:[A-Za-z0-9\\_\\-\\+]+}").Subrouter()
 
 	BaseRoutes.Webrtc = BaseRoutes.ApiRoot.PathPrefix("/webrtc").Subrouter()
 

--- a/api4/context.go
+++ b/api4/context.go
@@ -6,6 +6,7 @@ package api4
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -504,7 +505,9 @@ func (c *Context) RequireEmojiName() *Context {
 		return c
 	}
 
-	if len(c.Params.EmojiName) == 0 || len(c.Params.EmojiName) > 64 || !model.IsValidAlphaNumHyphenUnderscore(c.Params.EmojiName, false) {
+	validName := regexp.MustCompile(`^[a-zA-Z0-9\-\+_]+$`)
+
+	if len(c.Params.EmojiName) == 0 || len(c.Params.EmojiName) > 64 || !validName.MatchString(c.Params.EmojiName) {
 		c.SetInvalidUrlParam("emoji_name")
 	}
 

--- a/model/reaction.go
+++ b/model/reaction.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"regexp"
 )
 
 type Reaction struct {
@@ -60,7 +61,9 @@ func (o *Reaction) IsValid() *AppError {
 		return NewLocAppError("Reaction.IsValid", "model.reaction.is_valid.post_id.app_error", nil, "post_id="+o.PostId)
 	}
 
-	if len(o.EmojiName) == 0 || len(o.EmojiName) > 64 || !IsValidAlphaNumHyphenUnderscore(o.EmojiName, false) {
+	validName := regexp.MustCompile(`^[a-zA-Z0-9\-\+_]+$`)
+
+	if len(o.EmojiName) == 0 || len(o.EmojiName) > 64 || !validName.MatchString(o.EmojiName) {
 		return NewLocAppError("Reaction.IsValid", "model.reaction.is_valid.emoji_name.app_error", nil, "emoji_name="+o.EmojiName)
 	}
 

--- a/model/reaction_test.go
+++ b/model/reaction_test.go
@@ -42,16 +42,6 @@ func TestReactionIsValid(t *testing.T) {
 	}
 
 	reaction.PostId = NewId()
-	reaction.EmojiName = ""
-	if err := reaction.IsValid(); err == nil {
-		t.Fatal("emoji name should be invalid")
-	}
-
-	reaction.EmojiName = strings.Repeat("a", 65)
-	if err := reaction.IsValid(); err == nil {
-		t.Fatal("emoji name should be invalid")
-	}
-
 	reaction.EmojiName = strings.Repeat("a", 64)
 	if err := reaction.IsValid(); err != nil {
 		t.Fatal(err)
@@ -67,9 +57,24 @@ func TestReactionIsValid(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	reaction.EmojiName = "+1"
+	if err := reaction.IsValid(); err != nil {
+		t.Fatal(err)
+	}
+
 	reaction.EmojiName = "emoji:"
 	if err := reaction.IsValid(); err == nil {
 		t.Fatal(err)
+	}
+
+	reaction.EmojiName = ""
+	if err := reaction.IsValid(); err == nil {
+		t.Fatal("emoji name should be invalid")
+	}
+
+	reaction.EmojiName = strings.Repeat("a", 65)
+	if err := reaction.IsValid(); err == nil {
+		t.Fatal("emoji name should be invalid")
 	}
 
 	reaction.CreateAt = 0


### PR DESCRIPTION
#### Summary
Fix regression on unable to react with :+1: or (`:+1:`)

#### Ticket Link
Jira ticket: [PLT-6387][6387]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers

[6387]: https://mattermost.atlassian.net/browse/PLT-6387
