### PR TITLE
Fixed detection of HTTPS without a proxy (3.7)

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -128,7 +128,7 @@ func DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, deviceId 
 }
 
 func GetProtocol(r *http.Request) string {
-	if r.Header.Get(model.HEADER_FORWARDED_PROTO) == "https" {
+	if r.Header.Get(model.HEADER_FORWARDED_PROTO) == "https" || r.TLS != nil {
 		return "https"
 	} else {
 		return "http"


### PR DESCRIPTION
This is to fix Gitlab login on a server using HTTPS without a proxy. Right now, it sends a redirect URI to Gitlab with `http://` instead of `https://`