### PR TITLE
PLT-6692 Removed wbr tags from single line markdown

### DIFF
--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -52,7 +52,10 @@ export function formatText(text, inputOptions) {
         output = replaceNewlines(output);
     }
 
-    output = insertLongLinkWbr(output);
+    // Add <wbr /> tags to recommend line breaking on slashes within URLs
+    if (!options.singleline) {
+        output = insertLongLinkWbr(output);
+    }
 
     return output;
 }


### PR DESCRIPTION
Those tags are used to hint that the browser should do a line break on the slashes in URLs. Obviously, we don't want to encourage the browser to wrap the line in single line mode.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6692

#### Checklist
- Has UI changes