### PR TITLE
PLT-7079: fix uncleared server errors in user settings

### DIFF
--- a/webapp/components/user_settings/user_settings_general/user_settings_general.jsx
+++ b/webapp/components/user_settings/user_settings_general/user_settings_general.jsx
@@ -132,10 +132,10 @@ class UserSettingsGeneralTab extends React.Component {
         const {formatMessage} = this.props.intl;
         const usernameError = Utils.isValidUsername(username);
         if (usernameError === 'Cannot use a reserved word as a username.') {
-            this.setState({clientError: formatMessage(holders.usernameReserved)});
+            this.setState({clientError: formatMessage(holders.usernameReserved), serverError: ''});
             return;
         } else if (usernameError) {
-            this.setState({clientError: formatMessage(holders.usernameRestrictions, {min: Constants.MIN_USERNAME_LENGTH, max: Constants.MAX_USERNAME_LENGTH})});
+            this.setState({clientError: formatMessage(holders.usernameRestrictions, {min: Constants.MIN_USERNAME_LENGTH, max: Constants.MAX_USERNAME_LENGTH}), serverError: ''});
             return;
         }
 
@@ -260,10 +260,10 @@ class UserSettingsGeneralTab extends React.Component {
         const file = this.state.pictureFile;
 
         if (file.type !== 'image/jpeg' && file.type !== 'image/png') {
-            this.setState({clientError: formatMessage(holders.validImage)});
+            this.setState({clientError: formatMessage(holders.validImage), serverError: ''});
             return;
         } else if (file.size > this.state.maxFileSize) {
-            this.setState({clientError: formatMessage(holders.imageTooLarge)});
+            this.setState({clientError: formatMessage(holders.imageTooLarge), serverError: ''});
             return;
         }
 


### PR DESCRIPTION
#### Summary

Failed client-side validation didn't clear previously displayed server-side errors.

I'm really not even sure why `SettingItemMax` is designed to be able to display both types of errors at once. They seem like they should always be mutually exclusive.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7079

#### Checklist
N/A