### PR TITLE
add more Ids for UI automation

### DIFF
--- a/webapp/components/new_channel_modal/new_channel_modal.jsx
+++ b/webapp/components/new_channel_modal/new_channel_modal.jsx
@@ -203,6 +203,7 @@ export default class NewChannelModal extends React.PureComponent {
         }
 
         var channelSwitchText = '';
+        let inputPrefixId = '';
         switch (this.props.channelType) {
         case 'P':
             channelSwitchText = (
@@ -214,6 +215,7 @@ export default class NewChannelModal extends React.PureComponent {
                     {createPublicChannelLink}
                 </div>
             );
+            inputPrefixId = 'newPrivateChannel';
             break;
         case 'O':
             channelSwitchText = (
@@ -225,6 +227,7 @@ export default class NewChannelModal extends React.PureComponent {
                     {createPrivateChannelLink}
                 </div>
             );
+            inputPrefixId = 'newPublicChannel';
             break;
         }
 
@@ -264,6 +267,7 @@ export default class NewChannelModal extends React.PureComponent {
                                 </label>
                                 <div className='col-sm-9'>
                                     <input
+                                        id={inputPrefixId + 'Name'}
                                         onChange={this.handleChange}
                                         type='text'
                                         ref='display_name'
@@ -307,6 +311,7 @@ export default class NewChannelModal extends React.PureComponent {
                                 </div>
                                 <div className='col-sm-9'>
                                     <textarea
+                                        id={inputPrefixId + 'Purpose'}
                                         className='form-control no-resize'
                                         ref='channel_purpose'
                                         rows='4'
@@ -341,6 +346,7 @@ export default class NewChannelModal extends React.PureComponent {
                                 </div>
                                 <div className='col-sm-9'>
                                     <textarea
+                                        id={inputPrefixId + 'Header'}
                                         className='form-control no-resize'
                                         ref='channel_header'
                                         rows='4'

--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -290,7 +290,12 @@ export default class SearchResultsItem extends React.Component {
                 <div
                     className={'post post--thread ' + compactClass}
                 >
-                    <div className='search-channel__name'>{channelName}</div>
+                    <div
+                        id={idCount === -1 ? null : Utils.createSafeId('searchChannelName' + idCount)}
+                        className='search-channel__name'
+                    >
+                        {channelName}
+                    </div>
                     <div className='post__content'>
                         {profilePicContainer}
                         <div>

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -691,6 +691,7 @@ export default class Sidebar extends React.Component {
         var directMessageMore = (
             <li key='more'>
                 <a
+                    id='moreDirectMessage'
                     href='#'
                     onClick={this.handleOpenMoreDirectChannelsModal}
                 >
@@ -749,6 +750,7 @@ export default class Sidebar extends React.Component {
                 overlay={createChannelTootlip}
             >
                 <a
+                    id='createPublicChannel'
                     className='add-channel-btn'
                     href='#'
                     onClick={this.showNewChannelModal.bind(this, Constants.OPEN_CHANNEL)}
@@ -766,6 +768,7 @@ export default class Sidebar extends React.Component {
                 overlay={createGroupTootlip}
             >
                 <a
+                    id='createPrivateChannel'
                     className='add-channel-btn'
                     href='#'
                     onClick={this.showNewChannelModal.bind(this, Constants.PRIVATE_CHANNEL)}

--- a/webapp/tests/components/__snapshots__/new_channel_modal.test.jsx.snap
+++ b/webapp/tests/components/__snapshots__/new_channel_modal.test.jsx.snap
@@ -92,6 +92,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
             <input
               autoFocus={true}
               className="form-control"
+              id="newPublicChannelName"
               maxLength={22}
               onChange={[Function]}
               placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
@@ -147,6 +148,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
           >
             <textarea
               className="form-control no-resize"
+              id="newPublicChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -195,6 +197,7 @@ exports[`components/NewChannelModal should match snapshot, modal not showing 1`]
           >
             <textarea
               className="form-control no-resize"
+              id="newPublicChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
@@ -339,6 +342,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
             <input
               autoFocus={true}
               className="form-control"
+              id="newPublicChannelName"
               maxLength={22}
               onChange={[Function]}
               placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
@@ -394,6 +398,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
           >
             <textarea
               className="form-control no-resize"
+              id="newPublicChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -442,6 +447,7 @@ exports[`components/NewChannelModal should match snapshot, modal showing 1`] = `
           >
             <textarea
               className="form-control no-resize"
+              id="newPublicChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""
@@ -586,6 +592,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
             <input
               autoFocus={true}
               className="form-control"
+              id="newPrivateChannelName"
               maxLength={22}
               onChange={[Function]}
               placeholder="E.g.: \\"Bugs\\", \\"Marketing\\", \\"客户支持\\""
@@ -641,6 +648,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
           >
             <textarea
               className="form-control no-resize"
+              id="newPrivateChannelPurpose"
               maxLength="250"
               onChange={[Function]}
               placeholder="E.g.: \\"A channel to file bugs and improvements\\""
@@ -689,6 +697,7 @@ exports[`components/NewChannelModal should match snapshot, private channel fille
           >
             <textarea
               className="form-control no-resize"
+              id="newPrivateChannelHeader"
               maxLength="1024"
               onChange={[Function]}
               placeholder="E.g.: \\"[Link Title](http://example.com)\\""


### PR DESCRIPTION
#### Summary
This is the last PR for below Jira ticket. Included in this PR are:
10. DM/GM `More...` link in LHS to add a new DM/GM => set ID to 'moreDirectMessage'
11. Name of channel in search results in RHS (can be multiple various) => set ID to 'searchChannelNameX' where X is 0 to 9
12. Public channel `+` button in LHS to add new public channel => set ID to 'createPublicChannel'
13. Private channel `+` button in LHS to add new private channel => set ID to 'createPrivateChannel'
14. Public Channels `More...` link in LHS to view more public channels
15. Form fields in Add New Public Channel form
 - Name => set ID to 'newPublicChannelName'
 - Purpose => set ID to 'newPublicChannelPurpose'
 - Header => set ID to 'newPublicChannelHeader'
16. Form fields in Add New Public Channel form
 - Name => set ID to 'newPrivateChannelName'
 - Purpose => set ID to 'newPrivateChannelPurpose'
 - Header => set ID to 'newPrivateChannelHeader'

#### Ticket Link
Jira ticket: [PLT-6363](https://mattermost.atlassian.net/browse/PLT-6363)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] For UI automation
