### PR TITLE
PLT-6548 fix order in the RHS menu

### DIFF
--- a/webapp/components/sidebar_right_menu.jsx
+++ b/webapp/components/sidebar_right_menu.jsx
@@ -520,8 +520,8 @@ export default class SidebarRightMenu extends React.Component {
                         {teamSettingsLink}
                         {manageLink}
                         {createTeam}
-                        {leaveTeam}
                         {joinAnotherTeamLink}
+                        {leaveTeam}
                         {consoleDivider}
                         {consoleLink}
                         <li className='divider'/>


### PR DESCRIPTION
#### Summary
`Leave Team` menu item was in a wrong position

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/PLT-6548
