### PR TITLE
[PLT-6842] Added websocket event and webapp handler for updating user roles

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -164,7 +164,16 @@ func UpdateTeamMemberRoles(teamId string, userId string, newRoles string) (*mode
 
 	ClearSessionCacheForUser(userId)
 
+	sendUpdatedMemberRoleEvent(userId, member)
+
 	return member, nil
+}
+
+func sendUpdatedMemberRoleEvent(userId string, member *model.TeamMember) {
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_MEMBERROLE_UPDATED, "", "", userId, nil)
+	message.Add("member", member.ToJson())
+
+	go Publish(message)
 }
 
 func AddUserToTeam(teamId string, userId string, userRequestorId string) (*model.Team, *model.AppError) {

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -24,6 +24,7 @@ const (
 	WEBSOCKET_EVENT_UPDATE_TEAM         = "update_team"
 	WEBSOCKET_EVENT_USER_ADDED          = "user_added"
 	WEBSOCKET_EVENT_USER_UPDATED        = "user_updated"
+	WEBSOCKET_EVENT_MEMBERROLE_UPDATED  = "memberrole_updated"
 	WEBSOCKET_EVENT_USER_REMOVED        = "user_removed"
 	WEBSOCKET_EVENT_PREFERENCE_CHANGED  = "preference_changed"
 	WEBSOCKET_EVENT_PREFERENCES_CHANGED = "preferences_changed"

--- a/webapp/actions/websocket_actions.jsx
+++ b/webapp/actions/websocket_actions.jsx
@@ -169,6 +169,10 @@ function handleEvent(msg) {
         handleUserUpdatedEvent(msg);
         break;
 
+    case SocketEvents.MEMBERROLE_UPDATED:
+        handleUpdateMemberRoleEvent(msg);
+        break;
+
     case SocketEvents.CHANNEL_CREATED:
         handleChannelCreatedEvent(msg);
         break;
@@ -308,6 +312,11 @@ function handleLeaveTeamEvent(msg) {
 
 function handleUpdateTeamEvent(msg) {
     TeamStore.updateTeam(msg.data.team);
+}
+
+function handleUpdateMemberRoleEvent(msg) {
+    const member = JSON.parse(msg.data.member);
+    TeamStore.updateMyRoles(member);
 }
 
 function handleDirectAddedEvent(msg) {

--- a/webapp/stores/team_store.jsx
+++ b/webapp/stores/team_store.jsx
@@ -341,6 +341,22 @@ class TeamStoreClass extends EventEmitter {
         return false;
     }
 
+    updateMyRoles(member) {
+        const teamMembers = this.getMyTeamMembers();
+        const teamMember = teamMembers.find((m) => m.user_id === member.user_id && m.team_id === member.team_id);
+
+        if (teamMember) {
+            const newMember = Object.assign({}, teamMember, {
+                roles: member.roles
+            });
+
+            store.dispatch({
+                type: TeamTypes.RECEIVED_MY_TEAM_MEMBER,
+                data: newMember
+            });
+        }
+    }
+
     subtractUnread(teamId, msgs, mentions) {
         let member = this.getMyTeamMembers().filter((m) => m.team_id === teamId)[0];
         if (member) {

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -232,6 +232,7 @@ export const SocketEvents = {
     USER_ADDED: 'user_added',
     USER_REMOVED: 'user_removed',
     USER_UPDATED: 'user_updated',
+    MEMBERROLE_UPDATED: 'memberrole_updated',
     TYPING: 'typing',
     PREFERENCE_CHANGED: 'preference_changed',
     PREFERENCES_CHANGED: 'preferences_changed',


### PR DESCRIPTION
#### Summary
When user A (admin) updates user B's role, user B's dropdown menu is updated to reflect the change without needing a refresh. 

#### Ticket Link
Github issue #6645 

#### Checklist
- [x] Has UI changes

