### PR TITLE
PLT-7126 Do not version detect on saml endpoints and remove config reloading

### DIFF
--- a/app/saml.go
+++ b/app/saml.go
@@ -68,7 +68,6 @@ func AddSamlPublicCertificate(fileData *multipart.FileHeader) *model.AppError {
 	}
 
 	utils.SaveConfig(utils.CfgFileName, cfg)
-	utils.LoadConfig(utils.CfgFileName)
 
 	return nil
 }
@@ -88,7 +87,6 @@ func AddSamlPrivateCertificate(fileData *multipart.FileHeader) *model.AppError {
 	}
 
 	utils.SaveConfig(utils.CfgFileName, cfg)
-	utils.LoadConfig(utils.CfgFileName)
 
 	return nil
 }
@@ -108,7 +106,6 @@ func AddSamlIdpCertificate(fileData *multipart.FileHeader) *model.AppError {
 	}
 
 	utils.SaveConfig(utils.CfgFileName, cfg)
-	utils.LoadConfig(utils.CfgFileName)
 
 	return nil
 }
@@ -144,7 +141,6 @@ func RemoveSamlPublicCertificate() *model.AppError {
 	}
 
 	utils.SaveConfig(utils.CfgFileName, cfg)
-	utils.LoadConfig(utils.CfgFileName)
 
 	return nil
 }
@@ -165,7 +161,6 @@ func RemoveSamlPrivateCertificate() *model.AppError {
 	}
 
 	utils.SaveConfig(utils.CfgFileName, cfg)
-	utils.LoadConfig(utils.CfgFileName)
 
 	return nil
 }
@@ -186,7 +181,6 @@ func RemoveSamlIdpCertificate() *model.AppError {
 	}
 
 	utils.SaveConfig(utils.CfgFileName, cfg)
-	utils.LoadConfig(utils.CfgFileName)
 
 	return nil
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -24,7 +24,7 @@
     "localforage": "1.5.0",
     "marked": "mattermost/marked#c0b5f4a651b0af63e974522b20b93b7999490c53",
     "match-at": "0.1.0",
-    "mattermost-redux": "mattermost/mattermost-redux#webapp-4.0-test2",
+    "mattermost-redux": "mattermost/mattermost-redux#webapp-4.0",
     "object-assign": "4.1.1",
     "pdfjs-dist": "1.8.474",
     "perfect-scrollbar": "0.7.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -24,7 +24,7 @@
     "localforage": "1.5.0",
     "marked": "mattermost/marked#c0b5f4a651b0af63e974522b20b93b7999490c53",
     "match-at": "0.1.0",
-    "mattermost-redux": "mattermost/mattermost-redux#webapp-4.0",
+    "mattermost-redux": "mattermost/mattermost-redux#webapp-4.0-test2",
     "object-assign": "4.1.1",
     "pdfjs-dist": "1.8.474",
     "perfect-scrollbar": "0.7.1",

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -5041,9 +5041,9 @@ math-expression-evaluator@^1.2.14:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
 
-mattermost-redux@mattermost/mattermost-redux#webapp-4.0-test2:
+mattermost-redux@mattermost/mattermost-redux#webapp-4.0:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/5086bc9f8fe28c3aac3b94d301aaad63d0d5d74b"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/ea67cb97d1e34b251e13a356583223284f544aa5"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -5041,9 +5041,9 @@ math-expression-evaluator@^1.2.14:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
 
-mattermost-redux@mattermost/mattermost-redux#webapp-4.0:
+mattermost-redux@mattermost/mattermost-redux#webapp-4.0-test2:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/a68c49c57130ed64e5a8fb3bdbd004ced437790b"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/5086bc9f8fe28c3aac3b94d301aaad63d0d5d74b"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
Manually loading the config during SAML certificate upload was conflicting with the config watcher routine and causing a crash. I removed the manual load call, the watcher will pick up any saved changes. Also stopped version checking on the SAML, config and logs endpoint on the client.

Has minor enterprise changes mattermost/enterprise#164

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7126