### PR TITLE
Add optional config parameter to test elasticsearch endpoint.

### DIFF
--- a/api4/elasticsearch.go
+++ b/api4/elasticsearch.go
@@ -19,12 +19,17 @@ func InitElasticsearch() {
 }
 
 func testElasticsearch(c *Context, w http.ResponseWriter, r *http.Request) {
+	cfg := model.ConfigFromJson(r.Body)
+	if cfg == nil {
+		cfg = utils.Cfg
+	}
+
 	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
 		return
 	}
 
-	if err := app.TestElasticsearch(); err != nil {
+	if err := app.TestElasticsearch(cfg); err != nil {
 		c.Err = err
 		return
 	}

--- a/app/elasticsearch.go
+++ b/app/elasticsearch.go
@@ -8,11 +8,20 @@ import (
 
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/einterfaces"
+	"github.com/mattermost/platform/utils"
 )
 
-func TestElasticsearch() *model.AppError {
+func TestElasticsearch(cfg *model.Config) *model.AppError {
+	if *cfg.ElasticSearchSettings.Password == model.FAKE_SETTING {
+		if *cfg.ElasticSearchSettings.ConnectionUrl == *utils.Cfg.ElasticSearchSettings.ConnectionUrl && *cfg.ElasticSearchSettings.Username == *utils.Cfg.ElasticSearchSettings.Username {
+			*cfg.ElasticSearchSettings.Password = *utils.Cfg.ElasticSearchSettings.Password
+		} else {
+			return model.NewAppError("TestElasticsearch", "ent.elasticsearch.test_config.reenter_password", nil, "", http.StatusBadRequest)
+		}
+	}
+
 	if esI := einterfaces.GetElasticSearchInterface(); esI != nil {
-		if err := esI.TestConfig(); err != nil {
+		if err := esI.TestConfig(cfg); err != nil {
 			return err
 		}
 	} else {

--- a/einterfaces/elasticsearch.go
+++ b/einterfaces/elasticsearch.go
@@ -10,7 +10,7 @@ type ElasticSearchInterface interface {
 	IndexPost(post *model.Post, teamId string)
 	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, *model.AppError)
 	DeletePost(postId string)
-	TestConfig() *model.AppError
+	TestConfig(cfg *model.Config) *model.AppError
 }
 
 var theElasticSearchInterface ElasticSearchInterface

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3532,6 +3532,10 @@
     "translation": "License does not support Elasticsearch."
   },
   {
+    "id": "ent.elasticsearch.test_config.reenter_password",
+    "translation": "The Elasticsearch Server URL or Username has changed. Please re-enter the Elasticsearch password to test connection."
+  },
+  {
     "id": "ent.emoji.licence_disable.app_error",
     "translation": "Custom emoji restrictions disabled by current license. Please contact your system administrator about upgrading your enterprise license."
   },


### PR DESCRIPTION
#### Summary
Add optional config parameter to test elasticsearch endpoint to allow testing config without clobbering the actual config.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6474

#### Checklist
- [x] Added API documentation https://github.com/mattermost/mattermost-api-reference/pull/268
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/160
- [x] Includes text changes and localization file updates
