### PR TITLE
PLT-6900: Hide DotMenu container when DotMenu empty.

### DIFF
--- a/webapp/components/post_view/post_info/post_info.jsx
+++ b/webapp/components/post_view/post_info/post_info.jsx
@@ -192,7 +192,7 @@ export default class PostInfo extends React.PureComponent {
                 />
             );
 
-            if (dotMenu) {
+            if (PostUtils.shouldShowDotMenu(this.props.post)) {
                 options = (
                     <div
                         ref='dotMenu'

--- a/webapp/utils/post_utils.jsx
+++ b/webapp/utils/post_utils.jsx
@@ -82,3 +82,23 @@ export function canEditPost(post, editDisableAction) {
     }
     return canEdit;
 }
+
+export function shouldShowDotMenu(post) {
+    if (Utils.isMobile()) {
+        return true;
+    }
+
+    if (!isSystemMessage(post)) {
+        return true;
+    }
+
+    if (canDeletePost(post)) {
+        return true;
+    }
+
+    if (canEditPost(post)) {
+        return true;
+    }
+
+    return false;
+}


### PR DESCRIPTION
#### Summary
Hide DotMenu container when DotMenu is empty.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6900

#### Checklist
- [x] Has UI changes