### PR TITLE
PLT-6346 - Show tooltips for channel name

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -554,6 +554,8 @@ export default class Sidebar extends React.Component {
             rowClass += ' has-badge';
         }
 
+        let displayName = channel.display_name;
+
         var icon = null;
         toolTip = channel.header;
         if (channel.type === Constants.OPEN_CHANNEL) {
@@ -564,6 +566,7 @@ export default class Sidebar extends React.Component {
             displayName = ChannelUtils.buildGroupChannelName(channel.id);
             icon = <div className='status status--group'>{UserStore.getProfileListInChannel(channel.id, true).length}</div>;
         } else {
+            toolTip = channel.display_name;
             // set up status icon for direct message channels (status is null for other channel types)
             icon = (
                 <StatusIcon
@@ -613,7 +616,6 @@ export default class Sidebar extends React.Component {
             link = '/' + this.state.currentTeam.name + '/channels/' + channel.name;
         }
 
-        let toolTip = channel.header
         return (
             <li
                 key={channel.name}
@@ -625,7 +627,6 @@ export default class Sidebar extends React.Component {
                     className={rowClass}
                     title={toolTip}
                     onClick={this.trackChannelSelectedEvent}
-                    title={toolTip}
                 >
                     {icon}
                     {displayName}

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -509,6 +509,7 @@ export default class Sidebar extends React.Component {
         const channelMember = members[channel.id];
         const unreadCount = this.state.unreadCounts[channel.id] || {msgs: 0, mentions: 0};
         let msgCount;
+        let toolTip;
 
         let linkClass = '';
         if (channel.id === activeId) {
@@ -553,9 +554,8 @@ export default class Sidebar extends React.Component {
             rowClass += ' has-badge';
         }
 
-        let displayName = channel.display_name;
-
         var icon = null;
+        toolTip = channel.header;
         if (channel.type === Constants.OPEN_CHANNEL) {
             icon = <div className='status'><i className='fa fa-globe'/></div>;
         } else if (channel.type === Constants.PRIVATE_CHANNEL) {
@@ -613,7 +613,6 @@ export default class Sidebar extends React.Component {
             link = '/' + this.state.currentTeam.name + '/channels/' + channel.name;
         }
 
-        const toolTip = channel.header
         return (
             <li
                 key={channel.name}

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -613,6 +613,7 @@ export default class Sidebar extends React.Component {
             link = '/' + this.state.currentTeam.name + '/channels/' + channel.name;
         }
 
+        let toolTip = channel.header
         return (
             <li
                 key={channel.name}
@@ -623,6 +624,7 @@ export default class Sidebar extends React.Component {
                     to={link}
                     className={rowClass}
                     onClick={this.trackChannelSelectedEvent}
+                    title={toolTip}
                 >
                     {icon}
                     {displayName}

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -613,7 +613,7 @@ export default class Sidebar extends React.Component {
             link = '/' + this.state.currentTeam.name + '/channels/' + channel.name;
         }
 
-        let toolTip = channel.header
+        const toolTip = channel.header
         return (
             <li
                 key={channel.name}


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Shows tooltips when mouse is hovered against channel name in sidebar.
The tooltip contains the channel header.

#### Ticket Link
https://github.com/prateeksriv/platform/tree/PLT-6346

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
