### PR TITLE
PLT-6472: Basic Elastic Search implementation.

### DIFF
--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -114,6 +114,12 @@ func runServer(configFileLocation string) {
 		einterfaces.GetMetricsInterface().StartServer()
 	}
 
+	if einterfaces.GetElasticSearchInterface() != nil {
+		if err := einterfaces.GetElasticSearchInterface().Start(); err != nil {
+			l4g.Error(err.Error())
+		}
+	}
+
 	// wait for kill signal before attempting to gracefully shutdown
 	// the running service
 	c := make(chan os.Signal)

--- a/config/config.json
+++ b/config/config.json
@@ -46,6 +46,13 @@
         "EnableUserStatuses": true,
         "ClusterLogTimeoutMilliseconds": 2000
     },
+    "ElasticSearchSettings": {
+        "ConnectionUrl": "http://dockerhost:9200",
+        "Username": "elastic",
+        "Password": "changeme",
+        "EnableIndexing": false,
+        "EnableSearching": false
+    },
     "TeamSettings": {
         "SiteName": "Mattermost",
         "MaxUsersPerTeam": 50,

--- a/config/config.json
+++ b/config/config.json
@@ -51,7 +51,8 @@
         "Username": "elastic",
         "Password": "changeme",
         "EnableIndexing": false,
-        "EnableSearching": false
+        "EnableSearching": false,
+        "Sniff": true
     },
     "TeamSettings": {
         "SiteName": "Mattermost",

--- a/einterfaces/elasticsearch.go
+++ b/einterfaces/elasticsearch.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package einterfaces
+
+import "github.com/mattermost/platform/model"
+
+type ElasticSearchInterface interface {
+	Start() *model.AppError
+	IndexPost(post *model.Post, teamId string)
+	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, *model.AppError)
+	DeletePost(postId string)
+}
+
+var theElasticSearchInterface ElasticSearchInterface
+
+func RegisterElasticSearchInterface(newInterface ElasticSearchInterface) {
+	theElasticSearchInterface = newInterface
+}
+
+func GetElasticSearchInterface() ElasticSearchInterface {
+	return theElasticSearchInterface
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3300,6 +3300,46 @@
     "translation": "Compliance export started for job '{{.JobName}}' at '{{.FilePath}}'"
   },
   {
+    "id": "ent.elasticsearch.start.connect_failed",
+    "translation": "Setting up ElasticSearch Client Failed"
+  },
+  {
+    "id": "ent.elasticsearch.start.index_exists_failed",
+    "translation": "Failed to establish whether ElasticSearch index exists"
+  },
+  {
+    "id": "ent.elasticsearch.start.index_create_failed",
+    "translation": "Failed to create ElasticSearch index"
+  },
+  {
+    "id": "ent.elasticsearch.start.index_close_failed",
+    "translation": "Failed to close ElasticSearch index"
+  },
+  {
+    "id": "ent.elasticsearch.start.index_settings_failed",
+    "translation": "Failed to set ElasticSearch index settings"
+  },
+  {
+    "id": "ent.elasticsearch.start.index_mapping_failed",
+    "translation": "Failed to setup ElasticSearch index mapping"
+  },
+  {
+    "id": "ent.elasticsearch.start.index_open_failed",
+    "translation": "Failed to opn ElasticSearch index"
+  },
+  {
+    "id": "ent.elasticsearch.search_posts.disabled",
+    "translation": "ElasticSearch searching is disabled on this server"
+  },
+  {
+    "id": "ent.elasticsearch.search_posts.search_failed",
+    "translation": "Search failed to complete"
+  },
+  {
+    "id": "ent.elasticsearch.search_posts.unmarshall_post_failed",
+    "translation": "Failed to decode search results"
+  },
+  {
     "id": "ent.emoji.licence_disable.app_error",
     "translation": "Custom emoji restrictions disabled by current license. Please contact your system administrator about upgrading your enterprise license."
   },
