### PR TITLE
[PLT-7001] Fix extra whitespace between search bar and "@" icon in channel header after expanding the right-hand side

### DIFF
--- a/webapp/sass/components/_webrtc.scss
+++ b/webapp/sass/components/_webrtc.scss
@@ -331,6 +331,6 @@
 
     .search__form {
         margin-left: 5px;
-        width: calc(100% - 80px);
+        width: calc(100% - 5px);
     }
 }

--- a/webapp/sass/components/_webrtc.scss
+++ b/webapp/sass/components/_webrtc.scss
@@ -328,9 +328,4 @@
     #videos.small {
         position: relative;
     }
-
-    .search__form {
-        margin-left: 5px;
-        width: calc(100% - 5px);
-    }
 }


### PR DESCRIPTION
#### Summary
Fix extra whitespace between search bar and "@" icon in channel header after expanding the right-hand side

#### Ticket Link
Jira ticket: [PLT-7001](https://mattermost.atlassian.net/browse/PLT-7001)

#### Checklist
- [x] Has UI changes