### PR TITLE
[PLT-6537] When at-mentioning someone in a GM who is not in the channel, warning shouldn't appear

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -98,7 +98,9 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 		if len(potentialOtherMentions) > 0 {
 			if result := <-Srv.Store.User().GetProfilesByUsernames(potentialOtherMentions, team.Id); result.Err == nil {
 				outOfChannelMentions := result.Data.([]*model.User)
-				go sendOutOfChannelMentions(sender, post, team.Id, outOfChannelMentions)
+				if channel.Type != model.CHANNEL_GROUP {
+					go sendOutOfChannelMentions(sender, post, team.Id, outOfChannelMentions)
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Summary
[PLT-6537] When at-mentioning someone in a GM who is not in the channel, warning shouldn't appear

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/PLT-6537
GitHub: https://github.com/mattermost/platform/issues/6364

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates

