### PR TITLE
[PLT-6694] Add StopServer() at the end of API v4 tests

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -105,6 +105,12 @@ func Setup() *TestHelper {
 	return th
 }
 
+func StopServer() {
+	if app.Srv != nil {
+		app.StopServer()
+	}
+}
+
 func TearDown() {
 	utils.DisableDebugLogForTest()
 

--- a/api4/websocket_test.go
+++ b/api4/websocket_test.go
@@ -71,3 +71,12 @@ func TestWebSocket(t *testing.T) {
 		}
 	}
 }
+
+func TestZZWebSocketTearDown(t *testing.T) {
+	// *IMPORTANT* - Kind of hacky
+	// This should be the last function in any test file
+	// that calls Setup()
+	// Should be in the last file too sorted by name
+	time.Sleep(2 * time.Second)
+	StopServer()
+}


### PR DESCRIPTION
#### Summary
Add `StopServer()` at the end of API v4 tests.
This is just a small fix hoping to narrow down real issue with random test failures during build.

The ticket specifically described issue with `TestIncomingWebhook`.

#### Ticket Link
Jira ticket: [PLT-6694](https://mattermost.atlassian.net/browse/PLT-6694)

#### Checklist
- [x] Added or updated unit tests (required for all new features)


