### PR TITLE
PLT-2780 Add RedirectTo after login for Universal linking or deep linking to work

### DIFF
--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -213,7 +213,7 @@ export default class LoginController extends React.Component {
     finishSignin(team) {
         const query = this.props.location.query;
         GlobalActions.loadCurrentLocale();
-        if (query.redirect_to) {
+        if (query.redirect_to && query.redirect_to.match(/^\//)) {
             browserHistory.push(query.redirect_to);
         } else if (team) {
             browserHistory.push(`/${team.name}`);

--- a/webapp/components/root.jsx
+++ b/webapp/components/root.jsx
@@ -96,7 +96,7 @@ export default class Root extends React.Component {
             } else if (UserStore.getCurrentUser()) {
                 GlobalActions.redirectUserToDefaultTeam();
             } else {
-                browserHistory.push('/login');
+                browserHistory.push('/login' + window.location.search);
             }
         }
     }

--- a/webapp/routes/route_team.jsx
+++ b/webapp/routes/route_team.jsx
@@ -94,7 +94,7 @@ function preNeedsTeam(nextState, replace, callback) {
     const team = TeamStore.getByName(teamName);
 
     if (!team) {
-        browserHistory.push('/');
+        browserHistory.push('/?redirect_to=' + encodeURIComponent(nextState.location.pathname));
         return;
     }
 


### PR DESCRIPTION
#### Summary
When the user comes with a link to a specific channel but is not logged in the original destination url is lost. This changes add the ability to have a redirect_to parameter for after successful login.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-2780

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
