### PR TITLE
PLT-6763 Implement user access tokens and new roles (server-side)

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -308,9 +308,13 @@ func (c *Context) LogDebug(err *model.AppError) {
 }
 
 func (c *Context) UserRequired() {
+	if !*utils.Cfg.ServiceSettings.EnableUserAccessTokens && c.Session.Props[model.SESSION_PROP_TYPE] == model.SESSION_TYPE_USER_ACCESS_TOKEN {
+		c.Err = model.NewAppError("", "api.context.session_expired.app_error", nil, "UserAccessToken", http.StatusUnauthorized)
+		return
+	}
+
 	if len(c.Session.UserId) == 0 {
-		c.Err = model.NewLocAppError("", "api.context.session_expired.app_error", nil, "UserRequired")
-		c.Err.StatusCode = http.StatusUnauthorized
+		c.Err = model.NewAppError("", "api.context.session_expired.app_error", nil, "UserRequired", http.StatusUnauthorized)
 		return
 	}
 }

--- a/api/post.go
+++ b/api/post.go
@@ -51,7 +51,16 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	post.UserId = c.Session.UserId
 
-	if !app.SessionHasPermissionToChannel(c.Session, post.ChannelId, model.PERMISSION_CREATE_POST) {
+	hasPermission := false
+	if app.SessionHasPermissionToChannel(c.Session, post.ChannelId, model.PERMISSION_CREATE_POST) {
+		hasPermission = true
+	} else if channel, err := app.GetChannel(post.ChannelId); err == nil {
+		if channel.Type == model.CHANNEL_OPEN && app.SessionHasPermissionToTeam(c.Session, channel.TeamId, model.PERMISSION_CREATE_POST_PUBLIC) {
+			hasPermission = true
+		}
+	}
+
+	if !hasPermission {
 		c.SetPermissionError(model.PERMISSION_CREATE_POST)
 		return
 	}

--- a/api/post.go
+++ b/api/post.go
@@ -55,6 +55,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	if app.SessionHasPermissionToChannel(c.Session, post.ChannelId, model.PERMISSION_CREATE_POST) {
 		hasPermission = true
 	} else if channel, err := app.GetChannel(post.ChannelId); err == nil {
+		// Temporary permission check method until advanced permissions, please do not copy
 		if channel.Type == model.CHANNEL_OPEN && app.SessionHasPermissionToTeam(c.Session, channel.TeamId, model.PERMISSION_CREATE_POST_PUBLIC) {
 			hasPermission = true
 		}

--- a/api4/context.go
+++ b/api4/context.go
@@ -239,6 +239,11 @@ func (c *Context) IsSystemAdmin() bool {
 }
 
 func (c *Context) SessionRequired() {
+	if !*utils.Cfg.ServiceSettings.EnableUserAccessTokens && c.Session.Props[model.SESSION_PROP_TYPE] == model.SESSION_TYPE_USER_ACCESS_TOKEN {
+		c.Err = model.NewAppError("", "api.context.session_expired.app_error", nil, "UserAccessToken", http.StatusUnauthorized)
+		return
+	}
+
 	if len(c.Session.UserId) == 0 {
 		c.Err = model.NewAppError("", "api.context.session_expired.app_error", nil, "UserRequired", http.StatusUnauthorized)
 		return
@@ -357,6 +362,17 @@ func (c *Context) RequireInviteId() *Context {
 
 	if len(c.Params.InviteId) == 0 {
 		c.SetInvalidUrlParam("invite_id")
+	}
+	return c
+}
+
+func (c *Context) RequireTokenId() *Context {
+	if c.Err != nil {
+		return c
+	}
+
+	if len(c.Params.TokenId) != 26 {
+		c.SetInvalidUrlParam("token_id")
 	}
 	return c
 }

--- a/api4/params.go
+++ b/api4/params.go
@@ -20,6 +20,7 @@ type ApiParams struct {
 	UserId         string
 	TeamId         string
 	InviteId       string
+	TokenId        string
 	ChannelId      string
 	PostId         string
 	FileId         string
@@ -58,6 +59,10 @@ func ApiParamsFromRequest(r *http.Request) *ApiParams {
 
 	if val, ok := props["invite_id"]; ok {
 		params.InviteId = val
+	}
+
+	if val, ok := props["token_id"]; ok {
+		params.TokenId = val
 	}
 
 	if val, ok := props["channel_id"]; ok {

--- a/api4/post.go
+++ b/api4/post.go
@@ -44,6 +44,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	if app.SessionHasPermissionToChannel(c.Session, post.ChannelId, model.PERMISSION_CREATE_POST) {
 		hasPermission = true
 	} else if channel, err := app.GetChannel(post.ChannelId); err == nil {
+		// Temporary permission check method until advanced permissions, please do not copy
 		if channel.Type == model.CHANNEL_OPEN && app.SessionHasPermissionToTeam(c.Session, channel.TeamId, model.PERMISSION_CREATE_POST_PUBLIC) {
 			hasPermission = true
 		}

--- a/app/session.go
+++ b/app/session.go
@@ -16,6 +16,8 @@ import (
 var sessionCache *utils.Cache = utils.NewLru(model.SESSION_CACHE_SIZE)
 
 func CreateSession(session *model.Session) (*model.Session, *model.AppError) {
+	session.Token = ""
+
 	if result := <-Srv.Store.Session().Save(session); result.Err != nil {
 		return nil, result.Err
 	} else {
@@ -43,22 +45,31 @@ func GetSession(token string) (*model.Session, *model.AppError) {
 	}
 
 	if session == nil {
-		if sessionResult := <-Srv.Store.Session().Get(token); sessionResult.Err != nil {
-			return nil, model.NewLocAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token, "Error": sessionResult.Err.DetailedError}, "")
-		} else {
+		if sessionResult := <-Srv.Store.Session().Get(token); sessionResult.Err == nil {
 			session = sessionResult.Data.(*model.Session)
 
-			if session == nil || session.IsExpired() || session.Token != token {
-				return nil, model.NewLocAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token, "Error": ""}, "")
-			} else {
-				AddSessionToCache(session)
-				return session, nil
+			if session != nil {
+				if session.Token != token {
+					return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token, "Error": ""}, "", http.StatusUnauthorized)
+				}
+
+				if !session.IsExpired() {
+					AddSessionToCache(session)
+				}
 			}
 		}
 	}
 
+	if session == nil {
+		var err *model.AppError
+		session, err = createSessionForUserAccessToken(token)
+		if err != nil {
+			return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token}, err.Error(), http.StatusUnauthorized)
+		}
+	}
+
 	if session == nil || session.IsExpired() {
-		return nil, model.NewLocAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token}, "")
+		return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token}, "", http.StatusUnauthorized)
 	}
 
 	return session, nil
@@ -199,4 +210,105 @@ func UpdateLastActivityAtIfNeeded(session model.Session) {
 
 	session.LastActivityAt = now
 	AddSessionToCache(&session)
+}
+
+func CreateUserAccessToken(token *model.UserAccessToken) (*model.UserAccessToken, *model.AppError) {
+	if !*utils.Cfg.ServiceSettings.EnableUserAccessTokens {
+		return nil, model.NewAppError("CreateUserAccessToken", "app.user_access_token.disabled", nil, "", http.StatusNotImplemented)
+	}
+
+	token.Token = model.NewId()
+
+	if result := <-Srv.Store.UserAccessToken().Save(token); result.Err != nil {
+		return nil, result.Err
+	} else {
+		return result.Data.(*model.UserAccessToken), nil
+	}
+}
+
+func createSessionForUserAccessToken(tokenString string) (*model.Session, *model.AppError) {
+	if !*utils.Cfg.ServiceSettings.EnableUserAccessTokens {
+		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "EnableUserAccessTokens=false", http.StatusUnauthorized)
+	}
+
+	var token *model.UserAccessToken
+	if result := <-Srv.Store.UserAccessToken().GetByToken(tokenString); result.Err != nil {
+		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, result.Err.Error(), http.StatusUnauthorized)
+	} else {
+		token = result.Data.(*model.UserAccessToken)
+	}
+
+	var user *model.User
+	if result := <-Srv.Store.User().Get(token.UserId); result.Err != nil {
+		return nil, result.Err
+	} else {
+		user = result.Data.(*model.User)
+	}
+
+	if user.DeleteAt != 0 {
+		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "inactive_user_id="+user.Id, http.StatusUnauthorized)
+	}
+
+	session := &model.Session{
+		Token:   token.Token,
+		UserId:  user.Id,
+		Roles:   user.GetRawRoles(),
+		IsOAuth: false,
+	}
+
+	session.AddProp(model.SESSION_PROP_USER_ACCESS_TOKEN_ID, token.Id)
+	session.AddProp(model.SESSION_PROP_TYPE, model.SESSION_TYPE_USER_ACCESS_TOKEN)
+	session.SetExpireInDays(model.SESSION_USER_ACCESS_TOKEN_EXPIRY)
+
+	if result := <-Srv.Store.Session().Save(session); result.Err != nil {
+		return nil, result.Err
+	} else {
+		session := result.Data.(*model.Session)
+
+		AddSessionToCache(session)
+
+		return session, nil
+	}
+}
+
+func RevokeUserAccessToken(token *model.UserAccessToken) *model.AppError {
+	var session *model.Session
+	if result := <-Srv.Store.Session().Get(token.Token); result.Err == nil {
+		session = result.Data.(*model.Session)
+	}
+
+	if result := <-Srv.Store.UserAccessToken().Delete(token.Id); result.Err != nil {
+		return result.Err
+	}
+
+	if session == nil {
+		return nil
+	}
+
+	return RevokeSession(session)
+}
+
+func GetUserAccessTokensForUser(userId string, page, perPage int) ([]*model.UserAccessToken, *model.AppError) {
+	if result := <-Srv.Store.UserAccessToken().GetByUser(userId, page*perPage, perPage); result.Err != nil {
+		return nil, result.Err
+	} else {
+		tokens := result.Data.([]*model.UserAccessToken)
+		for _, token := range tokens {
+			token.Token = ""
+		}
+
+		return tokens, nil
+	}
+}
+
+func GetUserAccessToken(tokenId string, sanitize bool) (*model.UserAccessToken, *model.AppError) {
+	if result := <-Srv.Store.UserAccessToken().Get(tokenId); result.Err != nil {
+		return nil, result.Err
+	} else {
+		token := result.Data.(*model.UserAccessToken)
+		if sanitize {
+			token.Token = ""
+		}
+		return token, nil
+	}
 }

