### PR TITLE
PLT-6211: Close emoji picker right away after react

### DIFF
--- a/webapp/components/post_view/components/post_info.jsx
+++ b/webapp/components/post_view/components/post_info.jsx
@@ -318,10 +318,9 @@ export default class PostInfo extends React.Component {
 
     reactEmojiClick(emoji) {
         const pickerOffset = 21;
-
+        this.setState({showEmojiPicker: false, reactionPickerOffset: pickerOffset});
         const emojiName = emoji.name || emoji.aliases[0];
         PostActions.addReaction(this.props.post.channel_id, this.props.post.id, emojiName);
-        this.setState({showEmojiPicker: false, reactionPickerOffset: pickerOffset});
     }
 
     render() {
@@ -374,7 +373,7 @@ export default class PostInfo extends React.Component {
                             container={this}
                             onHide={() => this.setState({showEmojiPicker: false})}
                             target={() => ReactDOM.findDOMNode(this.refs['reactIcon_' + post.id])}
-
+                            animation={false}
                         >
                             <EmojiPicker
                                 onEmojiClick={this.reactEmojiClick}

--- a/webapp/components/rhs_comment.jsx
+++ b/webapp/components/rhs_comment.jsx
@@ -597,7 +597,7 @@ export default class RhsComment extends React.Component {
                     container={this.refs['post_body_' + post.id]}
                     onHide={() => this.setState({showReactEmojiPicker: false})}
                     target={() => ReactDOM.findDOMNode(this.refs['rhs_reacticon_' + post.id])}
-
+                    animation={false}
                 >
                     <EmojiPicker
                         onEmojiClick={this.reactEmojiClick}

--- a/webapp/components/rhs_root_post.jsx
+++ b/webapp/components/rhs_root_post.jsx
@@ -171,9 +171,9 @@ export default class RhsRootPost extends React.Component {
     }
 
     reactEmojiClick(emoji) {
+        this.setState({showRHSEmojiPicker: false});
         const emojiName = emoji.name || emoji.aliases[0];
         addReaction(this.props.post.channel_id, this.props.post.id, emojiName);
-        this.setState({showRHSEmojiPicker: false});
     }
 
     render() {
@@ -245,7 +245,7 @@ export default class RhsRootPost extends React.Component {
                     container={this}
                     onHide={() => this.setState({showRHSEmojiPicker: false})}
                     target={() => ReactDOM.findDOMNode(this.refs.rhs_root_reacticon)}
-
+                    animation={false}
                 >
                     <EmojiPicker
                         onEmojiClick={this.reactEmojiClick}


### PR DESCRIPTION
Close emoji picker before adding emoji to recent used.

Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Close emoji picker before adding emoji to recent used.
RHS part also get fixed.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6211

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
