### PR TITLE
Changed default Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ else
 ALL_PACKAGES_COMMA=$(TE_PACKAGES_COMMA)
 endif
 
-all: dist
+all: run
 
 dist: | check-style test package
 


### PR DESCRIPTION
I made it do a simple build to act more like the Makefiles for other projects. I considered having it `make run` by default, but that runs background processes which may catch some people off guard