### PR TITLE
PLT-6844 Change file uploading to use superagent

### DIFF
--- a/webapp/actions/file_actions.jsx
+++ b/webapp/actions/file_actions.jsx
@@ -19,33 +19,31 @@ export function uploadFile(file, name, channelId, clientId, successCallback, err
             let e;
             if (res && res.body && res.body.id) {
                 e = res.body;
+            } else if (err.status === 0 || !err.status) {
+                e = {message: this.translations.connectionError};
             } else {
-                if (err.status === 0 || !err.status) {
-                    e = {message: this.translations.connectionError};
-                } else {
-                    e = {message: this.translations.unknownError + ' (' + err.status + ')'};
-                }
+                e = {message: this.translations.unknownError + ' (' + err.status + ')'};
             }
 
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(err, dispatch);
 
             const failure = {
                 type: FileTypes.UPLOAD_FILES_FAILURE,
-                clientIds,
+                clientIds: [clientId],
                 channelId,
                 rootId: null,
-                error
+                error: err
             };
 
-            dispatch(batchActions([failure, getLogErrorAction(error)]), getState);
+            dispatch(batchActions([failure, getLogErrorAction(err)]), getState);
 
             if (errorCallback) {
                 errorCallback(e, err, res);
             }
         } else if (res) {
-            const data = res.body.file_infos.map((file, index) => {
+            const data = res.body.file_infos.map((fileInfo, index) => {
                 return {
-                    ...file,
+                    ...fileInfo,
                     clientId: res.body.client_ids[index]
                 };
             });

--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -99,7 +99,7 @@ class FileUpload extends React.Component {
                 channelId,
                 clientId,
                 this.fileUploadSuccess.bind(this, channelId),
-                this.fileUploadFail.bind(this, clientId)
+                this.fileUploadFail.bind(this, clientId, channelId)
             );
 
             const requests = this.state.requests;


### PR DESCRIPTION
This is to fix the ability to cancel in-progress file uploads since fetch used by fetch doesn't support cancelling requests. It should still interact with the redux store just like the action in mattermost-redux

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6844