### PR TITLE
[GH-6742] Fix permission app error with updatePost

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -302,6 +302,10 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.RequirePostId()
+	if c.Err != nil {
+		return
+	}
+
 	post := model.PostFromJson(r.Body)
 
 	if post == nil {

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -137,6 +137,8 @@ func TestUpdatePost(t *testing.T) {
 
 	msg := "zz" + model.NewId() + " update post"
 	rpost.Message = msg
+	rpost.UserId = ""
+
 	rupost, resp := Client.UpdatePost(rpost.Id, rpost)
 	CheckNoError(t, resp)
 

--- a/app/post.go
+++ b/app/post.go
@@ -239,11 +239,6 @@ func UpdatePost(post *model.Post, safeUpdate bool) (*model.Post, *model.AppError
 			return nil, err
 		}
 
-		if oldPost.UserId != post.UserId {
-			err := model.NewAppError("UpdatePost", "api.post.update_post.permissions.app_error", nil, "oldUserId="+oldPost.UserId, http.StatusBadRequest)
-			return nil, err
-		}
-
 		if oldPost.DeleteAt != 0 {
 			err := model.NewAppError("UpdatePost", "api.post.update_post.permissions_details.app_error", map[string]interface{}{"PostId": post.Id}, "", http.StatusBadRequest)
 			return nil, err


### PR DESCRIPTION
#### Summary
Fix permission app error when updating post where UserId is missing on post body.

Note that the `PUT /post/{post_id}` endpoint for v4 is initially intended for the entire post where full post information is expected from the request body including `UserId`. However, since `UserId` is not allowed to be changed, the `UserId` information is from the `oldPost` and not from the request body. That's why the condition check is removed as it seemed to be unnecessary.

For partial post update, it is always encourage to use `PUT /post/{post_id}/patch`.

#### Ticket Link
GitHub issue: #6742 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers
