### PR TITLE
[PLT-4951] Don't send a desktop notification and don't mark channel unread if a comment thread for that channel is open in right hand sidebar, and Mattermost is in focus

### DIFF
--- a/webapp/actions/notification_actions.jsx
+++ b/webapp/actions/notification_actions.jsx
@@ -4,6 +4,7 @@
 import Constants from 'utils/constants.jsx';
 import UserStore from 'stores/user_store.jsx';
 import ChannelStore from 'stores/channel_store.jsx';
+import PostStore from 'stores/post_store.jsx';
 import NotificationStore from 'stores/notification_store.jsx';
 
 import {isSystemMessage} from 'utils/post_utils.jsx';
@@ -38,6 +39,13 @@ export function sendDesktopNotification(post, msgProps) {
     if (notifyLevel === 'none') {
         return;
     } else if (notifyLevel === 'mention' && mentions.indexOf(user.id) === -1 && msgProps.channel_type !== Constants.DM_CHANNEL) {
+        return;
+    }
+
+    const sidebarOpenedPostId = PostStore.getSelectedPostId();
+
+    // Check if the message is not a comment for currently opened thread in right sidebar
+    if (sidebarOpenedPostId && NotificationStore.getFocus() && post.root_id === sidebarOpenedPostId) {
         return;
     }
 

--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -6,6 +6,8 @@ import EventEmitter from 'events';
 
 import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
+import PostStore from 'stores/post_store.jsx';
+import NotificationStore from 'stores/notification_store.jsx';
 
 var ChannelUtils;
 var Utils;
@@ -483,6 +485,14 @@ class ChannelStoreClass extends EventEmitter {
 
         if (!this.unreadCounts[id]) {
             return;
+        }
+
+        const sidebarSelectedPostId = PostStore.getSelectedPostId();
+        if (sidebarSelectedPostId && NotificationStore.getFocus()) {
+            const post = JSON.parse(msgProps.post);
+            if (sidebarSelectedPostId === post.root_id) {
+                return;
+            }
         }
 
         if (mentions.indexOf(UserStore.getCurrentId()) !== -1) {


### PR DESCRIPTION
#### Summary
Pull request for the PLT-4951. I hope I covered all the cases. I stoped showing mention count and notification when window is in focus and new message appeared in the thread on the right.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4951

#### Checklist