### PR TITLE
[PLT-6599] Added link to check websocket port error message.

### DIFF
--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -132,7 +132,7 @@ function handleFirstConnect() {
 
 function handleClose(failCount) {
     if (failCount > MAX_WEBSOCKET_FAILS) {
-        ErrorStore.storeLastError({message: Utils.localizeMessage('channel_loader.socketError', 'Please check connection, Mattermost unreachable. If issue persists, ask administrator to check WebSocket port.')});
+        ErrorStore.storeLastError({message: Utils.localizeMessage('channel_loader.socketError', 'Please check connection, Mattermost unreachable. If issue persists, ask administrator to <a href="https://about.mattermost.com/default-websocket-port-help" target="_blank">check WebSocket port.</a>')});
     }
 
     ErrorStore.setConnectionErrorCount(failCount);

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1110,7 +1110,7 @@
   "channel_invite.close": "Close",
   "channel_loader.connection_error": "There appears to be a problem with your internet connection.",
   "channel_loader.posted": "Posted",
-  "channel_loader.socketError": "Please check connection, Mattermost unreachable. If issue persists, ask administrator to check WebSocket port.",
+  "channel_loader.socketError": "Please check connection, Mattermost unreachable. If issue persists, ask administrator to <a href=\"https://about.mattermost.com/default-websocket-port-help\" target=\"_blank\">check WebSocket port.</a>",
   "channel_loader.someone": "Someone",
   "channel_loader.something": " did something new",
   "channel_loader.unknown_error": "We received an unexpected status code from the server.",


### PR DESCRIPTION
#### Summary
Changed value of `channel_loader.socketError` i18n message to include link to help page about websocket port issue. 
#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6599

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
