### PR TITLE
[PLT-5639] Show a message when invited addresses are blocked

### DIFF
--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -1449,6 +1449,22 @@ func TestInviteUsersToTeam(t *testing.T) {
 			}
 		}
 	}
+
+	restrictCreationToDomains := utils.Cfg.TeamSettings.RestrictCreationToDomains
+	defer func() {
+		utils.Cfg.TeamSettings.RestrictCreationToDomains = restrictCreationToDomains
+	}()
+	utils.Cfg.TeamSettings.RestrictCreationToDomains = "@example.com"
+
+	err := app.InviteNewUsersToTeam(emailList, th.BasicTeam.Id, th.BasicUser.Id)
+
+	if err == nil {
+		t.Fatal("Adding users with non-restricted domains was allowed")
+	}
+	if err.Where != "InviteNewUsersToTeam" || err.Message != "api.team.invite_members.invalid_email.app_error" {
+		t.Log(err)
+		t.Fatal("Got wrong error message!")
+	}
 }
 
 func TestGetTeamInviteInfo(t *testing.T) {

--- a/app/team.go
+++ b/app/team.go
@@ -55,13 +55,8 @@ func CreateTeamWithUser(team *model.Team, userId string) (*model.Team, *model.Ap
 	return rteam, nil
 }
 
-func isTeamEmailAllowed(user *model.User) bool {
-	email := strings.ToLower(user.Email)
-
-	if len(user.AuthService) > 0 && len(*user.AuthData) > 0 {
-		return true
-	}
-
+func isTeamEmailAddressAllowed(email string) bool {
+	email = strings.ToLower(email)
 	// commas and @ signs are optional
 	// can be in the form of "@corp.mattermost.com, mattermost.com mattermost.org" -> corp.mattermost.com mattermost.com mattermost.org
 	domains := strings.Fields(strings.TrimSpace(strings.ToLower(strings.Replace(strings.Replace(utils.Cfg.TeamSettings.RestrictCreationToDomains, "@", " ", -1), ",", " ", -1))))
@@ -79,6 +74,16 @@ func isTeamEmailAllowed(user *model.User) bool {
 	}
 
 	return true
+}
+
+func isTeamEmailAllowed(user *model.User) bool {
+	email := strings.ToLower(user.Email)
+
+	if len(user.AuthService) > 0 && len(*user.AuthData) > 0 {
+		return true
+	}
+
+	return isTeamEmailAddressAllowed(email)
 }
 
 func UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {
@@ -618,6 +623,20 @@ func InviteNewUsersToTeam(emailList []string, teamId, senderId string) *model.Ap
 	if len(emailList) == 0 {
 		err := model.NewLocAppError("InviteNewUsersToTeam", "api.team.invite_members.no_one.app_error", nil, "")
 		err.StatusCode = http.StatusBadRequest
+		return err
+	}
+
+	var invalidEmailList []string
+
+	for _, email := range emailList {
+		if ! isTeamEmailAddressAllowed(email) {
+			invalidEmailList = append(invalidEmailList, email)
+		}
+	}
+
+	if len(invalidEmailList) > 0 {
+		s := strings.Join(invalidEmailList, ", ")
+		err := model.NewAppError("InviteNewUsersToTeam", "api.team.invite_members.invalid_email.app_error", map[string]interface{}{"Addresses": s}, "", http.StatusBadRequest)
 		return err
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2096,6 +2096,10 @@
     "translation": "Failed to send invite email successfully err=%v"
   },
   {
+    "id": "api.team.invite_members.invalid_email.app_error",
+    "translation": "The following email addresses do not belong to an accepted domain: {{.Addresses}}. Please contact your System Administrator for details."
+  },
+  {
     "id": "api.team.invite_members.sending.info",
     "translation": "sending invitation to %v %v"
   },

--- a/webapp/components/invite_member_modal.jsx
+++ b/webapp/components/invite_member_modal.jsx
@@ -97,7 +97,8 @@ class InviteMemberModal extends React.Component {
 
     handleToggle(value) {
         this.setState({
-            show: value
+            show: value,
+            serverError: null
         });
     }
 


### PR DESCRIPTION
#### Summary
When using the "Send Email Invite" functionality. Emails were sent to domains that were not on the `RestrictCreationToDomains` list. This would lead to users getting a message that they can't create an account if they follow the link in the email.

This commit will check the email addresses before the mails are sent and warn the user typing them in which ones are blocked.

**note**: is this accepted as a "small contribution" under the current guidelines? Before I read the CLA 😄 

![](http://i.imgur.com/5io5v5E.png)

![](http://i.imgur.com/ROhZJKQ.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5639

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates