### PR TITLE
PLT-6951: Fix channel join slash command.

### DIFF
--- a/app/command_join.go
+++ b/app/command_join.go
@@ -58,7 +58,7 @@ func (me *JoinProvider) DoCommand(args *model.CommandArgs, message string) *mode
 				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 
-			return &model.CommandResponse{GotoLocation: args.SiteURL + "/" + team.Name + "/channels/" + channel.Name, Text: args.T("api.command_join.success"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+			return &model.CommandResponse{GotoLocation: args.SiteURL + "/" + team.Name + "/channels/" + channel.Name}
 		}
 	}
 


### PR DESCRIPTION
#### Summary
Fix channel join slash command. Don't show an ephemeral message when the channel join succeeds. Just redirect to the channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6951