### PR TITLE
Added MarkdownImage component

### DIFF
--- a/webapp/components/markdown_image.jsx
+++ b/webapp/components/markdown_image.jsx
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+
+import {postListScrollChange} from 'actions/global_actions.jsx';
+
+export default class MarkdownImage extends PureComponent {
+    handleLoad = () => {
+        postListScrollChange();
+    }
+
+    render() {
+        const props = {...this.props};
+        props.onLoad = this.handleLoad;
+
+        return <img {...props}/>;
+    }
+}

--- a/webapp/components/post_view/post_message_view/post_message_view.jsx
+++ b/webapp/components/post_view/post_message_view/post_message_view.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import AtMention from 'components/at_mention';
+import MarkdownImage from 'components/markdown_image';
 
 import store from 'stores/redux_store.jsx';
 
@@ -111,6 +112,22 @@ export default class PostMessageView extends React.PureComponent {
                     const mentionName = node.attribs[attrib];
 
                     return <AtMention mentionName={mentionName}/>;
+                }
+            },
+            {
+                shouldProcessNode: (node) => node.type === 'tag' && node.name === 'img',
+                processNode: (node) => {
+                    const {
+                        class: className,
+                        ...attribs
+                    } = node.attribs;
+
+                    return (
+                        <MarkdownImage
+                            className={className}
+                            {...attribs}
+                        />
+                    );
                 }
             },
             {

--- a/webapp/tests/utils/formatting_imgs.test.jsx
+++ b/webapp/tests/utils/formatting_imgs.test.jsx
@@ -9,7 +9,7 @@ describe('Markdown.Imgs', function() {
     it('Inline mage', function(done) {
         assert.equal(
             Markdown.format('![Mattermost](/images/icon.png)').trim(),
-            '<p><img src="/images/icon.png" alt="Mattermost" onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"></p>'
+            '<p><img src="/images/icon.png" alt="Mattermost" class="markdown-inline-img"></p>'
         );
 
         done();
@@ -18,7 +18,7 @@ describe('Markdown.Imgs', function() {
     it('Image with hover text', function(done) {
         assert.equal(
             Markdown.format('![Mattermost](/images/icon.png "Mattermost Icon")').trim(),
-            '<p><img src="/images/icon.png" alt="Mattermost" title="Mattermost Icon" onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"></p>'
+            '<p><img src="/images/icon.png" alt="Mattermost" title="Mattermost Icon" class="markdown-inline-img"></p>'
         );
 
         done();
@@ -27,7 +27,7 @@ describe('Markdown.Imgs', function() {
     it('Image with link', function(done) {
         assert.equal(
             Markdown.format('[![Mattermost](../../images/icon-76x76.png)](https://github.com/mattermost/platform)').trim(),
-            '<p><a class="theme markdown__link" href="https://github.com/mattermost/platform" rel="noreferrer" target="_blank"><img src="../../images/icon-76x76.png" alt="Mattermost" onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"></a></p>'
+            '<p><a class="theme markdown__link" href="https://github.com/mattermost/platform" rel="noreferrer" target="_blank"><img src="../../images/icon-76x76.png" alt="Mattermost" class="markdown-inline-img"></a></p>'
         );
 
         done();
@@ -36,7 +36,7 @@ describe('Markdown.Imgs', function() {
     it('Image with width and height', function(done) {
         assert.equal(
             Markdown.format('![Mattermost](../../images/icon-76x76.png =50x76 "Mattermost Icon")').trim(),
-            '<p><img src="../../images/icon-76x76.png" alt="Mattermost" title="Mattermost Icon" width="50" height="76" onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"></p>'
+            '<p><img src="../../images/icon-76x76.png" alt="Mattermost" title="Mattermost Icon" width="50" height="76" class="markdown-inline-img"></p>'
         );
 
         done();
@@ -45,7 +45,7 @@ describe('Markdown.Imgs', function() {
     it('Image with width', function(done) {
         assert.equal(
             Markdown.format('![Mattermost](../../images/icon-76x76.png =50 "Mattermost Icon")').trim(),
-            '<p><img src="../../images/icon-76x76.png" alt="Mattermost" title="Mattermost Icon" width="50" onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"></p>'
+            '<p><img src="../../images/icon-76x76.png" alt="Mattermost" title="Mattermost Icon" width="50" class="markdown-inline-img"></p>'
         );
 
         done();

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -4,28 +4,8 @@
 import * as TextFormatting from './text_formatting.jsx';
 import * as SyntaxHighlighting from './syntax_highlighting.jsx';
 
-import {postListScrollChange} from 'actions/global_actions.jsx';
-
 import marked from 'marked';
 import katex from 'katex';
-
-function markdownImageLoaded(image) {
-    if (image.hasAttribute('height') && image.attributes.height.value !== 'auto') {
-        const maxHeight = parseInt(global.getComputedStyle(image).maxHeight, 10);
-
-        if (image.attributes.height.value > maxHeight) {
-            image.style.height = maxHeight + 'px';
-            image.style.width = ((maxHeight * image.attributes.width.value) / image.attributes.height.value) + 'px';
-        } else {
-            image.style.height = image.attributes.height.value + 'px';
-        }
-    } else {
-        image.style.height = 'auto';
-    }
-
-    postListScrollChange();
-}
-global.markdownImageLoaded = markdownImageLoaded;
 
 class MattermostMarkdownRenderer extends marked.Renderer {
     constructor(options, formattingOptions = {}) {
@@ -155,7 +135,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         if (dimensions.length > 1) {
             out += ' height="' + dimensions[1] + '"';
         }
-        out += ' onload="window.markdownImageLoaded(this)" onerror="window.markdownImageLoaded(this)" class="markdown-inline-img"';
+        out += ' class="markdown-inline-img"';
         out += this.options.xhtml ? '/>' : '>';
         return out;
     }


### PR DESCRIPTION
This is to allow for better control over inline markdown images so that we can fix the scroll pop caused by them.

The height changing code from `window.markdownImageLoaded` didn't appear to do anything when I posted test-markdown-basics.md, so I didn't bother porting it over.