### PR TITLE
Comet as a WebSocket Fallback (Demo / Work-in-Progress)

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -207,6 +207,7 @@ func InitApi(full bool) {
 	InitReaction()
 	InitWebrtc()
 	InitOpenGraph()
+	InitComet()
 
 	app.Srv.Router.Handle("/api/v4/{anything:.*}", http.HandlerFunc(Handle404))
 

--- a/api4/comet.go
+++ b/api4/comet.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package api4
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	l4g "github.com/alecthomas/log4go"
+	"github.com/mattermost/platform/app"
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+func InitComet() {
+	l4g.Debug(utils.T("api.comet.init.debug"))
+
+	BaseRoutes.ApiRoot.Handle("/comet", ApiSessionRequired(connectComet)).Methods("GET")
+}
+
+func connectComet(c *Context, w http.ResponseWriter, r *http.Request) {
+	type Response struct {
+		Events      []interface{} `json:"events"`
+		ResumeToken string        `json:"resume_token"`
+	}
+
+	resumeToken := r.URL.Query().Get("resume_token")
+	hub := app.GetHubForUserId(c.Session.UserId)
+
+	firstEventContext, firstEventCancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer firstEventCancel()
+	batchedEventContext, batchedEventCancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+	defer batchedEventCancel()
+
+	ctx := firstEventContext
+
+	var response Response
+
+	for {
+		select {
+		case <-ctx.Done():
+			if len(response.Events) > 0 {
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+				}
+			} else {
+				http.Error(w, "request timeout", http.StatusRequestTimeout)
+			}
+			return
+		default:
+		}
+		if result, err := hub.NextCometEvent(ctx, resumeToken, &c.Session); err == context.DeadlineExceeded {
+			continue
+		} else if err != nil {
+			c.Err = model.NewAppError("connectComet", "api.comet.connect.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return
+		} else {
+			response.ResumeToken = result.ResumeToken
+			response.Events = append(response.Events, result.Event)
+			ctx = batchedEventContext
+			resumeToken = result.ResumeToken
+		}
+	}
+
+}

--- a/app/comet.go
+++ b/app/comet.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pborman/uuid"
+
+	"github.com/mattermost/platform/model"
+)
+
+type cometQueueListElement struct {
+	UUID          string
+	InsertionTime time.Time
+}
+
+type cometQueueMapElement struct {
+	NextUUID string
+	Event    *model.WebSocketEvent
+}
+
+type cometQueueWaitingResult struct {
+	Result *CometResult
+	Error  error
+}
+
+type cometQueueWaiting struct {
+	Filter  func(*model.WebSocketEvent) bool
+	Result  chan<- *cometQueueWaitingResult
+	Context context.Context
+}
+
+type CometQueue struct {
+	duration  time.Duration
+	eventList *list.List
+	eventMap  map[string]*cometQueueMapElement
+	mutex     sync.Mutex
+	waiting   *list.List
+	lastUUID  string
+}
+
+type CometResult struct {
+	ResumeToken string
+	Event       *model.WebSocketEvent
+}
+
+func NewCometQueue(d time.Duration) *CometQueue {
+	return &CometQueue{
+		duration:  d,
+		eventList: list.New(),
+		eventMap:  make(map[string]*cometQueueMapElement),
+		waiting:   list.New(),
+	}
+}
+
+func (q *CometQueue) Insert(event *model.WebSocketEvent) {
+	now := time.Now()
+	cutoff := now.Add(-q.duration)
+
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	for e := q.eventList.Front(); e != nil; {
+		v := e.Value.(*cometQueueListElement)
+		if v.InsertionTime.After(cutoff) {
+			break
+		}
+		next := e.Next()
+		delete(q.eventMap, v.UUID)
+		q.eventList.Remove(e)
+		e = next
+	}
+	e := &cometQueueListElement{
+		UUID:          uuid.New(),
+		InsertionTime: now,
+	}
+	q.eventList.PushBack(e)
+	q.eventMap[e.UUID] = &cometQueueMapElement{
+		Event: event,
+	}
+	if prev, ok := q.eventMap[q.lastUUID]; ok {
+		prev.NextUUID = e.UUID
+	}
+	q.lastUUID = e.UUID
+
+	result := &cometQueueWaitingResult{
+		Result: &CometResult{
+			ResumeToken: e.UUID,
+			Event:       event,
+		},
+	}
+	for e := q.waiting.Front(); e != nil; {
+		v := e.Value.(*cometQueueWaiting)
+		select {
+		case <-v.Context.Done():
+		default:
+			if v.Filter != nil && !v.Filter(event) {
+				e = e.Next()
+				continue
+			}
+			v.Result <- result
+		}
+		next := e.Next()
+		q.waiting.Remove(e)
+		e = next
+	}
+}
+
+func (q *CometQueue) Next(ctx context.Context, resumeToken string, filter func(*model.WebSocketEvent) bool) (*CometResult, error) {
+	q.mutex.Lock()
+
+	if prev, ok := q.eventMap[resumeToken]; ok {
+		for {
+			if next, ok := q.eventMap[prev.NextUUID]; ok {
+				if filter != nil && !filter(next.Event) {
+					prev = next
+					continue
+				}
+				q.mutex.Unlock()
+				return &CometResult{
+					ResumeToken: prev.NextUUID,
+					Event:       next.Event,
+				}, nil
+			}
+			break
+		}
+	}
+
+	result := make(chan *cometQueueWaitingResult, 1)
+	q.waiting.PushBack(&cometQueueWaiting{
+		Filter:  filter,
+		Result:  result,
+		Context: ctx,
+	})
+	q.mutex.Unlock()
+
+	select {
+	case ret := <-result:
+		return ret.Result, ret.Error
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/app/comet_test.go
+++ b/app/comet_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mattermost/platform/model"
+)
+
+func cometQueueInserter(q *CometQueue) *time.Ticker {
+	ticker := time.NewTicker(time.Millisecond * 5)
+	go func() {
+		i := 0
+		for _ = range ticker.C {
+			q.Insert(&model.WebSocketEvent{
+				Sequence: int64(i),
+			})
+			i++
+		}
+	}()
+	return ticker
+}
+
+func TestCometQueue(t *testing.T) {
+	q := NewCometQueue(time.Hour)
+
+	inserter := cometQueueInserter(q)
+	prev := &CometResult{}
+	for i := 0; i < 10; i++ {
+		result, _ := q.Next(context.Background(), prev.ResumeToken, func(event *model.WebSocketEvent) bool {
+			return event.Sequence%2 == 0
+		})
+		if result.Event.Sequence%2 > 0 || (i > 0 && result.Event.Sequence != prev.Event.Sequence+2) {
+			t.Fatal("unexpected sequence number")
+		}
+		prev = result
+	}
+	inserter.Stop()
+}
+
+func TestCometQueue_Deadline(t *testing.T) {
+	q := NewCometQueue(time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		cancel()
+	}()
+	q.Next(ctx, "", nil)
+}
+
+func BenchmarkCometQueue_Insert(b *testing.B) {
+	q := NewCometQueue(time.Hour)
+	for n := 0; n < b.N; n++ {
+		q.Insert(&model.WebSocketEvent{})
+	}
+}
+
+func BenchmarkCometQueue_Next(b *testing.B) {
+	q := NewCometQueue(time.Hour)
+	inserter := cometQueueInserter(q)
+	result, _ := q.Next(context.Background(), "", nil)
+	resumeToken := result.ResumeToken
+	inserter.Stop()
+	for i := 0; i < b.N; i++ {
+		q.Insert(&model.WebSocketEvent{
+			Sequence: int64(i),
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, _ = q.Next(context.Background(), resumeToken, nil)
+		resumeToken = result.ResumeToken
+	}
+}

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"hash/fnv"
 	"runtime"
@@ -27,6 +28,7 @@ const (
 )
 
 type Hub struct {
+	cometQueue      *CometQueue
 	connections     []*WebConn
 	connectionCount int64
 	connectionIndex int
@@ -44,6 +46,7 @@ var stopCheckingForDeadlock chan bool
 
 func NewWebHub() *Hub {
 	return &Hub{
+		cometQueue:     NewCometQueue(time.Second * 15),
 		register:       make(chan *WebConn),
 		unregister:     make(chan *WebConn),
 		connections:    make([]*WebConn, 0, model.SESSION_CACHE_SIZE),
@@ -344,9 +347,11 @@ func (h *Hub) Unregister(webConn *WebConn) {
 }
 
 func (h *Hub) Broadcast(message *model.WebSocketEvent) {
-	if message != nil {
-		h.broadcast <- message
+	if message == nil {
+		return
 	}
+	h.broadcast <- message
+	h.cometQueue.Insert(message)
 }
 
 func (h *Hub) InvalidateUser(userId string) {
@@ -425,7 +430,7 @@ func (h *Hub) Start() {
 
 			case msg := <-h.broadcast:
 				for _, webCon := range h.connections {
-					if webCon.ShouldSendEvent(msg) {
+					if webCon.IsAuthenticated() && ShouldSendWebSocketEvent(webCon.Session, msg) {
 						select {
 						case webCon.Send <- msg:
 						default:
@@ -473,4 +478,42 @@ func (h *Hub) Start() {
 	}
 
 	go doRecoverableStart()
+}
+
+func (h *Hub) NextCometEvent(ctx context.Context, resumeToken string, session *model.Session) (*CometResult, error) {
+	return h.cometQueue.Next(ctx, resumeToken, func(event *model.WebSocketEvent) bool {
+		return ShouldSendWebSocketEvent(session, event)
+	})
+}
+
+func ShouldSendWebSocketEvent(session *model.Session, msg *model.WebSocketEvent) bool {
+	if session == nil || session.UserId == "" {
+		return false
+	}
+
+	if len(msg.Broadcast.UserId) > 0 {
+		return session.UserId == msg.Broadcast.UserId
+	}
+
+	if len(msg.Broadcast.OmitUsers) > 0 {
+		if _, ok := msg.Broadcast.OmitUsers[session.UserId]; ok {
+			return false
+		}
+	}
+
+	if len(msg.Broadcast.ChannelId) > 0 {
+		if result := <-Srv.Store.Channel().GetAllChannelMembersForUser(session.UserId, true); result.Err != nil {
+			l4g.Error("comet.shouldSendEvent: " + result.Err.Error())
+			return false
+		} else {
+			_, ok := result.Data.(map[string]string)[msg.Broadcast.ChannelId]
+			return ok
+		}
+	}
+
+	if len(msg.Broadcast.TeamId) > 0 {
+		return session.GetTeamByTeamId(msg.Broadcast.TeamId) != nil
+	}
+
+	return true
 }

--- a/webapp/client/comet_client.jsx
+++ b/webapp/client/comet_client.jsx
@@ -1,0 +1,162 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import $ from 'jquery';
+
+const MIN_COMET_RETRY_TIME = 3000; // 3 sec
+const MAX_COMET_RETRY_TIME = 300000; // 5 mins
+
+export default class CometClient {
+    constructor() {
+        this.isActive = false;
+        this.connectionUrl = null;
+        this.xhr = null;
+        this.resumeToken = '';
+        this.failureCount = 0;
+        this.didFirstConnect = false;
+
+        this.eventCallback = null;
+        this.firstConnectCallback = null;
+        this.reconnectCallback = null;
+        this.missedEventCallback = null;
+        this.errorCallback = null;
+        this.closeCallback = null;
+    }
+
+    initialize(connectionUrl = this.connectionUrl, token) {
+        if (this.isActive) {
+            return;
+        }
+
+        if (connectionUrl == null) {
+            console.log('comet must have connection url'); //eslint-disable-line no-console
+            return;
+        }
+
+        this.connectionUrl = connectionUrl;
+        this.resumeToken = '';
+        this.failureCount = 0;
+        this.isActive = true;
+        this.didFirstConnect = false;
+
+        this.poll()
+    }
+
+    poll() {
+        if (!this.isActive) {
+            return;
+        }
+
+        this.xhr = $.ajax({
+            type: 'GET',
+            url: this.connectionUrl + '?resume_token=' + encodeURIComponent(this.resumeToken),
+            context: this,
+        }).done(this.handleSuccess).fail(this.handleFailure);
+    }
+
+    handleSuccess(data, textStatus, jqXHR) {
+        if (!this.didFirstConnect) {
+            this.didFirstConnect = true;
+            if (this.firstConnectCallback) {
+                this.firstConnectCallback();
+            }
+        }
+        if (this.failureCount > 0) {
+            if (this.reconnectCallback) {
+                this.reconnectCallback();
+            }
+            this.failureCount = 0;
+        }
+
+        this.resumeToken = data.resume_token;
+        if (this.eventCallback) {
+            for (let i = 0; i < data.events.length; i++) {
+                this.eventCallback(data.events[i]);
+            }
+        }
+
+        this.poll();
+    }
+
+    handleFailure(jqXHR, textStatus, errorThrown) {
+        if (jqXHR.status != 408) {
+            this.failureCount += 1;
+            if (this.errorCallback) {
+                this.errorCallback(errorThrown);
+            }
+            let delay = this.failureCount * this.failureCount * MIN_COMET_RETRY_TIME;
+            if (delay > MAX_COMET_RETRY_TIME) {
+                delay = MAX_COMET_RETRY_TIME;
+            }
+            setTimeout(
+                () => {
+                    this.poll();
+                },
+                delay
+            );
+            return;
+        }
+
+        this.poll();
+    }
+
+    setEventCallback(callback) {
+        this.eventCallback = callback;
+    }
+
+    setFirstConnectCallback(callback) {
+        this.firstConnectCallback = callback;
+    }
+
+    setReconnectCallback(callback) {
+        this.reconnectCallback = callback;
+    }
+
+    setMissedEventCallback(callback) {
+        this.missedEventCallback = callback;
+    }
+
+    setErrorCallback(callback) {
+        this.errorCallback = callback;
+    }
+
+    setCloseCallback(callback) {
+        this.closeCallback = callback;
+    }
+
+    close() {
+        if (this.isActive) {
+            if (this.xhr !== null) {
+                this.xhr.abort();
+            }
+            this.isActive = false;
+
+            if (this.closeCallback) {
+                this.closeCallback(this.connectFailCount);
+            }
+        }
+    }
+
+    sendMessage(action, data, responseCallback) {
+        // TODO
+    }
+
+    userTyping(channelId, parentId, callback) {
+        const data = {};
+        data.channel_id = channelId;
+        data.parent_id = parentId;
+
+        this.sendMessage('user_typing', data, callback);
+    }
+
+    getStatuses(callback) {
+        this.sendMessage('get_statuses', null, callback);
+    }
+
+    getStatusesByIds(userIds, callback) {
+        const data = {};
+        data.user_ids = userIds;
+        this.sendMessage('get_statuses_by_ids', data, callback);
+    }
+}
+

--- a/webapp/client/web_comet_client.jsx
+++ b/webapp/client/web_comet_client.jsx
@@ -1,0 +1,7 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import CometClient from './comet_client.jsx';
+
+var WebClient = new CometClient();
+export default WebClient;


### PR DESCRIPTION
#### Summary
Adds Comet (a.k.a. long polling) as a fallback for WebSockets.

This works (see the Gyfcat link below), but lacks some of our minor features like the typing notifications. And it won't pass the Jenkins build because I don't feel like fixing my eslint errors right now.

I need to make it bidirectional and propagate a signal when messages are skipped. These are both pretty easy.

I can finish it and polish it up if we decide we want to invest another day or two of my time into this.

Gfycat demo with WebSockets disabled entirely: https://gfycat.com/RemoteAnxiousKrill

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
