### PR TITLE
[PLT-5465/APIV4] GET /system/health - Improve ping health check to have limits

### DIFF
--- a/api4/system.go
+++ b/api4/system.go
@@ -36,10 +36,6 @@ func InitSystem() {
 }
 
 func getSystemPing(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
-		return
-	}
 
 	actualGoroutines := runtime.NumGoroutine()
 	if *utils.Cfg.ServiceSettings.GoroutineHealthThreshold <= 0 || actualGoroutines <= *utils.Cfg.ServiceSettings.GoroutineHealthThreshold {
@@ -47,7 +43,9 @@ func getSystemPing(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		rdata := map[string]string{}
 		rdata["status"] = "unhealthy"
+
 		l4g.Warn(utils.T("api.system.go_routines"), actualGoroutines, *utils.Cfg.ServiceSettings.GoroutineHealthThreshold)
+
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(model.MapToJson(rdata)))
 	}

--- a/api4/system.go
+++ b/api4/system.go
@@ -18,7 +18,6 @@ func InitSystem() {
 	l4g.Debug(utils.T("api.system.init.debug"))
 
 	BaseRoutes.System.Handle("/ping", ApiHandler(getSystemPing)).Methods("GET")
-	BaseRoutes.System.Handle("/health", ApiSessionRequired(healthCheck)).Methods("GET")
 
 	BaseRoutes.ApiRoot.Handle("/config", ApiSessionRequired(getConfig)).Methods("GET")
 	BaseRoutes.ApiRoot.Handle("/config", ApiSessionRequired(updateConfig)).Methods("PUT")
@@ -37,7 +36,21 @@ func InitSystem() {
 }
 
 func getSystemPing(c *Context, w http.ResponseWriter, r *http.Request) {
-	ReturnStatusOK(w)
+	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	actualGoroutines := runtime.NumGoroutine()
+	if *utils.Cfg.ServiceSettings.GoroutineHealthThreshold <= 0 || actualGoroutines <= *utils.Cfg.ServiceSettings.GoroutineHealthThreshold {
+		ReturnStatusOK(w)
+	} else {
+		rdata := map[string]string{}
+		rdata["status"] = "unhealthy"
+		l4g.Warn(utils.T("api.system.go_routines"), actualGoroutines, *utils.Cfg.ServiceSettings.GoroutineHealthThreshold)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(model.MapToJson(rdata)))
+	}
 }
 
 func testEmail(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -244,21 +257,4 @@ func getClientLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 	w.Write([]byte(model.MapToJson(clientLicense)))
-}
-
-func healthCheck(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
-		return
-	}
-
-	actualGoroutines := runtime.NumGoroutine()
-	if *utils.Cfg.ServiceSettings.GoroutineHealthThreshold <= 0 || actualGoroutines <= *utils.Cfg.ServiceSettings.GoroutineHealthThreshold {
-		ReturnStatusOK(w)
-	} else {
-		rdata := map[string]string{}
-		rdata["status"] = "unhealthy"
-		l4g.Warn(utils.T("api.system.go_routines"), actualGoroutines, *utils.Cfg.ServiceSettings.GoroutineHealthThreshold)
-		w.Write([]byte(model.MapToJson(rdata)))
-	}
 }

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -21,10 +21,7 @@ func TestGetPing(t *testing.T) {
 		*utils.Cfg.ServiceSettings.GoroutineHealthThreshold = goRoutineHealthThreshold
 	}()
 
-	_, resp := Client.GetPing()
-	CheckForbiddenStatus(t, resp)
-
-	status, resp := th.SystemAdminClient.GetPing()
+	status, resp := Client.GetPing()
 	CheckNoError(t, resp)
 	if status != "OK" {
 		t.Fatal("should return OK")

--- a/config/config.json
+++ b/config/config.json
@@ -12,6 +12,7 @@
         "ReadTimeout": 300,
         "WriteTimeout": 300,
         "MaximumLoginAttempts": 10,
+        "GoroutineHealthThreshold": -1,
         "GoogleDeveloperKey": "",
         "EnableOAuthServiceProvider": false,
         "EnableIncomingWebhooks": true,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6237,6 +6237,6 @@
   },
   {
     "id": "api.system.go_routines",
-    "translation": "The number of running goroutine is over the health threshold %v of %v"
+    "translation": "The number of running goroutines is over the health threshold %v of %v"
   }
 ]

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6234,5 +6234,9 @@
   {
     "id": "wsapi.webrtc.init.debug",
     "translation": "Initializing webrtc WebSocket API routes"
+  },
+  {
+    "id": "api.system.go_routines",
+    "translation": "The number of running goroutine is over the health threshold %v of %v"
   }
 ]

