### PR TITLE
Fixed detection of HTTPS without a proxy (3.6)

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -292,7 +292,7 @@ func (cw *CorsWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetProtocol(r *http.Request) string {
-	if r.Header.Get(model.HEADER_FORWARDED_PROTO) == "https" {
+	if r.Header.Get(model.HEADER_FORWARDED_PROTO) == "https" || r.TLS != nil {
 		return "https"
 	} else {
 		return "http"


### PR DESCRIPTION
This is to fix Gitlab login on a server using HTTPS without a proxy. Right now, it sends a redirect URI to Gitlab with `http://` instead of `https://`