### PR TITLE
PLT-4457 Added AtMention component to better render at mentions

### DIFF
--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -507,3 +507,11 @@ export function storePostDraft(channelId, draft) {
         draft
     });
 }
+
+export function searchForTerm(term) {
+    AppDispatcher.handleServerAction({
+        type: ActionTypes.RECEIVED_SEARCH_TERM,
+        term,
+        do_search: true
+    });
+}

--- a/webapp/components/at_mention/at_mention.jsx
+++ b/webapp/components/at_mention/at_mention.jsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class AtMention extends React.PureComponent {
+    static propTypes = {
+        mentionName: PropTypes.string.isRequired,
+        usersByUsername: PropTypes.object.isRequired,
+        actions: PropTypes.shape({
+            searchForTerm: PropTypes.func.isRequired
+        }).isRequired
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            username: this.getUsernameFromMentionName(props)
+        };
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.mentionName !== this.props.mentionName || nextProps.usersByUsername !== this.props.usersByUsername) {
+            this.setState({
+                username: this.getUsernameFromMentionName(nextProps)
+            });
+        }
+    }
+
+    getUsernameFromMentionName(props) {
+        let mentionName = props.mentionName;
+
+        while (mentionName.length > 0) {
+            if (props.usersByUsername[mentionName]) {
+                return props.usersByUsername[mentionName].username;
+            }
+
+            // Repeatedly trim off trailing punctuation in case this is at the end of a sentence
+            if ((/[._-]$/).test(mentionName)) {
+                mentionName = mentionName.substring(0, mentionName.length - 1);
+            } else {
+                break;
+            }
+        }
+
+        return '';
+    }
+
+    search = (e) => {
+        e.preventDefault();
+
+        this.props.actions.searchForTerm(this.state.username);
+    }
+
+    render() {
+        const username = this.state.username;
+
+        if (!username) {
+            return <span>{'@' + this.props.mentionName}</span>;
+        }
+
+        const suffix = this.props.mentionName.substring(username.length);
+
+        return (
+            <span>
+                <a
+                    className='mention-link'
+                    href='#'
+                    onClick={this.search}
+                >
+                    {'@' + username}
+                </a>
+                {suffix}
+            </span>
+        );
+    }
+}

--- a/webapp/components/at_mention/index.jsx
+++ b/webapp/components/at_mention/index.jsx
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {getUsersByUsername} from 'mattermost-redux/selectors/entities/users';
+
+import {searchForTerm} from 'actions/post_actions.jsx';
+
+import AtMention from './at_mention.jsx';
+
+function mapStateToProps(state, ownProps) {
+    return {
+        ...ownProps,
+        usersByUsername: getUsersByUsername(state)
+    };
+}
+
+function mapDispatchToProps() {
+    return {
+        actions: {
+            searchForTerm
+        }
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AtMention);

--- a/webapp/components/post_view/components/post_body.jsx
+++ b/webapp/components/post_view/components/post_body.jsx
@@ -1,27 +1,43 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import UserStore from 'stores/user_store.jsx';
-import * as Utils from 'utils/utils.jsx';
-import * as GlobalActions from 'actions/global_actions.jsx';
-import * as PostUtils from 'utils/post_utils.jsx';
-import Constants from 'utils/constants.jsx';
-import CommentedOnFilesMessageContainer from './commented_on_files_message_container.jsx';
-import FileAttachmentListContainer from 'components/file_attachment_list_container.jsx';
-import PostBodyAdditionalContent from './post_body_additional_content.jsx';
-import PostMessageContainer from './post_message_container.jsx';
-import PendingPostOptions from './pending_post_options.jsx';
-import ReactionListContainer from './reaction_list_container.jsx';
-
+import PropTypes from 'prop-types';
+import React from 'react';
 import {FormattedMessage} from 'react-intl';
+
+import * as GlobalActions from 'actions/global_actions.jsx';
+import * as PostActions from 'actions/post_actions.jsx';
+
+import FileAttachmentListContainer from 'components/file_attachment_list_container.jsx';
 
 import loadingGif from 'images/load.gif';
 
-import PropTypes from 'prop-types';
+import UserStore from 'stores/user_store.jsx';
 
-import React from 'react';
+import Constants from 'utils/constants.jsx';
+import * as PostUtils from 'utils/post_utils.jsx';
+import * as Utils from 'utils/utils.jsx';
+
+import CommentedOnFilesMessageContainer from './commented_on_files_message_container.jsx';
+import PendingPostOptions from './pending_post_options.jsx';
+import PostBodyAdditionalContent from './post_body_additional_content.jsx';
+import PostMessageContainer from './post_message_container.jsx';
+import ReactionListContainer from './reaction_list_container.jsx';
 
 export default class PostBody extends React.Component {
+    static propTypes = {
+        post: PropTypes.object.isRequired,
+        currentUser: PropTypes.object.isRequired,
+        parentPost: PropTypes.object,
+        retryPost: PropTypes.func,
+        lastPostCount: PropTypes.number,
+        handleCommentClick: PropTypes.func.isRequired,
+        compactDisplay: PropTypes.bool,
+        previewCollapsed: PropTypes.string,
+        isCommentMention: PropTypes.bool,
+        childComponentDidUpdateFunction: PropTypes.func
+    }
+
     constructor(props) {
         super(props);
 
@@ -93,7 +109,7 @@ export default class PostBody extends React.Component {
                 name = (
                     <a
                         className='theme'
-                        onClick={Utils.searchForTerm.bind(null, username)}
+                        onClick={PostActions.searchForTerm.bind(null, username)}
                     >
                         {username}
                     </a>
@@ -208,16 +224,3 @@ export default class PostBody extends React.Component {
         );
     }
 }
-
-PostBody.propTypes = {
-    post: PropTypes.object.isRequired,
-    currentUser: PropTypes.object.isRequired,
-    parentPost: PropTypes.object,
-    retryPost: PropTypes.func,
-    lastPostCount: PropTypes.number,
-    handleCommentClick: PropTypes.func.isRequired,
-    compactDisplay: PropTypes.bool,
-    previewCollapsed: PropTypes.string,
-    isCommentMention: PropTypes.bool,
-    childComponentDidUpdateFunction: PropTypes.func
-};

--- a/webapp/components/post_view/components/post_message_container.jsx
+++ b/webapp/components/post_view/components/post_message_container.jsx
@@ -40,7 +40,6 @@ export default class PostMessageContainer extends React.Component {
             emojis: EmojiStore.getEmojis(),
             enableFormatting: PreferenceStore.getBool(Preferences.CATEGORY_ADVANCED_SETTINGS, 'formatting', true),
             mentionKeys,
-            usernameMap: UserStore.getProfilesUsernameMap(),
             channelNamesMap: ChannelStore.getChannelNamesMap(),
             team: TeamStore.getCurrent()
         };
@@ -77,8 +76,7 @@ export default class PostMessageContainer extends React.Component {
         mentionKeys.push('@here');
 
         this.setState({
-            mentionKeys,
-            usernameMap: UserStore.getProfilesUsernameMap()
+            mentionKeys
         });
     }
 
@@ -97,7 +95,6 @@ export default class PostMessageContainer extends React.Component {
                 emojis={this.state.emojis}
                 enableFormatting={this.state.enableFormatting}
                 mentionKeys={this.state.mentionKeys}
-                usernameMap={this.state.usernameMap}
                 channelNamesMap={this.state.channelNamesMap}
                 team={this.state.team}
             />

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,6 +15,7 @@
     "flux": "3.1.2",
     "font-awesome": "4.7.0",
     "highlight.js": "9.11.0",
+    "html-to-react": "1.2.9",
     "inobounce": "0.1.4",
     "intl": "1.2.5",
     "jasny-bootstrap": "3.1.3",

--- a/webapp/tests/utils/formatting_hashtags.test.jsx
+++ b/webapp/tests/utils/formatting_hashtags.test.jsx
@@ -160,13 +160,11 @@ describe('TextFormatting.Hashtags', function() {
         );
 
         let options = {
-            usernameMap: {
-                test: {id: '1234', username: 'test'}
-            }
+            atMentions: true
         };
         assert.equal(
             TextFormatting.formatText('#@test', options).trim(),
-            "<p>#<a class='mention-link' href='#' data-mention='test'>@test</a></p>"
+            '<p>#<span data-mention="test">@test</a></p>'
         );
 
         assert.equal(

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -1298,16 +1298,11 @@ export function isValidPassword(password) {
 }
 
 export function handleFormattedTextClick(e) {
-    const mentionAttribute = e.target.getAttributeNode('data-mention');
     const hashtagAttribute = e.target.getAttributeNode('data-hashtag');
     const linkAttribute = e.target.getAttributeNode('data-link');
     const channelMentionAttribute = e.target.getAttributeNode('data-channel-mention');
 
-    if (mentionAttribute) {
-        e.preventDefault();
-
-        searchForTerm(mentionAttribute.value);
-    } else if (hashtagAttribute) {
+    if (hashtagAttribute) {
         e.preventDefault();
 
         searchForTerm(hashtagAttribute.value);

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -383,14 +383,6 @@ export function insertHtmlEntities(text) {
     return newtext;
 }
 
-export function searchForTerm(term) {
-    AppDispatcher.handleServerAction({
-        type: ActionTypes.RECEIVED_SEARCH_TERM,
-        term,
-        do_search: true
-    });
-}
-
 export function getFileType(extin) {
     var ext = extin.toLowerCase();
     if (Constants.IMAGE_TYPES.indexOf(ext) > -1) {
@@ -1331,6 +1323,15 @@ export function handleFormattedTextClick(e) {
         e.preventDefault();
         browserHistory.push('/' + TeamStore.getCurrent().name + '/channels/' + channelMentionAttribute.value);
     }
+}
+
+// This should eventually be removed once everywhere else calls the action
+function searchForTerm(term) {
+    AppDispatcher.handleServerAction({
+        type: ActionTypes.RECEIVED_SEARCH_TERM,
+        term,
+        do_search: true
+    });
 }
 
 export function isEmptyObject(object) {

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -241,7 +241,8 @@ var config = {
         alias: {
             jquery: 'jquery/dist/jquery',
             superagent: 'node_modules/superagent/lib/client'
-        }
+        },
+        extensions: ['.js', '.jsx']
     },
     performance: {
         hints: 'warning'


### PR DESCRIPTION
This is a followup to a PR made early in 3.10 where we pull down any users mentioned in a post. This will now only render at mentions for users that the client has, and it'll also slightly improve the handling of punctuation following the mention.

@saturninoabril I ended up re-adding the html-to-react library myself to get this in. I tried to leave everything the same with it, so hopefully it won't conflict with your changes to the at mentions

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4457

#### Checklist
- Added or updated unit tests (required for all new features)
- Has UI changes
