### PR TITLE
[PLT-4374] Added active state for recent mentions and flagged posts.

### DIFF
--- a/webapp/components/search_bar.jsx
+++ b/webapp/components/search_bar.jsx
@@ -248,6 +248,8 @@ export default class SearchBar extends React.Component {
         let mentionBtn;
         let flagBtn;
         if (this.props.showMentionFlagBtns) {
+            var mentionBtnClass = SearchStore.isMentionSearch ? 'active' : '';
+
             mentionBtn = (
                 <div
                     className='dropdown channel-header__links'
@@ -262,12 +264,15 @@ export default class SearchBar extends React.Component {
                             href='#'
                             type='button'
                             onClick={this.searchMentions}
+                            className={mentionBtnClass}
                         >
                             {'@'}
                         </a>
                     </OverlayTrigger>
                 </div>
             );
+
+            var flagBtnClass = SearchStore.isFlaggedPosts ? 'active' : '';
 
             flagBtn = (
                 <div
@@ -283,6 +288,7 @@ export default class SearchBar extends React.Component {
                             href='#'
                             type='button'
                             onClick={this.getFlagged}
+                            className={flagBtnClass}
                         >
                             <span
                                 className='icon icon__flag'

--- a/webapp/sass/layout/_headers.scss
+++ b/webapp/sass/layout/_headers.scss
@@ -454,11 +454,19 @@
             text-decoration: none;
 
             &:hover {
-                @include opacity(1);
+                @include opacity(0.5);
             }
 
             &:focus {
                 color: inherit;
+            }
+
+            &.active {
+                color: $primary-color;
+                @include opacity(1);
+                .icon {
+                    fill: $primary-color;
+                }
             }
         }
     }

--- a/webapp/sass/layout/_headers.scss
+++ b/webapp/sass/layout/_headers.scss
@@ -454,7 +454,7 @@
             text-decoration: none;
 
             &:hover {
-                @include opacity(0.5);
+                @include opacity(0.7);
             }
 
             &:focus {


### PR DESCRIPTION
 #### Summary
[PLT-4374] Menitons and flagged posts icons in the topbar are no highlighted when they are active on right pane.

![town_square_-_test_mattermost](https://cloud.githubusercontent.com/assets/2923943/25489282/9d5ceca0-2b69-11e7-934f-18699fefda6e.png)


#### Ticket Link
https://github.com/mattermost/platform/issues/4363
https://mattermost.atlassian.net/browse/PLT-4374
#### Checklist
- [x] Has UI changes
