### PR TITLE
PLT-6431 Prevented autocompleting while suggestions are being received

### DIFF
--- a/webapp/components/suggestion/at_mention_provider.jsx
+++ b/webapp/components/suggestion/at_mention_provider.jsx
@@ -113,7 +113,7 @@ export default class AtMentionProvider extends Provider {
 
         const prefix = captured[1];
 
-        this.startNewRequest(prefix);
+        this.startNewRequest(suggestionId, prefix);
 
         autocompleteUsersInChannel(
             prefix,

--- a/webapp/components/suggestion/channel_mention_provider.jsx
+++ b/webapp/components/suggestion/channel_mention_provider.jsx
@@ -75,7 +75,7 @@ export default class ChannelMentionProvider extends Provider {
 
         const prefix = captured[3];
 
-        this.startNewRequest(prefix);
+        this.startNewRequest(suggestionId, prefix);
 
         autocompleteChannels(
             prefix,

--- a/webapp/components/suggestion/provider.jsx
+++ b/webapp/components/suggestion/provider.jsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import SuggestionStore from 'stores/suggestion_store.jsx';
+
 export default class Provider {
     constructor() {
         this.latestPrefix = '';
@@ -11,9 +13,12 @@ export default class Provider {
         // NO-OP for inherited classes to override
     }
 
-    startNewRequest(prefix) {
+    startNewRequest(suggestionId, prefix) {
         this.latestPrefix = prefix;
         this.latestComplete = false;
+
+        // Don't use the dispatcher here since this is only called while handling an event
+        SuggestionStore.setSuggestionsPending(suggestionId, true);
     }
 
     shouldCancelDispatch(prefix) {

--- a/webapp/components/suggestion/search_channel_provider.jsx
+++ b/webapp/components/suggestion/search_channel_provider.jsx
@@ -40,7 +40,7 @@ export default class SearchChannelProvider extends Provider {
         if (captured) {
             const channelPrefix = captured[1];
 
-            this.startNewRequest(channelPrefix);
+            this.startNewRequest(suggestionId, channelPrefix);
 
             autocompleteChannels(
                 channelPrefix,

--- a/webapp/components/suggestion/search_user_provider.jsx
+++ b/webapp/components/suggestion/search_user_provider.jsx
@@ -63,7 +63,7 @@ export default class SearchUserProvider extends Provider {
         if (captured) {
             const usernamePrefix = captured[1];
 
-            this.startNewRequest(usernamePrefix);
+            this.startNewRequest(suggestionId, usernamePrefix);
 
             autocompleteUsersInTeam(
                 usernamePrefix,

--- a/webapp/components/suggestion/switch_channel_provider.jsx
+++ b/webapp/components/suggestion/switch_channel_provider.jsx
@@ -60,7 +60,7 @@ class SwitchChannelSuggestion extends Suggestion {
 export default class SwitchChannelProvider extends Provider {
     handlePretextChanged(suggestionId, channelPrefix) {
         if (channelPrefix) {
-            this.startNewRequest(channelPrefix);
+            this.startNewRequest(suggestionId, channelPrefix);
 
             const allChannels = ChannelStore.getAll();
             const channels = [];


### PR DESCRIPTION
Letting the user autocomplete an at mention while they're still being received results in some strange behaviour (like when typing `@abc` quickly and pressing enter, it may autocomplete for `@aaa`). I've changed it so that pressing enter to complete a word will be buffered to wait until all autocomplete results have been received. It will then pick the first item that matches the entire search term.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6431

#### Checklist
- Has UI changes