### PR TITLE
[PLT-6847] If a message starts with a / but is not a slash command, put the text back in the input box when it fails to send

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -230,7 +230,7 @@ func ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.App
 		}
 	}
 
-	return nil, model.NewAppError("command", "api.command.execute_command.not_found.app_error", nil, "", http.StatusNotFound)
+	return nil, model.NewAppError("command", "api.command.execute_command.not_found.app_error", map[string]interface{}{"Trigger": trigger}, "", http.StatusNotFound)
 }
 
 func HandleCommandResponse(command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.CommandResponse, *model.AppError) {

--- a/app/command.go
+++ b/app/command.go
@@ -230,7 +230,7 @@ func ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.App
 		}
 	}
 
-	return nil, model.NewAppError("command", "api.command.execute_command.not_found.app_error", map[string]interface{}{"Trigger": trigger}, "", http.StatusNotFound)
+	return nil, model.NewAppError("command", "api.command.execute_command.not_found.app_error", nil, "", http.StatusNotFound)
 }
 
 func HandleCommandResponse(command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.CommandResponse, *model.AppError) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -429,7 +429,7 @@
   },
   {
     "id": "api.command.execute_command.not_found.app_error",
-    "translation": "Command with a trigger of '{{.Trigger}}' not found"
+    "translation": "To send a message beginning with \"/\", try adding an empty space at the beginning of the message."
   },
   {
     "id": "api.command.execute_command.save.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -429,7 +429,7 @@
   },
   {
     "id": "api.command.execute_command.not_found.app_error",
-    "translation": "To send a message beginning with \"/\", try adding an empty space at the beginning of the message."
+    "translation": "Command with a trigger of '{{.Trigger}}' not found. To send a message beginning with \"/\", try adding an empty space at the beginning of the message."
   },
   {
     "id": "api.command.execute_command.save.app_error",

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -172,7 +172,10 @@ export default class CreatePost extends React.Component {
                         const state = {};
                         state.serverError = err.message;
                         state.submitting = false;
-                        this.setState({state});
+                        this.setState({
+                            state,
+                            message: post.message
+                        });
                     }
                 }
             );

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -169,11 +169,9 @@ export default class CreatePost extends React.Component {
                     if (err.sendMessage) {
                         this.sendMessage(post);
                     } else {
-                        const state = {};
-                        state.serverError = err.message;
-                        state.submitting = false;
                         this.setState({
-                            state,
+                            serverError: err.message,
+                            submitting: false,
                             message: post.message
                         });
                     }


### PR DESCRIPTION
#### Summary
If a message starts with a / but is not a slash command, put the text back in the input box when it fails to send

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/PLT-6847
Github: https://github.com/mattermost/platform/issues/6659

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
