### PR TITLE
Improve perf for channel switching, fix team switching issues

### DIFF
--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -25,7 +25,7 @@ import store from 'stores/redux_store.jsx';
 const dispatch = store.dispatch;
 const getState = store.getState;
 import {getProfilesByIds} from 'mattermost-redux/actions/users';
-import {getChannelMember} from 'mattermost-redux/actions/channels';
+import {getMyChannelMember} from 'mattermost-redux/actions/channels';
 
 export function handleNewPost(post, msg) {
     let websocketMessageProps = {};
@@ -41,7 +41,7 @@ export function handleNewPost(post, msg) {
             Client.setTeamId(msg.data.team_id);
         }
 
-        getChannelMember(post.channel_id, UserStore.getCurrentId())(dispatch, getState).then(() => completePostReceive(post, websocketMessageProps));
+        getMyChannelMember(post.channel_id)(dispatch, getState).then(() => completePostReceive(post, websocketMessageProps));
     }
 
     if (msg && msg.data) {

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -116,14 +116,19 @@ export default class Sidebar extends React.Component {
         const currentChannelId = ChannelStore.getCurrentId();
         const tutorialStep = PreferenceStore.getInt(Preferences.TUTORIAL_STEP, UserStore.getCurrentId(), 999);
 
-        const allChannels = ChannelStore.getAll().map((channel) => Object.assign({}, channel));
-        const channelList = ChannelUtils.buildDisplayableChannelList(allChannels);
+        const channels = ChannelStore.getAll();
+        let displayableChannels = {};
+        if (channels !== this.oldChannels) {
+            const channelsArray = channels.map((channel) => Object.assign({}, channel));
+            displayableChannels = ChannelUtils.buildDisplayableChannelList(channelsArray);
+        }
+        this.oldChannels = channels;
 
         return {
             activeId: currentChannelId,
             members,
             teamMembers,
-            ...channelList,
+            ...displayableChannels,
             unreadCounts: JSON.parse(JSON.stringify(ChannelStore.getUnreadCounts())),
             showTutorialTip: tutorialStep === TutorialSteps.CHANNEL_POPOVER,
             currentTeam: TeamStore.getCurrent(),

--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -261,7 +261,7 @@ class ChannelStoreClass extends EventEmitter {
     }
 
     getChannelById(id) {
-        return Selectors.getChannelsInCurrentTeam(store.getState())[id];
+        return this.get(id);
     }
 
     storeMyChannelMember(channelMember) {

--- a/webapp/stores/team_store.jsx
+++ b/webapp/stores/team_store.jsx
@@ -342,20 +342,6 @@ class TeamStoreClass extends EventEmitter {
         return false;
     }
 
-    updateUnreadCount(teamId, totalMsgCount, channelMember) {
-        let member = this.getMyTeamMembers().filter((m) => m.team_id === teamId)[0];
-        if (member) {
-            member = Object.assign({}, member);
-            member.msg_count -= (totalMsgCount - channelMember.msg_count);
-            member.mention_count -= channelMember.mention_count;
-
-            store.dispatch({
-                type: TeamTypes.RECEIVED_MY_TEAM_MEMBER,
-                data: member
-            });
-        }
-    }
-
     subtractUnread(teamId, msgs, mentions) {
         let member = this.getMyTeamMembers().filter((m) => m.team_id === teamId)[0];
         if (member) {
@@ -442,11 +428,6 @@ TeamStore.dispatchToken = AppDispatcher.register((payload) => {
         break;
     case ActionTypes.RECEIVED_TEAM_STATS:
         TeamStore.saveStats(action.team_id, action.stats);
-        break;
-    case ActionTypes.CLICK_CHANNEL:
-        if (action.channelMember) {
-            TeamStore.updateUnreadCount(action.team_id, action.total_msg_count, action.channelMember);
-        }
         break;
     case ActionTypes.RECEIVED_POST:
         if (action.post.type === PostTypes.JOIN_LEAVE || action.post.type === PostTypes.JOIN_CHANNEL || action.post.type === PostTypes.LEAVE_CHANNEL) {


### PR DESCRIPTION
#### Summary
The CPU profiler was showing that sorting all the channels was taking a bunch of time so I updated it to only sort if the channels actually changed (temp fix until sidebar and the sorting logic moves into redux).

Also fixed the -1 mention issue, sidebar flicker and ignoring of channel prefs when team switching.