### PR TITLE
[PLT-6343] JavaScript errors after pinning a post to a channel with an empty pinned post list open in RHS

### DIFF
--- a/webapp/stores/search_store.jsx
+++ b/webapp/stores/search_store.jsx
@@ -122,7 +122,7 @@ class SearchStoreClass extends EventEmitter {
 
     togglePinPost(postId, isPinned) {
         const results = this.getSearchResults();
-        if (results == null) {
+        if (results == null || results.posts == null) {
             return;
         }
 


### PR DESCRIPTION
#### Summary
Fix JS error after pinning a post with an empty pinned post list open in RHS

#### Ticket Link
Jira ticket: [PLT-6343][6343]
GitHub issue: #6145 

#### Checklist
- [x] JS error

[6343]: https://mattermost.atlassian.net/browse/PLT-6343
