### PR TITLE
Add GET /analytics/old endpoint for v4

### DIFF
--- a/api4/system.go
+++ b/api4/system.go
@@ -37,6 +37,8 @@ func InitSystem() {
 
 	BaseRoutes.ApiRoot.Handle("/logs", ApiSessionRequired(getLogs)).Methods("GET")
 	BaseRoutes.ApiRoot.Handle("/logs", ApiSessionRequired(postLog)).Methods("POST")
+
+	BaseRoutes.ApiRoot.Handle("/analytics/old", ApiSessionRequired(getAnalytics)).Methods("GET")
 }
 
 func getSystemPing(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -335,4 +337,31 @@ func removeLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("success")
 	ReturnStatusOK(w)
+}
+
+func getAnalytics(c *Context, w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	teamId := r.URL.Query().Get("team_id")
+
+	if name == "" {
+		name = "standard"
+	}
+
+	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	rows, err := app.GetAnalytics(name, teamId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	if rows == nil {
+		c.SetInvalidParam("name")
+		return
+	}
+
+	w.Write([]byte(rows.ToJson()))
 }

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -392,3 +392,45 @@ func TestRemoveLicenseFile(t *testing.T) {
 		t.Fatal("should pass")
 	}
 }
+
+func TestGetAnalyticsOld(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+	Client := th.Client
+
+	rows, resp := Client.GetAnalyticsOld("", "")
+	CheckForbiddenStatus(t, resp)
+	if rows != nil {
+		t.Fatal("should be nil")
+	}
+
+	rows, resp = th.SystemAdminClient.GetAnalyticsOld("", "")
+	CheckNoError(t, resp)
+
+	found := false
+	for _, row := range rows {
+		if row.Name == "unique_user_count" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatal("should return unique user count")
+	}
+
+	_, resp = th.SystemAdminClient.GetAnalyticsOld("post_counts_day", "")
+	CheckNoError(t, resp)
+
+	_, resp = th.SystemAdminClient.GetAnalyticsOld("user_counts_with_posts_day", "")
+	CheckNoError(t, resp)
+
+	_, resp = th.SystemAdminClient.GetAnalyticsOld("extra_counts", "")
+	CheckNoError(t, resp)
+
+	_, resp = th.SystemAdminClient.GetAnalyticsOld("", th.BasicTeam.Id)
+	CheckNoError(t, resp)
+
+	Client.Logout()
+	_, resp = Client.GetAnalyticsOld("", th.BasicTeam.Id)
+	CheckUnauthorizedStatus(t, resp)
+}

--- a/model/client4.go
+++ b/model/client4.go
@@ -258,6 +258,10 @@ func (c *Client4) GetJobsRoute() string {
 	return fmt.Sprintf("/jobs")
 }
 
+func (c *Client4) GetAnalyticsRoute() string {
+	return fmt.Sprintf("/analytics")
+}
+
 func (c *Client4) DoApiGet(url string, etag string) (*http.Response, *AppError) {
 	return c.DoApiRequest(http.MethodGet, c.ApiUrl+url, "", etag)
 }
@@ -1886,6 +1890,20 @@ func (c *Client4) RemoveLicenseFile() (bool, *Response) {
 	} else {
 		defer closeBody(r)
 		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
+// GetAnalyticsOld will retrieve analytics using the old format. New format is not
+// available but the "/analytics" endpoint is reserved for it. The "name" argument is optional
+// and defaults to "standard". The "teamId" argument is optional and will limit results
+// to a specific team.
+func (c *Client4) GetAnalyticsOld(name, teamId string) (AnalyticsRows, *Response) {
+	query := fmt.Sprintf("?name=%v&teamId=%v", name, teamId)
+	if r, err := c.DoApiGet(c.GetAnalyticsRoute()+"/old"+query, ""); err != nil {
+		return nil, &Response{StatusCode: r.StatusCode, Error: err}
+	} else {
+		defer closeBody(r)
+		return AnalyticsRowsFromJson(r.Body), BuildResponse(r)
 	}
 }
 


### PR DESCRIPTION
#### Summary
Add GET /analytics/old endpoint for v4. Reserving /analytics for a new format with different functionality.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#254)
- [x] All new/modified APIs include changes to the drivers