### PR TITLE
Send status change event if status changes on channel view

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1016,9 +1016,13 @@ func GetNumberOfChannelsOnTeam(teamId string) (int, *model.AppError) {
 
 func SetActiveChannel(userId string, channelId string) *model.AppError {
 	status, err := GetStatus(userId)
+
+	oldStatus := model.STATUS_OFFLINE
+
 	if err != nil {
 		status = &model.Status{UserId: userId, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: model.GetMillis(), ActiveChannel: channelId}
 	} else {
+		oldStatus = status.Status
 		status.ActiveChannel = channelId
 		if !status.Manual {
 			status.Status = model.STATUS_ONLINE
@@ -1027,6 +1031,10 @@ func SetActiveChannel(userId string, channelId string) *model.AppError {
 	}
 
 	AddStatusCache(status)
+
+	if status.Status != oldStatus {
+		BroadcastStatus(status)
+	}
 
 	return nil
 }

--- a/app/status.go
+++ b/app/status.go
@@ -209,11 +209,15 @@ func SetStatusOnline(userId string, sessionId string, manual bool) {
 	}
 
 	if broadcast {
-		event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_STATUS_CHANGE, "", "", status.UserId, nil)
-		event.Add("status", model.STATUS_ONLINE)
-		event.Add("user_id", status.UserId)
-		go Publish(event)
+		BroadcastStatus(status)
 	}
+}
+
+func BroadcastStatus(status *model.Status) {
+	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_STATUS_CHANGE, "", "", status.UserId, nil)
+	event.Add("status", status.Status)
+	event.Add("user_id", status.UserId)
+	go Publish(event)
 }
 
 func SetStatusOffline(userId string, manual bool) {


### PR DESCRIPTION
#### Summary
This is an old bug that was uncovered by recent changes to how statuses work on the client. Essentially coming back from away would sometimes not update your status until the next 60s status update interval.

CH and I chatted about it and we both agree that the extra "status_change" event shouldn't be a problem. The extra status change event will only be sent when the user clicks to view the app and their status changes (aka coming back being away if status is not set to manually be away).