### PR TITLE
PLT-7028 Deleting the focused post now sends user to normal channel view

### DIFF
--- a/webapp/actions/post_actions.jsx
+++ b/webapp/actions/post_actions.jsx
@@ -14,6 +14,8 @@ import {sendDesktopNotification} from 'actions/notification_actions.jsx';
 import Constants from 'utils/constants.jsx';
 const ActionTypes = Constants.ActionTypes;
 
+import {browserHistory} from 'react-router/es6';
+
 // Redux actions
 import store from 'stores/redux_store.jsx';
 const dispatch = store.dispatch;
@@ -235,6 +237,12 @@ export function deletePost(channelId, post, success) {
                 type: PostTypes.REMOVE_POST,
                 data: post
             });
+
+            const {focusedPostId} = getState().views.channel;
+            const channel = getState().entities.channels.channels[post.channel_id];
+            if (post.id === focusedPostId && channel) {
+                browserHistory.push(TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name);
+            }
 
             if (success) {
                 success();

--- a/webapp/reducers/views/channel.js
+++ b/webapp/reducers/views/channel.js
@@ -62,8 +62,20 @@ function loadingPosts(state = {}, action) {
     }
 }
 
+function focusedPostId(state = '', action) {
+    switch (action.type) {
+    case ActionTypes.RECEIVED_FOCUSED_POST:
+        return action.data;
+    case ChannelTypes.SELECT_CHANNEL:
+        return '';
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
     postVisibility,
     lastChannelViewTime,
-    loadingPosts
+    loadingPosts,
+    focusedPostId
 });


### PR DESCRIPTION
#### Summary
Deleting the focused post now sends user to normal channel view instead of getting stuck on a loading screen.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7028