### PR TITLE
PLT-7212: fix missing webhook post attachments

### DIFF
--- a/app/webhook_test.go
+++ b/app/webhook_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+func TestCreateWebhookPost(t *testing.T) {
+	th := Setup().InitBasic()
+	defer TearDown()
+
+	enableIncomingHooks := utils.Cfg.ServiceSettings.EnableIncomingWebhooks
+	defer func() {
+		utils.Cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks
+		utils.SetDefaultRolesBasedOnConfig()
+	}()
+	utils.Cfg.ServiceSettings.EnableIncomingWebhooks = true
+	utils.SetDefaultRolesBasedOnConfig()
+
+	hook, err := CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &model.IncomingWebhook{ChannelId: th.BasicChannel.Id})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer DeleteIncomingWebhook(hook.Id)
+
+	post, err := CreateWebhookPost(hook.UserId, hook.TeamId, th.BasicChannel.Id, "foo", "user", "http://iconurl", model.StringInterface{
+		"attachments": []*model.SlackAttachment{
+			&model.SlackAttachment{
+				Text: "text",
+			},
+		},
+	}, model.POST_SLACK_ATTACHMENT)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	for _, k := range []string{"from_webhook", "attachments"} {
+		if _, ok := post.Props[k]; !ok {
+			t.Fatal(k)
+		}
+	}
+}

--- a/model/command_response.go
+++ b/model/command_response.go
@@ -14,12 +14,12 @@ const (
 )
 
 type CommandResponse struct {
-	ResponseType string           `json:"response_type"`
-	Text         string           `json:"text"`
-	Username     string           `json:"username"`
-	IconURL      string           `json:"icon_url"`
-	GotoLocation string           `json:"goto_location"`
-	Attachments  SlackAttachments `json:"attachments"`
+	ResponseType string             `json:"response_type"`
+	Text         string             `json:"text"`
+	Username     string             `json:"username"`
+	IconURL      string             `json:"icon_url"`
+	GotoLocation string             `json:"goto_location"`
+	Attachments  []*SlackAttachment `json:"attachments"`
 }
 
 func (o *CommandResponse) ToJson() string {
@@ -40,7 +40,7 @@ func CommandResponseFromJson(data io.Reader) *CommandResponse {
 	}
 
 	o.Text = ExpandAnnouncement(o.Text)
-	o.Attachments.Process()
+	ProcessSlackAttachments(&o.Attachments)
 
 	return &o
 }

--- a/model/command_response.go
+++ b/model/command_response.go
@@ -40,7 +40,7 @@ func CommandResponseFromJson(data io.Reader) *CommandResponse {
 	}
 
 	o.Text = ExpandAnnouncement(o.Text)
-	ProcessSlackAttachments(&o.Attachments)
+	o.Attachments = ProcessSlackAttachments(o.Attachments)
 
 	return &o
 }

--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -207,7 +207,7 @@ func IncomingWebhookRequestFromJson(data io.Reader) *IncomingWebhookRequest {
 	}
 
 	o.Text = ExpandAnnouncement(o.Text)
-	ProcessSlackAttachments(&o.Attachments)
+	o.Attachments = ProcessSlackAttachments(o.Attachments)
 
 	return o
 }

--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -27,13 +27,13 @@ type IncomingWebhook struct {
 }
 
 type IncomingWebhookRequest struct {
-	Text        string           `json:"text"`
-	Username    string           `json:"username"`
-	IconURL     string           `json:"icon_url"`
-	ChannelName string           `json:"channel"`
-	Props       StringInterface  `json:"props"`
-	Attachments SlackAttachments `json:"attachments"`
-	Type        string           `json:"type"`
+	Text        string             `json:"text"`
+	Username    string             `json:"username"`
+	IconURL     string             `json:"icon_url"`
+	ChannelName string             `json:"channel"`
+	Props       StringInterface    `json:"props"`
+	Attachments []*SlackAttachment `json:"attachments"`
+	Type        string             `json:"type"`
 }
 
 func (o *IncomingWebhook) ToJson() string {
@@ -207,7 +207,7 @@ func IncomingWebhookRequestFromJson(data io.Reader) *IncomingWebhookRequest {
 	}
 
 	o.Text = ExpandAnnouncement(o.Text)
-	o.Attachments.Process()
+	ProcessSlackAttachments(&o.Attachments)
 
 	return o
 }

