### PR TITLE
PLT-6523: Don't crash when replying to a post whose poster has left the channel

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -83,7 +83,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 
 				for _, threadPost := range list.Posts {
 					profile := profileMap[threadPost.UserId]
-					if profile.NotifyProps["comments"] == "any" || (profile.NotifyProps["comments"] == "root" && threadPost.Id == list.Order[0]) {
+					if profile != nil && (profile.NotifyProps["comments"] == "any" || (profile.NotifyProps["comments"] == "root" && threadPost.Id == list.Order[0])) {
 						mentionedUserIds[threadPost.UserId] = true
 					}
 				}

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/mattermost/platform/model"
+	"fmt"
+)
+
+func TestPostReplyToPostWhereRootPosterLeftChannel(t *testing.T) {
+	// This test ensures that when replying to a root post made by a user who has since left the channel, the reply
+	// post completes successfully. This is a regression test for PLT-6523.
+	th := Setup().InitBasic()
+
+	channel := th.BasicChannel
+	userInChannel := th.BasicUser2
+	userNotInChannel := th.BasicUser
+	rootPost := th.BasicPost
+
+	if _, err := AddUserToChannel(userInChannel, channel); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveUserFromChannel(userNotInChannel.Id, "", channel); err != nil {
+		t.Fatal(err)
+	}
+
+	replyPost := model.Post{
+		Message: "asd",
+		ChannelId: channel.Id,
+		RootId: rootPost.Id,
+		ParentId: rootPost.Id,
+		PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+		UserId: userInChannel.Id,
+		CreateAt: 0,
+	}
+
+	if _, err := CreatePostAsUser(&replyPost); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
#### Summary

Don't crash when replying to a post whose poster has left the channel

#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-6523

#### Checklist
- [x] Added or updated unit tests (required for all new features)