### PR TITLE
[PLT-6796] Regression: Code tag is empty for html code blocks

### DIFF
--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -66,7 +66,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         if (SyntaxHighlighting.canHighlight(usedLanguage)) {
             header = (
                 '<span class="post-code__language">' +
-                    SyntaxHighlighting.getLanguageName(language) +
+                    SyntaxHighlighting.getLanguageName(usedLanguage) +
                 '</span>'
             );
         }


### PR DESCRIPTION
#### Summary
Regression: Code tag is empty for html code blocks

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/PLT-6796
Github: https://github.com/mattermost/platform/issues/6772

