### PR TITLE
PLT-6487 Drag and drop on left hand sidebar leads the picture in the browser

### DIFF
--- a/webapp/root.jsx
+++ b/webapp/root.jsx
@@ -106,6 +106,17 @@ function preRenderSetup(callwhendone) {
     } else {
         I18n.safariFix(afterIntl);
     }
+
+    // Prevent drag and drop files from navigating away from the app
+    document.addEventListener('drop', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+    });
+
+    document.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+    });
 }
 
 function renderRootComponent() {


### PR DESCRIPTION
#### Summary
Currently when a user drags and drops a file in the left hand sidebar the file opens in the browser leading the user away from MM. The fix avoids this behavior:
![plt-6487_dragdroponlefthandsidebardisplaysinbrowser](https://cloud.githubusercontent.com/assets/160621/25667447/1b82bc3a-2fe9-11e7-8430-a14723d2f29e.gif)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6487

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
