### PR TITLE
PLT-6714: add /settings command

### DIFF
--- a/api/command_settings_test.go
+++ b/api/command_settings_test.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api
+
+import (
+	"testing"
+)
+
+func TestSettingsCommand(t *testing.T) {
+	th := Setup().InitBasic()
+	th.BasicClient.Must(th.BasicClient.Command(th.BasicChannel.Id, "/settings"))
+}

--- a/app/command_settings.go
+++ b/app/command_settings.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"github.com/mattermost/platform/model"
+	goi18n "github.com/nicksnyder/go-i18n/i18n"
+)
+
+type SettingsProvider struct {
+}
+
+const (
+	CMD_SETTINGS = "settings"
+)
+
+func init() {
+	RegisterCommandProvider(&SettingsProvider{})
+}
+
+func (me *SettingsProvider) GetTrigger() string {
+	return CMD_SETTINGS
+}
+
+func (me *SettingsProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
+	return &model.Command{
+		Trigger:          CMD_SETTINGS,
+		AutoComplete:     true,
+		AutoCompleteDesc: T("api.command_settings.desc"),
+		AutoCompleteHint: "",
+		DisplayName:      T("api.command_settings.name"),
+	}
+}
+
+func (me *SettingsProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+	// This command is handled client-side and shouldn't hit the server.
+	return &model.CommandResponse{
+		Text:         args.T("api.command_settings.unsupported.app_error"),
+		ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+	}
+}

--- a/app/command_settings.go
+++ b/app/command_settings.go
@@ -19,11 +19,11 @@ func init() {
 	RegisterCommandProvider(&SettingsProvider{})
 }
 
