### PR TITLE
PLT-7145: `platform user deleteall` expects a user as argument

### DIFF
--- a/cmd/platform/user.go
+++ b/cmd/platform/user.go
@@ -37,12 +37,11 @@ var userDeactivateCmd = &cobra.Command{
 }
 
 var userCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create a user",
-	Long:  "Create a user",
-	Example: `  user create --email user@example.com --username userexample --password Password1
-  user create --firstname Joe --system_admin --email joe@example.com --username joe --password Password1`,
-	RunE: userCreateCmdF,
+	Use:     "create",
+	Short:   "Create a user",
+	Long:    "Create a user",
+	Example: `  user create --email user@example.com --username userexample --password Password1`,
+	RunE:    userCreateCmdF,
 }
 
 var userInviteCmd = &cobra.Command{
@@ -86,7 +85,7 @@ var deleteAllUsersCmd = &cobra.Command{
 	Short:   "Delete all users and all posts",
 	Long:    "Permanently delete all users and all related information including posts.",
 	Example: "  user deleteall",
-	RunE:    deleteUserCmdF,
+	RunE:    deleteAllUsersCommandF,
 }
 
 var migrateAuthCmd = &cobra.Command{
@@ -128,14 +127,14 @@ var searchUserCmd = &cobra.Command{
 }
 
 func init() {
-	userCreateCmd.Flags().String("username", "", "Username")
-	userCreateCmd.Flags().String("email", "", "Email")
-	userCreateCmd.Flags().String("password", "", "Password")
-	userCreateCmd.Flags().String("nickname", "", "Nickname")
-	userCreateCmd.Flags().String("firstname", "", "First Name")
-	userCreateCmd.Flags().String("lastname", "", "Last Name")
-	userCreateCmd.Flags().String("locale", "", "Locale (ex: en, fr)")
-	userCreateCmd.Flags().Bool("system_admin", false, "Make the user a system administrator")
+	userCreateCmd.Flags().String("username", "", "Required. Username for the new user account")
+	userCreateCmd.Flags().String("email", "", "Required. The email address for the new user account")
+	userCreateCmd.Flags().String("password", "", "Required. The password for the new user account")
+	userCreateCmd.Flags().String("nickname", "", "Optional. The nickname for the new user account")
+	userCreateCmd.Flags().String("firstname", "", "Optional. The given name for the new user account")
+	userCreateCmd.Flags().String("lastname", "", "Optional. The family or hereditary name for the new user account")
+	userCreateCmd.Flags().String("locale", "", "Optional. The locale (ex: en, fr) for the new user account")
+	userCreateCmd.Flags().Bool("system_admin", false, "Optional. If supplied, the new user will be a system administrator. Defaults to false")
 
 	deleteUserCmd.Flags().Bool("confirm", false, "Confirm you really want to delete the user and a DB backup has been performed.")
 
@@ -164,7 +163,7 @@ func userActivateCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) < 1 {
-		return errors.New("Enter user(s) to activate.")
+		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
 	changeUsersActiveStatus(args, true)
@@ -187,7 +186,7 @@ func changeUserActiveStatus(user *model.User, userArg string, activate bool) err
 		return fmt.Errorf("Can't find user '%v'", userArg)
 	}
 	if user.IsLDAPUser() {
-		return errors.New(utils.T("api.user.update_active.no_deactivate_ldap.app_error"))
+		return errors.New("You can not modify the activation status of AD/LDAP accounts. Please modify through the AD/LDAP server.")
 	}
 	if _, err := app.UpdateActive(user, activate); err != nil {
 		return fmt.Errorf("Unable to change activation status of user: %v", userArg)
@@ -202,7 +201,7 @@ func userDeactivateCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) < 1 {
-		return errors.New("Enter user(s) to deactivate.")
+		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
 	changeUsersActiveStatus(args, false)
@@ -230,7 +229,7 @@ func userCreateCmdF(cmd *cobra.Command, args []string) error {
 	firstname, _ := cmd.Flags().GetString("firstname")
 	lastname, _ := cmd.Flags().GetString("lastname")
 	locale, _ := cmd.Flags().GetString("locale")
-	system_admin, _ := cmd.Flags().GetBool("system_admin")
+	systemAdmin, _ := cmd.Flags().GetBool("system_admin")
 
 	user := &model.User{
 		Username:  username,
@@ -247,7 +246,7 @@ func userCreateCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Unable to create user. Error: " + err.Error())
 	}
 
-	if system_admin {
+	if systemAdmin {
 		app.UpdateUserRoles(ruser.Id, "system_user system_admin")
 	}
 
@@ -264,7 +263,7 @@ func userInviteCmdF(cmd *cobra.Command, args []string) error {
 	utils.InitHTML()
 
 	if len(args) < 2 {
-		return errors.New("Not enough arguments.")
+		return errors.New("Expected at least two arguments. See help text for details.")
 	}
 
 	email := args[0]
@@ -302,7 +301,7 @@ func resetUserPasswordCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) != 2 {
-		return errors.New("Incorect number of arguments.")
+		return errors.New("Expected two arguments. See help text for details.")
 	}
 
 	user := getUserFromUserArg(args[0])
@@ -324,7 +323,7 @@ func resetUserMfaCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) < 1 {
-		return errors.New("Enter at least one user.")
+		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
 	users := getUsersFromUserArgs(args)
@@ -348,7 +347,7 @@ func deleteUserCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) < 1 {
-		return errors.New("Enter at least one user.")
+		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
 	confirmFlag, _ := cmd.Flags().GetBool("confirm")
@@ -360,7 +359,7 @@ func deleteUserCmdF(cmd *cobra.Command, args []string) error {
 		if confirm != "YES" {
 			return errors.New("ABORTED: You did not answer YES exactly, in all capitals.")
 		}
-		CommandPrettyPrintln("Are you sure you want to delete the teams specified?  All data will be permanently deleted? (YES/NO): ")
+		CommandPrettyPrintln("Are you sure you want to permanently delete the specified users? (YES/NO): ")
 		fmt.Scanln(&confirm)
 		if confirm != "YES" {
 			return errors.New("ABORTED: You did not answer YES exactly, in all capitals.")
@@ -388,7 +387,7 @@ func deleteAllUsersCommandF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) > 0 {
-		return errors.New("Don't enter any agruments.")
+		return errors.New("Expected zero arguments.")
 	}
 
 	confirmFlag, _ := cmd.Flags().GetBool("confirm")
@@ -400,7 +399,7 @@ func deleteAllUsersCommandF(cmd *cobra.Command, args []string) error {
 		if confirm != "YES" {
 			return errors.New("ABORTED: You did not answer YES exactly, in all capitals.")
 		}
-		CommandPrettyPrintln("Are you sure you want to delete the teams specified?  All data will be permanently deleted? (YES/NO): ")
+		CommandPrettyPrintln("Are you sure you want to permanently delete all user accounts? (YES/NO): ")
 		fmt.Scanln(&confirm)
 		if confirm != "YES" {
 			return errors.New("ABORTED: You did not answer YES exactly, in all capitals.")
@@ -409,10 +408,9 @@ func deleteAllUsersCommandF(cmd *cobra.Command, args []string) error {
 
 	if err := app.PermanentDeleteAllUsers(); err != nil {
 		return err
-	} else {
-		CommandPrettyPrintln("Sucsessfull. All users deleted.")
 	}
 
+	CommandPrettyPrintln("All user accounts successfully deleted.")
 	return nil
 }
 
@@ -422,7 +420,7 @@ func migrateAuthCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) != 3 {
-		return errors.New("Enter the correct number of arguments.")
+		return errors.New("Expected three arguments. See help text for details.")
 	}
 
 	fromAuth := args[0]
@@ -451,9 +449,9 @@ func migrateAuthCmdF(cmd *cobra.Command, args []string) error {
 	if migrate := einterfaces.GetAccountMigrationInterface(); migrate != nil {
 		if err := migrate.MigrateToLdap(fromAuth, matchField, forceFlag); err != nil {
 			return errors.New("Error while migrating users: " + err.Error())
-		} else {
-			CommandPrettyPrintln("Sucessfully migrated accounts.")
 		}
+
+		CommandPrettyPrintln("Sucessfully migrated accounts.")
 	}
 
 	return nil
@@ -465,7 +463,7 @@ func verifyUserCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) < 1 {
-		return errors.New("Enter at least one user.")
+		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
 	users := getUsersFromUserArgs(args)
@@ -489,7 +487,7 @@ func searchUserCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) < 1 {
-		return errors.New("Enter at least one query.")
+		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
 	users := getUsersFromUserArgs(args)

--- a/cmd/platform/user.go
+++ b/cmd/platform/user.go
@@ -127,14 +127,14 @@ var searchUserCmd = &cobra.Command{
 }
 
 func init() {
-	userCreateCmd.Flags().String("username", "", "Required. Username for the new user account")
-	userCreateCmd.Flags().String("email", "", "Required. The email address for the new user account")
-	userCreateCmd.Flags().String("password", "", "Required. The password for the new user account")
-	userCreateCmd.Flags().String("nickname", "", "Optional. The nickname for the new user account")
-	userCreateCmd.Flags().String("firstname", "", "Optional. The given name for the new user account")
-	userCreateCmd.Flags().String("lastname", "", "Optional. The family or hereditary name for the new user account")
-	userCreateCmd.Flags().String("locale", "", "Optional. The locale (ex: en, fr) for the new user account")
-	userCreateCmd.Flags().Bool("system_admin", false, "Optional. If supplied, the new user will be a system administrator. Defaults to false")
+	userCreateCmd.Flags().String("username", "", "Required. Username for the new user account.")
+	userCreateCmd.Flags().String("email", "", "Required. The email address for the new user account.")
+	userCreateCmd.Flags().String("password", "", "Required. The password for the new user account.")
+	userCreateCmd.Flags().String("nickname", "", "Optional. The nickname for the new user account.")
+	userCreateCmd.Flags().String("firstname", "", "Optional. The first name for the new user account.")
+	userCreateCmd.Flags().String("lastname", "", "Optional. The last name for the new user account.")
+	userCreateCmd.Flags().String("locale", "", "Optional. The locale (ex: en, fr) for the new user account.")
+	userCreateCmd.Flags().Bool("system_admin", false, "Optional. If supplied, the new user will be a system administrator. Defaults to false.")
 
 	deleteUserCmd.Flags().Bool("confirm", false, "Confirm you really want to delete the user and a DB backup has been performed.")
 


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Fixed typo preventing deleteall command from working as expected. Cleaned up spelling and error messages throughout the user module

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7145
https://github.com/mattermost/platform/issues/6925

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]