### PR TITLE
Use mutex flag with yarn to prevent concurrent builds interfering

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -5,7 +5,7 @@ BUILD_SERVER_DIR = ..
 check-style: .yarninstall
 	@echo Checking for style guide compliance
 
-	yarn run check
+	yarn run check --mutex file:/tmp/.yarn-mutex
 
 test: .yarninstall
 	cd $(BUILD_SERVER_DIR) && $(MAKE) internal-test-web-client
@@ -13,7 +13,7 @@ test: .yarninstall
 .yarninstall: package.json
 	@echo Getting dependencies using yarn
 
-	yarn install --pure-lockfile
+	yarn install --pure-lockfile --mutex file:/tmp/.yarn-mutex
 
 	touch $@
 
@@ -22,7 +22,7 @@ build: .yarninstall
 
 	rm -rf dist
 
-	yarn run build
+	yarn run build --mutex file:/tmp/.yarn-mutex
 
 run: .yarninstall
 	@echo Running mattermost Webapp for development
@@ -53,4 +53,4 @@ clean:
 	rm -rf node_modules
 	rm -f .yarninstall
 
-	yarn cache clean
+	yarn cache clean --mutex file:/tmp/.yarn-mutex

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -49,8 +49,9 @@ endif
 clean:
 	@echo Cleaning Webapp
 
+	yarn cache clean --mutex file:/tmp/.yarn-mutex
+
 	rm -rf dist
 	rm -rf node_modules
 	rm -f .yarninstall
-
-	yarn cache clean --mutex file:/tmp/.yarn-mutex
+	rm -f /tmp/.yarn-mutex

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -6048,7 +6048,7 @@ react-bootstrap@0.31.0:
     uncontrollable "^4.1.0"
     warning "^3.0.0"
 
-react-color@^2.11.7:
+react-color@2.11.7:
   version "2.11.7"
   resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.11.7.tgz#746465b75feda63c2567607dfbcb276fc954a5b7"
   dependencies:


### PR DESCRIPTION
#### Summary
Use mutex flag with yarn to prevent concurrent builds interfering. If two yarn commands were being on the same machine, they could cause interference. This interference could result in some packages having incorrect versions in webapp builds.