### PR TITLE
PLT-6813 Removed misleading and outdated link tests

### DIFF
--- a/tests/test-links.md
+++ b/tests/test-links.md
@@ -23,9 +23,9 @@ http://192.168.1.1:4040
 http://[::1]:80
 http://[::1]:8065
 https://[::1]:80
-http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80
+http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]
 http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:8065
-https://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:443
+https://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]
 http://username:password@example.com
 http://username:password@127.0.0.1
 http://username:password@[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80

--- a/tests/test-links.md
+++ b/tests/test-links.md
@@ -26,9 +26,6 @@ https://[::1]:80
 http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]
 http://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:8065
 https://[2001:0:5ef5:79fb:303a:62d5:3312:ff42]
-http://username:password@example.com
-http://username:password@127.0.0.1
-http://username:password@[2001:0:5ef5:79fb:303a:62d5:3312:ff42]:80
 test@example.com
 http://example.com/more_(than)_one_(parens)
 http://example.com/(something)?after=parens


### PR DESCRIPTION
Some tests used default ports which didn't show up in the address bar (so were reported as incorrect) and then some included the use of basic HTTP authentication which is no longer supported by some major browsers (ie Chrome)

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6813