### PR TITLE
[PLT-5988] when a channel is update propagate the channel to everybody

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -281,6 +281,11 @@ func UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
 		return nil, result.Err
 	} else {
 		InvalidateCacheForChannel(channel)
+
+		messageWs := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_UPDATED, "", channel.Id, "", nil)
+		messageWs.Add("channel", channel.ToJson())
+		Publish(messageWs)
+
 		return channel, nil
 	}
 }

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -15,6 +15,7 @@ const (
 	WEBSOCKET_EVENT_POST_DELETED        = "post_deleted"
 	WEBSOCKET_EVENT_CHANNEL_DELETED     = "channel_deleted"
 	WEBSOCKET_EVENT_CHANNEL_CREATED     = "channel_created"
+	WEBSOCKET_EVENT_CHANNEL_UPDATED     = "channel_updated"
 	WEBSOCKET_EVENT_DIRECT_ADDED        = "direct_added"
 	WEBSOCKET_EVENT_GROUP_ADDED         = "group_added"
 	WEBSOCKET_EVENT_NEW_USER            = "new_user"

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -186,6 +186,10 @@ function handleEvent(msg) {
         handleChannelDeletedEvent(msg);
         break;
 
+    case SocketEvents.CHANNEL_UPDATED:
+        handleChannelUpdatedEvent(msg);
+        break;
+
     case SocketEvents.DIRECT_ADDED:
         handleDirectAddedEvent(msg);
         break;
@@ -357,6 +361,11 @@ function handleUserRemovedEvent(msg) {
     } else if (ChannelStore.getCurrentId() === msg.broadcast.channel_id) {
         getChannelStats(ChannelStore.getCurrentId())(dispatch, getState);
     }
+}
+
+function handleChannelUpdatedEvent(msg) {
+    const channel = JSON.parse(msg.data.channel);
+    dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
 }
 
 function handleUserUpdatedEvent(msg) {

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -220,6 +220,7 @@ export const SocketEvents = {
     POST_DELETED: 'post_deleted',
     CHANNEL_CREATED: 'channel_created',
     CHANNEL_DELETED: 'channel_deleted',
+    CHANNEL_UPDATED: 'channel_updated',
     CHANNEL_VIEWED: 'channel_viewed',
     DIRECT_ADDED: 'direct_added',
     NEW_USER: 'new_user',


### PR DESCRIPTION
#### Summary
This is a collaborative PR with @ruzette @jwilander 
This fix originally come from the @ruzette PR: https://github.com/mattermost/platform/pull/6360

When any update on the channel happens, we propagate the changes to all clients.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/PLT-5988
GitHub: https://github.com/mattermost/platform/issues/5834

#### Checklist
- [X] Added API documentation: mattermost/mattermost-api-reference#249


Thanks for all @ruzette and @jwilander your support was really crucial to this 🎉 
