### PR TITLE
[PLT-6690] Fix regression for LDAP users not showing email address

### DIFF
--- a/webapp/components/user_settings/user_settings_general/user_settings_general.jsx
+++ b/webapp/components/user_settings/user_settings_general/user_settings_general.jsx
@@ -487,7 +487,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 id='user.settings.general.emailGitlabCantUpdate'
                                 defaultMessage='Login occurs through GitLab. Email cannot be updated. Email address used for notifications is {email}.'
                                 values={{
-                                    email: this.state.email
+                                    email: this.state.originalEmail
                                 }}
                             />
                         </div>
@@ -505,7 +505,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 id='user.settings.general.emailGoogleCantUpdate'
                                 defaultMessage='Login occurs through Google Apps. Email cannot be updated. Email address used for notifications is {email}.'
                                 values={{
-                                    email: this.state.email
+                                    email: this.state.originalEmail
                                 }}
                             />
                         </div>
@@ -523,7 +523,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 id='user.settings.general.emailOffice365CantUpdate'
                                 defaultMessage='Login occurs through Office 365. Email cannot be updated. Email address used for notifications is {email}.'
                                 values={{
-                                    email: this.state.email
+                                    email: this.state.originalEmail
                                 }}
                             />
                         </div>
@@ -541,7 +541,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 id='user.settings.general.emailLdapCantUpdate'
                                 defaultMessage='Login occurs through AD/LDAP. Email cannot be updated. Email address used for notifications is {email}.'
                                 values={{
-                                    email: this.state.email
+                                    email: this.state.originalEmail
                                 }}
                             />
                         </div>
@@ -558,7 +558,7 @@ class UserSettingsGeneralTab extends React.Component {
                                 id='user.settings.general.emailSamlCantUpdate'
                                 defaultMessage='Login occurs through SAML. Email cannot be updated. Email address used for notifications is {email}.'
                                 values={{
-                                    email: this.state.email
+                                    email: this.state.originalEmail
                                 }}
                             />
                         </div>
@@ -617,7 +617,7 @@ class UserSettingsGeneralTab extends React.Component {
                         id='user.settings.general.loginGitlab'
                         defaultMessage='Login done through GitLab ({email})'
                         values={{
-                            email: this.state.email
+                            email: this.state.originalEmail
                         }}
                     />
                 );
@@ -627,7 +627,7 @@ class UserSettingsGeneralTab extends React.Component {
                         id='user.settings.general.loginGoogle'
                         defaultMessage='Login done through Google Apps ({email})'
                         values={{
-                            email: this.state.email
+                            email: this.state.originalEmail
                         }}
                     />
                 );
@@ -637,7 +637,7 @@ class UserSettingsGeneralTab extends React.Component {
                         id='user.settings.general.loginOffice365'
                         defaultMessage='Login done through Office 365 ({email})'
                         values={{
-                            email: this.state.email
+                            email: this.state.originalEmail
                         }}
                     />
                 );
@@ -647,7 +647,7 @@ class UserSettingsGeneralTab extends React.Component {
                         id='user.settings.general.loginLdap'
                         defaultMessage='Login done through AD/LDAP ({email})'
                         values={{
-                            email: this.state.email
+                            email: this.state.originalEmail
                         }}
                     />
                 );
@@ -657,7 +657,7 @@ class UserSettingsGeneralTab extends React.Component {
                         id='user.settings.general.loginSaml'
                         defaultMessage='Login done through SAML ({email})'
                         values={{
-                            email: this.state.email
+                            email: this.state.originalEmail
                         }}
                     />
                 );


### PR DESCRIPTION
#### Summary
Fix regression for LDAP users not showing email address. Then follow the same format for:
- Gitlab
- Google
- Office365
-SAML

#### Ticket Link
Jira ticket: [PLT-6690](https://mattermost.atlassian.net/browse/PLT-6690)

#### Checklist
- [x] Has UI changes
