### PR TITLE
[PLT-6270] Deleting a post that is open in the RHS causes a JS error

### DIFF
--- a/webapp/components/rhs_thread.jsx
+++ b/webapp/components/rhs_thread.jsx
@@ -321,17 +321,15 @@ export default class RhsThread extends React.Component {
     }
 
     render() {
-        const postsArray = this.state.postsArray;
-        const selected = this.state.selected;
-        const profiles = this.state.profiles || {};
-        const rootPostDay = Utils.getDateForUnixTicks(selected.create_at);
-        let previousPostDay = rootPostDay;
-
-        if (postsArray == null || selected == null) {
+        if (this.state.postsArray == null || this.state.selected == null) {
             return (
                 <div/>
             );
         }
+
+        const postsArray = this.state.postsArray;
+        const selected = this.state.selected;
+        const profiles = this.state.profiles || {};
 
         let profile;
         if (UserStore.getCurrentId() === selected.user_id) {
@@ -349,6 +347,9 @@ export default class RhsThread extends React.Component {
         if (this.state.statuses) {
             rootStatus = this.state.statuses[selected.user_id] || 'offline';
         }
+
+        const rootPostDay = Utils.getDateForUnixTicks(selected.create_at);
+        let previousPostDay = rootPostDay;
 
         const commentsLists = [];
         for (let i = 0; i < postsArray.length; i++) {


### PR DESCRIPTION
#### Summary
Fix JS error when deleting RHS root by having null check first on `this.state.postsArray ` and `this.state.selected`. Return empty `div` if any of those is null.

#### Ticket Link
Jira ticket : [6270][6270]
Github issue: #6228 

#### Checklist
- [x] Has UI changes

[6270]: https://mattermost.atlassian.net/browse/PLT-6270