### PR TITLE
PLT-6353 Add config setting to disable statuses

### DIFF
--- a/app/status.go
+++ b/app/status.go
@@ -31,6 +31,10 @@ func AddStatusCache(status *model.Status) {
 }
 
 func GetAllStatuses() map[string]*model.Status {
+	if !*utils.Cfg.ServiceSettings.EnableUserStatuses {
+		return map[string]*model.Status{}
+	}
+
 	userIds := statusCache.Keys()
 	statusMap := map[string]*model.Status{}
 
@@ -49,6 +53,10 @@ func GetAllStatuses() map[string]*model.Status {
 }
 
 func GetStatusesByIds(userIds []string) (map[string]interface{}, *model.AppError) {
+	if !*utils.Cfg.ServiceSettings.EnableUserStatuses {
+		return map[string]interface{}{}, nil
+	}
+
 	statusMap := map[string]interface{}{}
 	metrics := einterfaces.GetMetricsInterface()
 
@@ -92,6 +100,10 @@ func GetStatusesByIds(userIds []string) (map[string]interface{}, *model.AppError
 
 //GetUserStatusesByIds used by apiV4
 func GetUserStatusesByIds(userIds []string) ([]*model.Status, *model.AppError) {
+	if !*utils.Cfg.ServiceSettings.EnableUserStatuses {
+		return []*model.Status{}, nil
+	}
+
 	var statusMap []*model.Status
 	metrics := einterfaces.GetMetricsInterface()
 
@@ -145,6 +157,10 @@ func GetUserStatusesByIds(userIds []string) ([]*model.Status, *model.AppError) {
 }
 
 func SetStatusOnline(userId string, sessionId string, manual bool) {
+	if !*utils.Cfg.ServiceSettings.EnableUserStatuses {
+		return
+	}
+
 	broadcast := false
 
 	var oldStatus string = model.STATUS_OFFLINE
@@ -206,6 +222,10 @@ func SetStatusOnline(userId string, sessionId string, manual bool) {
 }
 
 func SetStatusOffline(userId string, manual bool) {
+	if !*utils.Cfg.ServiceSettings.EnableUserStatuses {
+		return
+	}
+
 	status, err := GetStatus(userId)
 	if err == nil && status.Manual && !manual {
 		return // manually set status always overrides non-manual one
@@ -226,6 +246,10 @@ func SetStatusOffline(userId string, manual bool) {
 }
 
 func SetStatusAwayIfNeeded(userId string, manual bool) {
+	if !*utils.Cfg.ServiceSettings.EnableUserStatuses {
+		return
+	}
+
 	status, err := GetStatus(userId)
 
 	if err != nil {
@@ -274,6 +298,10 @@ func GetStatusFromCache(userId string) *model.Status {
 }
 
 func GetStatus(userId string) (*model.Status, *model.AppError) {
+	if !*utils.Cfg.ServiceSettings.EnableUserStatuses {
+		return &model.Status{}, nil
+	}
+
 	status := GetStatusFromCache(userId)
 	if status != nil {
 		return status, nil

--- a/config/config.json
+++ b/config/config.json
@@ -43,6 +43,7 @@
         "TimeBetweenUserTypingUpdatesMilliseconds": 5000,
         "EnablePostSearch": true,
         "EnableUserTypingMessages": true,
+        "EnableUserStatuses": true,
         "ClusterLogTimeoutMilliseconds": 2000
     },
     "TeamSettings": {

--- a/model/config.go
+++ b/model/config.go
@@ -153,6 +153,7 @@ type ServiceSettings struct {
 	TimeBetweenUserTypingUpdatesMilliseconds *int64
 	EnablePostSearch                         *bool
 	EnableUserTypingMessages                 *bool
+	EnableUserStatuses                       *bool
 	ClusterLogTimeoutMilliseconds            *int
 }
 
@@ -1161,6 +1162,11 @@ func (o *Config) SetDefaults() {
 	if o.ServiceSettings.EnableUserTypingMessages == nil {
 		o.ServiceSettings.EnableUserTypingMessages = new(bool)
 		*o.ServiceSettings.EnableUserTypingMessages = true
+	}
+
+	if o.ServiceSettings.EnableUserStatuses == nil {
+		o.ServiceSettings.EnableUserStatuses = new(bool)
+		*o.ServiceSettings.EnableUserStatuses = true
 	}
 
 	if o.ServiceSettings.ClusterLogTimeoutMilliseconds == nil {

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -229,9 +229,7 @@ function handleNewPostEvent(msg) {
     posts[post.id] = post;
     loadProfilesForPosts(posts);
 
-    if (UserStore.getStatus(post.user_id) !== UserStatuses.ONLINE) {
-        StatusActions.loadStatusesByIds([post.user_id]);
-    }
+    UserStore.setStatus(post.user_id, UserStatuses.ONLINE);
 }
 
 function handlePostEditEvent(msg) {
@@ -375,9 +373,7 @@ function handlePreferencesDeletedEvent(msg) {
 function handleUserTypingEvent(msg) {
     GlobalActions.emitRemoteUserTypingEvent(msg.broadcast.channel_id, msg.data.user_id, msg.data.parent_id);
 
-    if (UserStore.getStatus(msg.data.user_id) !== UserStatuses.ONLINE) {
-        StatusActions.loadStatusesByIds([msg.data.user_id]);
-    }
+    UserStore.setStatus(msg.data.user_id, UserStatuses.ONLINE);
 }
 
 function handleStatusChangedEvent(msg) {


### PR DESCRIPTION
#### Summary
Adds a config setting that will disable statuses.

Also changes some client functionality to not request statuses for offline/away users when receiving a typing/new post event from them. Now it just sets them online from the client's perspective. This should reduce server load even when statuses are enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6353