--- a/model/client4.go
+++ b/model/client4.go
@@ -1739,19 +1739,12 @@ func (c *Client4) GetFileInfosForPost(postId string, etag string) ([]*FileInfo, 
 
 // General/System Section
 
-// GetPing will ping the server and to see if it is up and running.
-func (c *Client4) GetPing() (bool, *Response) {
-	if r, err := c.DoApiGet(c.GetSystemRoute()+"/ping", ""); err != nil {
-		return false, &Response{StatusCode: r.StatusCode, Error: err}
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
-	}
-}
-
-// HealthCheck will return ok if the running goRoutines are below the threshold and unhealthy for above.
-func (c *Client4) HealthCheck() (string, *Response) {
-	if r, err := c.DoApiGet(c.GetSystemRoute()+"/health", ""); err != nil {
+// GetPing will return ok if the running goRoutines are below the threshold and unhealthy for above.
+func (c *Client4) GetPing() (string, *Response) {
+	if r, err := c.DoApiGet(c.GetSystemRoute()+"/ping", ""); r.StatusCode == 500 {
+		defer r.Body.Close()
+		return "unhealthy", &Response{StatusCode: r.StatusCode, Error: err}
+	} else if err != nil {
 		return "", &Response{StatusCode: r.StatusCode, Error: err}
 	} else {
 		defer closeBody(r)

--- a/model/client4.go
+++ b/model/client4.go
@@ -1737,7 +1737,7 @@ func (c *Client4) GetFileInfosForPost(postId string, etag string) ([]*FileInfo, 
 	}
 }
 
-// General Section
+// General/System Section
 
 // GetPing will ping the server and to see if it is up and running.
 func (c *Client4) GetPing() (bool, *Response) {
@@ -1746,6 +1746,16 @@ func (c *Client4) GetPing() (bool, *Response) {
 	} else {
 		defer closeBody(r)
 		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
+// HealthCheck will return ok if the running goRoutines are below the threshold and unhealthy for above.
+func (c *Client4) HealthCheck() (string, *Response) {
+	if r, err := c.DoApiGet(c.GetSystemRoute()+"/health", ""); err != nil {
+		return "", &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return MapFromJson(r.Body)["status"], BuildResponse(r)
 	}
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -126,6 +126,7 @@ type ServiceSettings struct {
 	ReadTimeout                              *int
 	WriteTimeout                             *int
 	MaximumLoginAttempts                     int
+	GoroutineHealthThreshold                 *int
 	GoogleDeveloperKey                       string
 	EnableOAuthServiceProvider               bool
 	EnableIncomingWebhooks                   bool
@@ -1162,6 +1163,11 @@ func (o *Config) SetDefaults() {
 	if o.RateLimitSettings.Enable == nil {
 		o.RateLimitSettings.Enable = new(bool)
 		*o.RateLimitSettings.Enable = false
+	}
+
+	if o.ServiceSettings.GoroutineHealthThreshold == nil {
+		o.ServiceSettings.GoroutineHealthThreshold = new(int)
+		*o.ServiceSettings.GoroutineHealthThreshold = -1
 	}
 
 	if o.RateLimitSettings.MaxBurst == nil {


### PR DESCRIPTION
#### Summary
[PLT-5465/APIV4] GET /system/health - Improve ping health check to have limits
returns OK if the running Goroutines is not over the defined settings otherwise return unhealthy

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/PLT-5465
GitHub: https://github.com/mattermost/platform/issues/6300

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs) PR: https://github.com/mattermost/mattermost-api-reference/pull/234
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
