### PR TITLE
PLT-6268 Clear blue bar correctly when removing expiring license

### DIFF
--- a/api4/system.go
+++ b/api4/system.go
@@ -231,6 +231,14 @@ func getClientLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var clientLicense map[string]string
+
+	if app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		clientLicense = utils.ClientLicense
+	} else {
+		clientLicense = utils.GetSanitizedClientLicense()
+	}
+
 	w.Header().Set(model.HEADER_ETAG_SERVER, etag)
-	w.Write([]byte(model.MapToJson(utils.GetSanitizedClientLicense())))
+	w.Write([]byte(model.MapToJson(clientLicense)))
 }

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -161,27 +161,11 @@ func TestGetOldClientLicense(t *testing.T) {
 	defer TearDown()
 	Client := th.Client
 
-	isLicensed := utils.IsLicensed
-	clientLicense := utils.ClientLicense
-	defer func() {
-		utils.IsLicensed = isLicensed
-		utils.ClientLicense = clientLicense
-	}()
-	utils.IsLicensed = true
-	utils.ClientLicense = map[string]string{
-		"IsLicensed": "true",
-		"IssuedAt":   "123",
-	}
-
 	license, resp := Client.GetOldClientLicense("")
 	CheckNoError(t, resp)
 
 	if len(license["IsLicensed"]) == 0 {
 		t.Fatal("license not returned correctly")
-	}
-
-	if len(license["IssuedAt"]) != 0 {
-		t.Fatal("license not sanitized correctly")
 	}
 
 	Client.Logout()
@@ -200,7 +184,7 @@ func TestGetOldClientLicense(t *testing.T) {
 	license, resp = th.SystemAdminClient.GetOldClientLicense("")
 	CheckNoError(t, resp)
 
-	if len(license["IssuedAt"]) == 0 {
+	if len(license["IsLicensed"]) == 0 {
 		t.Fatal("license not returned correctly")
 	}
 }

--- a/webapp/components/admin_console/license_settings.jsx
+++ b/webapp/components/admin_console/license_settings.jsx
@@ -5,6 +5,7 @@ import $ from 'jquery';
 import ReactDOM from 'react-dom';
 import * as Utils from 'utils/utils.jsx';
 
+import ErrorStore from 'stores/error_store.jsx';
 import {uploadLicenseFile, removeLicenseFile} from 'actions/admin_actions.jsx';
 
 import {injectIntl, intlShape, defineMessages, FormattedMessage, FormattedHTMLMessage} from 'react-intl';
@@ -80,6 +81,7 @@ class LicenseSettings extends React.Component {
             () => {
                 $('#remove-button').button('reset');
                 this.setState({fileSelected: false, fileName: null, serverError: null});
+                ErrorStore.clearLastError(true);
                 window.location.reload(true);
             },
             (error) => {


### PR DESCRIPTION
#### Summary
Clear blue bar correctly when removing expiring license and also don't sanitize license for system admins.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6268

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#226)