### PR TITLE
PLT-6717: add /open command

### DIFF
--- a/api/command_join_test.go
+++ b/api/command_join_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/mattermost/platform/model"
 )
 
-func TestJoinCommands(t *testing.T) {
+// also used to test /open (see command_open_test.go)
+func testJoinCommands(t *testing.T, alias string) {
 	th := Setup().InitBasic()
 	Client := th.BasicClient
 	team := th.BasicTeam
@@ -29,12 +30,12 @@ func TestJoinCommands(t *testing.T) {
 
 	channel3 := Client.Must(Client.CreateDirectChannel(user2.Id)).Data.(*model.Channel)
 
-	rs5 := Client.Must(Client.Command(channel0.Id, "/join "+channel2.Name)).Data.(*model.CommandResponse)
+	rs5 := Client.Must(Client.Command(channel0.Id, "/"+alias+" "+channel2.Name)).Data.(*model.CommandResponse)
 	if !strings.HasSuffix(rs5.GotoLocation, "/"+team.Name+"/channels/"+channel2.Name) {
 		t.Fatal("failed to join channel")
 	}
 
-	rs6 := Client.Must(Client.Command(channel0.Id, "/join "+channel3.Name)).Data.(*model.CommandResponse)
+	rs6 := Client.Must(Client.Command(channel0.Id, "/"+alias+" "+channel3.Name)).Data.(*model.CommandResponse)
 	if strings.HasSuffix(rs6.GotoLocation, "/"+team.Name+"/channels/"+channel3.Name) {
 		t.Fatal("should not have joined direct message channel")
 	}
@@ -51,4 +52,8 @@ func TestJoinCommands(t *testing.T) {
 	if !found {
 		t.Fatal("did not join channel")
 	}
+}
+
+func TestJoinCommands(t *testing.T) {
+	testJoinCommands(t, "join")
 }

--- a/api/command_open_test.go
+++ b/api/command_open_test.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api
+
+import (
+	"testing"
+)
+
+func TestOpenCommands(t *testing.T) {
+	testJoinCommands(t, "open")
+}

--- a/app/command_open.go
+++ b/app/command_open.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"github.com/mattermost/platform/model"
+	goi18n "github.com/nicksnyder/go-i18n/i18n"
+)
+
+type OpenProvider struct {
+	JoinProvider
+}
+
+const (
+	CMD_OPEN = "open"
+)
+
+func init() {
+	RegisterCommandProvider(&OpenProvider{})
+}
+
+func (open *OpenProvider) GetTrigger() string {
+	return CMD_OPEN
+}
+
+func (open *OpenProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
+	cmd := open.JoinProvider.GetCommand(T)
+	cmd.Trigger = CMD_OPEN
+	cmd.DisplayName = T("api.command_open.name")
+	return cmd
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -672,6 +672,10 @@
     "translation": "The settings command is not supported on your device"
   },
   {
+    "id": "api.command_open.name",
+    "translation": "open"
+  },
+  {
     "id": "api.command_shortcuts.browser.channel_next",
     "translation": "{{.ChannelNextCmd}}: Next channel in your history\n"
   },


### PR DESCRIPTION
#### Summary
Add duplicate /open command for joining a new channel. The /open command should perform the same action as /join.

#### Ticket Link
https://github.com/mattermost/platform/issues/6545

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
