### PR TITLE
PLT-6834 For team unreads return empty array instead of null

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -656,7 +656,7 @@ func GetTeamsUnreadForUser(excludeTeamId string, userId string) ([]*model.TeamUn
 		return nil, result.Err
 	} else {
 		data := result.Data.([]*model.ChannelUnread)
-		var members []*model.TeamUnread
+		members := []*model.TeamUnread{}
 		membersMap := make(map[string]*model.TeamUnread)
 
 		unreads := func(cu *model.ChannelUnread, tu *model.TeamUnread) *model.TeamUnread {


### PR DESCRIPTION
#### Summary
For team unreads return empty array instead of null when there are no teams.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6834