### PR TITLE
PLT-3744: verify domain for oauth user creation

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -176,7 +176,7 @@ func IsFirstUserAccount() bool {
 }
 
 func CreateUser(user *model.User) (*model.User, *model.AppError) {
-	if !user.IsSSOUser() && !CheckUserDomain(user, utils.Cfg.TeamSettings.RestrictCreationToDomains) {
+	if !user.IsLDAPUser() && !user.IsSAMLUser() && !CheckUserDomain(user, utils.Cfg.TeamSettings.RestrictCreationToDomains) {
 		return nil, model.NewLocAppError("CreateUser", "api.user.create_user.accepted_domain.app_error", nil, "")
 	}
 
@@ -313,15 +313,13 @@ func CheckUserDomain(user *model.User, domains string) bool {
 
 	domainArray := strings.Fields(strings.TrimSpace(strings.ToLower(strings.Replace(strings.Replace(domains, "@", " ", -1), ",", " ", -1))))
 
-	matched := false
 	for _, d := range domainArray {
 		if strings.HasSuffix(strings.ToLower(user.Email), "@"+d) {
-			matched = true
-			break
+			return true
 		}
 	}
 
-	return matched
+	return false
 }
 
 // Check if the username is already used by another user. Return false if the username is invalid.

--- a/model/user.go
+++ b/model/user.go
@@ -457,31 +457,25 @@ func IsInRole(userRoles string, inRole string) bool {
 		if r == inRole {
 			return true
 		}
-
 	}
 
 	return false
 }
 
 func (u *User) IsSSOUser() bool {
-	if u.AuthService != "" && u.AuthService != USER_AUTH_SERVICE_EMAIL {
-		return true
-	}
-	return false
+	return u.AuthService != "" && u.AuthService != USER_AUTH_SERVICE_EMAIL
 }
 
 func (u *User) IsOAuthUser() bool {
-	if u.AuthService == USER_AUTH_SERVICE_GITLAB {
-		return true
-	}
-	return false
+	return u.AuthService == USER_AUTH_SERVICE_GITLAB
 }
 
 func (u *User) IsLDAPUser() bool {
-	if u.AuthService == USER_AUTH_SERVICE_LDAP {
-		return true
-	}
-	return false
+	return u.AuthService == USER_AUTH_SERVICE_LDAP
+}
+
+func (u *User) IsSAMLUser() bool {
+	return u.AuthService == USER_AUTH_SERVICE_SAML
 }
 
 // UserFromJson will decode the input and return a User


### PR DESCRIPTION
#### Summary
Apply the Restrict account creation to specified email domains setting for GitLab/Google/Office365 SSO. If the restricted domain is set to "mattermost.com" then a user must have a GitLab/Google/Office365 account pointing to that domain when creating an account.

[![Demo](https://thumbs.gfycat.com/DisfiguredColorfulKentrosaurus-size_restricted.gif)](https://gfycat.com/DisfiguredColorfulKentrosaurus)

I also simplified some surrounding code.

#### Ticket Link
https://github.com/mattermost/platform/issues/5356

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
