### PR TITLE
PLT-6486 Add an `@username` button to the profile popover, that puts the username in the post when clicked

### DIFF
--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -578,9 +578,10 @@ export function postListScrollChange(forceScrollToBottom = false) {
     });
 }
 
-export function emitPopoverMentionKeyClick(mentionKey) {
+export function emitPopoverMentionKeyClick(isRHS, mentionKey) {
     AppDispatcher.handleViewAction({
         type: ActionTypes.POPOVER_MENTION_KEY_CLICK,
+        isRHS,
         mentionKey
     });
 }

--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -577,3 +577,10 @@ export function postListScrollChange(forceScrollToBottom = false) {
         value: forceScrollToBottom
     });
 }
+
+export function emitPopoverMentionKeyClick(mentionKey) {
+    AppDispatcher.handleViewAction({
+        type: ActionTypes.POPOVER_MENTION_KEY_CLICK,
+        mentionKey
+    });
+}

--- a/webapp/components/at_mention/at_mention.jsx
+++ b/webapp/components/at_mention/at_mention.jsx
@@ -11,8 +11,15 @@ import {OverlayTrigger} from 'react-bootstrap';
 export default class AtMention extends React.PureComponent {
     static propTypes = {
         mentionName: PropTypes.string.isRequired,
-        usersByUsername: PropTypes.object.isRequired
+        usersByUsername: PropTypes.object.isRequired,
+        isRHS: PropTypes.bool,
+        hasMention: PropTypes.bool
     };
+
+    static defaultProps = {
+        isRHS: false,
+        hasMention: false
+    }
 
     constructor(props) {
         super(props);
@@ -76,6 +83,8 @@ export default class AtMention extends React.PureComponent {
                             user={user}
                             src={Client4.getProfilePictureUrl(user.id, user.last_picture_update)}
                             hide={this.hideProfilePopover}
+                            isRHS={this.props.isRHS}
+                            hasMention={this.props.hasMention}
                         />
                     }
                 >

--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -617,6 +617,8 @@ export default class CreateComment extends React.Component {
                                 emojiEnabled={window.mm_config.EnableEmojiPicker === 'true'}
                                 initialText=''
                                 channelId={this.props.channelId}
+                                isRHS={true}
+                                popoverMentionKeyClick={true}
                                 id='reply_textbox'
                                 ref='textbox'
                             />

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -774,6 +774,7 @@ export default class CreatePost extends React.Component {
                                 emojiEnabled={window.mm_config.EnableEmojiPicker === 'true'}
                                 createMessage={Utils.localizeMessage('create_post.write', 'Write a message...')}
                                 channelId={this.state.channelId}
+                                popoverMentionKeyClick={true}
                                 id='post_textbox'
                                 ref='textbox'
                             />

--- a/webapp/components/post_view/post/post.jsx
+++ b/webapp/components/post_view/post/post.jsx
@@ -210,6 +210,7 @@ export default class Post extends React.PureComponent {
                 status={status}
                 user={this.props.user}
                 isBusy={this.props.isBusy}
+                hasMention={true}
             />
         );
 

--- a/webapp/components/post_view/post_body/post_body.jsx
+++ b/webapp/components/post_view/post_body/post_body.jsx
@@ -163,6 +163,7 @@ export default class PostBody extends React.PureComponent {
                     lastPostCount={this.props.lastPostCount}
                     post={this.props.post}
                     compactDisplay={this.props.compactDisplay}
+                    hasMention={true}
                 />
             </div>
         );

--- a/webapp/components/post_view/post_header/post_header.jsx
+++ b/webapp/components/post_view/post_header/post_header.jsx
@@ -91,6 +91,7 @@ export default class PostHeader extends React.PureComponent {
                 displayNameType={this.props.displayNameType}
                 status={this.props.status}
                 isBusy={this.props.isBusy}
+                hasMention={true}
             />
         );
         let botIndicator;

--- a/webapp/components/post_view/post_message_view/post_message_view.jsx
+++ b/webapp/components/post_view/post_message_view/post_message_view.jsx
@@ -66,12 +66,24 @@ export default class PostMessageView extends React.PureComponent {
         /**
          * Set to render post body compactly
          */
-        compactDisplay: PropTypes.bool
+        compactDisplay: PropTypes.bool,
+
+        /**
+         * Flags if the post_message_view is for the RHS (Reply).
+         */
+        isRHS: PropTypes.bool,
+
+        /**
+         * Flags if the post_message_view is for the RHS (Reply).
+         */
+        hasMention: PropTypes.bool
     };
 
     static defaultProps = {
         options: {},
-        mentionKeys: []
+        mentionKeys: [],
+        isRHS: false,
+        hasMention: false
     };
 
     renderDeletedPost() {
@@ -116,7 +128,13 @@ export default class PostMessageView extends React.PureComponent {
                 processNode: (node) => {
                     const mentionName = node.attribs[attrib];
 
-                    return <AtMention mentionName={mentionName}/>;
+                    return (
+                        <AtMention
+                            mentionName={mentionName}
+                            isRHS={this.props.isRHS}
+                            hasMention={this.props.hasMention}
+                        />
+                    );
                 }
             },
             {

--- a/webapp/components/profile_picture.jsx
+++ b/webapp/components/profile_picture.jsx
@@ -62,6 +62,7 @@ export default class ProfilePicture extends React.Component {
                             status={this.props.status}
                             isBusy={this.props.isBusy}
                             hide={this.hideProfilePopover}
+                            isRHS={this.props.isRHS}
                         />
                 }
                 >
@@ -93,7 +94,8 @@ export default class ProfilePicture extends React.Component {
 
 ProfilePicture.defaultProps = {
     width: '36',
-    height: '36'
+    height: '36',
+    isRHS: false
 };
 ProfilePicture.propTypes = {
     src: PropTypes.string.isRequired,
@@ -101,5 +103,6 @@ ProfilePicture.propTypes = {
     width: PropTypes.string,
     height: PropTypes.string,
     user: PropTypes.object,
-    isBusy: PropTypes.bool
+    isBusy: PropTypes.bool,
+    isRHS: PropTypes.bool
 };

--- a/webapp/components/profile_picture.jsx
+++ b/webapp/components/profile_picture.jsx
@@ -63,6 +63,7 @@ export default class ProfilePicture extends React.Component {
                             isBusy={this.props.isBusy}
                             hide={this.hideProfilePopover}
                             isRHS={this.props.isRHS}
+                            hasMention={this.props.hasMention}
                         />
                 }
                 >
@@ -95,7 +96,8 @@ export default class ProfilePicture extends React.Component {
 ProfilePicture.defaultProps = {
     width: '36',
     height: '36',
-    isRHS: false
+    isRHS: false,
+    hasMention: false
 };
 ProfilePicture.propTypes = {
     src: PropTypes.string.isRequired,
@@ -104,5 +106,6 @@ ProfilePicture.propTypes = {
     height: PropTypes.string,
     user: PropTypes.object,
     isBusy: PropTypes.bool,
-    isRHS: PropTypes.bool
+    isRHS: PropTypes.bool,
+    hasMention: PropTypes.bool
 };

--- a/webapp/components/profile_popover.jsx
+++ b/webapp/components/profile_popover.jsx
@@ -24,6 +24,7 @@ export default class ProfilePopover extends React.Component {
 
         this.initWebrtc = this.initWebrtc.bind(this);
         this.handleShowDirectChannel = this.handleShowDirectChannel.bind(this);
+        this.handleUsernameButtonClick = this.handleUsernameButtonClick.bind(this);
         this.state = {
             currentUserId: UserStore.getCurrentId(),
             loadingDMChannel: -1
@@ -101,6 +102,18 @@ export default class ProfilePopover extends React.Component {
             GlobalActions.emitCloseRightHandSide();
             WebrtcActions.initWebrtc(this.props.user.id, true);
         }
+    }
+
+    handleUsernameButtonClick(e) {
+        e.preventDefault();
+
+        if (!this.props.user) {
+            return;
+        }
+        if (this.props.hide) {
+            this.props.hide();
+        }
+        GlobalActions.emitPopoverMentionKeyClick(this.props.user.username);
     }
 
     render() {
@@ -250,7 +263,11 @@ export default class ProfilePopover extends React.Component {
         return (
             <Popover
                 {...popoverProps}
-                title={'@' + this.props.user.username}
+                title={(
+                    <a onClick={this.handleUsernameButtonClick}>
+                        {`@${this.props.user.username}`}
+                    </a>
+                )}
                 id='user-profile-popover'
             >
                 {dataContent}

--- a/webapp/components/profile_popover.jsx
+++ b/webapp/components/profile_popover.jsx
@@ -24,7 +24,7 @@ export default class ProfilePopover extends React.Component {
 
         this.initWebrtc = this.initWebrtc.bind(this);
         this.handleShowDirectChannel = this.handleShowDirectChannel.bind(this);
-        this.handleUsernameButtonClick = this.handleUsernameButtonClick.bind(this);
+        this.handleMentionKeyClick = this.handleMentionKeyClick.bind(this);
         this.state = {
             currentUserId: UserStore.getCurrentId(),
             loadingDMChannel: -1
@@ -104,7 +104,7 @@ export default class ProfilePopover extends React.Component {
         }
     }
 
-    handleUsernameButtonClick(e) {
+    handleMentionKeyClick(e) {
         e.preventDefault();
 
         if (!this.props.user) {
@@ -113,7 +113,7 @@ export default class ProfilePopover extends React.Component {
         if (this.props.hide) {
             this.props.hide();
         }
-        GlobalActions.emitPopoverMentionKeyClick(this.props.user.username);
+        GlobalActions.emitPopoverMentionKeyClick(this.props.isRHS, this.props.user.username);
     }
 
     render() {
@@ -123,6 +123,7 @@ export default class ProfilePopover extends React.Component {
         delete popoverProps.status;
         delete popoverProps.isBusy;
         delete popoverProps.hide;
+        delete popoverProps.isRHS;
 
         let webrtc;
         const userMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
@@ -264,7 +265,7 @@ export default class ProfilePopover extends React.Component {
             <Popover
                 {...popoverProps}
                 title={(
-                    <a onClick={this.handleUsernameButtonClick}>
+                    <a onClick={this.handleMentionKeyClick}>
                         {`@${this.props.user.username}`}
                     </a>
                 )}
@@ -281,6 +282,7 @@ ProfilePopover.propTypes = Object.assign({
     user: PropTypes.object.isRequired,
     status: PropTypes.string,
     isBusy: PropTypes.bool,
-    hide: PropTypes.func
+    hide: PropTypes.func,
+    isRHS: PropTypes.bool
 }, Popover.propTypes);
 delete ProfilePopover.propTypes.id;

--- a/webapp/components/profile_popover.jsx
+++ b/webapp/components/profile_popover.jsx
@@ -124,6 +124,7 @@ export default class ProfilePopover extends React.Component {
         delete popoverProps.isBusy;
         delete popoverProps.hide;
         delete popoverProps.isRHS;
+        delete popoverProps.hasMention;
 
         let webrtc;
         const userMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
@@ -193,6 +194,7 @@ export default class ProfilePopover extends React.Component {
                     delayShow={Constants.WEBRTC_TIME_DELAY}
                     placement='top'
                     overlay={<Tooltip id='fullNameTooltip'>{fullname}</Tooltip>}
+                    key='user-popover-fullname'
                 >
                     <div
                         className='overflow--ellipsis text-nowrap padding-bottom'
@@ -261,14 +263,15 @@ export default class ProfilePopover extends React.Component {
             dataContent.push(webrtc);
         }
 
+        let title = `@${this.props.user.username}`;
+        if (this.props.hasMention) {
+            title = <a onClick={this.handleMentionKeyClick}>{title}</a>;
+        }
+
         return (
             <Popover
                 {...popoverProps}
-                title={(
-                    <a onClick={this.handleMentionKeyClick}>
-                        {`@${this.props.user.username}`}
-                    </a>
-                )}
+                title={title}
                 id='user-profile-popover'
             >
                 {dataContent}
@@ -277,12 +280,18 @@ export default class ProfilePopover extends React.Component {
     }
 }
 
+ProfilePopover.defaultProps = {
+    isRHS: false,
+    hasMention: false
+};
+
 ProfilePopover.propTypes = Object.assign({
     src: PropTypes.string.isRequired,
     user: PropTypes.object.isRequired,
     status: PropTypes.string,
     isBusy: PropTypes.bool,
     hide: PropTypes.func,
-    isRHS: PropTypes.bool
+    isRHS: PropTypes.bool,
+    hasMention: PropTypes.bool
 }, Popover.propTypes);
 delete ProfilePopover.propTypes.id;

--- a/webapp/components/rhs_comment.jsx
+++ b/webapp/components/rhs_comment.jsx
@@ -223,6 +223,7 @@ export default class RhsComment extends React.Component {
                 user={this.props.user}
                 status={status}
                 isBusy={this.props.isBusy}
+                isRHS={true}
             />
         );
 
@@ -291,6 +292,7 @@ export default class RhsComment extends React.Component {
                 height='36'
                 user={this.props.user}
                 isBusy={this.props.isBusy}
+                isRHS={true}
             />
         );
 
@@ -327,6 +329,7 @@ export default class RhsComment extends React.Component {
                         status={status}
                         user={this.props.user}
                         isBusy={this.props.isBusy}
+                        isRHS={true}
                     />
                 );
             }

--- a/webapp/components/rhs_comment.jsx
+++ b/webapp/components/rhs_comment.jsx
@@ -224,6 +224,7 @@ export default class RhsComment extends React.Component {
                 status={status}
                 isBusy={this.props.isBusy}
                 isRHS={true}
+                hasMention={true}
             />
         );
 
@@ -293,6 +294,7 @@ export default class RhsComment extends React.Component {
                 user={this.props.user}
                 isBusy={this.props.isBusy}
                 isRHS={true}
+                hasMention={true}
             />
         );
 
@@ -330,6 +332,7 @@ export default class RhsComment extends React.Component {
                         user={this.props.user}
                         isBusy={this.props.isBusy}
                         isRHS={true}
+                        hasMention={true}
                     />
                 );
             }
@@ -450,7 +453,11 @@ export default class RhsComment extends React.Component {
                         <div className='post__body' >
                             <div className={postClass}>
                                 {failedPostOptions}
-                                <PostMessageContainer post={post}/>
+                                <PostMessageContainer
+                                    post={post}
+                                    isRHS={true}
+                                    hasMention={true}
+                                />
                             </div>
                             {fileAttachment}
                             <ReactionListContainer post={post}/>

--- a/webapp/components/rhs_root_post.jsx
+++ b/webapp/components/rhs_root_post.jsx
@@ -256,6 +256,7 @@ export default class RhsRootPost extends React.Component {
                 user={user}
                 status={this.props.status}
                 isBusy={this.props.isBusy}
+                isRHS={true}
             />
         );
         let botIndicator;
@@ -308,6 +309,7 @@ export default class RhsRootPost extends React.Component {
                 height='36'
                 user={this.props.user}
                 isBusy={this.props.isBusy}
+                isRHS={true}
             />
         );
 
@@ -344,6 +346,7 @@ export default class RhsRootPost extends React.Component {
                         status={status}
                         user={this.props.user}
                         isBusy={this.props.isBusy}
+                        isRHS={true}
                     />
                 );
             }

--- a/webapp/components/rhs_root_post.jsx
+++ b/webapp/components/rhs_root_post.jsx
@@ -257,6 +257,7 @@ export default class RhsRootPost extends React.Component {
                 status={this.props.status}
                 isBusy={this.props.isBusy}
                 isRHS={true}
+                hasMention={true}
             />
         );
         let botIndicator;
@@ -310,6 +311,7 @@ export default class RhsRootPost extends React.Component {
                 user={this.props.user}
                 isBusy={this.props.isBusy}
                 isRHS={true}
+                hasMention={true}
             />
         );
 
@@ -347,6 +349,7 @@ export default class RhsRootPost extends React.Component {
                         user={this.props.user}
                         isBusy={this.props.isBusy}
                         isRHS={true}
+                        hasMention={true}
                     />
                 );
             }
@@ -420,7 +423,13 @@ export default class RhsRootPost extends React.Component {
                             <div className={postClass}>
                                 <PostBodyAdditionalContent
                                     post={post}
-                                    message={<PostMessageContainer post={post}/>}
+                                    message={
+                                        <PostMessageContainer
+                                            post={post}
+                                            isRHS={true}
+                                            hasMention={true}
+                                        />
+                                    }
                                     previewCollapsed={this.props.previewCollapsed}
                                 />
                             </div>

--- a/webapp/components/textbox.jsx
+++ b/webapp/components/textbox.jsx
@@ -37,11 +37,13 @@ export default class Textbox extends React.Component {
         handlePostError: PropTypes.func,
         suggestionListStyle: PropTypes.string,
         emojiEnabled: PropTypes.bool,
+        isRHS: PropTypes.bool,
         popoverMentionKeyClick: React.PropTypes.bool
     };
 
     static defaultProps = {
-        supportsCommands: true
+        supportsCommands: true,
+        isRHS: false
     };
 
     constructor(props) {
@@ -297,6 +299,7 @@ export default class Textbox extends React.Component {
                     channelId={this.props.channelId}
                     value={this.props.value}
                     renderDividers={true}
+                    isRHS={this.props.isRHS}
                     popoverMentionKeyClick={this.props.popoverMentionKeyClick}
                 />
                 <div

--- a/webapp/components/textbox.jsx
+++ b/webapp/components/textbox.jsx
@@ -43,7 +43,8 @@ export default class Textbox extends React.Component {
 
     static defaultProps = {
         supportsCommands: true,
-        isRHS: false
+        isRHS: false,
+        popoverMentionKeyClick: false
     };
 
     constructor(props) {

--- a/webapp/components/textbox.jsx
+++ b/webapp/components/textbox.jsx
@@ -36,7 +36,8 @@ export default class Textbox extends React.Component {
         supportsCommands: PropTypes.bool.isRequired,
         handlePostError: PropTypes.func,
         suggestionListStyle: PropTypes.string,
-        emojiEnabled: PropTypes.bool
+        emojiEnabled: PropTypes.bool,
+        popoverMentionKeyClick: React.PropTypes.bool
     };
 
     static defaultProps = {
@@ -296,6 +297,7 @@ export default class Textbox extends React.Component {
                     channelId={this.props.channelId}
                     value={this.props.value}
                     renderDividers={true}
+                    popoverMentionKeyClick={this.props.popoverMentionKeyClick}
                 />
                 <div
                     ref='preview'

--- a/webapp/components/user_profile.jsx
+++ b/webapp/components/user_profile.jsx
@@ -82,6 +82,7 @@ export default class UserProfile extends React.Component {
                         status={this.props.status}
                         isBusy={this.props.isBusy}
                         hide={this.hideProfilePopover}
+                        isRHS={this.props.isRHS}
                     />
                 }
             >
@@ -99,7 +100,8 @@ UserProfile.defaultProps = {
     user: {},
     overwriteName: '',
     overwriteImage: '',
-    disablePopover: false
+    disablePopover: false,
+    isRHS: false
 };
 UserProfile.propTypes = {
     user: PropTypes.object,
@@ -108,5 +110,6 @@ UserProfile.propTypes = {
     disablePopover: PropTypes.bool,
     displayNameType: PropTypes.string,
     status: PropTypes.string,
-    isBusy: PropTypes.bool
+    isBusy: PropTypes.bool,
+    isRHS: PropTypes.bool
 };

--- a/webapp/components/user_profile.jsx
+++ b/webapp/components/user_profile.jsx
@@ -83,6 +83,7 @@ export default class UserProfile extends React.Component {
                         isBusy={this.props.isBusy}
                         hide={this.hideProfilePopover}
                         isRHS={this.props.isRHS}
+                        hasMention={this.props.hasMention}
                     />
                 }
             >
@@ -101,7 +102,8 @@ UserProfile.defaultProps = {
     overwriteName: '',
     overwriteImage: '',
     disablePopover: false,
-    isRHS: false
+    isRHS: false,
+    hasMention: false
 };
 UserProfile.propTypes = {
     user: PropTypes.object,
@@ -111,5 +113,6 @@ UserProfile.propTypes = {
     displayNameType: PropTypes.string,
     status: PropTypes.string,
     isBusy: PropTypes.bool,
-    isRHS: PropTypes.bool
+    isRHS: PropTypes.bool,
+    hasMention: PropTypes.bool
 };

--- a/webapp/stores/search_store.jsx
+++ b/webapp/stores/search_store.jsx
@@ -122,7 +122,7 @@ class SearchStoreClass extends EventEmitter {
 
     updatePost(post) {
         const results = this.getSearchResults();
-        if (results == null) {
+        if (!post || results == null) {
             return;
         }
 

--- a/webapp/stores/suggestion_store.jsx
+++ b/webapp/stores/suggestion_store.jsx
@@ -76,14 +76,14 @@ class SuggestionStore extends EventEmitter {
         this.emit(COMPLETE_WORD_EVENT + id, term, matchedPretext);
     }
 
-    addPopoverMentionKeyClickListener(callback) {
-        this.on(POPOVER_MENTION_KEY_CLICK_EVENT, callback);
+    addPopoverMentionKeyClickListener(id, callback) {
+        this.on(POPOVER_MENTION_KEY_CLICK_EVENT + id, callback);
     }
-    removePopoverMentionKeyClickListener(callback) {
-        this.removeListener(POPOVER_MENTION_KEY_CLICK_EVENT, callback);
+    removePopoverMentionKeyClickListener(id, callback) {
+        this.removeListener(POPOVER_MENTION_KEY_CLICK_EVENT + id, callback);
     }
-    emitPopoverMentionKeyClick(mentionKey) {
-        this.emit(POPOVER_MENTION_KEY_CLICK_EVENT, mentionKey);
+    emitPopoverMentionKeyClick(isRHS, mentionKey) {
+        this.emit(POPOVER_MENTION_KEY_CLICK_EVENT + isRHS, mentionKey);
     }
 
     registerSuggestionBox(id) {
@@ -320,7 +320,7 @@ class SuggestionStore extends EventEmitter {
             }
             break;
         case ActionTypes.POPOVER_MENTION_KEY_CLICK:
-            this.emitPopoverMentionKeyClick(other.mentionKey);
+            this.emitPopoverMentionKeyClick(other.isRHS, other.mentionKey);
             break;
         }
     }

--- a/webapp/stores/suggestion_store.jsx
+++ b/webapp/stores/suggestion_store.jsx
@@ -10,6 +10,7 @@ const ActionTypes = Constants.ActionTypes;
 const COMPLETE_WORD_EVENT = 'complete_word';
 const PRETEXT_CHANGED_EVENT = 'pretext_changed';
 const SUGGESTIONS_CHANGED_EVENT = 'suggestions_changed';
+const POPOVER_MENTION_KEY_CLICK_EVENT = 'popover_mention_key_click';
 
 class SuggestionStore extends EventEmitter {
     constructor() {
@@ -26,6 +27,10 @@ class SuggestionStore extends EventEmitter {
         this.addCompleteWordListener = this.addCompleteWordListener.bind(this);
         this.removeCompleteWordListener = this.removeCompleteWordListener.bind(this);
         this.emitCompleteWord = this.emitCompleteWord.bind(this);
+
+        this.addPopoverMentionKeyClickListener = this.addPopoverMentionKeyClickListener.bind(this);
+        this.removePopoverMentionKeyClickListener = this.removePopoverMentionKeyClickListener.bind(this);
+        this.emitPopoverMentionKeyClick = this.emitPopoverMentionKeyClick.bind(this);
 
         this.handleEventPayload = this.handleEventPayload.bind(this);
         this.dispatchToken = AppDispatcher.register(this.handleEventPayload);
@@ -69,6 +74,16 @@ class SuggestionStore extends EventEmitter {
     }
     emitCompleteWord(id, term, matchedPretext) {
         this.emit(COMPLETE_WORD_EVENT + id, term, matchedPretext);
+    }
+
+    addPopoverMentionKeyClickListener(callback) {
+        this.on(POPOVER_MENTION_KEY_CLICK_EVENT, callback);
+    }
+    removePopoverMentionKeyClickListener(callback) {
+        this.removeListener(POPOVER_MENTION_KEY_CLICK_EVENT, callback);
+    }
+    emitPopoverMentionKeyClick(mentionKey) {
+        this.emit(POPOVER_MENTION_KEY_CLICK_EVENT, mentionKey);
     }
 
     registerSuggestionBox(id) {
@@ -303,6 +318,9 @@ class SuggestionStore extends EventEmitter {
             } else {
                 this.completeWord(id, other.term, other.matchedPretext);
             }
+            break;
+        case ActionTypes.POPOVER_MENTION_KEY_CLICK:
+            this.emitPopoverMentionKeyClick(other.mentionKey);
             break;
         }
     }

--- a/webapp/utils/channel_intro_messages.jsx
+++ b/webapp/utils/channel_intro_messages.jsx
@@ -114,6 +114,7 @@ export function createDMIntroMessage(channel, centeredIntro) {
                         width='50'
                         height='50'
                         user={teammate}
+                        hasMention={true}
                     />
                 </div>
                 <div className='channel-intro-profile'>
@@ -121,6 +122,7 @@ export function createDMIntroMessage(channel, centeredIntro) {
                         <UserProfile
                             user={teammate}
                             disablePopover={false}
+                            hasMention={true}
                         />
                     </strong>
                 </div>


### PR DESCRIPTION
#### Summary
Click the @username mention on the profile popover title. A mention for `@username` should be added to your post draft:
![plt-6486_add usernamebuttontoprofilepopover](https://cloud.githubusercontent.com/assets/160621/25783061/597813d4-331b-11e7-962b-800aa4e7f3a0.gif)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6485

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
