### PR TITLE
PLT-6867 Make channel switcher partially obey RestrictDirectMessage setting

### DIFF
--- a/webapp/components/suggestion/switch_channel_provider.jsx
+++ b/webapp/components/suggestion/switch_channel_provider.jsx
@@ -121,7 +121,11 @@ export default class SwitchChannelProvider extends Provider {
     }
 
     async fetchUsersAndChannels(channelPrefix, suggestionId) {
-        const usersAsync = Client4.autocompleteUsers(channelPrefix, '', '');
+        let teamId = '';
+        if (global.window.mm_config.RestrictDirectMessage === 'team') {
+            teamId = store.getState().entities.teams.currentTeamId;
+        }
+        const usersAsync = Client4.autocompleteUsers(channelPrefix, teamId, '');
         const channelsAsync = Client4.searchChannels(getCurrentTeamId(getState()), channelPrefix);
 
         let usersFromServer = [];


### PR DESCRIPTION
#### Summary
Make channel switcher partially obey RestrictDirectMessage setting. If you have multiple teams and previously loaded users, they will still show up regardless of the setting. If the user is only on a single team it should work as expected.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6867