### PR TITLE
Removed outdated item from link tests

### DIFF
--- a/tests/test-links.md
+++ b/tests/test-links.md
@@ -50,7 +50,6 @@ https://groups.google.com/forum/#!msg
 
 example.com
 readme.md
-@example.com
 ./make-compiled-client.sh
 test.:test
 `https://example.com`


### PR DESCRIPTION
Removed test for `@example.com`; it does create a link, which triggers a username search.

(No Jira ticket)