### PR TITLE
Remove unneeded return and add logging for marking channels unread

### DIFF
--- a/webapp/stores/channel_store.jsx
+++ b/webapp/stores/channel_store.jsx
@@ -448,7 +448,8 @@ class ChannelStoreClass extends EventEmitter {
 
     incrementMessages(id, markRead = false) {
         if (!this.unreadCounts[id]) {
-            return;
+            // Should never happen
+            console.log(`Missing channel_id=${id} in unreads object`); //eslint-disable-line no-console
         }
 
         const member = this.getMyMember(id);
@@ -483,11 +484,11 @@ class ChannelStoreClass extends EventEmitter {
         }
 
         if (!this.unreadCounts[id]) {
-            return;
+            // Should never happen
+            console.log(`Missing channel_id=${id} in unreads object`); //eslint-disable-line no-console
         }
 
         if (mentions.indexOf(UserStore.getCurrentId()) !== -1) {
-            this.unreadCounts[id].mentions++;
             const member = {...this.getMyMember(id)};
             member.mention_count++;
             store.dispatch({


### PR DESCRIPTION
#### Summary
Remove unneeded return and add logging for marking channels unread. If we ever see the logging then we can be pretty confident that this was the issue.

The removed `this.unreadCounts[id].mentions++;` had no effect since changing the channel member results in `this.unreadCounts` getting immediately recalculated.