### PR TITLE
[PLT-6949] Fix collapsed image preview that doesn't stay collapsed after posting a message in the channel

### DIFF
--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -951,7 +951,7 @@ export const Constants = {
     ANIMATION_TIMEOUT: 1000,
     SEARCH_TIMEOUT_MILLISECONDS: 100,
     DIAGNOSTICS_SEGMENT_KEY: 'fwb7VPbFeQ7SKp3wHm1RzFUuXZudqVok',
-    TEST_ID_COUNT: 10,
+    TEST_ID_COUNT: 0,
     CENTER: 'center',
     RHS: 'rhs',
     RHS_ROOT: 'rhsroot',


### PR DESCRIPTION
#### Summary
Fix collapsed image preview that doesn't stay collapsed after posting a message in the channel by temporarily setting the `TEST_COUNT_ID` from 10 to 0.
The setting 10 makes the last 10 posts re-render every time a new message is posted even if `post` object of those were unchanged (only the `lastPostCount` changed).
Maybe we need to consider to move the TEST_COUNT_ID to System Console > Developer Setting so it can be configurable depending on Selenium test requirement.

#### Ticket Link
Jira ticket: [PLT-6949](https://mattermost.atlassian.net/browse/PLT-6949)

#### Checklist
- [x] Updated Constants - TEST_ID_COUNT
