### PR TITLE
PLT-6488: Reduce database queries in user bulk import.

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -286,10 +286,6 @@ func joinUserToTeam(team *model.Team, user *model.User) (bool, *model.AppError) 
 		}
 	}
 
-	if uua := <-Srv.Store.User().UpdateUpdateAt(user.Id); uua.Err != nil {
-		return false, uua.Err
-	}
-
 	return false, nil
 }
 
@@ -298,6 +294,10 @@ func JoinUserToTeam(team *model.Team, user *model.User, userRequestorId string) 
 		return err
 	} else if alreadyAdded {
 		return nil
+	}
+
+	if uua := <-Srv.Store.User().UpdateUpdateAt(user.Id); uua.Err != nil {
+		return uua.Err
 	}
 
 	channelRole := model.ROLE_CHANNEL_USER.Id


### PR DESCRIPTION
#### Summary
Reduce unnecessary database reads and writes when bulk importing users. This gets a speed up of about 10% when running the bulk importer over 20k users for the *second* time.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6488
