### PR TITLE
PLT-6249: Erase custom emoji in "recently used" after deleted

### DIFF
--- a/webapp/stores/emoji_store.jsx
+++ b/webapp/stores/emoji_store.jsx
@@ -139,6 +139,17 @@ class EmojiStore extends EventEmitter {
         return this.map.get(name);
     }
 
+    removeRecentEmoji(id) {
+        const recentEmojis = this.getRecentEmojis();
+        for (let i = recentEmojis.length - 1; i >= 0; i--) {
+            if (recentEmojis[i].id === id) {
+                recentEmojis.splice(i, 1);
+                break;
+            }
+        }
+        localStorage.setItem(Constants.RECENT_EMOJI_KEY, JSON.stringify(recentEmojis));
+    }
+
     addRecentEmoji(rawAlias) {
         const recentEmojis = this.getRecentEmojis();
 
@@ -214,6 +225,7 @@ class EmojiStore extends EventEmitter {
             break;
         case ActionTypes.REMOVED_CUSTOM_EMOJI:
             this.removeCustomEmoji(action.id);
+            this.removeRecentEmoji(action.id);
             this.emitChange();
             break;
         case ActionTypes.EMOJI_POSTED:


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Erase custom emoji in "recently used" after deleted.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6249

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

