### PR TITLE
PLT-6926 Fix IE and Edge by upgrading redux-persist

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -40,7 +40,7 @@
     "react-router": "2.8.1",
     "react-select": "1.0.0-rc.5",
     "redux-batched-actions": "0.2.0",
-    "redux-persist": "4.8.0",
+    "redux-persist": "4.8.2",
     "redux-persist-transform-filter": "0.0.13",
     "superagent": "3.5.2",
     "twemoji": "2.3.0",

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -6487,9 +6487,9 @@ redux-persist@4.6.0:
     lodash "^4.17.4"
     lodash-es "^4.17.4"
 
-redux-persist@4.8.0, redux-persist@^4.5.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.8.0.tgz#17fd998949bdeef9275e4cf60ad5bbe1c73675fc"
+redux-persist@4.8.2, redux-persist@^4.5.0:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.8.2.tgz#7941202e0ce0a9fcc0263d66965f5263d34f43b9"
   dependencies:
     json-stringify-safe "^5.0.1"
     lodash "^4.17.4"


### PR DESCRIPTION
#### Summary
IE and Edge were broken in a recent release of redux-persist that we upgraded to. This upgrades to the release including their fix for the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6926