--- a/model/slack_attachment.go
+++ b/model/slack_attachment.go
@@ -33,8 +33,6 @@ type SlackAttachmentField struct {
 	Short bool        `json:"short"`
 }
 
-type SlackAttachments []*SlackAttachment
-
 // To mention @channel via a webhook in Slack, the message should contain
 // <!channel>, as explained at the bottom of this article:
 // https://get.slack.help/hc/en-us/articles/202009646-Making-announcements
@@ -51,7 +49,7 @@ func ExpandAnnouncement(text string) string {
 // can be found in the text attribute, or in the pretext, text, title and value
 // attributes of the attachment structure. The Slack attachment structure is
 // documented here: https://api.slack.com/docs/attachments
-func (a *SlackAttachments) Process() {
+func ProcessSlackAttachments(a *[]*SlackAttachment) {
 	var nonNilAttachments []*SlackAttachment
 	for _, attachment := range *a {
 		if attachment == nil {

--- a/model/slack_attachment.go
+++ b/model/slack_attachment.go
@@ -49,9 +49,9 @@ func ExpandAnnouncement(text string) string {
 // can be found in the text attribute, or in the pretext, text, title and value
 // attributes of the attachment structure. The Slack attachment structure is
 // documented here: https://api.slack.com/docs/attachments
-func ProcessSlackAttachments(a *[]*SlackAttachment) {
+func ProcessSlackAttachments(a []*SlackAttachment) []*SlackAttachment {
 	var nonNilAttachments []*SlackAttachment
-	for _, attachment := range *a {
+	for _, attachment := range a {
 		if attachment == nil {
 			continue
 		}
@@ -75,5 +75,5 @@ func ProcessSlackAttachments(a *[]*SlackAttachment) {
 		}
 		attachment.Fields = nonNilFields
 	}
-	*a = nonNilAttachments
+	return nonNilAttachments
 }

--- a/model/slack_attachment_test.go
+++ b/model/slack_attachment_test.go
@@ -10,8 +10,8 @@ func TestExpandAnnouncement(t *testing.T) {
 	}
 }
 
-func TestSlackAnnouncementProcess(t *testing.T) {
-	attachments := SlackAttachments{
+func TestProcessSlackAnnouncement(t *testing.T) {
+	attachments := []*SlackAttachment{
 		{
 			Pretext: "<!channel> pretext",
 			Text:    "<!channel> text",
@@ -25,7 +25,7 @@ func TestSlackAnnouncementProcess(t *testing.T) {
 			},
 		}, nil,
 	}
-	attachments.Process()
+	ProcessSlackAttachments(&attachments)
 	if len(attachments) != 1 || len(attachments[0].Fields) != 1 {
 		t.Fail()
 	}

--- a/model/slack_attachment_test.go
+++ b/model/slack_attachment_test.go
@@ -25,7 +25,7 @@ func TestProcessSlackAnnouncement(t *testing.T) {
 			},
 		}, nil,
 	}
-	ProcessSlackAttachments(&attachments)
+	attachments = ProcessSlackAttachments(attachments)
 	if len(attachments) != 1 || len(attachments[0].Fields) != 1 {
 		t.Fail()
 	}


### PR DESCRIPTION
#### Summary
I broke webhook and command attachments (just on master, not in any releases).

The bad commit was merged here: https://github.com/mattermost/platform/pull/6904

I made an initial commit `ignore null array items in incoming webhooks / command responses`. But after doing my manual testing, I made another commit `make a bit more idiomatic, add tests` in which I added a named type `SlackAttachments`. This breaks things because we insert objects of this type into a `map[string]interface{}` and later read them out via...

```go
if attachments, success := val.([]*model.SlackAttachment); success {
	parseSlackAttachment(post, attachments)
}
```

I'm fixing this by removing the named type for now.

I'll be sure to make less assumptions about our type-safety in the future, but as far as I've seen, there's no reason post props can't actually be made into a proper, type-safe struct. That would be a very nice change to see.

I'm also adding a test because I'm not sure any existing tests actually exercise the `CreateWebhookPost` method.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7212
https://github.com/mattermost/platform/issues/7009

#### Checklist
- [x] Added or updated unit tests (required for all new features)