### PR TITLE
Revert "PLT-7039 Use loadProfilesAndStatusesForPosts from the redux library"

### DIFF
--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -15,7 +15,7 @@ import WebSocketClient from 'client/web_websocket_client.jsx';
 import * as WebrtcActions from './webrtc_actions.jsx';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
-import {handleNewPost} from 'actions/post_actions.jsx';
+import {handleNewPost, loadProfilesForPosts} from 'actions/post_actions.jsx';
 import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
 import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
 import * as StatusActions from 'actions/status_actions.jsx';
@@ -34,7 +34,7 @@ import {getSiteURL} from 'utils/url.jsx';
 
 import * as TeamActions from 'mattermost-redux/actions/teams';
 import {viewChannel, getChannelAndMyMember, getChannelStats} from 'mattermost-redux/actions/channels';
-import {getPosts, getProfilesAndStatusesForPosts} from 'mattermost-redux/actions/posts';
+import {getPosts} from 'mattermost-redux/actions/posts';
 import {setServerVersion} from 'mattermost-redux/actions/general';
 import {ChannelTypes, TeamTypes, UserTypes, PostTypes, EmojiTypes} from 'mattermost-redux/action_types';
 
@@ -242,7 +242,9 @@ function handleNewPostEvent(msg) {
     const post = JSON.parse(msg.data.post);
     handleNewPost(post, msg);
 
-    getProfilesAndStatusesForPosts([post], dispatch, getState);
+    const posts = {};
+    posts[post.id] = post;
+    loadProfilesForPosts(posts);
 
     if (post.user_id !== UserStore.getCurrentId()) {
         UserStore.setStatus(post.user_id, UserStatuses.ONLINE);


### PR DESCRIPTION
Reverts mattermost/platform#6881.

After having a quick run with this PR merged, I've got JS error on getProfilesAndStatusesForPosts (see screenshots).
I'm reverting this PR and will queue for next v4.0.0-rc3.
![screen shot 2017-07-08 at 9 08 55 am](https://user-images.githubusercontent.com/5334504/27981566-46d90ac8-63c0-11e7-853b-5ee204cd66f7.png)
![screen shot 2017-07-08 at 9 26 48 am](https://user-images.githubusercontent.com/5334504/27981567-4c5ab1ae-63c0-11e7-8e9d-b4b7682fd17f.png)



