### PR TITLE
Fixed error information being obscured when joining teams with API v4

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -373,14 +373,8 @@ func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request)
 
 	if len(hash) > 0 && len(data) > 0 {
 		member, err = app.AddTeamMemberByHash(c.Session.UserId, hash, data)
-		if err != nil {
-			err = model.NewAppError("addTeamMember", "api.team.add_user_to_team.invalid_data.app_error", nil, "", http.StatusBadRequest)
-		}
 	} else if len(inviteId) > 0 {
 		member, err = app.AddTeamMemberByInviteId(inviteId, c.Session.UserId)
-		if err != nil {
-			err = model.NewAppError("addTeamMember", "api.team.add_user_to_team.invalid_invite_id.app_error", nil, "", http.StatusBadRequest)
-		}
 	} else {
 		err = model.NewAppError("addTeamMember", "api.team.add_user_to_team.missing_parameter.app_error", nil, "", http.StatusBadRequest)
 	}

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -781,7 +781,7 @@ func TestAddTeamMember(t *testing.T) {
 	tm, resp := Client.AddTeamMember(team.Id, otherUser.Id)
 	CheckForbiddenStatus(t, resp)
 	if resp.Error == nil {
-		t.Fatalf("ERror is nhul")
+		t.Fatalf("Error is nhul")
 	}
 	Client.Logout()
 
@@ -971,14 +971,11 @@ func TestAddTeamMember(t *testing.T) {
 	}
 
 	tm, resp = Client.AddTeamMemberFromInvite("", "", "junk")
-	CheckBadRequestStatus(t, resp)
+	CheckNotFoundStatus(t, resp)
 
 	if tm != nil {
 		t.Fatal("should have not returned team member")
 	}
-
-	_, resp = Client.AddTeamMemberFromInvite("", "", "junk")
-	CheckBadRequestStatus(t, resp)
 }
 
 func TestAddTeamMembers(t *testing.T) {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -261,7 +261,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 		inviteId := model.NewId()
 
 		_, resp := Client.CreateUserWithInviteId(&user, inviteId)
-		CheckInternalErrorStatus(t, resp)
+		CheckNotFoundStatus(t, resp)
 		CheckErrorMessage(t, resp, "store.sql_team.get_by_invite_id.find.app_error")
 	})
 
@@ -283,7 +283,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 		CheckNoError(t, resp)
 
 		_, resp = Client.CreateUserWithInviteId(&user, inviteId)
-		CheckInternalErrorStatus(t, resp)
+		CheckNotFoundStatus(t, resp)
 		CheckErrorMessage(t, resp, "store.sql_team.get_by_invite_id.find.app_error")
 	})
 

--- a/app/team.go
+++ b/app/team.go
@@ -199,12 +199,12 @@ func AddUserToTeamByHash(userId string, hash string, data string) (*model.Team, 
 	props := model.MapFromJson(strings.NewReader(data))
 
 	if hash != utils.HashSha256(fmt.Sprintf("%v:%v", data, utils.Cfg.EmailSettings.InviteSalt)) {
-		return nil, model.NewLocAppError("JoinUserToTeamByHash", "api.user.create_user.signup_link_invalid.app_error", nil, "")
+		return nil, model.NewAppError("JoinUserToTeamByHash", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	t, timeErr := strconv.ParseInt(props["time"], 10, 64)
 	if timeErr != nil || model.GetMillis()-t > 1000*60*60*48 { // 48 hours
-		return nil, model.NewLocAppError("JoinUserToTeamByHash", "api.user.create_user.signup_link_expired.app_error", nil, "")
+		return nil, model.NewAppError("JoinUserToTeamByHash", "api.user.create_user.signup_link_expired.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	tchan := Srv.Store.Team().Get(props["id"])

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2004,14 +2004,6 @@
     "translation": "The number of running goroutines is over the health threshold %v of %v"
   },
   {
-    "id": "api.team.add_user_to_team.invalid_data.app_error",
-    "translation": "Invalid data."
-  },
-  {
-    "id": "api.team.add_user_to_team.invalid_invite_id.app_error",
-    "translation": "Invalid invite id. No team matches with this invite id."
-  },
-  {
     "id": "api.team.add_user_to_team.missing_parameter.app_error",
     "translation": "Parameter required to add user to team."
   },

--- a/store/sql_team_store.go
+++ b/store/sql_team_store.go
@@ -191,7 +191,7 @@ func (s SqlTeamStore) GetByInviteId(inviteId string) StoreChannel {
 		team := model.Team{}
 
 		if err := s.GetReplica().SelectOne(&team, "SELECT * FROM Teams WHERE Id = :InviteId OR InviteId = :InviteId", map[string]interface{}{"InviteId": inviteId}); err != nil {
-			result.Err = model.NewLocAppError("SqlTeamStore.GetByInviteId", "store.sql_team.get_by_invite_id.finding.app_error", nil, "inviteId="+inviteId+", "+err.Error())
+			result.Err = model.NewAppError("SqlTeamStore.GetByInviteId", "store.sql_team.get_by_invite_id.finding.app_error", nil, "inviteId="+inviteId+", "+err.Error(), http.StatusNotFound)
 		}
 
 		if len(team.InviteId) == 0 {
@@ -199,7 +199,7 @@ func (s SqlTeamStore) GetByInviteId(inviteId string) StoreChannel {
 		}
 
 		if len(inviteId) == 0 || team.InviteId != inviteId {
-			result.Err = model.NewLocAppError("SqlTeamStore.GetByInviteId", "store.sql_team.get_by_invite_id.find.app_error", nil, "inviteId="+inviteId)
+			result.Err = model.NewAppError("SqlTeamStore.GetByInviteId", "store.sql_team.get_by_invite_id.find.app_error", nil, "inviteId="+inviteId, http.StatusNotFound)
 		}
 
 		result.Data = &team

--- a/webapp/components/signup/signup_controller.jsx
+++ b/webapp/components/signup/signup_controller.jsx
@@ -113,7 +113,7 @@ export default class SignupController extends React.Component {
 
     handleInvalidInvite = (err) => {
         let serverError;
-        if (err.id === 'store.sql_user.save.max_accounts.app_error') {
+        if (err.server_error_id === 'store.sql_user.save.max_accounts.app_error') {
             serverError = err.message;
         } else {
             serverError = (
@@ -209,7 +209,7 @@ export default class SignupController extends React.Component {
                         </span>
                     </span>
                 </a>
-           );
+            );
         }
 
         if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_config.EnableLdap === 'true') {


### PR DESCRIPTION
API v4 currently overwrites the error messages passed back by the app and DB layers, so I removed those and added status codes to any relevant calls.

If anyone can figure out what status code should be used for the "you can't join the team because it's at the max number of members" error, let me know and I'll add that