### PR TITLE
PLT-6566 Prevented terms of service link from being blank

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -714,7 +714,7 @@ func (o *Config) SetDefaults() {
 	}
 
 	if !IsSafeLink(o.SupportSettings.TermsOfServiceLink) {
-		*o.SupportSettings.TermsOfServiceLink = ""
+		*o.SupportSettings.TermsOfServiceLink = SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK
 	}
 
 	if o.SupportSettings.TermsOfServiceLink == nil {

--- a/webapp/components/header_footer_template.jsx
+++ b/webapp/components/header_footer_template.jsx
@@ -33,20 +33,18 @@ export default class NotLoggedIn extends React.Component {
             );
         }
 
-        if (global.window.mm_config.TermsOfServiceLink) {
-            content.push(
-                <a
-                    key='terms_link'
-                    id='terms_link'
-                    className='pull-right footer-link'
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    href={global.window.mm_config.TermsOfServiceLink}
-                >
-                    <FormattedMessage id='web.footer.terms'/>
-                </a>
-            );
-        }
+        content.push(
+            <a
+                key='terms_link'
+                id='terms_link'
+                className='pull-right footer-link'
+                target='_blank'
+                rel='noopener noreferrer'
+                href={global.window.mm_config.TermsOfServiceLink}
+            >
+                <FormattedMessage id='web.footer.terms'/>
+            </a>
+        );
 
         if (global.window.mm_config.PrivacyPolicyLink) {
             content.push(


### PR DESCRIPTION
Setting the link to blank in the System Console causes the link to disappear in the UI, which we don't want. I talked to @jasonblais about it and we agreed that the most obvious behaviour was to have it set to a default in the System Console if you entered anything that wasn't a link for the setting value. Otherwise, you might set it to blank and then be confused as to why the link is still in the UI.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6566
