### PR TITLE
Fix issue when mention a user which is not in the channel

### DIFF
--- a/webapp/components/common/post_flag_icon.jsx
+++ b/webapp/components/common/post_flag_icon.jsx
@@ -68,7 +68,7 @@ export default function PostFlagIcon(props) {
         );
     }
 
-    return '';
+    return null;
 }
 
 PostFlagIcon.propTypes = {


### PR DESCRIPTION
#### Summary
When mentioning a user which is not in the channel was observed the issue in the picture attached

![screen shot 2017-05-11 at 15 15 07](https://cloud.githubusercontent.com/assets/4115580/25951854/3dccc34a-365f-11e7-9ae9-4fcd159378b2.png)

Test Case:
1 - enter in a channel or create a new one
2 - mention a user which not belong to the channel. eg, `hello @user_not_in_channel` 

#### Ticket Link
N/A
