### PR TITLE
Fixing client4 ping

### DIFF
--- a/model/client4.go
+++ b/model/client4.go
@@ -1811,7 +1811,7 @@ func (c *Client4) GetFileInfosForPost(postId string, etag string) ([]*FileInfo, 
 
 // GetPing will return ok if the running goRoutines are below the threshold and unhealthy for above.
 func (c *Client4) GetPing() (string, *Response) {
-	if r, err := c.DoApiGet(c.GetSystemRoute()+"/ping", ""); r.StatusCode == 500 {
+	if r, err := c.DoApiGet(c.GetSystemRoute()+"/ping", ""); r != nil && r.StatusCode == 500 {
 		defer r.Body.Close()
 		return "unhealthy", BuildErrorResponse(r, err)
 	} else if err != nil {


### PR DESCRIPTION
So the loadtests don't fail when the server is unreachable over HTTP. 