### PR TITLE
PLT-6706: add /code command

### DIFF
--- a/app/command_code.go
+++ b/app/command_code.go
@@ -36,9 +36,9 @@ func (me *CodeProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *CodeProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	rmsg := ""
-	if len(message) > 0 {
-		rmsg = "    " + strings.Join(strings.Split(message, "\n"), "\n    ")
+	if len(message) == 0 {
+		return &model.CommandResponse{Text: args.T("api.command_code.message.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
+	rmsg := "    " + strings.Join(strings.Split(message, "\n"), "\n    ")
 	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, Text: rmsg}
 }

--- a/app/command_code.go
+++ b/app/command_code.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"strings"
+
+	"github.com/mattermost/platform/model"
+	goi18n "github.com/nicksnyder/go-i18n/i18n"
+)
+
+type CodeProvider struct {
+}
+
+const (
+	CMD_CODE = "code"
+)
+
+func init() {
+	RegisterCommandProvider(&CodeProvider{})
+}
+
+func (me *CodeProvider) GetTrigger() string {
+	return CMD_CODE
+}
+
+func (me *CodeProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
+	return &model.Command{
+		Trigger:          CMD_CODE,
+		AutoComplete:     true,
+		AutoCompleteDesc: T("api.command_code.desc"),
+		AutoCompleteHint: T("api.command_code.hint"),
+		DisplayName:      T("api.command_code.name"),
+	}
+}
+
+func (me *CodeProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+	rmsg := ""
+	if len(message) > 0 {
+		rmsg = "    " + strings.Join(strings.Split(message, "\n"), "\n    ")
+	}
+	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, Text: rmsg}
+}

--- a/app/command_code_test.go
+++ b/app/command_code_test.go
@@ -7,14 +7,18 @@ import (
 )
 
 func TestCodeProviderDoCommand(t *testing.T) {
+	cp := CodeProvider{}
+	args := &model.CommandArgs{
+		T: func(s string, args ...interface{}) string { return s },
+	}
+
 	for msg, expected := range map[string]string{
-		"":           "",
+		"":           "api.command_code.message.app_error",
 		"foo":        "    foo",
 		"foo\nbar":   "    foo\n    bar",
 		"foo\nbar\n": "    foo\n    bar\n    ",
 	} {
-		cp := CodeProvider{}
-		actual := cp.DoCommand(&model.CommandArgs{}, msg).Text
+		actual := cp.DoCommand(args, msg).Text
 		if actual != expected {
 			t.Errorf("expected `%v`, got `%v`", expected, actual)
 		}

--- a/app/command_code_test.go
+++ b/app/command_code_test.go
@@ -1,0 +1,22 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/mattermost/platform/model"
+)
+
+func TestCodeProviderDoCommand(t *testing.T) {
+	for msg, expected := range map[string]string{
+		"":           "",
+		"foo":        "    foo",
+		"foo\nbar":   "    foo\n    bar",
+		"foo\nbar\n": "    foo\n    bar\n    ",
+	} {
+		cp := CodeProvider{}
+		actual := cp.DoCommand(&model.CommandArgs{}, msg).Text
+		if actual != expected {
+			t.Errorf("expected `%v`, got `%v`", expected, actual)
+		}
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -888,6 +888,18 @@
     "translation": "ALT+SHIFT+UP: Previous channel or direct message in left hand sidebar with unread messages\n"
   },
   {
+    "id": "api.command_code.desc",
+    "translation": "Display text as a code block"
+  },
+  {
+    "id": "api.command_code.hint",
+    "translation": "[text]"
+  },
+  {
+    "id": "api.command_code.name",
+    "translation": "code"
+  },
+  {
     "id": "api.command_shrug.desc",
     "translation": "Adds ¯\\_(ツ)_/¯ to your message"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -900,6 +900,10 @@
     "translation": "code"
   },
   {
+    "id": "api.command_code.message.app_error",
+    "translation": "A message must be provided with the /code command."
+  },
+  {
     "id": "api.command_shrug.desc",
     "translation": "Adds ¯\\_(ツ)_/¯ to your message"
   },


### PR DESCRIPTION
#### Summary
/code [text] slash command: Display the text as a code block

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6706

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates