### PR TITLE
Fix places where we still refer to "/loadtest"

### DIFF
--- a/api/command_loadtest_test.go
+++ b/api/command_loadtest_test.go
@@ -17,7 +17,7 @@ func TestLoadTestHelpCommands(t *testing.T) {
 	Client := th.BasicClient
 	channel := th.BasicChannel
 
-	// enable testing to use /loadtest but don't save it since we don't want to overwrite config.json
+	// enable testing to use /test but don't save it since we don't want to overwrite config.json
 	enableTesting := utils.Cfg.ServiceSettings.EnableTesting
 	defer func() {
 		utils.Cfg.ServiceSettings.EnableTesting = enableTesting
@@ -80,7 +80,7 @@ func TestLoadTestChannelsCommands(t *testing.T) {
 	Client := th.BasicClient
 	channel := th.BasicChannel
 
-	// enable testing to use /loadtest but don't save it since we don't want to overwrite config.json
+	// enable testing to use /test but don't save it since we don't want to overwrite config.json
 	enableTesting := utils.Cfg.ServiceSettings.EnableTesting
 	defer func() {
 		utils.Cfg.ServiceSettings.EnableTesting = enableTesting
@@ -101,7 +101,7 @@ func TestLoadTestPostsCommands(t *testing.T) {
 	Client := th.BasicClient
 	channel := th.BasicChannel
 
-	// enable testing to use /loadtest but don't save it since we don't want to overwrite config.json
+	// enable testing to use /test but don't save it since we don't want to overwrite config.json
 	enableTesting := utils.Cfg.ServiceSettings.EnableTesting
 	defer func() {
 		utils.Cfg.ServiceSettings.EnableTesting = enableTesting

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,18 +1,18 @@
 # Testing Text Processing  
-The text processing tests located in the [doc/developer/tests folder](https://github.com/mattermost/platform/tree/master/doc/developer/tests) are designed for use with the `/loadtest url` command. This command posts the raw contents of a specified .md file in the doc/developer/test folder into Mattermost.
+The text processing tests located in the [doc/developer/tests folder](https://github.com/mattermost/platform/tree/master/doc/developer/tests) are designed for use with the `/test url` command. This command posts the raw contents of a specified .md file in the doc/developer/test folder into Mattermost.
 
 ## Turning on /test  
 Access the **System Console** from the Main Menu. Under *Service Settings* make sure that *Enable Testing* is set to `true`, then click **Save**. You may also change this setting from `config.json` by setting `”EnableTesting”: true`. Changing this setting requires a server restart to take effect.
 
 ## Running the Tests  
-In the text input box in Mattermost, type: `/loadtest url [file-name-in-testing-folder].md`. Some examples:
+In the text input box in Mattermost, type: `/test url [file-name-in-testing-folder].md`. Some examples:
 
-`/load url test-emoticons.md`  
-`/load url test-links.md`
+`/test url test-emoticons.md`  
+`/test url test-links.md`
 
 #### Notes:    
 1. If a test has prerequisites, make sure your Mattermost setup meets the requirements described at the top of the test file.
 2. Some tests are over 4000 characters in length and will render across multiple posts.
 
 ## Manual Testing  
-It is possible to manually test specific sections of any test, instead of using the /loadtest command. Do this by clicking **Raw** in the header for the file when it’s open in GitHub, then copy and paste any section into Mattermost to post it. Manual testing only supports sections of 4000 characters or less per post.
+It is possible to manually test specific sections of any test, instead of using the /test command. Do this by clicking **Raw** in the header for the file when it’s open in GitHub, then copy and paste any section into Mattermost to post it. Manual testing only supports sections of 4000 characters or less per post.

--- a/webapp/components/admin_console/developer_settings.jsx
+++ b/webapp/components/admin_console/developer_settings.jsx
@@ -54,7 +54,7 @@ export default class DeveloperSettings extends AdminSettings {
                     helpText={
                         <FormattedMessage
                             id='admin.service.testingDescription'
-                            defaultMessage='When true, /loadtest slash command is enabled to load test accounts, data and text formatting. Changing this requires a server restart before taking effect.'
+                            defaultMessage='When true, /test slash command is enabled to load test accounts, data and text formatting. Changing this requires a server restart before taking effect.'
                         />
                     }
                     value={this.state.enableTesting}


### PR DESCRIPTION
Fix places where we still refer to "/loadtest"
