### PR TITLE
PLT-6925 Only show unreads below indicator after first load is complete

### DIFF
--- a/webapp/components/post_view/post_list.jsx
+++ b/webapp/components/post_view/post_list.jsx
@@ -152,7 +152,7 @@ export default class PostList extends React.PureComponent {
                 return;
             }
 
-            if (!this.wasAtBottom() && this.props.posts !== nextProps.posts) {
+            if (!this.wasAtBottom() && this.props.posts !== nextProps.posts && this.hasScrolledToNewMessageSeparator) {
                 const unViewedCount = nextProps.posts.reduce((count, post) => {
                     if (post.create_at > this.state.lastViewed &&
                         post.user_id !== nextProps.currentUserId &&


### PR DESCRIPTION
#### Summary
Only show unreads below indicator after first load is complete. I wasn't able to reliably reproduce the bug but this should alleviate the problem either way. We can reopen the ticket if it still occurs after this gets merged.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6925