### PR TITLE
Fix for SignupEmail invite handling

### DIFF
--- a/webapp/components/signup/components/signup_email.jsx
+++ b/webapp/components/signup/components/signup_email.jsx
@@ -53,8 +53,8 @@ export default class SignupEmail extends React.Component {
         let teamName = '';
         let teamId = '';
         let loading = false;
-        let serverError = '';
-        let noOpenServerError = false;
+        const serverError = '';
+        const noOpenServerError = false;
 
         if (hash && hash.length > 0) {
             const parsedData = JSON.parse(data);
@@ -68,7 +68,7 @@ export default class SignupEmail extends React.Component {
                 inviteId,
                 (inviteData) => {
                     if (!inviteData) {
-                        this.setState({ loading: false });
+                        this.setState({loading: false});
                         return;
                     }
 
@@ -85,10 +85,10 @@ export default class SignupEmail extends React.Component {
                         loading: false,
                         noOpenServerError: true,
                         serverError: (
-                          <FormattedMessage
-                              id='signup_user_completed.invalid_invite'
-                              defaultMessage='The invite link was invalid.  Please speak with your Administrator to receive an invitation.'
-                          />
+                            <FormattedMessage
+                                id='signup_user_completed.invalid_invite'
+                                defaultMessage='The invite link was invalid.  Please speak with your Administrator to receive an invitation.'
+                            />
                         )
                     });
                 }

--- a/webapp/components/signup/components/signup_email.jsx
+++ b/webapp/components/signup/components/signup_email.jsx
@@ -52,7 +52,7 @@ export default class SignupEmail extends React.Component {
         let teamDisplayName = '';
         let teamName = '';
         let teamId = '';
-        let loading = true;
+        let loading = false;
         let serverError = '';
         let noOpenServerError = false;
 
@@ -62,37 +62,40 @@ export default class SignupEmail extends React.Component {
             teamDisplayName = parsedData.display_name;
             teamName = parsedData.name;
             teamId = parsedData.id;
-            loading = false;
         } else if (inviteId && inviteId.length > 0) {
             loading = true;
             getInviteInfo(
                 inviteId,
                 (inviteData) => {
                     if (!inviteData) {
+                        this.setState({ loading: false });
                         return;
                     }
 
-                    serverError = '';
-                    teamDisplayName = inviteData.display_name;
-                    teamName = inviteData.name;
-                    teamId = inviteData.id;
+                    this.setState({
+                        loading: false,
+                        serverError: '',
+                        teamDisplayName: inviteData.display_name,
+                        teamName: inviteData.name,
+                        teamId: inviteData.id
+                    });
                 },
                 () => {
-                    noOpenServerError = true;
-                    serverError = (
-                        <FormattedMessage
-                            id='signup_user_completed.invalid_invite'
-                            defaultMessage='The invite link was invalid.  Please speak with your Administrator to receive an invitation.'
-                        />
-                    );
+                    this.setState({
+                        loading: false,
+                        noOpenServerError: true,
+                        serverError: (
+                          <FormattedMessage
+                              id='signup_user_completed.invalid_invite'
+                              defaultMessage='The invite link was invalid.  Please speak with your Administrator to receive an invitation.'
+                          />
+                        )
+                    });
                 }
             );
 
-            loading = false;
             data = null;
             hash = null;
-        } else {
-            loading = false;
         }
 
         return {


### PR DESCRIPTION
#### Summary
`SignupEmail.getInviteInfo` made some assignments that had no effect. The callback functions appeared to be trying to set the state, but were doing so by modifying some function local variables rather than by using `setState`, which made them ineffective.

I've changed this to instead use `setState`, and, if we are relying on callbacks, to set `state.loading` to `true` whilst the requests are in flight. I believe that this fixes a minor bug:

In master, specifying a bad invite id just directs to the standard signup form:
![2017-07-02-190621_477x896_scrot](https://user-images.githubusercontent.com/18551327/27772645-953e8b90-5f5e-11e7-9a8c-ffa44846603c.png)

With this change, it instead displays a relevant error message:
![2017-07-02-190631_477x896_scrot](https://user-images.githubusercontent.com/18551327/27772644-953d2f02-5f5e-11e7-8b09-8c27bdb548aa.png)

This result was found on https://lgtm.com/projects/g/mattermost/platform/alerts/. (Full disclosure: I work on lgtm.com)