### PR TITLE
PLT-5988: update sidebar on rename channel

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -277,8 +277,14 @@ func UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
 		return nil, result.Err
 	} else {
 		InvalidateCacheForChannel(channel)
+
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_UPDATED, channel.TeamId, "", "", nil)
+		message.Add("channel_id", channel.Id)
+
+		Publish(message)
 		return channel, nil
 	}
+
 }
 
 func PatchChannel(channel *model.Channel, patch *model.ChannelPatch, userId string) (*model.Channel, *model.AppError) {

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -15,6 +15,7 @@ const (
 	WEBSOCKET_EVENT_POST_DELETED        = "post_deleted"
 	WEBSOCKET_EVENT_CHANNEL_DELETED     = "channel_deleted"
 	WEBSOCKET_EVENT_CHANNEL_CREATED     = "channel_created"
+	WEBSOCKET_EVENT_CHANNEL_UPDATED     = "channel_updated"
 	WEBSOCKET_EVENT_DIRECT_ADDED        = "direct_added"
 	WEBSOCKET_EVENT_GROUP_ADDED         = "group_added"
 	WEBSOCKET_EVENT_NEW_USER            = "new_user"

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -181,6 +181,10 @@ function handleEvent(msg) {
         handleChannelCreatedEvent(msg);
         break;
 
+    case SocketEvents.CHANNEL_UPDATED:
+        handleChannelUpdatedEvent();
+        break;
+
     case SocketEvents.CHANNEL_DELETED:
         handleChannelDeletedEvent(msg);
         break;
@@ -353,6 +357,10 @@ function handleChannelCreatedEvent(msg) {
     if (TeamStore.getCurrentId() === teamId && !ChannelStore.getChannelById(channelId)) {
         getChannelAndMyMember(channelId)(dispatch, getState);
     }
+}
+
+function handleChannelUpdatedEvent() {
+    loadChannelsForCurrentUser();
 }
 
 function handleChannelDeletedEvent(msg) {

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -217,6 +217,7 @@ export const SocketEvents = {
     POST_EDITED: 'post_edited',
     POST_DELETED: 'post_deleted',
     CHANNEL_CREATED: 'channel_created',
+    CHANNEL_UPDATED: 'channel_updated',
     CHANNEL_DELETED: 'channel_deleted',
     CHANNEL_VIEWED: 'channel_viewed',
     DIRECT_ADDED: 'direct_added',


### PR DESCRIPTION
#### Summary
Initial commit to fix item 3 of (mattermost/platform/pull/6067) which also affects the rename channel bug.

#### Ticket Link
- mattermost/platform/issues/5834
- [PLT-5988](https://mattermost.atlassian.net/browse/PLT-5988)
- mattermost/platform/pull/6067

#### Checklist
- [x] Has UI changes
- [x] Touches critical sections of the codebase (websocket)
