### PR TITLE
[PLT-6392] Make the message "Failed to add from email address" more explicit

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6013,7 +6013,7 @@
   },
   {
     "id": "utils.mail.send_mail.from_address.app_error",
-    "translation": "Failed to add from email address"
+    "translation": "Notification From Address setting is missing or invalid."
   },
   {
     "id": "utils.mail.send_mail.msg.app_error",
@@ -6029,7 +6029,7 @@
   },
   {
     "id": "utils.mail.send_mail.to_address.app_error",
-    "translation": "Failed to add to email address"
+    "translation": "Notification To Address setting is missing or invalid."
   },
   {
     "id": "utils.mail.test.configured.error",


### PR DESCRIPTION
#### Summary
[PLT-6392] Make the message "Failed to add from email address" more explicit

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/PLT-6392
GitHub: https://github.com/mattermost/platform/issues/6479

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
