### PR TITLE
PLT-6658 Ignore correct message types for setting unreads for teams

### DIFF
--- a/webapp/stores/team_store.jsx
+++ b/webapp/stores/team_store.jsx
@@ -430,7 +430,7 @@ TeamStore.dispatchToken = AppDispatcher.register((payload) => {
         TeamStore.saveStats(action.team_id, action.stats);
         break;
     case ActionTypes.RECEIVED_POST:
-        if (action.post.type === PostTypes.JOIN_LEAVE || action.post.type === PostTypes.JOIN_CHANNEL || action.post.type === PostTypes.LEAVE_CHANNEL) {
+        if (Constants.IGNORE_POST_TYPES.indexOf(action.post.type) !== -1) {
             return;
         }
 

--- a/webapp/stores/team_store.jsx
+++ b/webapp/stores/team_store.jsx
@@ -8,7 +8,6 @@ import ChannelStore from 'stores/channel_store.jsx';
 
 import Constants from 'utils/constants.jsx';
 const NotificationPrefs = Constants.NotificationPrefs;
-const PostTypes = Constants.PostTypes;
 
 import {getSiteURL} from 'utils/url.jsx';
 const ActionTypes = Constants.ActionTypes;


### PR DESCRIPTION
#### Summary
Ignore correct message types for setting unreads for teams. I couldn't reproduce it with channels but could with teams

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6658