### PR TITLE
PLT-6909 Remove deleted emojis from cache

### DIFF
--- a/api4/emoji_test.go
+++ b/api4/emoji_test.go
@@ -413,7 +413,7 @@ func TestGetEmojiImage(t *testing.T) {
 	CheckNotFoundStatus(t, resp)
 
 	_, resp = Client.GetEmojiImage(model.NewId())
-	CheckInternalErrorStatus(t, resp)
+	CheckNotFoundStatus(t, resp)
 
 	_, resp = Client.GetEmojiImage("")
 	CheckBadRequestStatus(t, resp)

--- a/api4/emoji_test.go
+++ b/api4/emoji_test.go
@@ -251,11 +251,11 @@ func TestDeleteEmoji(t *testing.T) {
 
 	// Try to delete just deleted emoji
 	_, resp = Client.DeleteEmoji(newEmoji.Id)
-	CheckInternalErrorStatus(t, resp)
+	CheckNotFoundStatus(t, resp)
 
 	//Try to delete non-existing emoji
 	_, resp = Client.DeleteEmoji(model.NewId())
-	CheckInternalErrorStatus(t, resp)
+	CheckNotFoundStatus(t, resp)
 
 	//Try to delete without Id
 	_, resp = Client.DeleteEmoji("")
@@ -297,7 +297,7 @@ func TestGetEmoji(t *testing.T) {
 	}
 
 	_, resp = Client.GetEmoji(model.NewId())
-	CheckInternalErrorStatus(t, resp)
+	CheckNotFoundStatus(t, resp)
 }
 
 func TestGetEmojiImage(t *testing.T) {

--- a/store/sql_emoji_store.go
+++ b/store/sql_emoji_store.go
@@ -4,6 +4,8 @@
 package store
 
 import (
+	"net/http"
+
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
@@ -104,7 +106,7 @@ func (es SqlEmojiStore) Get(id string, allowFromCache bool) StoreChannel {
 			WHERE
 				Id = :Id
 				AND DeleteAt = 0`, map[string]interface{}{"Id": id}); err != nil {
-			result.Err = model.NewLocAppError("SqlEmojiStore.Get", "store.sql_emoji.get.app_error", nil, "id="+id+", "+err.Error())
+			result.Err = model.NewAppError("SqlEmojiStore.Get", "store.sql_emoji.get.app_error", nil, "id="+id+", "+err.Error(), http.StatusNotFound)
 		} else {
 			result.Data = emoji
 
@@ -194,6 +196,8 @@ func (es SqlEmojiStore) Delete(id string, time int64) StoreChannel {
 		} else if rows, _ := sqlResult.RowsAffected(); rows == 0 {
 			result.Err = model.NewLocAppError("SqlEmojiStore.Delete", "store.sql_emoji.delete.no_results", nil, "id="+id+", err="+err.Error())
 		}
+
+		emojiCache.Remove(id)
 
 		storeChannel <- result
 		close(storeChannel)


### PR DESCRIPTION
One of the unit tests randomly fails because it deletes an emoji and then checks for a 404. I assume that's causing some sort of caching thing because it's not being removed from the cache

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6909