### PR TITLE
Ability to use OAuth login from mobile

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -157,7 +157,7 @@ func loginWithOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if authUrl, err := app.GetOAuthLoginEndpoint(service, teamId, redirectTo, loginHint); err != nil {
+	if authUrl, err := app.GetOAuthLoginEndpoint(service, teamId, model.OAUTH_ACTION_LOGIN, redirectTo, loginHint); err != nil {
 		c.Err = err
 		return
 	} else {

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -290,9 +290,9 @@ func newSessionUpdateToken(appName string, accessData *model.AccessData, user *m
 	return accessRsp, nil
 }
 
-func GetOAuthLoginEndpoint(service, teamId, redirectTo, loginHint string) (string, *model.AppError) {
+func GetOAuthLoginEndpoint(service, teamId, action, redirectTo, loginHint string) (string, *model.AppError) {
 	stateProps := map[string]string{}
-	stateProps["action"] = model.OAUTH_ACTION_LOGIN
+	stateProps["action"] = action
 	if len(teamId) != 0 {
 		stateProps["team_id"] = teamId
 	}


### PR DESCRIPTION
#### Summary
This PR adds the ability to login using OAuth through the RN app.

* Adds a new endpoint `/oauth/{service}/mobile_login
* Sets the proper action to the oauth login state

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
