### PR TITLE
[PLT-6400] Add README file to config directory

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,3 @@
+# CONFIG.JSON
+
+This is the system configuration file for your Mattermost server. Settings are specific to different editions of Mattermost. Please read the documentation before making changes: https://about.mattermost.com/default-config-docs/


### PR DESCRIPTION
#### Summary
Added `README.md` under `config` to specify what the `config.json` file is used for.

#### Ticket Link
https://github.com/mattermost/platform/issues/6496
https://mattermost.atlassian.net/browse/PLT-6400
