### PR TITLE
PLT-6474: Server: Add elasticsearch/test endpoint to API.

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -77,6 +77,8 @@ type Routes struct {
 
 	LDAP *mux.Router // 'api/v4/ldap'
 
+	Elasticsearch *mux.Router // 'api/v4/elasticsearch'
+
 	Brand *mux.Router // 'api/v4/brand'
 
 	System *mux.Router // 'api/v4/system'
@@ -171,6 +173,7 @@ func InitApi(full bool) {
 	BaseRoutes.Public = BaseRoutes.ApiRoot.PathPrefix("/public").Subrouter()
 	BaseRoutes.Reactions = BaseRoutes.ApiRoot.PathPrefix("/reactions").Subrouter()
 	BaseRoutes.Jobs = BaseRoutes.ApiRoot.PathPrefix("/jobs").Subrouter()
+	BaseRoutes.Elasticsearch = BaseRoutes.ApiRoot.PathPrefix("/elasticsearch").Subrouter()
 
 	BaseRoutes.Emojis = BaseRoutes.ApiRoot.PathPrefix("/emoji").Subrouter()
 	BaseRoutes.Emoji = BaseRoutes.Emojis.PathPrefix("/{emoji_id:[A-Za-z0-9]+}").Subrouter()
@@ -193,6 +196,7 @@ func InitApi(full bool) {
 	InitCompliance()
 	InitCluster()
 	InitLdap()
+	InitElasticsearch()
 	InitBrand()
 	InitJob()
 	InitCommand()

--- a/api4/elasticsearch.go
+++ b/api4/elasticsearch.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"net/http"
+
+	l4g "github.com/alecthomas/log4go"
+	"github.com/mattermost/platform/app"
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+func InitElasticsearch() {
+	l4g.Debug(utils.T("api.elasticsearch.init.debug"))
+
+	BaseRoutes.Elasticsearch.Handle("/test", ApiSessionRequired(testElasticsearch)).Methods("POST")
+}
+
+func testElasticsearch(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	if err := app.TestElasticsearch(); err != nil {
+		c.Err = err
+		return
+	}
+
+	ReturnStatusOK(w)
+}

--- a/api4/elasticsearch_test.go
+++ b/api4/elasticsearch_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"testing"
+)
+
+func TestElasticsearchTest(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+
+	_, resp := th.Client.TestElasticsearch()
+	CheckForbiddenStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.TestElasticsearch()
+	CheckNotImplementedStatus(t, resp)
+}

--- a/app/elasticsearch.go
+++ b/app/elasticsearch.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"net/http"
+
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/einterfaces"
+)
+
+func TestElasticsearch() *model.AppError {
+	if esI := einterfaces.GetElasticSearchInterface(); esI != nil {
+		if err := esI.TestConfig(); err != nil {
+			return err
+		}
+	} else {
+		err := model.NewAppError("TestElasticsearch", "ent.elasticsearch.test_config.license.error", nil, "", http.StatusNotImplemented)
+		return err
+	}
+
+	return nil
+}

--- a/einterfaces/elasticsearch.go
+++ b/einterfaces/elasticsearch.go
@@ -10,6 +10,7 @@ type ElasticSearchInterface interface {
 	IndexPost(post *model.Post, teamId string)
 	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, *model.AppError)
 	DeletePost(postId string)
+	TestConfig() *model.AppError
 }
 
 var theElasticSearchInterface ElasticSearchInterface

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3456,6 +3456,14 @@
     "translation": "Failed to set ElasticSearch index settings"
   },
   {
+    "id": "ent.elasticsearch.test_config.indexing_disabled.error",
+    "translation": "Elasticsearch is disabled."
+  },
+  {
+    "id": "ent.elasticsearch.test_config.license.error",
+    "translation": "License does not support Elasticsearch."
+  },
+  {
     "id": "ent.emoji.licence_disable.app_error",
     "translation": "Custom emoji restrictions disabled by current license. Please contact your system administrator about upgrading your enterprise license."
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -230,6 +230,10 @@ func (c *Client4) GetBrandRoute() string {
 	return fmt.Sprintf("/brand")
 }
 
+func (c *Client4) GetElasticsearchRoute() string {
+	return fmt.Sprintf("/elasticsearch")
+}
+
 func (c *Client4) GetCommandsRoute() string {
 	return fmt.Sprintf("/commands")
 }
@@ -2507,6 +2511,19 @@ func (c *Client4) AuthorizeOAuthApp(authRequest *AuthorizeRequest) (string, *Res
 func (c *Client4) DeauthorizeOAuthApp(appId string) (bool, *Response) {
 	requestData := map[string]string{"client_id": appId}
 	if r, err := c.DoApiRequest(http.MethodPost, c.Url+"/oauth/deauthorize", MapToJson(requestData), ""); err != nil {
+		return false, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
+// Elasticsearch Section
+
+// TestElasticsearch will attempt to connect to the configured Elasticsearch server and return OK if configured
+// correctly.
+func (c *Client4) TestElasticsearch() (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetElasticsearchRoute()+"/test", ""); err != nil {
 		return false, BuildErrorResponse(r, err)
 	} else {
 		defer closeBody(r)


### PR DESCRIPTION
#### Summary
Adds an API endpoint to test the elasticsearch config.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6474

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation: https://github.com/mattermost/mattermost-api-reference/pull/262
- [x] All new/modified APIs include changes to the drivers: https://github.com/mattermost/mattermost-redux/pull/183
- [x] Has enterprise changes: https://github.com/mattermost/enterprise/pull/150
- [x] Includes text changes and localization file updates
