### PR TITLE
[PLT-3038] Update notification for webhooks sending attachments

### DIFF
--- a/webapp/actions/notification_actions.jsx
+++ b/webapp/actions/notification_actions.jsx
@@ -73,7 +73,21 @@ export function sendDesktopNotification(post, msgProps) {
         }
     }
 
-    let notifyText = post.message.replace(/\n+/g, ' ');
+    let notifyText = post.message;
+
+    const msgPropsPost = JSON.parse(msgProps.post);
+    const attachments = msgPropsPost && msgPropsPost.props && msgPropsPost.props.attachments ? msgPropsPost.props.attachments : [];
+    let image = false;
+    attachments.forEach((attachment) => {
+        if (notifyText.length === 0) {
+            notifyText = attachment.fallback ||
+                         attachment.pretext ||
+                         attachment.text;
+        }
+        image |= attachment.image_url.length > 0;
+    });
+
+    notifyText.replace(/\n+/g, ' ');
     if (notifyText.length > 50) {
         notifyText = notifyText.substring(0, 49) + '...';
     }
@@ -84,6 +98,8 @@ export function sendDesktopNotification(post, msgProps) {
             body = username + Utils.localizeMessage('channel_loader.uploadedImage', ' uploaded an image');
         } else if (msgProps.otherFile) {
             body = username + Utils.localizeMessage('channel_loader.uploadedFile', ' uploaded a file');
+        } else if (image) {
+            body = username + Utils.localizeMessage('channel_loader.postedImage', ' posted an image');
         } else {
             body = username + Utils.localizeMessage('channel_loader.something', ' did something new');
         }

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1127,6 +1127,7 @@
   "channel_loader.unknown_error": "We received an unexpected status code from the server.",
   "channel_loader.uploadedFile": " uploaded a file",
   "channel_loader.uploadedImage": " uploaded an image",
+  "channel_loader.postedImage": " posted an image",
   "channel_loader.wrote": " wrote: ",
   "channel_members_dropdown.channel_admin": "Channel Admin",
   "channel_members_dropdown.channel_member": "Channel Member",


### PR DESCRIPTION
#### Summary
add attachments notification. (if webhook is attachments only.)
1) fallback text
2) pre-text
3) text
4) "posted an image" if there is an image URL
5) "did something new"

#### Ticket Link
- [PLT-3038](https://mattermost.atlassian.net/browse/PLT-3038)
- #6465

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
