### PR TITLE
[PLT-6469] use Hostname() instead of Host which will contain the port

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -73,5 +73,6 @@ func GetSiteName(siteURL string) string {
 	if err != nil {
 		return ""
 	}
-	return u.Host
+
+	return u.Hostname()
 }


### PR DESCRIPTION
#### Summary
use Hostname() instead of Host which will contain the port

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/PLT-6469
