### PR TITLE
[PLT-6586] Fixed JS error when adding reaction to channel with latest post as ephemeral

### DIFF
--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -234,11 +234,11 @@ export default class CreatePost extends React.Component {
         const action = isReaction[1];
 
         const emojiName = isReaction[2];
-        const postId = PostStore.getLatestPost(this.state.channelId).id;
+        const postId = PostStore.getLatestNonEphemeralPost(this.state.channelId).id;
 
-        if (action === '+') {
+        if (postId && action === '+') {
             PostActions.addReaction(this.state.channelId, postId, emojiName);
-        } else if (action === '-') {
+        } else if (postId && action === '-') {
             PostActions.removeReaction(this.state.channelId, postId, emojiName);
         }
 

--- a/webapp/stores/post_store.jsx
+++ b/webapp/stores/post_store.jsx
@@ -148,6 +148,20 @@ class PostStoreClass extends EventEmitter {
         return null;
     }
 
+    getLatestNonEphemeralPost(id) {
+        if (this.postsInfo.hasOwnProperty(id)) {
+            const postList = this.postsInfo[id].postList;
+
+            for (const postId of postList.order) {
+                if (postList.posts[postId].state !== Constants.POST_DELETED && postList.posts[postId].type !== Constants.PostTypes.EPHEMERAL) {
+                    return postList.posts[postId];
+                }
+            }
+        }
+
+        return null;
+    }
+
     getLatestPostFromPageTime(id) {
         if (this.latestPageTime.hasOwnProperty(id)) {
             return this.latestPageTime[id];


### PR DESCRIPTION
#### Summary
Fixed JS error when adding reaction to channel with latest post as ephemeral
- added `getLatestNonEphemeralPost` at post_store.jsx
- used it when saving reaction

#### Ticket Link
GitHub issue: #6421
Jira ticket: [PLT-6586](https://mattermost.atlassian.net/browse/PLT-6586)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All new/modified APIs include changes to the drivers
