### PR TITLE
[PLT-6363-2] Create CommentIcon component and add IDs for reply arrows at center and RHS

### DIFF
--- a/webapp/components/common/comment_icon.jsx
+++ b/webapp/components/common/comment_icon.jsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import Constants from 'utils/constants.jsx';
+import * as Utils from 'utils/utils.jsx';
+
+export default function CommentIcon(props) {
+    let commentCountSpan = '';
+    let iconStyle = 'comment-icon__container';
+    if (props.commentCount > 0) {
+        iconStyle += ' icon--show';
+        commentCountSpan = (
+            <span className='comment-count'>
+                {props.commentCount}
+            </span>
+        );
+    } else if (props.searchStyle !== '') {
+        iconStyle = iconStyle + ' ' + props.searchStyle;
+    }
+
+    let commentIconId = props.idPrefix;
+    if (props.idCount > -1) {
+        commentIconId += props.idCount;
+    }
+
+    return (
+        <a
+            id={Utils.createSafeId(commentIconId)}
+            href='#'
+            className={iconStyle}
+            onClick={props.handleCommentClick}
+        >
+            <span
+                className='comment-icon'
+                dangerouslySetInnerHTML={{__html: Constants.REPLY_ICON}}
+            />
+            {commentCountSpan}
+        </a>
+    );
+}
+
+CommentIcon.propTypes = {
+    idPrefix: React.PropTypes.string.isRequired,
+    idCount: React.PropTypes.number,
+    handleCommentClick: React.PropTypes.func.isRequired,
+    searchStyle: React.PropTypes.string,
+    commentCount: React.PropTypes.number
+};
+
+CommentIcon.defaultProps = {
+    idCount: -1,
+    searchStyle: '',
+    commentCount: 0
+};

--- a/webapp/components/post_view/components/post_info.jsx
+++ b/webapp/components/post_view/components/post_info.jsx
@@ -9,6 +9,7 @@ import PostFlagIcon from 'components/common/post_flag_icon.jsx';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import * as PostActions from 'actions/post_actions.jsx';
+import CommentIcon from 'components/common/comment_icon.jsx';
 
 import * as Utils from 'utils/utils.jsx';
 import * as PostUtils from 'utils/post_utils.jsx';
@@ -342,30 +343,13 @@ export default class PostInfo extends React.Component {
         let comments = null;
         let react = null;
         if (!isEphemeral && !isPending && !isSystemMessage) {
-            let showCommentClass;
-            let commentCountText;
-            if (this.props.commentCount >= 1) {
-                showCommentClass = ' icon--show';
-                commentCountText = this.props.commentCount;
-            } else {
-                showCommentClass = '';
-                commentCountText = '';
-            }
-
             comments = (
-                <a
-                    href='#'
-                    className={'comment-icon__container' + showCommentClass}
-                    onClick={this.props.handleCommentClick}
-                >
-                    <span
-                        className='comment-icon'
-                        dangerouslySetInnerHTML={{__html: Constants.REPLY_ICON}}
-                    />
-                    <span className='comment-count'>
-                        {commentCountText}
-                    </span>
-                </a>
+                <CommentIcon
+                    idPrefix={'commentIcon'}
+                    idCount={idCount}
+                    handleCommentClick={this.props.handleCommentClick}
+                    commentCount={this.props.commentCount}
+                />
             );
 
             if (Utils.isFeatureEnabled(Constants.PRE_RELEASE_FEATURES.EMOJI_PICKER_PREVIEW)) {

--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -6,6 +6,7 @@ import PostMessageContainer from 'components/post_view/components/post_message_c
 import UserProfile from './user_profile.jsx';
 import FileAttachmentListContainer from './file_attachment_list_container.jsx';
 import ProfilePicture from './profile_picture.jsx';
+import CommentIcon from 'components/common/comment_icon.jsx';
 
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
@@ -200,16 +201,12 @@ export default class SearchResultsItem extends React.Component {
 
             rhsControls = (
                 <li className='col__controls'>
-                    <a
-                        href='#'
-                        className='comment-icon__container search-item__comment'
-                        onClick={this.handleFocusRHSClick}
-                    >
-                        <span
-                            className='comment-icon'
-                            dangerouslySetInnerHTML={{__html: Constants.REPLY_ICON}}
-                        />
-                    </a>
+                    <CommentIcon
+                        idPrefix={'searchCommentIcon'}
+                        idCount={idCount}
+                        handleCommentClick={this.handleFocusRHSClick}
+                        searchStyle={'search-item__comment'}
+                    />
                     <a
                         onClick={
                             () => {


### PR DESCRIPTION
#### Summary
Create `CommentIcon` component and add IDs to reply arrows at center and RHS. Dynamic IDs are applied to last 10 comment icons.

This PR is for Selenium UI automation testing. Included are:
 - add comment icon IDs to comment icons at center: e.g. `commentIcon`, `commentIcon0`, etc.
 - add comment icon IDs to comment icons at RHS: e.g. `searchCommentIcon`, `searchCommentIcon0`, etc.
 - refactor comment icon, create `CommentIcon` component and move to separate folder

Note: This PR is on top of other PRs ([6257][6257] & [6271][6271]) since this depends on some shared code but is submitted on separate PR for ease of review (hopefully). I'll just rebase once those are accepted.

#### Ticket Link
Jira ticket: [PLT-6363][6363]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All new/modified APIs include changes to the drivers

[6363]: https://mattermost.atlassian.net/browse/PLT-6363
[6257]: https://github.com/mattermost/platform/pull/6257
[6271]: https://github.com/mattermost/platform/pull/6271
