### PR TITLE
PLT-6333 Only update status when clicking onto app

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1041,7 +1041,7 @@ func SetActiveChannel(userId string, channelId string) *model.AppError {
 	} else {
 		oldStatus = status.Status
 		status.ActiveChannel = channelId
-		if !status.Manual {
+		if !status.Manual && channelId != "" {
 			status.Status = model.STATUS_ONLINE
 		}
 		status.LastActivityAt = model.GetMillis()


### PR DESCRIPTION
#### Summary
This fixes a race condition, that was causing some user statuses to get stuck online, between setting the active channel to blank and the closing of the websocket setting the status to offline.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6333