-func (me *SettingsProvider) GetTrigger() string {
+func (settings *SettingsProvider) GetTrigger() string {
 	return CMD_SETTINGS
 }
 
-func (me *SettingsProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
+func (settings *SettingsProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	return &model.Command{
 		Trigger:          CMD_SETTINGS,
 		AutoComplete:     true,
@@ -33,7 +33,7 @@ func (me *SettingsProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *SettingsProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (settings *SettingsProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
 	// This command is handled client-side and shouldn't hit the server.
 	return &model.CommandResponse{
 		Text:         args.T("api.command_settings.unsupported.app_error"),

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -660,6 +660,18 @@
     "translation": "You are now online"
   },
   {
+    "id": "api.command_settings.desc",
+    "translation": "Open the Account Settings dialog"
+  },
+  {
+    "id": "api.command_settings.name",
+    "translation": "settings"
+  },
+  {
+    "id": "api.command_settings.unsupported.app_error",
+    "translation": "The settings command is not supported on your device"
+  },
+  {
     "id": "api.command_shortcuts.browser.channel_next",
     "translation": "{{.ChannelNextCmd}}: Next channel in your history\n"
   },

--- a/webapp/actions/channel_actions.jsx
+++ b/webapp/actions/channel_actions.jsx
@@ -9,6 +9,8 @@ import ChannelStore from 'stores/channel_store.jsx';
 import * as ChannelUtils from 'utils/channel_utils.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 
+import * as GlobalActions from 'actions/global_actions.jsx';
+
 import {loadProfilesForSidebar, loadNewDMIfNeeded, loadNewGMIfNeeded} from 'actions/user_actions.jsx';
 import {trackEvent} from 'actions/diagnostics_actions.jsx';
 
@@ -66,9 +68,15 @@ export function goToChannel(channel) {
 export function executeCommand(message, args, success, error) {
     let msg = message;
 
-    msg = msg.substring(0, msg.indexOf(' ')).toLowerCase() + msg.substring(msg.indexOf(' '), msg.length);
+    let cmdLength = msg.indexOf(' ');
+    if (cmdLength < 0) {
+        cmdLength = msg.length;
+    }
+    const cmd = msg.substring(0, cmdLength).toLowerCase();
+    msg = cmd + msg.substring(cmdLength, msg.length);
 
-    if (message.indexOf('/shortcuts') !== -1) {
+    switch (cmd) {
+    case '/shortcuts':
         if (UserAgent.isMobile()) {
             const err = {message: Utils.localizeMessage('create_post.shortcutsNotSupported', 'Keyboard shortcuts are not supported on your device')};
             error(err);
@@ -78,7 +86,12 @@ export function executeCommand(message, args, success, error) {
         } else if (message.indexOf('mac') !== -1) {
             msg = '/shortcuts';
         }
+        break;
+    case '/settings':
+        GlobalActions.showAccountSettingsModal();
+        return;
     }
+
     Client.executeCommand(msg, args, success,
         (err) => {
             AsyncClient.dispatchError(err, 'executeCommand');
@@ -86,7 +99,8 @@ export function executeCommand(message, args, success, error) {
             if (error) {
                 error(err);
             }
-        });
+        }
+    );
 }
 
 export function setChannelAsRead(channelIdParam) {

--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -196,6 +196,13 @@ export function emitUserCommentedEvent(post) {
     });
 }
 
+export function showAccountSettingsModal() {
+    AppDispatcher.handleViewAction({
+        type: ActionTypes.TOGGLE_ACCOUNT_SETTINGS_MODAL,
+        value: true
+    });
+}
+
 export function showDeletePostModal(post, commentCount = 0) {
     AppDispatcher.handleViewAction({
         type: ActionTypes.TOGGLE_DELETE_POST_MODAL,

--- a/webapp/components/needs_team/needs_team.jsx
+++ b/webapp/components/needs_team/needs_team.jsx
@@ -33,6 +33,7 @@ import store from 'stores/redux_store.jsx';
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
 // Modals
+import UserSettingsModal from 'components/user_settings/user_settings_modal.jsx';
 import GetPostLinkModal from 'components/get_post_link_modal.jsx';
 import GetPublicLinkModal from 'components/get_public_link_modal.jsx';
 import GetTeamInviteLinkModal from 'components/get_team_invite_link_modal.jsx';
@@ -218,6 +219,7 @@ export default class NeedsTeam extends React.Component {
                     <WebrtcSidebar/>
                     {content}
 
+                    <UserSettingsModal/>
                     <GetPostLinkModal/>
                     <GetPublicLinkModal/>
                     <GetTeamInviteLinkModal/>

--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -13,7 +13,6 @@ import WebrtcStore from 'stores/webrtc_store.jsx';
 import AboutBuildModal from './about_build_modal.jsx';
 import SidebarHeaderDropdownButton from './sidebar_header_dropdown_button.jsx';
 import TeamMembersModal from './team_members_modal.jsx';
-import UserSettingsModal from './user_settings/user_settings_modal.jsx';
 import AddUsersToTeam from 'components/add_users_to_team';
 
 import {Constants, WebrtcActionTypes} from 'utils/constants.jsx';
@@ -45,7 +44,7 @@ export default class SidebarHeaderDropdown extends React.Component {
 
         this.handleAboutModal = this.handleAboutModal.bind(this);
         this.aboutModalDismissed = this.aboutModalDismissed.bind(this);
-        this.toggleAccountSettingsModal = this.toggleAccountSettingsModal.bind(this);
+        this.showAccountSettingsModal = this.showAccountSettingsModal.bind(this);
         this.showAddUsersToTeamModal = this.showAddUsersToTeamModal.bind(this);
         this.hideAddUsersToTeamModal = this.hideAddUsersToTeamModal.bind(this);
         this.showInviteMemberModal = this.showInviteMemberModal.bind(this);
@@ -54,7 +53,6 @@ export default class SidebarHeaderDropdown extends React.Component {
         this.hideTeamMembersModal = this.hideTeamMembersModal.bind(this);
 
         this.onTeamChange = this.onTeamChange.bind(this);
-        this.openAccountSettings = this.openAccountSettings.bind(this);
 
         this.renderCustomEmojiLink = this.renderCustomEmojiLink.bind(this);
 
@@ -66,7 +64,6 @@ export default class SidebarHeaderDropdown extends React.Component {
             showAboutModal: false,
             showDropdown: false,
             showTeamMembersModal: false,
-            showUserSettingsModal: false,
             showAddUsersToTeamModal: false
         };
     }
@@ -104,13 +101,12 @@ export default class SidebarHeaderDropdown extends React.Component {
         this.setState({showAboutModal: false});
     }
 
-    toggleAccountSettingsModal(e) {
+    showAccountSettingsModal(e) {
         e.preventDefault();
 
-        this.setState({
-            showUserSettingsModal: !this.state.showUserSettingsModal,
-            showDropdown: false
-        });
+        this.setState({showDropdown: false});
+
+        GlobalActions.showAccountSettingsModal();
     }
 
     showAddUsersToTeamModal(e) {
@@ -160,7 +156,6 @@ export default class SidebarHeaderDropdown extends React.Component {
 
     componentDidMount() {
         TeamStore.addChangeListener(this.onTeamChange);
-        document.addEventListener('keydown', this.openAccountSettings);
     }
 
     onTeamChange() {
@@ -174,13 +169,6 @@ export default class SidebarHeaderDropdown extends React.Component {
     componentWillUnmount() {
         $(ReactDOM.findDOMNode(this.refs.dropdown)).off('hide.bs.dropdown');
         TeamStore.removeChangeListener(this.onTeamChange);
-        document.removeEventListener('keydown', this.openAccountSettings);
-    }
-
-    openAccountSettings(e) {
-        if (Utils.cmdOrCtrlPressed(e) && e.shiftKey && e.keyCode === Constants.KeyCodes.A) {
-            this.toggleAccountSettingsModal(e);
-        }
     }
 
     renderCustomEmojiLink() {
@@ -527,7 +515,7 @@ export default class SidebarHeaderDropdown extends React.Component {
                 <a
                     id='accountSettings'
                     href='#'
-                    onClick={this.toggleAccountSettingsModal}
+                    onClick={this.showAccountSettingsModal}
                 >
                     <FormattedMessage
                         id='navbar_dropdown.accountSettings'
@@ -634,10 +622,6 @@ export default class SidebarHeaderDropdown extends React.Component {
                     {about}
                     {logoutDivider}
                     {logout}
-                    <UserSettingsModal
-                        show={this.state.showUserSettingsModal}
-                        onModalDismissed={() => this.setState({showUserSettingsModal: false})}
-                    />
                     {teamMembersModal}
                     <AboutBuildModal
                         show={this.state.showAboutModal}

--- a/webapp/components/sidebar_right_menu.jsx
+++ b/webapp/components/sidebar_right_menu.jsx
@@ -4,7 +4,6 @@
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import TeamMembersModal from './team_members_modal.jsx';
 import ToggleModalButton from './toggle_modal_button.jsx';
-import UserSettingsModal from './user_settings/user_settings_modal.jsx';
 import AboutBuildModal from './about_build_modal.jsx';
 import AddUsersToTeam from 'components/add_users_to_team';
 
@@ -46,7 +45,6 @@ export default class SidebarRightMenu extends React.Component {
         this.getFlagged = this.getFlagged.bind(this);
 
         const state = this.getStateFromStores();
-        state.showUserSettingsModal = false;
         state.showAboutModal = false;
         state.showAddUsersToTeamModal = false;
 
@@ -503,7 +501,7 @@ export default class SidebarRightMenu extends React.Component {
                         <li>
                             <a
                                 href='#'
-                                onClick={() => this.setState({showUserSettingsModal: true})}
+                                onClick={() => GlobalActions.showAccountSettingsModal()}
                             >
                                 <i className='icon fa fa-cog'/>
                                 <FormattedMessage
@@ -555,10 +553,6 @@ export default class SidebarRightMenu extends React.Component {
                         </li>
                     </ul>
                 </div>
-                <UserSettingsModal
-                    show={this.state.showUserSettingsModal}
-                    onModalDismissed={() => this.setState({showUserSettingsModal: false})}
-                />
                 <AboutBuildModal
                     show={this.state.showAboutModal}
                     onModalDismissed={this.aboutModalDismissed}

--- a/webapp/stores/modal_store.jsx
+++ b/webapp/stores/modal_store.jsx
@@ -31,6 +31,7 @@ class ModalStoreClass extends EventEmitter {
         const {type, value, ...args} = payload.action; //eslint-disable-line no-use-before-define
 
         switch (type) {
+        case ActionTypes.TOGGLE_ACCOUNT_SETTINGS_MODAL:
         case ActionTypes.TOGGLE_IMPORT_THEME_MODAL:
         case ActionTypes.TOGGLE_INVITE_MEMBER_MODAL:
         case ActionTypes.TOGGLE_LEAVE_TEAM_MODAL:

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -166,6 +166,7 @@ export const ActionTypes = keyMirror({
 
     USER_TYPING: null,
 
+    TOGGLE_ACCOUNT_SETTINGS_MODAL: null,
     TOGGLE_IMPORT_THEME_MODAL: null,
     TOGGLE_INVITE_MEMBER_MODAL: null,
     TOGGLE_LEAVE_TEAM_MODAL: null,


### PR DESCRIPTION
#### Summary
/settings slash command: Open the Account Settings dialog

I believe this is the first slash command that performs only client-side operations. So what I've done is implement the command as usual, but the server-side execution only does one thing: result in an error saying the command is not supported by your device. The command is handled client-side and never sent to the server.

I have slight hesitations about this approach since it spreads out the command implementation, but there's at least some precedence for it with the "/shortcuts" command. The alternative would be a mechanism to enable the server to interact with the front-end (i.e. respond with a message saying "open the account settings"), but I don't think that's any better.

If this approach is reasonable, I'll be doing a very similar thing for https://github.com/mattermost/platform/issues/6556.

[![Demo](https://thumbs.gfycat.com/FortunateGrizzledGoldeneye-size_restricted.gif)](https://gfycat.com/FortunateGrizzledGoldeneye)

#### Ticket Link
https://github.com/mattermost/platform/issues/6555

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates