### PR TITLE
PLT-6595: API to purge Elasticsearch indexes.

### DIFF
--- a/api4/elasticsearch.go
+++ b/api4/elasticsearch.go
@@ -16,6 +16,7 @@ func InitElasticsearch() {
 	l4g.Debug(utils.T("api.elasticsearch.init.debug"))
 
 	BaseRoutes.Elasticsearch.Handle("/test", ApiSessionRequired(testElasticsearch)).Methods("POST")
+	BaseRoutes.Elasticsearch.Handle("/purge_indexes", ApiSessionRequired(purgeElasticsearchIndexes)).Methods("POST")
 }
 
 func testElasticsearch(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -30,6 +31,20 @@ func testElasticsearch(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := app.TestElasticsearch(cfg); err != nil {
+		c.Err = err
+		return
+	}
+
+	ReturnStatusOK(w)
+}
+
+func purgeElasticsearchIndexes(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	if err := app.PurgeElasticsearchIndexes(); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/elasticsearch_test.go
+++ b/api4/elasticsearch_test.go
@@ -17,3 +17,14 @@ func TestElasticsearchTest(t *testing.T) {
 	_, resp = th.SystemAdminClient.TestElasticsearch()
 	CheckNotImplementedStatus(t, resp)
 }
+
+func TestElasticsearchPurgeIndexes(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer TearDown()
+
+	_, resp := th.Client.PurgeElasticsearchIndexes()
+	CheckForbiddenStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.PurgeElasticsearchIndexes()
+	CheckNotImplementedStatus(t, resp)
+}

--- a/app/elasticsearch.go
+++ b/app/elasticsearch.go
@@ -31,3 +31,16 @@ func TestElasticsearch(cfg *model.Config) *model.AppError {
 
 	return nil
 }
+
+func PurgeElasticsearchIndexes() *model.AppError {
+	if esI := einterfaces.GetElasticsearchInterface(); esI != nil {
+		if err := esI.PurgeIndexes(); err != nil {
+			return err
+		}
+	} else {
+		err := model.NewAppError("PurgeElasticsearchIndexes", "ent.elasticsearch.test_config.license.error", nil, "", http.StatusNotImplemented)
+		return err
+	}
+
+	return nil
+}

--- a/einterfaces/elasticsearch.go
+++ b/einterfaces/elasticsearch.go
@@ -11,6 +11,7 @@ type ElasticsearchInterface interface {
 	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, *model.AppError)
 	DeletePost(postId string) *model.AppError
 	TestConfig(cfg *model.Config) *model.AppError
+	PurgeIndexes() *model.AppError
 }
 
 var theElasticsearchInterface ElasticsearchInterface

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3508,6 +3508,14 @@
     "translation": "ElasticSearch searching is disabled on this server"
   },
   {
+    "id": "ent.elasticsearch.generic.disabled",
+    "translation": "ElasticSearch search is not enabled on this server"
+  },
+  {
+    "id": "ent.elasticsearch.purge_indexes.delete_failed",
+    "translation": "Failed to delete Elasticsearch index"
+  },
+  {
     "id": "ent.elasticsearch.search_posts.search_failed",
     "translation": "Search failed to complete"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -2553,6 +2553,16 @@ func (c *Client4) TestElasticsearch() (bool, *Response) {
 	}
 }
 
+// PurgeElasticsearchIndexes immediately deletes all Elasticsearch indexes.
+func (c *Client4) PurgeElasticsearchIndexes() (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetElasticsearchRoute()+"/test", ""); err != nil {
+		return false, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // Commands Section
 
 // CreateCommand will create a new command if the user have the right permissions.


### PR DESCRIPTION
#### Summary
Adds an APIv4 Endpoint to purge Elasticsearch indexes.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6595

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation https://github.com/mattermost/mattermost-api-reference/pull/274
- [x] All new/modified APIs include changes to the drivers
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/165
- [x] Includes text changes and localization file updates
