### PR TITLE
PLT-6485 Add ability to disable `@here` notifications

### DIFF
--- a/webapp/components/user_settings/user_settings_notifications.jsx
+++ b/webapp/components/user_settings/user_settings_notifications.jsx
@@ -587,7 +587,7 @@ export default class NotificationsTab extends React.Component {
                             />
                             <FormattedMessage
                                 id='user.settings.notifications.channelWide'
-                                defaultMessage='Channel-wide mentions "@channel", "@all"'
+                                defaultMessage='Channel-wide mentions "@channel", "@all", "@here"'
                             />
                         </label>
                     </div>
@@ -656,6 +656,7 @@ export default class NotificationsTab extends React.Component {
             if (this.state.channelKey) {
                 keys.push('@channel');
                 keys.push('@all');
+                keys.push('@here');
             }
             if (this.state.customKeys.length > 0) {
                 keys = keys.concat(this.state.customKeys.split(','));

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -2249,7 +2249,7 @@
   "user.settings.modal.security": "Security",
   "user.settings.modal.title": "Account Settings",
   "user.settings.notifications.allActivity": "For all activity",
-  "user.settings.notifications.channelWide": "Channel-wide mentions \"@channel\", \"@all\"",
+  "user.settings.notifications.channelWide": "Channel-wide mentions \"@channel\", \"@all\", \"@here\"",
   "user.settings.notifications.close": "Close",
   "user.settings.notifications.comments": "Reply notifications",
   "user.settings.notifications.commentsAny": "Trigger notifications on messages in reply threads that I start or participate in",


### PR DESCRIPTION
#### Summary
In Account Settings > Notifications > Words that trigger mentions, add `@here` to the list of channel wide mentions.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6485

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
