### PR TITLE
[PLT-7060] Create global action to close sidebar right menu and hit it when leaving a team

### DIFF
--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -497,6 +497,23 @@ export function toggleSideBarAction(visible) {
     }
 }
 
+export function toggleSideBarRightMenuAction() {
+    AppDispatcher.handleServerAction({
+        type: ActionTypes.RECEIVED_SEARCH,
+        results: null
+    });
+
+    AppDispatcher.handleServerAction({
+        type: ActionTypes.RECEIVED_POST_SELECTED,
+        postId: null
+    });
+
+    document.querySelector('.app__body .inner-wrap').classList.remove('move--right', 'move--left', 'move--left-small');
+    document.querySelector('.app__body .sidebar--left').classList.remove('move--right');
+    document.querySelector('.app__body .sidebar--right').classList.remove('move--left');
+    document.querySelector('.app__body .sidebar--menu').classList.remove('move--left');
+}
+
 export function emitBrowserFocus(focus) {
     AppDispatcher.handleViewAction({
         type: ActionTypes.BROWSER_CHANGE_FOCUS,

--- a/webapp/components/leave_team_modal.jsx
+++ b/webapp/components/leave_team_modal.jsx
@@ -61,6 +61,7 @@ class LeaveTeamModal extends React.Component {
         }
 
         GlobalActions.emitLeaveTeam();
+        GlobalActions.toggleSideBarRightMenuAction();
     }
 
     handleHide() {

--- a/webapp/components/sidebar_right_menu.jsx
+++ b/webapp/components/sidebar_right_menu.jsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import TeamMembersModal from './team_members_modal.jsx';
 import ToggleModalButton from './toggle_modal_button.jsx';
 import AboutBuildModal from './about_build_modal.jsx';
@@ -19,7 +18,6 @@ import * as UserAgent from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 import {Constants, WebrtcActionTypes} from 'utils/constants.jsx';
 
-const ActionTypes = Constants.ActionTypes;
 const Preferences = Constants.Preferences;
 const TutorialSteps = Constants.TutorialSteps;
 
@@ -143,20 +141,7 @@ export default class SidebarRightMenu extends React.Component {
 
     hideSidebars() {
         if (Utils.isMobile()) {
-            AppDispatcher.handleServerAction({
-                type: ActionTypes.RECEIVED_SEARCH,
-                results: null
-            });
-
-            AppDispatcher.handleServerAction({
-                type: ActionTypes.RECEIVED_POST_SELECTED,
-                postId: null
-            });
-
-            document.querySelector('.app__body .inner-wrap').classList.remove('move--right', 'move--left', 'move--left-small');
-            document.querySelector('.app__body .sidebar--left').classList.remove('move--right');
-            document.querySelector('.app__body .sidebar--right').classList.remove('move--left');
-            document.querySelector('.app__body .sidebar--menu').classList.remove('move--left');
+            GlobalActions.toggleSideBarRightMenuAction();
         }
     }
 


### PR DESCRIPTION
#### Summary
Fix "Mobile web view: UX after leaving a team is confusing" by creating a global action to close sidebar right menu. Hit such action when leaving a team.

#### Ticket Link
Jira ticket: [PLT-7060](https://mattermost.atlassian.net/browse/PLT-7060)

#### Checklist
- [x] Has UI changes