### PR TITLE
Remove systemwide mutex from Yarn commands.

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -5,7 +5,7 @@ BUILD_SERVER_DIR = ..
 check-style: .yarninstall
 	@echo Checking for style guide compliance
 
-	yarn run check --mutex file:/tmp/.yarn-mutex
+	yarn run check
 
 test: .yarninstall
 	cd $(BUILD_SERVER_DIR) && $(MAKE) internal-test-web-client
@@ -13,7 +13,7 @@ test: .yarninstall
 .yarninstall: package.json
 	@echo Getting dependencies using yarn
 
-	yarn install --pure-lockfile --mutex file:/tmp/.yarn-mutex
+	yarn install
 
 	touch $@
 
@@ -22,7 +22,7 @@ build: .yarninstall
 
 	rm -rf dist
 
-	yarn run build --mutex file:/tmp/.yarn-mutex
+	yarn run build
 
 run: .yarninstall
 	@echo Running mattermost Webapp for development
@@ -49,9 +49,8 @@ endif
 clean:
 	@echo Cleaning Webapp
 
-	yarn cache clean --mutex file:/tmp/.yarn-mutex
+	yarn cache clean
 
 	rm -rf dist
 	rm -rf node_modules
 	rm -f .yarninstall
-	rm -f /tmp/.yarn-mutex


### PR DESCRIPTION
#### Summary
Jenkins is now configured to use a local yarn cache in the workspace for each job, so there should be no interaction between different jobs running on the same server.

This removes the global mutex to simplify the interaction between parallel builds, as it is now no longer needed.

~~DO NOT MERGE UNTIL SOME BUILDS HAVE SUCCEEDED WITH THE NEW YARN CACHE DIRECTORY~~

OK, I think this is good to merge now.