### PR TITLE
PLT-7076 Show expand button when previews defaulted to collapsed

### DIFF
--- a/webapp/components/post_view/post_body_additional_content.jsx
+++ b/webapp/components/post_view/post_body_additional_content.jsx
@@ -187,7 +187,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
             );
 
             const contents = [message];
-            if (this.state.linkLoaded) {
+            if (this.state.linkLoaded || this.props.previewCollapsed.startsWith('true')) {
                 if (prependToggle) {
                     contents.unshift(toggle);
                 } else {


### PR DESCRIPTION
#### Summary
Show expand button when previews defaulted to collapsed.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7076