### PR TITLE
PLT-6799 Removed <wbr> tags from markdown links

### DIFF
--- a/webapp/tests/utils/formatting_hashtags.test.jsx
+++ b/webapp/tests/utils/formatting_hashtags.test.jsx
@@ -53,7 +53,7 @@ describe('TextFormatting.Hashtags', function() {
 
         assert.equal(
             TextFormatting.formatText('#test1/#test2').trim(),
-            "<p><a class='mention-link' href='#' data-hashtag='#test1'>#test1</a>/<wbr /><a class='mention-link' href='#' data-hashtag='#test2'>#test2</a></p>"
+            "<p><a class='mention-link' href='#' data-hashtag='#test1'>#test1</a>/<a class='mention-link' href='#' data-hashtag='#test2'>#test2</a></p>"
         );
 
         assert.equal(
@@ -137,12 +137,12 @@ describe('TextFormatting.Hashtags', function() {
 
         assert.equal(
             TextFormatting.formatText('#foo/#bar', {searchTerm: '#foo'}).trim(),
-            "<p><span class='search-highlight'><a class='mention-link' href='#' data-hashtag='#foo'>#foo</a></span>/<wbr /><a class='mention-link' href='#' data-hashtag='#bar'>#bar</a></p>"
+            "<p><span class='search-highlight'><a class='mention-link' href='#' data-hashtag='#foo'>#foo</a></span>/<a class='mention-link' href='#' data-hashtag='#bar'>#bar</a></p>"
         );
 
         assert.equal(
             TextFormatting.formatText('#foo/#bar', {searchTerm: 'bar'}).trim(),
-            "<p><a class='mention-link' href='#' data-hashtag='#foo'>#foo</a>/<wbr /><span class='search-highlight'><a class='mention-link' href='#' data-hashtag='#bar'>#bar</a></span></p>"
+            "<p><a class='mention-link' href='#' data-hashtag='#foo'>#foo</a>/<span class='search-highlight'><a class='mention-link' href='#' data-hashtag='#bar'>#bar</a></span></p>"
         );
 
         assert.equal(

--- a/webapp/tests/utils/formatting_links.test.jsx
+++ b/webapp/tests/utils/formatting_links.test.jsx
@@ -489,7 +489,7 @@ describe('Markdown.Links', function() {
     it('Searching for links', function(done) {
         assert.equal(
             TextFormatting.formatText('https://en.wikipedia.org/wiki/Unix', {searchTerm: 'wikipedia'}).trim(),
-            '<p><a class="theme markdown__link search-highlight" href="https://en.wikipedia.org/wiki/Unix" rel="noreferrer" target="_blank">https:/<wbr />/<wbr />en.wikipedia.org/<wbr />wiki/<wbr />Unix</a></p>'
+            '<p><a class="theme markdown__link search-highlight" href="https://en.wikipedia.org/wiki/Unix" rel="noreferrer" target="_blank">https://en.wikipedia.org/wiki/Unix</a></p>'
         );
 
         assert.equal(

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -53,11 +53,6 @@ export function formatText(text, inputOptions) {
         output = replaceNewlines(output);
     }
 
-    // Add <wbr /> tags to recommend line breaking on slashes within URLs
-    if (!options.singleline) {
-        output = insertLongLinkWbr(output);
-    }
-
     return output;
 }
 
@@ -476,11 +471,4 @@ export function replaceTokens(text, tokens) {
 
 function replaceNewlines(text) {
     return text.replace(/\n/g, ' ');
-}
-
-//replace all "/" inside <a> tags to "/<wbr />"
-function insertLongLinkWbr(test) {
-    return test.replace(/\//g, (match, position, string) => {
-        return match + ((/a[^>]*>[^<]*$/).test(string.substr(0, position)) ? '<wbr />' : '');
-    });
 }


### PR DESCRIPTION
These were added originally to help break long links up across lines, but they kept being inserted in places we didn't want them. Other services (Github, Slack, etc) don't bother with them, so I removed the behaviour.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6799

#### Checklist
- Has UI changes
![image](https://user-images.githubusercontent.com/3277310/27590975-598e236a-5b1e-11e7-8e70-5f159b7b1f0f.png)

