### PR TITLE
PLT-6518 Fixed user's locale not being loaded with redux actions

### DIFF
--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -402,12 +402,12 @@ export function newLocalizationSelected(locale) {
 }
 
 export function loadDefaultLocale() {
-    const defaultLocale = global.window.mm_config.DefaultClientLocale;
-    let locale = global.window.mm_user ? global.window.mm_user.locale || defaultLocale : defaultLocale;
+    let locale = global.window.mm_config.DefaultClientLocale;
 
     if (!I18n.getLanguageInfo(locale)) {
         locale = 'en';
     }
+
     return newLocalizationSelected(locale);
 }
 

--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -379,7 +379,7 @@ export function newLocalizationSelected(locale) {
             translations: en
         });
     } else {
-        const localeInfo = I18n.getLanguageInfo(locale) || I18n.getLanguageInfo(global.window.mm_config.DefaultClientLocale);
+        const localeInfo = I18n.getLanguageInfo(locale);
 
         Client.getTranslations(
             localeInfo.url,
@@ -398,6 +398,16 @@ export function newLocalizationSelected(locale) {
                 AsyncClient.dispatchError(err, 'getTranslations');
             }
         );
+    }
+}
+
+export function loadCurrentLocale() {
+    const user = UserStore.getCurrentUser();
+
+    if (user && user.locale) {
+        newLocalizationSelected(user.locale);
+    } else {
+        loadDefaultLocale();
     }
 }
 

--- a/webapp/actions/user_actions.jsx
+++ b/webapp/actions/user_actions.jsx
@@ -9,6 +9,7 @@ import UserStore from 'stores/user_store.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
 
 import {getChannelMembersForUserIds} from 'actions/channel_actions.jsx';
+import {loadCurrentLocale} from 'actions/global_actions.jsx';
 import {loadStatusesForProfilesList, loadStatusesForProfilesMap} from 'actions/status_actions.jsx';
 
 import {getDirectChannelName, getUserIdFromChannelName} from 'utils/utils.jsx';
@@ -51,6 +52,8 @@ import {getTeamMembersByIds, getMyTeamMembers} from 'mattermost-redux/actions/te
 export function loadMe(callback) {
     loadMeRedux()(dispatch, getState).then(
         () => {
+            loadCurrentLocale();
+
             if (callback) {
                 callback();
             }

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -210,7 +210,7 @@ export default class LoginController extends React.Component {
 
     finishSignin(team) {
         const query = this.props.location.query;
-        GlobalActions.loadDefaultLocale();
+        GlobalActions.loadCurrentLocale();
         if (query.redirect_to) {
             browserHistory.push(query.redirect_to);
         } else if (team) {

--- a/webapp/components/root.jsx
+++ b/webapp/components/root.jsx
@@ -20,8 +20,8 @@ export default class Root extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            locale: 'en',
-            translations: null
+            locale: LocalizationStore.getLocale(),
+            translations: LocalizationStore.getTranslations()
         };
 
         this.localizationChanged = this.localizationChanged.bind(this);
@@ -113,7 +113,7 @@ export default class Root extends React.Component {
         LocalizationStore.addChangeListener(this.localizationChanged);
 
         // Get our localizaiton
-        GlobalActions.loadDefaultLocale();
+        GlobalActions.loadCurrentLocale();
     }
 
     componentWillUnmount() {

--- a/webapp/components/user_settings/manage_languages.jsx
+++ b/webapp/components/user_settings/manage_languages.jsx
@@ -33,12 +33,10 @@ export default class ManageLanguage extends React.Component {
     changeLanguage(e) {
         e.preventDefault();
 
-        var user = this.props.user;
-        var locale = this.state.locale;
-
-        user.locale = locale;
-
-        this.submitUser(user);
+        this.submitUser({
+            ...this.props.user,
+            locale: this.state.locale
+        });
     }
     submitUser(user) {
         updateUser(user, Constants.UserUpdateEvents.LANGUAGE,

--- a/webapp/i18n/i18n.jsx
+++ b/webapp/i18n/i18n.jsx
@@ -133,14 +133,11 @@ export function getLanguages() {
 }
 
 export function getLanguageInfo(locale) {
-    if (!availableLanguages) {
-        setAvailableLanguages();
-    }
-    return availableLanguages[locale];
+    return getAllLanguages()[locale];
 }
 
 export function isLanguageAvailable(locale) {
-    return Boolean(availableLanguages[locale]);
+    return Boolean(getLanguages()[locale]);
 }
 
 export function safariFix(callback) {

--- a/webapp/stores/localization_store.jsx
+++ b/webapp/stores/localization_store.jsx
@@ -12,7 +12,7 @@ class LocalizationStoreClass extends EventEmitter {
     constructor() {
         super();
 
-        this.currentLocale = 'en';
+        this.currentLocale = '';
         this.currentTranslations = null;
     }
 


### PR DESCRIPTION
Since the redux changes went in for the UserStore, we weren't setting the UI text to match the current user's locale. I've tested every case I can come up with here (logging in, refreshing after logged in, combinations of those with different allowed languages), and it appears to work, but I'd like someone else to double check

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6518

#### Checklist
- Has UI changes