--- a/app/user.go
+++ b/app/user.go
@@ -1224,6 +1224,10 @@ func PermanentDeleteUser(user *model.User) *model.AppError {
 		return result.Err
 	}
 
+	if result := <-Srv.Store.UserAccessToken().DeleteAllForUser(user.Id); result.Err != nil {
+		return result.Err
+	}
+
 	if result := <-Srv.Store.OAuth().PermanentDeleteAuthDataByUser(user.Id); result.Err != nil {
 		return result.Err
 	}

--- a/config/config.json
+++ b/config/config.json
@@ -29,6 +29,7 @@
         "EnableInsecureOutgoingConnections": false,
         "EnableMultifactorAuthentication": false,
         "EnforceMultifactorAuthentication": false,
+        "EnableUserAccessTokens": false,
         "AllowCorsFrom": "",
         "SessionLengthWebInDays": 30,
         "SessionLengthMobileInDays": 30,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3056,6 +3056,14 @@
     "translation": "Invalid {{.Name}} parameter"
   },
   {
+    "id": "app.user_access_token.disabled",
+    "translation": "User access tokens are disabled on this server. Please contact your system administrator for details."
+  },
+  {
+    "id": "app.user_access_token.invalid_or_missing",
+    "translation": "Invalid or missing token"
+  },
+  {
     "id": "app.channel.create_channel.no_team_id.app_error",
     "translation": "Must specify the team ID to create a channel"
   },
@@ -3458,6 +3466,62 @@
   {
     "id": "app.import.validate_user_teams_import_data.team_name_missing.error",
     "translation": "Team name missing from User's Team Membership."
+  },
+  {
+    "id": "authentication.roles.system_post_all_public.name",
+    "translation": "Post in Public Channels"
+  },
+  {
+    "id": "authentication.roles.system_post_all_public.description",
+    "translation": "A role with the permission to post in any public channel on the system"
+  },
+  {
+    "id": "authentication.roles.team_post_all_public.name",
+    "translation": "Post in Public Channels"
+  },
+  {
+    "id": "authentication.roles.team_post_all_public.description",
+    "translation": "A role with the permission to post in any public channel on the team"
+  },
+  {
+    "id": "authentication.roles.system_user_access_token.name",
+    "translation": "User Access Token"
+  },
+  {
+    "id": "authentication.roles.system_user_access_token.description",
+    "translation": "A role with the permissions to create, read and revoke user access tokens"
+  },
+  {
+    "id": "authentication.permissions.create_post_public.name",
+    "translation": "Create Posts in Public Channels"
+  },
+  {
+    "id": "authentication.permissions.create_post_public.description",
+    "translation": "Ability to create posts in public channels"
+  },
+  {
+    "id": "authentication.permissions.create_user_access_token.name",
+    "translation": "Create User Access Token"
+  },
+  {
+    "id": "authentication.permissions.create_user_access_token.description",
+    "translation": "Ability to create user access tokens"
+  },
+  {
+    "id": "authentication.permissions.read_user_access_token.name",
+    "translation": "Read User Access Tokens"
+  },
+  {
+    "id": "authentication.permissions.read_user_access_token.description",
+    "translation": "Ability to read user access tokens' id, description and user_id fields"
+  },
+  {
+    "id": "authentication.permissions.revoke_user_access_token.name",
+    "translation": "Revoke User Access Token"
+  },
+  {
+    "id": "authentication.permissions.revoke_user_access_token.description",
+    "translation": "Ability to revoke user access tokens"
   },
   {
     "id": "authentication.permissions.create_group_channel.description",
@@ -3978,6 +4042,18 @@
   {
     "id": "model.access.is_valid.access_token.app_error",
     "translation": "Invalid access token"
+  },
+  {
+    "id": "model.user_access_token.is_valid.token.app_error",
+    "translation": "Invalid access token"
+  },
+  {
+    "id": "model.user_access_token.is_valid.user_id.app_error",
+    "translation": "Invalid user id"
+  },
+  {
+    "id": "model.user_access_token.is_valid.description.app_error",
+    "translation": "Invalid description, must be 255 or less characters"
   },
   {
     "id": "model.access.is_valid.client_id.app_error",
@@ -6018,6 +6094,26 @@
   {
     "id": "store.sql_team.update_display_name.app_error",
     "translation": "We couldn't update the team name"
+  },
+  {
+    "id": "store.sql_user_access_token.get_by_user.app_error",
+    "translation": "We couldn't get the user access tokens by user"
+  },
+  {
+    "id": "store.sql_user_access_token.get_by_token.app_error",
+    "translation": "We couldn't get the user access token by token"
+  },
+  {
+    "id": "store.sql_user_access_token.get.app_error",
+    "translation": "We couldn't get the user access token"
+  },
+  {
+    "id": "store.sql_user_access_token.delete.app_error",
+    "translation": "We couldn't delete the user access token"
+  },
+  {
+    "id": "store.sql_user_access_token.save.app_error",
+    "translation": "We couldn't save the user access token"
   },
   {
     "id": "store.sql_user.analytics_get_inactive_users_count.app_error",

--- a/model/authorization.go
+++ b/model/authorization.go
@@ -48,6 +48,7 @@ var PERMISSION_MANAGE_OTHERS_WEBHOOKS *Permission
 var PERMISSION_MANAGE_OAUTH *Permission
 var PERMISSION_MANAGE_SYSTEM_WIDE_OAUTH *Permission
 var PERMISSION_CREATE_POST *Permission
+var PERMISSION_CREATE_POST_PUBLIC *Permission
 var PERMISSION_EDIT_POST *Permission
 var PERMISSION_EDIT_OTHERS_POSTS *Permission
 var PERMISSION_DELETE_POST *Permission
@@ -59,6 +60,9 @@ var PERMISSION_IMPORT_TEAM *Permission
 var PERMISSION_VIEW_TEAM *Permission
 var PERMISSION_LIST_USERS_WITHOUT_TEAM *Permission
 var PERMISSION_MANAGE_JOBS *Permission
+var PERMISSION_CREATE_USER_ACCESS_TOKEN *Permission
+var PERMISSION_READ_USER_ACCESS_TOKEN *Permission
+var PERMISSION_REVOKE_USER_ACCESS_TOKEN *Permission
 
 // General permission that encompases all system admin functions
 // in the future this could be broken up to allow access to some
@@ -67,9 +71,12 @@ var PERMISSION_MANAGE_SYSTEM *Permission
 
 var ROLE_SYSTEM_USER *Role
 var ROLE_SYSTEM_ADMIN *Role
+var ROLE_SYSTEM_POST_ALL_PUBLIC *Role
+var ROLE_SYSTEM_USER_ACCESS_TOKEN *Role
 
 var ROLE_TEAM_USER *Role
 var ROLE_TEAM_ADMIN *Role
+var ROLE_TEAM_POST_ALL_PUBLIC *Role
 
 var ROLE_CHANNEL_USER *Role
 var ROLE_CHANNEL_ADMIN *Role
@@ -243,6 +250,11 @@ func InitalizePermissions() {
 		"authentication.permissions.create_post.name",
 		"authentication.permissions.create_post.description",
 	}
+	PERMISSION_CREATE_POST_PUBLIC = &Permission{
+		"create_post_public",
+		"authentication.permissions.create_post_public.name",
+		"authentication.permissions.create_post_public.description",
+	}
 	PERMISSION_EDIT_POST = &Permission{
 		"edit_post",
 		"authentication.permissions.edit_post.name",
@@ -290,8 +302,23 @@ func InitalizePermissions() {
 	}
 	PERMISSION_LIST_USERS_WITHOUT_TEAM = &Permission{
 		"list_users_without_team",
-		"authentication.permisssions.list_users_without_team.name",
-		"authentication.permisssions.list_users_without_team.description",
+		"authentication.permissions.list_users_without_team.name",
+		"authentication.permissions.list_users_without_team.description",
+	}
+	PERMISSION_CREATE_USER_ACCESS_TOKEN = &Permission{
+		"create_user_access_token",
+		"authentication.permissions.create_user_access_token.name",
+		"authentication.permissions.create_user_access_token.description",
+	}
+	PERMISSION_READ_USER_ACCESS_TOKEN = &Permission{
+		"read_user_access_token",
+		"authentication.permissions.read_user_access_token.name",
+		"authentication.permissions.read_user_access_token.description",
+	}
+	PERMISSION_REVOKE_USER_ACCESS_TOKEN = &Permission{
+		"revoke_user_access_token",
+		"authentication.permissions.revoke_user_access_token.name",
+		"authentication.permissions.revoke_user_access_token.description",
 	}
 	PERMISSION_MANAGE_JOBS = &Permission{
 		"manage_jobs",
@@ -348,6 +375,17 @@ func InitalizeRoles() {
 		},
 	}
 	BuiltInRoles[ROLE_TEAM_USER.Id] = ROLE_TEAM_USER
+
+	ROLE_TEAM_POST_ALL_PUBLIC = &Role{
+		"team_post_all_public",
+		"authentication.roles.team_post_all_public.name",
+		"authentication.roles.team_post_all_public.description",
+		[]string{
+			PERMISSION_CREATE_POST_PUBLIC.Id,
+		},
+	}
+	BuiltInRoles[ROLE_TEAM_POST_ALL_PUBLIC.Id] = ROLE_TEAM_POST_ALL_PUBLIC
+
 	ROLE_TEAM_ADMIN = &Role{
 		"team_admin",
 		"authentication.roles.team_admin.name",
@@ -378,6 +416,29 @@ func InitalizeRoles() {
 		},
 	}
 	BuiltInRoles[ROLE_SYSTEM_USER.Id] = ROLE_SYSTEM_USER
+
+	ROLE_SYSTEM_POST_ALL_PUBLIC = &Role{
+		"system_post_all_public",
+		"authentication.roles.system_post_all_public.name",
+		"authentication.roles.system_post_all_public.description",
+		[]string{
+			PERMISSION_CREATE_POST_PUBLIC.Id,
+		},
+	}
+	BuiltInRoles[ROLE_SYSTEM_POST_ALL_PUBLIC.Id] = ROLE_SYSTEM_POST_ALL_PUBLIC
+
+	ROLE_SYSTEM_USER_ACCESS_TOKEN = &Role{
+		"system_user_access_token",
+		"authentication.roles.system_user_access_token.name",
+		"authentication.roles.system_user_access_token.description",
+		[]string{
+			PERMISSION_CREATE_USER_ACCESS_TOKEN.Id,
+			PERMISSION_READ_USER_ACCESS_TOKEN.Id,
+			PERMISSION_REVOKE_USER_ACCESS_TOKEN.Id,
+		},
+	}
+	BuiltInRoles[ROLE_SYSTEM_USER_ACCESS_TOKEN.Id] = ROLE_SYSTEM_USER_ACCESS_TOKEN
+
 	ROLE_SYSTEM_ADMIN = &Role{
 		"system_admin",
 		"authentication.roles.global_admin.name",
@@ -412,6 +473,10 @@ func InitalizeRoles() {
 							PERMISSION_ADD_USER_TO_TEAM.Id,
 							PERMISSION_LIST_USERS_WITHOUT_TEAM.Id,
 							PERMISSION_MANAGE_JOBS.Id,
+							PERMISSION_CREATE_POST_PUBLIC.Id,
+							PERMISSION_CREATE_USER_ACCESS_TOKEN.Id,
+							PERMISSION_READ_USER_ACCESS_TOKEN.Id,
+							PERMISSION_REVOKE_USER_ACCESS_TOKEN.Id,
 						},
 						ROLE_TEAM_USER.Permissions...,
 					),

--- a/model/config.go
+++ b/model/config.go
@@ -150,6 +150,7 @@ type ServiceSettings struct {
 	EnableInsecureOutgoingConnections        *bool
 	EnableMultifactorAuthentication          *bool
 	EnforceMultifactorAuthentication         *bool
+	EnableUserAccessTokens                   *bool
 	AllowCorsFrom                            *string
 	SessionLengthWebInDays                   *int
 	SessionLengthMobileInDays                *int
@@ -604,6 +605,11 @@ func (o *Config) SetDefaults() {
 	if o.ServiceSettings.EnforceMultifactorAuthentication == nil {
 		o.ServiceSettings.EnforceMultifactorAuthentication = new(bool)
 		*o.ServiceSettings.EnforceMultifactorAuthentication = false
+	}
+
+	if o.ServiceSettings.EnableUserAccessTokens == nil {
+		o.ServiceSettings.EnableUserAccessTokens = new(bool)
+		*o.ServiceSettings.EnableUserAccessTokens = false
 	}
 
 	if o.PasswordSettings.MinimumLength == nil {

--- a/model/session.go
+++ b/model/session.go
@@ -10,13 +10,17 @@ import (
 )
 
 const (
-	SESSION_COOKIE_TOKEN     = "MMAUTHTOKEN"
-	SESSION_COOKIE_USER      = "MMUSERID"
-	SESSION_CACHE_SIZE       = 35000
-	SESSION_PROP_PLATFORM    = "platform"
-	SESSION_PROP_OS          = "os"
-	SESSION_PROP_BROWSER     = "browser"
-	SESSION_ACTIVITY_TIMEOUT = 1000 * 60 * 5 // 5 minutes
+	SESSION_COOKIE_TOKEN              = "MMAUTHTOKEN"
+	SESSION_COOKIE_USER               = "MMUSERID"
+	SESSION_CACHE_SIZE                = 35000
+	SESSION_PROP_PLATFORM             = "platform"
+	SESSION_PROP_OS                   = "os"
+	SESSION_PROP_BROWSER              = "browser"
+	SESSION_PROP_TYPE                 = "type"
+	SESSION_PROP_USER_ACCESS_TOKEN_ID = "user_access_token_id"
+	SESSION_TYPE_USER_ACCESS_TOKEN    = "UserAccessToken"
+	SESSION_ACTIVITY_TIMEOUT          = 1000 * 60 * 5 // 5 minutes
+	SESSION_USER_ACCESS_TOKEN_EXPIRY  = 100 * 365     // 100 years
 )
 
 type Session struct {
@@ -58,7 +62,9 @@ func (me *Session) PreSave() {
 		me.Id = NewId()
 	}
 
-	me.Token = NewId()
+	if me.Token == "" {
+		me.Token = NewId()
+	}
 
 	me.CreateAt = GetMillis()
 	me.LastActivityAt = me.CreateAt

--- a/model/user_access_token.go
+++ b/model/user_access_token.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+type UserAccessToken struct {
+	Id          string `json:"id"`
+	Token       string `json:"token,omitempty"`
+	UserId      string `json:"user_id"`
+	Description string `json:"description"`
+}
+
+// IsValid validates the AuthData and returns an error if it isn't configured
+// correctly.
+func (t *UserAccessToken) IsValid() *AppError {
+	if len(t.Id) != 26 {
+		return NewAppError("UserAccessToken.IsValid", "model.user_access_token.is_valid.id.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(t.Token) != 26 {
+		return NewAppError("UserAccessToken.IsValid", "model.user_access_token.is_valid.token.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(t.UserId) != 26 {
+		return NewAppError("UserAccessToken.IsValid", "model.user_access_token.is_valid.user_id.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(t.Description) > 255 {
+		return NewAppError("UserAccessToken.IsValid", "model.user_access_token.is_valid.description.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	return nil
+}
+
+func (t *UserAccessToken) PreSave() {
+	t.Id = NewId()
+}
+
+func (t *UserAccessToken) ToJson() string {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func UserAccessTokenFromJson(data io.Reader) *UserAccessToken {
+	decoder := json.NewDecoder(data)
+	var t UserAccessToken
+	err := decoder.Decode(&t)
+	if err == nil {
+		return &t
+	} else {
+		return nil
+	}
+}
+
+func UserAccessTokenListToJson(t []*UserAccessToken) string {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func UserAccessTokenListFromJson(data io.Reader) []*UserAccessToken {
+	decoder := json.NewDecoder(data)
+	var t []*UserAccessToken
+	err := decoder.Decode(&t)
+	if err == nil {
+		return t
+	} else {
+		return nil
+	}
+}

--- a/model/user_access_token.go
+++ b/model/user_access_token.go
@@ -16,8 +16,6 @@ type UserAccessToken struct {
 	Description string `json:"description"`
 }
 
-// IsValid validates the AuthData and returns an error if it isn't configured
-// correctly.
 func (t *UserAccessToken) IsValid() *AppError {
 	if len(t.Id) != 26 {
 		return NewAppError("UserAccessToken.IsValid", "model.user_access_token.is_valid.id.app_error", nil, "", http.StatusBadRequest)

--- a/model/user_access_token_test.go
+++ b/model/user_access_token_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUserAccessTokenJson(t *testing.T) {
+	a1 := UserAccessToken{}
+	a1.UserId = NewId()
+	a1.Token = NewId()
+
+	json := a1.ToJson()
+	ra1 := UserAccessTokenFromJson(strings.NewReader(json))
+
+	if a1.Token != ra1.Token {
+		t.Fatal("tokens didn't match")
+	}
+
+	tokens := []*UserAccessToken{&a1}
+	json = UserAccessTokenListToJson(tokens)
+	tokens = UserAccessTokenListFromJson(strings.NewReader(json))
+
+	if tokens[0].Token != a1.Token {
+		t.Fatal("tokens didn't match")
+	}
+}
+
+func TestUserAccessTokenIsValid(t *testing.T) {
+	ad := UserAccessToken{}
+
+	if err := ad.IsValid(); err == nil || err.Id != "model.user_access_token.is_valid.token.app_error" {
+		t.Fatal(err)
+	}
+
+	ad.Token = NewRandomString(26)
+	if err := ad.IsValid(); err == nil || err.Id != "model.user_access_token.is_valid.user_id.app_error" {
+		t.Fatal(err)
+	}
+
+	ad.UserId = NewRandomString(26)
+	if err := ad.IsValid(); err != nil {
+		t.Fatal(err)
+	}
+
+	ad.Description = NewRandomString(256)
+	if err := ad.IsValid(); err == nil || err.Id != "model.user_access_token.is_valid.description.app_error" {
+		t.Fatal(err)
+	}
+}

--- a/model/user_access_token_test.go
+++ b/model/user_access_token_test.go
@@ -32,6 +32,11 @@ func TestUserAccessTokenJson(t *testing.T) {
 func TestUserAccessTokenIsValid(t *testing.T) {
 	ad := UserAccessToken{}
 
+	if err := ad.IsValid(); err == nil || err.Id != "model.user_access_token.is_valid.id.app_error" {
+		t.Fatal(err)
+	}
+
+	ad.Id = NewRandomString(26)
 	if err := ad.IsValid(); err == nil || err.Id != "model.user_access_token.is_valid.token.app_error" {
 		t.Fatal(err)
 	}

--- a/store/layered_store.go
+++ b/store/layered_store.go
@@ -123,6 +123,10 @@ func (s *LayeredStore) Job() JobStore {
 	return s.DatabaseLayer.Job()
 }
 
+func (s *LayeredStore) UserAccessToken() UserAccessTokenStore {
+	return s.DatabaseLayer.UserAccessToken()
+}
+
 func (s *LayeredStore) MarkSystemRanUnitTests() {
 	s.DatabaseLayer.MarkSystemRanUnitTests()
 }

--- a/store/sql_store.go
+++ b/store/sql_store.go
@@ -80,4 +80,5 @@ type SqlStore interface {
 	FileInfo() FileInfoStore
 	Reaction() ReactionStore
 	Job() JobStore
+	UserAccessToken() UserAccessTokenStore
 }

--- a/store/sql_supplier.go
+++ b/store/sql_supplier.go
@@ -63,26 +63,27 @@ type SqlSupplierResult struct {
 }
 
 type SqlSupplierOldStores struct {
-	team       TeamStore
-	channel    ChannelStore
-	post       PostStore
-	user       UserStore
-	audit      AuditStore
-	cluster    ClusterDiscoveryStore
-	compliance ComplianceStore
-	session    SessionStore
-	oauth      OAuthStore
-	system     SystemStore
-	webhook    WebhookStore
-	command    CommandStore
-	preference PreferenceStore
-	license    LicenseStore
-	token      TokenStore
-	emoji      EmojiStore
-	status     StatusStore
-	fileInfo   FileInfoStore
-	reaction   ReactionStore
-	job        JobStore
+	team            TeamStore
+	channel         ChannelStore
+	post            PostStore
+	user            UserStore
+	audit           AuditStore
+	cluster         ClusterDiscoveryStore
+	compliance      ComplianceStore
+	session         SessionStore
+	oauth           OAuthStore
+	system          SystemStore
+	webhook         WebhookStore
+	command         CommandStore
+	preference      PreferenceStore
+	license         LicenseStore
+	token           TokenStore
+	emoji           EmojiStore
+	status          StatusStore
+	fileInfo        FileInfoStore
+	reaction        ReactionStore
+	job             JobStore
+	userAccessToken UserAccessTokenStore
 }
 
 type SqlSupplier struct {
@@ -122,6 +123,7 @@ func NewSqlSupplier() *SqlSupplier {
 	supplier.oldStores.fileInfo = NewSqlFileInfoStore(supplier)
 	supplier.oldStores.reaction = NewSqlReactionStore(supplier)
 	supplier.oldStores.job = NewSqlJobStore(supplier)
+	supplier.oldStores.userAccessToken = NewSqlUserAccessTokenStore(supplier)
 
 	err := supplier.GetMaster().CreateTablesIfNotExists()
 	if err != nil {
@@ -151,6 +153,7 @@ func NewSqlSupplier() *SqlSupplier {
 	supplier.oldStores.fileInfo.(*SqlFileInfoStore).CreateIndexesIfNotExists()
 	supplier.oldStores.reaction.(*SqlReactionStore).CreateIndexesIfNotExists()
 	supplier.oldStores.job.(*SqlJobStore).CreateIndexesIfNotExists()
+	supplier.oldStores.userAccessToken.(*SqlUserAccessTokenStore).CreateIndexesIfNotExists()
 
 	supplier.oldStores.preference.(*SqlPreferenceStore).DeleteUnusedFeatures()
 
@@ -754,6 +757,10 @@ func (ss *SqlSupplier) Reaction() ReactionStore {
 
 func (ss *SqlSupplier) Job() JobStore {
 	return ss.oldStores.job
+}
+
+func (ss *SqlSupplier) UserAccessToken() UserAccessTokenStore {
+	return ss.oldStores.userAccessToken
 }
 
 func (ss *SqlSupplier) DropAllTables() {

--- a/store/sql_user_access_token_store.go
+++ b/store/sql_user_access_token_store.go
@@ -24,13 +24,15 @@ func NewSqlUserAccessTokenStore(sqlStore SqlStore) UserAccessTokenStore {
 		table.ColMap("Id").SetMaxSize(26)
 		table.ColMap("Token").SetMaxSize(26).SetUnique(true)
 		table.ColMap("UserId").SetMaxSize(26)
-		table.ColMap("Description").SetMaxSize(255)
+		table.ColMap("Description").SetMaxSize(512)
 	}
 
 	return s
 }
 
 func (s SqlUserAccessTokenStore) CreateIndexesIfNotExists() {
+	s.CreateIndexIfNotExists("idx_user_access_tokens_token", "UserAccessTokens", "Token")
+	s.CreateIndexIfNotExists("idx_user_access_tokens_user_id", "UserAccessTokens", "UserId")
 }
 
 func (s SqlUserAccessTokenStore) Save(token *model.UserAccessToken) StoreChannel {

--- a/store/sql_user_access_token_store.go
+++ b/store/sql_user_access_token_store.go
@@ -74,7 +74,7 @@ func (s SqlUserAccessTokenStore) Delete(tokenId string) StoreChannel {
 		if err != nil {
 			result.Err = model.NewAppError("SqlUserAccessTokenStore.Delete", "store.sql_user_access_token.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
 		} else {
-			if extrasResult := s.deleteSessionsById(transaction, tokenId); extrasResult.Err != nil {
+			if extrasResult := s.deleteSessionsAndTokensById(transaction, tokenId); extrasResult.Err != nil {
 				result = extrasResult
 			}
 
@@ -97,7 +97,7 @@ func (s SqlUserAccessTokenStore) Delete(tokenId string) StoreChannel {
 	return storeChannel
 }
 
-func (s SqlUserAccessTokenStore) deleteSessionsById(transaction *gorp.Transaction, tokenId string) StoreResult {
+func (s SqlUserAccessTokenStore) deleteSessionsAndTokensById(transaction *gorp.Transaction, tokenId string) StoreResult {
 	result := StoreResult{}
 
 	query := ""
@@ -136,7 +136,7 @@ func (s SqlUserAccessTokenStore) DeleteAllForUser(userId string) StoreChannel {
 		if err != nil {
 			result.Err = model.NewAppError("SqlUserAccessTokenStore.DeleteAllForUser", "store.sql_user_access_token.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
 		} else {
-			if extrasResult := s.deleteSessionsByUser(transaction, userId); extrasResult.Err != nil {
+			if extrasResult := s.deleteSessionsandTokensByUser(transaction, userId); extrasResult.Err != nil {
 				result = extrasResult
 			}
 
@@ -159,7 +159,7 @@ func (s SqlUserAccessTokenStore) DeleteAllForUser(userId string) StoreChannel {
 	return storeChannel
 }
 
-func (s SqlUserAccessTokenStore) deleteSessionsByUser(transaction *gorp.Transaction, userId string) StoreResult {
+func (s SqlUserAccessTokenStore) deleteSessionsandTokensByUser(transaction *gorp.Transaction, userId string) StoreResult {
 	result := StoreResult{}
 
 	query := ""

--- a/store/sql_user_access_token_store.go
+++ b/store/sql_user_access_token_store.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package store
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/mattermost/gorp"
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+type SqlUserAccessTokenStore struct {
+	SqlStore
+}
+
+func NewSqlUserAccessTokenStore(sqlStore SqlStore) UserAccessTokenStore {
+	s := &SqlUserAccessTokenStore{sqlStore}
+
+	for _, db := range sqlStore.GetAllConns() {
+		table := db.AddTableWithName(model.UserAccessToken{}, "UserAccessTokens").SetKeys(false, "Id")
+		table.ColMap("Id").SetMaxSize(26)
+		table.ColMap("Token").SetMaxSize(26).SetUnique(true)
+		table.ColMap("UserId").SetMaxSize(26)
+		table.ColMap("Description").SetMaxSize(255)
+	}
+
+	return s
+}
+
+func (s SqlUserAccessTokenStore) CreateIndexesIfNotExists() {
+}
+
+func (s SqlUserAccessTokenStore) Save(token *model.UserAccessToken) StoreChannel {
+
+	storeChannel := make(StoreChannel, 1)
+
+	go func() {
+		result := StoreResult{}
+
+		token.PreSave()
+
+		if result.Err = token.IsValid(); result.Err != nil {
+			storeChannel <- result
+			close(storeChannel)
+			return
+		}
+
+		if err := s.GetMaster().Insert(token); err != nil {
+			result.Err = model.NewAppError("SqlUserAccessTokenStore.Save", "store.sql_user_access_token.save.app_error", nil, "", http.StatusInternalServerError)
+		} else {
+			result.Data = token
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlUserAccessTokenStore) Delete(tokenId string) StoreChannel {
+
+	storeChannel := make(StoreChannel, 1)
+
+	go func() {
+		result := StoreResult{}
+
+		transaction, err := s.GetMaster().Begin()
+		if err != nil {
+			result.Err = model.NewAppError("SqlUserAccessTokenStore.Delete", "store.sql_user_access_token.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+		} else {
+			if extrasResult := s.deleteSessionsById(transaction, tokenId); extrasResult.Err != nil {
+				result = extrasResult
+			}
+
+			if result.Err == nil {
+				if err := transaction.Commit(); err != nil {
+					// don't need to rollback here since the transaction is already closed
+					result.Err = model.NewAppError("SqlUserAccessTokenStore.Delete", "store.sql_user_access_token.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+				}
+			} else {
+				if err := transaction.Rollback(); err != nil {
+					result.Err = model.NewAppError("SqlUserAccessTokenStore.Delete", "store.sql_user_access_token.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+				}
+			}
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlUserAccessTokenStore) deleteSessionsById(transaction *gorp.Transaction, tokenId string) StoreResult {
+	result := StoreResult{}
+
+	query := ""
+	if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		query = "DELETE FROM Sessions s USING UserAccessTokens o WHERE o.Token = s.Token AND o.Id = :Id"
+	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+		query = "DELETE s.* FROM Sessions s INNER JOIN UserAccessTokens o ON o.Token = s.Token WHERE o.Id = :Id"
+	}
+
+	if _, err := transaction.Exec(query, map[string]interface{}{"Id": tokenId}); err != nil {
+		result.Err = model.NewAppError("SqlUserAccessTokenStore.deleteSessionsById", "store.sql_user_access_token.delete.app_error", nil, "id="+tokenId+", err="+err.Error(), http.StatusInternalServerError)
+		return result
+	}
+
+	return s.deleteTokensById(transaction, tokenId)
+}
+
+func (s SqlUserAccessTokenStore) deleteTokensById(transaction *gorp.Transaction, tokenId string) StoreResult {
+	result := StoreResult{}
+
+	if _, err := transaction.Exec("DELETE FROM UserAccessTokens WHERE Id = :Id", map[string]interface{}{"Id": tokenId}); err != nil {
+		result.Err = model.NewAppError("SqlUserAccessTokenStore.deleteTokensById", "store.sql_user_access_token.delete.app_error", nil, "", http.StatusInternalServerError)
+	}
+
+	return result
+}
+
+func (s SqlUserAccessTokenStore) DeleteAllForUser(userId string) StoreChannel {
+
+	storeChannel := make(StoreChannel, 1)
+
+	go func() {
+		result := StoreResult{}
+
+		transaction, err := s.GetMaster().Begin()
+		if err != nil {
+			result.Err = model.NewAppError("SqlUserAccessTokenStore.DeleteAllForUser", "store.sql_user_access_token.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+		} else {
+			if extrasResult := s.deleteSessionsByUser(transaction, userId); extrasResult.Err != nil {
+				result = extrasResult
+			}
+
+			if result.Err == nil {
+				if err := transaction.Commit(); err != nil {
+					// don't need to rollback here since the transaction is already closed
+					result.Err = model.NewAppError("SqlUserAccessTokenStore.DeleteAllForUser", "store.sql_user_access_token.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+				}
+			} else {
+				if err := transaction.Rollback(); err != nil {
+					result.Err = model.NewAppError("SqlUserAccessTokenStore.DeleteAllForUser", "store.sql_user_access_token.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+				}
+			}
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlUserAccessTokenStore) deleteSessionsByUser(transaction *gorp.Transaction, userId string) StoreResult {
+	result := StoreResult{}
+
+	query := ""
+	if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		query = "DELETE FROM Sessions s USING UserAccessTokens o WHERE o.Token = s.Token AND o.UserId = :UserId"
+	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+		query = "DELETE s.* FROM Sessions s INNER JOIN UserAccessTokens o ON o.Token = s.Token WHERE o.UserId = :UserId"
+	}
+
+	if _, err := transaction.Exec(query, map[string]interface{}{"UserId": userId}); err != nil {
+		result.Err = model.NewAppError("SqlUserAccessTokenStore.deleteSessionsByUser", "store.sql_user_access_token.delete.app_error", nil, "user_id="+userId+", err="+err.Error(), http.StatusInternalServerError)
+		return result
+	}
+
+	return s.deleteTokensByUser(transaction, userId)
+}
+
+func (s SqlUserAccessTokenStore) deleteTokensByUser(transaction *gorp.Transaction, userId string) StoreResult {
+	result := StoreResult{}
+
+	if _, err := transaction.Exec("DELETE FROM UserAccessTokens WHERE UserId = :UserId", map[string]interface{}{"UserId": userId}); err != nil {
+		result.Err = model.NewAppError("SqlUserAccessTokenStore.deleteTokensByUser", "store.sql_user_access_token.delete.app_error", nil, "", http.StatusInternalServerError)
+	}
+
+	return result
+}
+
+func (s SqlUserAccessTokenStore) Get(tokenId string) StoreChannel {
+
+	storeChannel := make(StoreChannel, 1)
+
+	go func() {
+		result := StoreResult{}
+
+		token := model.UserAccessToken{}
+
+		if err := s.GetReplica().SelectOne(&token, "SELECT * FROM UserAccessTokens WHERE Id = :Id", map[string]interface{}{"Id": tokenId}); err != nil {
+			if err == sql.ErrNoRows {
+				result.Err = model.NewAppError("SqlUserAccessTokenStore.Get", "store.sql_user_access_token.get.app_error", nil, err.Error(), http.StatusNotFound)
+			} else {
+				result.Err = model.NewAppError("SqlUserAccessTokenStore.Get", "store.sql_user_access_token.get.app_error", nil, err.Error(), http.StatusInternalServerError)
+			}
+		}
+
+		result.Data = &token
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlUserAccessTokenStore) GetByToken(tokenString string) StoreChannel {
+
+	storeChannel := make(StoreChannel, 1)
+
+	go func() {
+		result := StoreResult{}
+
+		token := model.UserAccessToken{}
+
+		if err := s.GetReplica().SelectOne(&token, "SELECT * FROM UserAccessTokens WHERE Token = :Token", map[string]interface{}{"Token": tokenString}); err != nil {
+			if err == sql.ErrNoRows {
+				result.Err = model.NewAppError("SqlUserAccessTokenStore.GetByToken", "store.sql_user_access_token.get_by_token.app_error", nil, err.Error(), http.StatusNotFound)
+			} else {
+				result.Err = model.NewAppError("SqlUserAccessTokenStore.GetByToken", "store.sql_user_access_token.get_by_token.app_error", nil, err.Error(), http.StatusInternalServerError)
+			}
+		}
+
+		result.Data = &token
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
+func (s SqlUserAccessTokenStore) GetByUser(userId string, offset, limit int) StoreChannel {
+
+	storeChannel := make(StoreChannel, 1)
+
+	go func() {
+		result := StoreResult{}
+
+		tokens := []*model.UserAccessToken{}
+
+		if _, err := s.GetReplica().Select(&tokens, "SELECT * FROM UserAccessTokens WHERE UserId = :UserId LIMIT :Limit OFFSET :Offset", map[string]interface{}{"UserId": userId, "Offset": offset, "Limit": limit}); err != nil {
+			result.Err = model.NewAppError("SqlUserAccessTokenStore.GetByUser", "store.sql_user_access_token.get_by_user.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+
+		result.Data = tokens
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}

--- a/store/sql_user_access_token_store_test.go
+++ b/store/sql_user_access_token_store_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package store
+
+import (
+	"testing"
+
+	"github.com/mattermost/platform/model"
+)
+
+func TestUserAccessTokenSaveGetDelete(t *testing.T) {
+	Setup()
+
+	uat := &model.UserAccessToken{
+		Token:       model.NewId(),
+		UserId:      model.NewId(),
+		Description: "testtoken",
+	}
+
+	s1 := model.Session{}
+	s1.UserId = uat.UserId
+	s1.Token = uat.Token
+
+	Must(store.Session().Save(&s1))
+
+	if result := <-store.UserAccessToken().Save(uat); result.Err != nil {
+		t.Fatal(result.Err)
+	}
+
+	if result := <-store.UserAccessToken().Get(uat.Id); result.Err != nil {
+		t.Fatal(result.Err)
+	} else if received := result.Data.(*model.UserAccessToken); received.Token != uat.Token {
+		t.Fatal("received incorrect token after save")
+	}
+
+	if result := <-store.UserAccessToken().GetByToken(uat.Token); result.Err != nil {
+		t.Fatal(result.Err)
+	} else if received := result.Data.(*model.UserAccessToken); received.Token != uat.Token {
+		t.Fatal("received incorrect token after save")
+	}
+
+	if result := <-store.UserAccessToken().GetByToken("notarealtoken"); result.Err == nil {
+		t.Fatal("should have failed on bad token")
+	}
+
+	if result := <-store.UserAccessToken().GetByUser(uat.UserId, 0, 100); result.Err != nil {
+		t.Fatal(result.Err)
+	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
+		t.Fatal("received incorrect number of tokens after save")
+	}
+
+	if result := <-store.UserAccessToken().Delete(uat.Id); result.Err != nil {
+		t.Fatal(result.Err)
+	}
+
+	if err := (<-store.Session().Get(s1.Token)).Err; err == nil {
+		t.Fatal("should error - session should be deleted")
+	}
+
+	if err := (<-store.UserAccessToken().GetByToken(s1.Token)).Err; err == nil {
+		t.Fatal("should error - access token should be deleted")
+	}
+
+	s2 := model.Session{}
+	s2.UserId = uat.UserId
+	s2.Token = uat.Token
+
+	Must(store.Session().Save(&s2))
+
+	if result := <-store.UserAccessToken().Save(uat); result.Err != nil {
+		t.Fatal(result.Err)
+	}
+
+	if result := <-store.UserAccessToken().DeleteAllForUser(uat.UserId); result.Err != nil {
+		t.Fatal(result.Err)
+	}
+
+	if err := (<-store.Session().Get(s2.Token)).Err; err == nil {
+		t.Fatal("should error - session should be deleted")
+	}
+
+	if err := (<-store.UserAccessToken().GetByToken(s2.Token)).Err; err == nil {
+		t.Fatal("should error - access token should be deleted")
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	FileInfo() FileInfoStore
 	Reaction() ReactionStore
 	Job() JobStore
+	UserAccessToken() UserAccessTokenStore
 	MarkSystemRanUnitTests()
 	Close()
 	DropAllTables()
@@ -396,4 +397,13 @@ type JobStore interface {
 	GetAllByTypePage(jobType string, offset int, limit int) StoreChannel
 	GetAllByStatus(status string) StoreChannel
 	Delete(id string) StoreChannel
+}
+
+type UserAccessTokenStore interface {
+	Save(token *model.UserAccessToken) StoreChannel
+	Delete(tokenId string) StoreChannel
+	DeleteAllForUser(userId string) StoreChannel
+	Get(tokenId string) StoreChannel
+	GetByToken(tokenString string) StoreChannel
+	GetByUser(userId string, page, perPage int) StoreChannel
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -421,6 +421,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["EnableOnlyAdminIntegrations"] = strconv.FormatBool(*c.ServiceSettings.EnableOnlyAdminIntegrations)
 	props["EnablePostUsernameOverride"] = strconv.FormatBool(c.ServiceSettings.EnablePostUsernameOverride)
 	props["EnablePostIconOverride"] = strconv.FormatBool(c.ServiceSettings.EnablePostIconOverride)
+	props["EnableUserAccessTokens"] = strconv.FormatBool(*c.ServiceSettings.EnableUserAccessTokens)
 	props["EnableLinkPreviews"] = strconv.FormatBool(*c.ServiceSettings.EnableLinkPreviews)
 	props["EnableTesting"] = strconv.FormatBool(c.ServiceSettings.EnableTesting)
 	props["EnableDeveloper"] = strconv.FormatBool(*c.ServiceSettings.EnableDeveloper)


### PR DESCRIPTION
#### Summary
* Adds a model and store for user access tokens
* Adds four APIv4 endpoints for creating, deleting and getting user access tokens
* Adds a new config setting to enable user access tokens
* When config setting is set sessions can now be created from valid user access tokens for active users
* Disabling config setting deauthorizes (but does not delete) existing user access token sessions
* Added three new permissions for user access tokens and one for posting in public channels
* Added two new system-level roles, one for user access token access and another for posting in public channels
* Added one new team-level role, for posting in public channels
* Updated permission on createPost API handlers to handle new public posting permission (@crspeller we might want to run a load test on this to make sure it's not too slow)
* Permanently deleting a user will remove all their user access tokens

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6763

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#275)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (authentication and permissions)
