### PR TITLE
[PLT-6838] Restrict channel delete option per permission policy even for last channel member

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -428,7 +428,7 @@ func getDeletedChannelsForTeam(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if channels, err := app.GetDeletedChannels(c.Params.TeamId, c.Params.Page * c.Params.PerPage, c.Params.PerPage); err != nil {
+	if channels, err := app.GetDeletedChannels(c.Params.TeamId, c.Params.Page*c.Params.PerPage, c.Params.PerPage); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -540,17 +540,20 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Allow delete if user is the only member left in channel
-	if memberCount > 1 {
-		if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
-			c.SetPermissionError(model.PERMISSION_DELETE_PUBLIC_CHANNEL)
-			return
-		}
+	// Do not allow delete if there's only one member left in a private channel
+	if memberCount == 1 && channel.Type == model.CHANNEL_PRIVATE && !c.IsSystemAdmin() {
+		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.private.last_member.cannot.app_error", map[string]interface{}{"Channel": channel.DisplayName}, "", http.StatusForbidden)
+		return
+	}
 
-		if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
-			c.SetPermissionError(model.PERMISSION_DELETE_PRIVATE_CHANNEL)
-			return
-		}
+	if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
+		c.SetPermissionError(model.PERMISSION_DELETE_PUBLIC_CHANNEL)
+		return
+	}
+
+	if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
+		c.SetPermissionError(model.PERMISSION_DELETE_PRIVATE_CHANNEL)
+		return
 	}
 
 	err = app.DeleteChannel(channel, c.Session.UserId)

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -540,18 +540,13 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Do not allow delete if there's only one member left in a private channel
-	if memberCount == 1 && channel.Type == model.CHANNEL_PRIVATE && !c.IsSystemAdmin() {
-		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.private.last_member.cannot.app_error", map[string]interface{}{"Channel": channel.DisplayName}, "", http.StatusForbidden)
-		return
-	}
-
 	if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_DELETE_PUBLIC_CHANNEL)
 		return
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
+	// Allow delete if there's only one member left in a private channel
+	if memberCount > 1 && channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_DELETE_PRIVATE_CHANNEL)
 		return
 	}

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -814,10 +814,6 @@ func TestDeleteChannel(t *testing.T) {
 	// successful delete of private channel
 	privateChannel2 := th.CreatePrivateChannel()
 	_, resp = Client.DeleteChannel(privateChannel2.Id)
-	CheckForbiddenStatus(t, resp)
-
-	app.AddUserToChannel(user2, privateChannel2)
-	_, resp = Client.DeleteChannel(privateChannel2.Id)
 	CheckNoError(t, resp)
 
 	// successful delete of channel with multiple members
@@ -905,12 +901,14 @@ func TestDeleteChannel(t *testing.T) {
 	Client = th.Client
 	team = th.BasicTeam
 	user = th.BasicUser
+	user2 = th.BasicUser2
 
 	// channels created by SystemAdmin
 	publicChannel6 := th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
 	privateChannel7 := th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	app.AddUserToChannel(user, publicChannel6)
 	app.AddUserToChannel(user, privateChannel7)
+	app.AddUserToChannel(user2, privateChannel7)
 
 	// successful delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -928,6 +926,7 @@ func TestDeleteChannel(t *testing.T) {
 	privateChannel7 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	app.AddUserToChannel(user, publicChannel6)
 	app.AddUserToChannel(user, privateChannel7)
+	app.AddUserToChannel(user2, privateChannel7)
 
 	// cannot delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -952,6 +951,7 @@ func TestDeleteChannel(t *testing.T) {
 	privateChannel7 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	app.AddUserToChannel(user, publicChannel6)
 	app.AddUserToChannel(user, privateChannel7)
+	app.AddUserToChannel(user2, privateChannel7)
 
 	// successful delete by team admin
 	UpdateUserToTeamAdmin(user, team)
@@ -980,6 +980,7 @@ func TestDeleteChannel(t *testing.T) {
 	privateChannel7 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	app.AddUserToChannel(user, publicChannel6)
 	app.AddUserToChannel(user, privateChannel7)
+	app.AddUserToChannel(user2, privateChannel7)
 
 	// cannot delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -1021,6 +1022,7 @@ func TestDeleteChannel(t *testing.T) {
 	privateChannel7 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	app.AddUserToChannel(user, publicChannel6)
 	app.AddUserToChannel(user, privateChannel7)
+	app.AddUserToChannel(user2, privateChannel7)
 
 	// cannot delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -1058,6 +1060,18 @@ func TestDeleteChannel(t *testing.T) {
 	CheckNoError(t, resp)
 
 	_, resp = th.SystemAdminClient.DeleteChannel(privateChannel7.Id)
+	CheckNoError(t, resp)
+
+	// last member of a public channel should have required permission to delete
+	publicChannel6 = th.CreateChannelWithClient(th.Client, model.CHANNEL_OPEN)
+
+	_, resp = Client.DeleteChannel(publicChannel6.Id)
+	CheckForbiddenStatus(t, resp)
+
+	// last member of a private channel should be able to delete it regardless of required permissions
+	privateChannel7 = th.CreateChannelWithClient(th.Client, model.CHANNEL_PRIVATE)
+
+	_, resp = Client.DeleteChannel(privateChannel7.Id)
 	CheckNoError(t, resp)
 }
 

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -814,6 +814,10 @@ func TestDeleteChannel(t *testing.T) {
 	// successful delete of private channel
 	privateChannel2 := th.CreatePrivateChannel()
 	_, resp = Client.DeleteChannel(privateChannel2.Id)
+	CheckForbiddenStatus(t, resp)
+
+	app.AddUserToChannel(user2, privateChannel2)
+	_, resp = Client.DeleteChannel(privateChannel2.Id)
 	CheckNoError(t, resp)
 
 	// successful delete of channel with multiple members
@@ -1054,16 +1058,6 @@ func TestDeleteChannel(t *testing.T) {
 	CheckNoError(t, resp)
 
 	_, resp = th.SystemAdminClient.DeleteChannel(privateChannel7.Id)
-	CheckNoError(t, resp)
-
-	// last member of a channel should be able to delete it regardless of required permissions
-	publicChannel6 = th.CreateChannelWithClient(th.Client, model.CHANNEL_OPEN)
-	privateChannel7 = th.CreateChannelWithClient(th.Client, model.CHANNEL_PRIVATE)
-
-	_, resp = Client.DeleteChannel(publicChannel6.Id)
-	CheckNoError(t, resp)
-
-	_, resp = Client.DeleteChannel(privateChannel7.Id)
 	CheckNoError(t, resp)
 }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -240,6 +240,10 @@
     "translation": "Cannot delete the default channel {{.Channel}}"
   },
   {
+    "id": "api.channel.delete_channel.private.last_member.cannot.app_error",
+    "translation": "Cannot delete a private channel {{.Channel}} with only one member left"
+  },
+  {
     "id": "api.channel.delete_channel.deleted.app_error",
     "translation": "The channel has been archived or deleted"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -240,10 +240,6 @@
     "translation": "Cannot delete the default channel {{.Channel}}"
   },
   {
-    "id": "api.channel.delete_channel.private.last_member.cannot.app_error",
-    "translation": "Cannot delete a private channel {{.Channel}} with only one member left"
-  },
-  {
     "id": "api.channel.delete_channel.deleted.app_error",
     "translation": "The channel has been archived or deleted"
   },

--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -724,8 +724,6 @@ export default class ChannelHeader extends React.Component {
                 if (!ChannelStore.isDefault(channel)) {
                     dropdownContents.push(deleteOption);
                 }
-            } else if (this.state.userCount === 1) {
-                dropdownContents.push(deleteOption);
             }
 
             const canLeave = channel.type === Constants.PRIVATE_CHANNEL ? this.state.userCount > 1 : true;

--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -720,10 +720,8 @@ export default class ChannelHeader extends React.Component {
                 );
             }
 
-            if (ChannelUtils.showDeleteOption(channel, isAdmin, isSystemAdmin, isChannelAdmin)) {
-                if (!ChannelStore.isDefault(channel)) {
-                    dropdownContents.push(deleteOption);
-                }
+            if (ChannelUtils.showDeleteOption(channel, isAdmin, isSystemAdmin, isChannelAdmin, this.state.userCount)) {
+                dropdownContents.push(deleteOption);
             }
 
             const canLeave = channel.type === Constants.PRIVATE_CHANNEL ? this.state.userCount > 1 : true;

--- a/webapp/components/delete_channel_modal.jsx
+++ b/webapp/components/delete_channel_modal.jsx
@@ -33,6 +33,7 @@ export default class DeleteChannelModal extends React.Component {
 
         browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/town-square');
         deleteChannel(this.props.channel.id);
+        this.onHide();
     }
 
     onHide() {

--- a/webapp/components/navbar.jsx
+++ b/webapp/components/navbar.jsx
@@ -529,23 +529,21 @@ export default class Navbar extends React.Component {
                     );
                 }
 
-                if (ChannelUtils.showDeleteOption(channel, isAdmin, isSystemAdmin, isChannelAdmin) || this.state.userCount === 1) {
-                    if (!ChannelStore.isDefault(channel)) {
-                        deleteChannelOption = (
-                            <li role='presentation'>
-                                <ToggleModalButton
-                                    role='menuitem'
-                                    dialogType={DeleteChannelModal}
-                                    dialogProps={{channel}}
-                                >
-                                    <FormattedMessage
-                                        id='channel_header.delete'
-                                        defaultMessage='Delete Channel'
-                                    />
-                                </ToggleModalButton>
-                            </li>
-                        );
-                    }
+                if (ChannelUtils.showDeleteOption(channel, isAdmin, isSystemAdmin, isChannelAdmin, this.state.userCount)) {
+                    deleteChannelOption = (
+                        <li role='presentation'>
+                            <ToggleModalButton
+                                role='menuitem'
+                                dialogType={DeleteChannelModal}
+                                dialogProps={{channel}}
+                            >
+                                <FormattedMessage
+                                    id='channel_header.delete'
+                                    defaultMessage='Delete Channel'
+                                />
+                            </ToggleModalButton>
+                        </li>
+                    );
                 }
 
                 const canLeave = channel.type === Constants.PRIVATE_CHANNEL ? this.state.userCount > 1 : true;

--- a/webapp/utils/channel_utils.jsx
+++ b/webapp/utils/channel_utils.jsx
@@ -190,9 +190,13 @@ export function showManagementOptions(channel, isAdmin, isSystemAdmin, isChannel
     return true;
 }
 
-export function showDeleteOption(channel, isAdmin, isSystemAdmin, isChannelAdmin) {
+export function showDeleteOption(channel, isAdmin, isSystemAdmin, isChannelAdmin, userCount) {
     if (global.window.mm_license.IsLicensed !== 'true') {
         return true;
+    }
+
+    if (ChannelStore.isDefault(channel)) {
+        return false;
     }
 
     if (channel.type === Constants.OPEN_CHANNEL) {
@@ -213,6 +217,9 @@ export function showDeleteOption(channel, isAdmin, isSystemAdmin, isChannelAdmin
             return false;
         }
         if (global.window.mm_config.RestrictPrivateChannelDeletion === Constants.PERMISSIONS_CHANNEL_ADMIN && !isChannelAdmin && !isAdmin) {
+            return false;
+        }
+        if (userCount === 1) {
             return false;
         }
     }

--- a/webapp/utils/channel_utils.jsx
+++ b/webapp/utils/channel_utils.jsx
@@ -210,6 +210,9 @@ export function showDeleteOption(channel, isAdmin, isSystemAdmin, isChannelAdmin
             return false;
         }
     } else if (channel.type === Constants.PRIVATE_CHANNEL) {
+        if (userCount === 1) {
+            return true;
+        }
         if (global.window.mm_config.RestrictPrivateChannelDeletion === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
             return false;
         }
@@ -217,9 +220,6 @@ export function showDeleteOption(channel, isAdmin, isSystemAdmin, isChannelAdmin
             return false;
         }
         if (global.window.mm_config.RestrictPrivateChannelDeletion === Constants.PERMISSIONS_CHANNEL_ADMIN && !isChannelAdmin && !isAdmin) {
-            return false;
-        }
-        if (userCount === 1) {
             return false;
         }
     }


### PR DESCRIPTION
#### Summary
Restrict channel delete option per permission policy even for last channel member

#### Ticket Link
Jira ticket: [PLT-6838](https://mattermost.atlassian.net/browse/PLT-6838)

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
