### PR TITLE
Teammate name display setting: username as default or full_name when LDAP/SAML is enabled

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -80,7 +80,7 @@
         "UserStatusAwayTimeout": 300,
         "MaxChannelsPerTeam": 2000,
         "MaxNotificationsPerChannel": 1000,
-        "TeammateNameDisplay": "full_name"
+        "TeammateNameDisplay": "username"
     },
     "SqlSettings": {
         "DriverName": "mysql",

--- a/model/config.go
+++ b/model/config.go
@@ -717,11 +717,6 @@ func (o *Config) SetDefaults() {
 		*o.TeamSettings.MaxNotificationsPerChannel = 1000
 	}
 
-	if o.TeamSettings.TeammateNameDisplay == nil {
-		o.TeamSettings.TeammateNameDisplay = new(string)
-		*o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
-	}
-
 	if o.EmailSettings.EnableSignInWithEmail == nil {
 		o.EmailSettings.EnableSignInWithEmail = new(bool)
 
@@ -1234,6 +1229,15 @@ func (o *Config) SetDefaults() {
 	if o.SamlSettings.LocaleAttribute == nil {
 		o.SamlSettings.LocaleAttribute = new(string)
 		*o.SamlSettings.LocaleAttribute = SAML_SETTINGS_DEFAULT_LOCALE_ATTRIBUTE
+	}
+
+	if o.TeamSettings.TeammateNameDisplay == nil {
+		o.TeamSettings.TeammateNameDisplay = new(string)
+		*o.TeamSettings.TeammateNameDisplay = SHOW_USERNAME
+
+		if *o.SamlSettings.Enable || *o.LdapSettings.Enable {
+			*o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
+		}
 	}
 
 	if o.NativeAppSettings.AppDownloadLink == nil {


### PR DESCRIPTION
#### Summary
Change config.json default for teammate name display setting to `username`, unless you have LDAP/SAML enabled in which case the default is `full_name`

Note: PR has been submitted on top of https://github.com/mattermost/platform/pull/6809 to avoid similar merge conflicts.

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