@@ -3850,6 +3890,22 @@
   {
     "id": "model.compliance.is_valid.start_end_at.app_error",
     "translation": "To must be greater than From"
+  },
+  {
+    "id": "model.config.is_valid.elastic_search.connection_url.app_error",
+    "translation": "Elastic Search ConnectionUrl setting must be provided when Elastic Search indexing is enabled."
+  },
+  {
+    "id": "model.config.is_valid.elastic_search.username.app_error",
+    "translation": "Elastic Search Username setting must be provided when Elastic Search indexing is enabled."
+  },
+  {
+    "id": "model.config.is_valid.elastic_search.password.app_error",
+    "translation": "Elastic Search Password setting must be provided when Elastic Search indexing is enabled."
+  },
+  {
+    "id": "model.config.is_valid.elastic_search.enable_searching.app_error",
+    "translation": "Elastic Search IndexingEnabled setting must be set to true when Elastic Search SearchEnabled is set to true."
   },
   {
     "id": "model.config.is_valid.cluster_email_batching.app_error",
@@ -5170,6 +5226,10 @@
   {
     "id": "store.sql_post.get.app_error",
     "translation": "We couldn't get the post"
+  },
+  {
+    "id": "store.sql_post.get_posts_by_ids.app_error",
+    "translation": "We couldn't get the posts"
   },
   {
     "id": "store.sql_post.get_parents_posts.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3312,20 +3312,12 @@
     "translation": "Failed to create ElasticSearch index"
   },
   {
-    "id": "ent.elasticsearch.start.index_close_failed",
-    "translation": "Failed to close ElasticSearch index"
-  },
-  {
     "id": "ent.elasticsearch.start.index_settings_failed",
     "translation": "Failed to set ElasticSearch index settings"
   },
   {
     "id": "ent.elasticsearch.start.index_mapping_failed",
     "translation": "Failed to setup ElasticSearch index mapping"
-  },
-  {
-    "id": "ent.elasticsearch.start.index_open_failed",
-    "translation": "Failed to opn ElasticSearch index"
   },
   {
     "id": "ent.elasticsearch.search_posts.disabled",

--- a/model/config.go
+++ b/model/config.go
@@ -407,6 +407,7 @@ type ElasticSearchSettings struct {
 	Password        *string
 	EnableIndexing  *bool
 	EnableSearching *bool
+	Sniff           *bool
 }
 
 type Config struct {
@@ -1243,6 +1244,11 @@ func (o *Config) SetDefaults() {
 		*o.ElasticSearchSettings.EnableSearching = false
 	}
 
+	if o.ElasticSearchSettings.Sniff == nil {
+		o.ElasticSearchSettings.Sniff = new(bool)
+		*o.ElasticSearchSettings.Sniff = true
+	}
+
 	o.defaultWebrtcSettings()
 }
 
@@ -1477,14 +1483,6 @@ func (o *Config) IsValid() *AppError {
 	if *o.ElasticSearchSettings.EnableIndexing {
 		if len(*o.ElasticSearchSettings.ConnectionUrl) == 0 {
 			return NewLocAppError("Config.IsValid", "model.config.is_valid.elastic_search.connection_url.app_error", nil, "")
-		}
-
-		if len(*o.ElasticSearchSettings.Username) == 0 {
-			return NewLocAppError("Config.IsValid", "model.config.is_valid.elastic_search.username.app_error", nil, "")
-		}
-
-		if len(*o.ElasticSearchSettings.Password) == 0 {
-			return NewLocAppError("Config.IsValid", "model.config.is_valid.elastic_search.password.app_error", nil, "")
 		}
 	}
 

--- a/model/config.go
+++ b/model/config.go
@@ -401,29 +401,38 @@ type WebrtcSettings struct {
 	TurnSharedKey       *string
 }
 
+type ElasticSearchSettings struct {
+	ConnectionUrl   *string
+	Username        *string
+	Password        *string
+	EnableIndexing  *bool
+	EnableSearching *bool
+}
+
 type Config struct {
-	ServiceSettings      ServiceSettings
-	TeamSettings         TeamSettings
-	SqlSettings          SqlSettings
-	LogSettings          LogSettings
-	PasswordSettings     PasswordSettings
-	FileSettings         FileSettings
-	EmailSettings        EmailSettings
-	RateLimitSettings    RateLimitSettings
-	PrivacySettings      PrivacySettings
-	SupportSettings      SupportSettings
-	GitLabSettings       SSOSettings
-	GoogleSettings       SSOSettings
-	Office365Settings    SSOSettings
-	LdapSettings         LdapSettings
-	ComplianceSettings   ComplianceSettings
-	LocalizationSettings LocalizationSettings
-	SamlSettings         SamlSettings
-	NativeAppSettings    NativeAppSettings
-	ClusterSettings      ClusterSettings
-	MetricsSettings      MetricsSettings
-	AnalyticsSettings    AnalyticsSettings
-	WebrtcSettings       WebrtcSettings
+	ServiceSettings       ServiceSettings
+	TeamSettings          TeamSettings
+	SqlSettings           SqlSettings
+	LogSettings           LogSettings
+	PasswordSettings      PasswordSettings
+	FileSettings          FileSettings
+	EmailSettings         EmailSettings
+	RateLimitSettings     RateLimitSettings
+	PrivacySettings       PrivacySettings
+	SupportSettings       SupportSettings
+	GitLabSettings        SSOSettings
+	GoogleSettings        SSOSettings
+	Office365Settings     SSOSettings
+	LdapSettings          LdapSettings
+	ComplianceSettings    ComplianceSettings
+	LocalizationSettings  LocalizationSettings
+	SamlSettings          SamlSettings
+	NativeAppSettings     NativeAppSettings
+	ClusterSettings       ClusterSettings
+	MetricsSettings       MetricsSettings
+	AnalyticsSettings     AnalyticsSettings
+	WebrtcSettings        WebrtcSettings
+	ElasticSearchSettings ElasticSearchSettings
 }
 
 func (o *Config) ToJson() string {
@@ -1209,6 +1218,31 @@ func (o *Config) SetDefaults() {
 		*o.ServiceSettings.ClusterLogTimeoutMilliseconds = 2000
 	}
 
+	if o.ElasticSearchSettings.ConnectionUrl == nil {
+		o.ElasticSearchSettings.ConnectionUrl = new(string)
+		*o.ElasticSearchSettings.ConnectionUrl = ""
+	}
+
+	if o.ElasticSearchSettings.Username == nil {
+		o.ElasticSearchSettings.Username = new(string)
+		*o.ElasticSearchSettings.Username = ""
+	}
+
+	if o.ElasticSearchSettings.Password == nil {
+		o.ElasticSearchSettings.Password = new(string)
+		*o.ElasticSearchSettings.Password = ""
+	}
+
+	if o.ElasticSearchSettings.EnableIndexing == nil {
+		o.ElasticSearchSettings.EnableIndexing = new(bool)
+		*o.ElasticSearchSettings.EnableIndexing = false
+	}
+
+	if o.ElasticSearchSettings.EnableSearching == nil {
+		o.ElasticSearchSettings.EnableSearching = new(bool)
+		*o.ElasticSearchSettings.EnableSearching = false
+	}
+
 	o.defaultWebrtcSettings()
 }
 
@@ -1440,6 +1474,24 @@ func (o *Config) IsValid() *AppError {
 		return NewLocAppError("Config.IsValid", "model.config.is_valid.time_between_user_typing.app_error", nil, "")
 	}
 
+	if *o.ElasticSearchSettings.EnableIndexing {
+		if len(*o.ElasticSearchSettings.ConnectionUrl) == 0 {
+			return NewLocAppError("Config.IsValid", "model.config.is_valid.elastic_search.connection_url.app_error", nil, "")
+		}
+
+		if len(*o.ElasticSearchSettings.Username) == 0 {
+			return NewLocAppError("Config.IsValid", "model.config.is_valid.elastic_search.username.app_error", nil, "")
+		}
+
+		if len(*o.ElasticSearchSettings.Password) == 0 {
+			return NewLocAppError("Config.IsValid", "model.config.is_valid.elastic_search.password.app_error", nil, "")
+		}
+	}
+
+	if *o.ElasticSearchSettings.EnableSearching && !*o.ElasticSearchSettings.EnableIndexing {
+		return NewLocAppError("Config.IsValid", "model.config.is_valid.elastic_search.enable_searching.app_error", nil, "")
+	}
+
 	return nil
 }
 
@@ -1480,6 +1532,10 @@ func (o *Config) Sanitize() {
 	for i := range o.SqlSettings.DataSourceSearchReplicas {
 		o.SqlSettings.DataSourceSearchReplicas[i] = FAKE_SETTING
 	}
+
+	*o.ElasticSearchSettings.ConnectionUrl = FAKE_SETTING
+	*o.ElasticSearchSettings.Username = FAKE_SETTING
+	*o.ElasticSearchSettings.Password = FAKE_SETTING
 }
 
 func (o *Config) defaultWebrtcSettings() {

--- a/store/store.go
+++ b/store/store.go
@@ -164,6 +164,7 @@ type PostStore interface {
 	InvalidateLastPostTimeCache(channelId string)
 	GetPostsCreatedAt(channelId string, time int64) StoreChannel
 	Overwrite(post *model.Post) StoreChannel
+	GetPostsByIds(postIds []string) StoreChannel
 }
 
 type UserStore interface {

--- a/utils/config.go
+++ b/utils/config.go
@@ -492,6 +492,11 @@ func getClientConfig(c *model.Config) map[string]string {
 			props["PasswordRequireNumber"] = strconv.FormatBool(*c.PasswordSettings.Number)
 			props["PasswordRequireSymbol"] = strconv.FormatBool(*c.PasswordSettings.Symbol)
 		}
+
+		if *License.Features.ElasticSearch {
+			props["ElasticSearchEnableIndexing"] = strconv.FormatBool(*c.ElasticSearchSettings.EnableIndexing)
+			props["ElasticSearchEnableSearching"] = strconv.FormatBool(*c.ElasticSearchSettings.EnableSearching)
+		}
 	}
 
 	return props
@@ -558,6 +563,16 @@ func Desanitize(cfg *model.Config) {
 	}
 	if cfg.SqlSettings.AtRestEncryptKey == model.FAKE_SETTING {
 		cfg.SqlSettings.AtRestEncryptKey = Cfg.SqlSettings.AtRestEncryptKey
+	}
+
+	if *cfg.ElasticSearchSettings.ConnectionUrl == model.FAKE_SETTING {
+		*cfg.ElasticSearchSettings.ConnectionUrl = *Cfg.ElasticSearchSettings.ConnectionUrl
+	}
+	if *cfg.ElasticSearchSettings.Username == model.FAKE_SETTING {
+		*cfg.ElasticSearchSettings.Username = *Cfg.ElasticSearchSettings.Username
+	}
+	if *cfg.ElasticSearchSettings.Password == model.FAKE_SETTING {
+		*cfg.ElasticSearchSettings.Password = *Cfg.ElasticSearchSettings.Password
 	}
 
 	for i := range cfg.SqlSettings.DataSourceReplicas {


### PR DESCRIPTION
#### Summary

Basic Elastic Search implementation.

This currently supports indexing of posts at create/update/delete time.
It does not support batch indexing or reindexing, and does not support
any entities other than posts yet. The purpose is to more-or-less
replicate the existing full-text search feature but with some of the
immediate benefits of using elastic search.

This PR does not include any UI changes. Configuration must be carried out directly in the config.json, and search results are presented exactly as before.

This PR won't work with mattermod. Instead, there's a spinmint here: http://george.spinmint.com:8065

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6472

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/137
- [x] Includes text changes and localization file updates
- [x] Touches critical sections of the codebase: config.
