### PR TITLE
PLT-7193: Fix DM custom slash command regression

### DIFF
--- a/api4/command.go
+++ b/api4/command.go
@@ -212,7 +212,13 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	commandArgs.TeamId = channel.TeamId
+	if commandArgs.TeamId == "" {
+		commandArgs.TeamId = channel.TeamId
+	} else if c.Session.GetTeamByTeamId(commandArgs.TeamId) == nil {
+		c.SetPermissionError(model.PERMISSION_USE_SLASH_COMMANDS)
+		return
+	}
+
 	commandArgs.UserId = c.Session.UserId
 	commandArgs.T = c.T
 	commandArgs.Session = c.Session

--- a/webapp/components/create_comment.jsx
+++ b/webapp/components/create_comment.jsx
@@ -10,6 +10,7 @@ import UserStore from 'stores/user_store.jsx';
 import PostDeletedModal from './post_deleted_modal.jsx';
 import PostStore from 'stores/post_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
+import TeamStore from 'stores/team_store.jsx';
 import MessageHistoryStore from 'stores/message_history_store.jsx';
 import Textbox from './textbox.jsx';
 import MsgTyping from './msg_typing.jsx';
@@ -199,6 +200,7 @@ export default class CreateComment extends React.Component {
 
         const args = {};
         args.channel_id = this.props.channelId;
+        args.team_id = TeamStore.getCurrentId();
         args.root_id = this.props.rootId;
         args.parent_id = this.props.rootId;
         ChannelActions.executeCommand(

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -23,6 +23,7 @@ import PostStore from 'stores/post_store.jsx';
 import MessageHistoryStore from 'stores/message_history_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
+import TeamStore from 'stores/team_store.jsx';
 import ConfirmModal from './confirm_modal.jsx';
 
 import Constants from 'utils/constants.jsx';
@@ -151,6 +152,7 @@ export default class CreatePost extends React.Component {
 
             const args = {};
             args.channel_id = this.state.channelId;
+            args.team_id = TeamStore.getCurrentId();
             ChannelActions.executeCommand(
                 post.message,
                 args,
@@ -466,6 +468,7 @@ export default class CreatePost extends React.Component {
             e.preventDefault();
             const args = {};
             args.channel_id = this.state.channelId;
+            args.team_id = TeamStore.getCurrentId();
             ChannelActions.executeCommand(
                 '/shortcuts',
                 args,


### PR DESCRIPTION
#### Summary
Reverts DM slash commands to pre-4.0 behavior.

That is, you can use slash commands for the team that you currently have selected in the UI.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7193

#### Checklist
N/A