### PR TITLE
PLT-7133 Updated marked to fix escaping of autolinked email addresses

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "jquery": "3.2.1",
     "key-mirror": "1.0.1",
     "localforage": "1.5.0",
-    "marked": "mattermost/marked#8f5902fff9bad793cd6c66e0c44002c9e79e1317",
+    "marked": "mattermost/marked#c0b5f4a651b0af63e974522b20b93b7999490c53",
     "match-at": "0.1.0",
     "mattermost-redux": "mattermost/mattermost-redux#webapp-4.0",
     "object-assign": "4.1.1",

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -5025,9 +5025,9 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@mattermost/marked#8f5902fff9bad793cd6c66e0c44002c9e79e1317:
+marked@mattermost/marked#c0b5f4a651b0af63e974522b20b93b7999490c53:
   version "0.3.5"
-  resolved "https://codeload.github.com/mattermost/marked/tar.gz/8f5902fff9bad793cd6c66e0c44002c9e79e1317"
+  resolved "https://codeload.github.com/mattermost/marked/tar.gz/c0b5f4a651b0af63e974522b20b93b7999490c53"
 
 match-at@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Escaping wasn't working correctly inside of an email link using angle brackets like `<noreply@example.com>` which caused problems when `html-to-react` went to render it into React components. This is also making me want to get commonmark used in the web app sooner than later. I remember seeing some other edge cases where marked didn't escape HTML entities, and that has me a bit worried that there's others that we're missing.

Changes to marked here: https://github.com/mattermost/marked/commit/c0b5f4a651b0af63e974522b20b93b7999490c53

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7133

#### Checklist
- Added or updated unit tests (see changes to marked)