### PR TITLE
PLT-6882 Disable /invite_people when account creation is set to false

### DIFF
--- a/app/command_invite_people.go
+++ b/app/command_invite_people.go
@@ -28,9 +28,13 @@ func (me *InvitePeopleProvider) GetTrigger() string {
 }
 
 func (me *InvitePeopleProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
+	autoComplete := true
+	if !utils.Cfg.EmailSettings.SendEmailNotifications || !utils.Cfg.TeamSettings.EnableUserCreation {
+		autoComplete = false
+	}
 	return &model.Command{
 		Trigger:          CMD_INVITE_PEOPLE,
-		AutoComplete:     true,
+		AutoComplete:     autoComplete,
 		AutoCompleteDesc: T("api.command.invite_people.desc"),
 		AutoCompleteHint: T("api.command.invite_people.hint"),
 		DisplayName:      T("api.command.invite_people.name"),

--- a/app/command_invite_people.go
+++ b/app/command_invite_people.go
@@ -42,6 +42,10 @@ func (me *InvitePeopleProvider) DoCommand(args *model.CommandArgs, message strin
 		return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command.invite_people.email_off")}
 	}
 
+	if !utils.Cfg.TeamSettings.EnableUserCreation {
+		return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command.invite_people.invite_off")}
+	}
+
 	emailList := strings.Fields(message)
 
 	for i := len(emailList) - 1; i >= 0; i-- {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -452,6 +452,10 @@
     "translation": "Email has not been configured, no invite(s) sent"
   },
   {
+    "id": "api.command.invite_people.invite_off",
+    "translation": "User creation has been disabled on this server, no invite(s) sent"
+  },
+  {
     "id": "api.command.invite_people.fail",
     "translation": "Encountered an error sending email invite(s)"
   },


### PR DESCRIPTION
#### Summary
Returns error `User creation has been disabled on this server, no invite(s) sent` when `TeamSettings.EnableUserCreation` is set to `false` and user attempts to `/invite_people`

#### Ticket Link
[Jira Ticket](https://mattermost.atlassian.net/browse/PLT-6882)
[PLT-6882](https://github.com/mattermost/platform/issues/6698)

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates