### PR TITLE
PLT-7040: Fix capitalisation of Elasticsearch in Config.

### DIFF
--- a/app/elasticsearch.go
+++ b/app/elasticsearch.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestElasticsearch(cfg *model.Config) *model.AppError {
-	if *cfg.ElasticSearchSettings.Password == model.FAKE_SETTING {
-		if *cfg.ElasticSearchSettings.ConnectionUrl == *utils.Cfg.ElasticSearchSettings.ConnectionUrl && *cfg.ElasticSearchSettings.Username == *utils.Cfg.ElasticSearchSettings.Username {
-			*cfg.ElasticSearchSettings.Password = *utils.Cfg.ElasticSearchSettings.Password
+	if *cfg.ElasticsearchSettings.Password == model.FAKE_SETTING {
+		if *cfg.ElasticsearchSettings.ConnectionUrl == *utils.Cfg.ElasticsearchSettings.ConnectionUrl && *cfg.ElasticsearchSettings.Username == *utils.Cfg.ElasticsearchSettings.Username {
+			*cfg.ElasticsearchSettings.Password = *utils.Cfg.ElasticsearchSettings.Password
 		} else {
 			return model.NewAppError("TestElasticsearch", "ent.elasticsearch.test_config.reenter_password", nil, "", http.StatusBadRequest)
 		}

--- a/app/post.go
+++ b/app/post.go
@@ -100,7 +100,7 @@ func CreatePost(post *model.Post, teamId string, triggerWebhooks bool) (*model.P
 	}
 
 	esInterface := einterfaces.GetElasticsearchInterface()
-	if esInterface != nil && *utils.Cfg.ElasticSearchSettings.EnableIndexing {
+	if esInterface != nil && *utils.Cfg.ElasticsearchSettings.EnableIndexing {
 		go esInterface.IndexPost(rpost, teamId)
 	}
 
@@ -285,10 +285,10 @@ func UpdatePost(post *model.Post, safeUpdate bool) (*model.Post, *model.AppError
 		rpost := result.Data.(*model.Post)
 
 		esInterface := einterfaces.GetElasticsearchInterface()
-		if esInterface != nil && *utils.Cfg.ElasticSearchSettings.EnableIndexing {
+		if esInterface != nil && *utils.Cfg.ElasticsearchSettings.EnableIndexing {
 			go func() {
 				if rchannel := <-Srv.Store.Channel().GetForPost(rpost.Id); rchannel.Err != nil {
-					l4g.Error("Couldn't get channel %v for post %v for ElasticSearch indexing.", rpost.ChannelId, rpost.Id)
+					l4g.Error("Couldn't get channel %v for post %v for Elasticsearch indexing.", rpost.ChannelId, rpost.Id)
 				} else {
 					esInterface.IndexPost(rpost, rchannel.Data.(*model.Channel).TeamId)
 				}
@@ -472,7 +472,7 @@ func DeletePost(postId string) (*model.Post, *model.AppError) {
 		go DeleteFlaggedPosts(post.Id)
 
 		esInterface := einterfaces.GetElasticsearchInterface()
-		if esInterface != nil && *utils.Cfg.ElasticSearchSettings.EnableIndexing {
+		if esInterface != nil && *utils.Cfg.ElasticsearchSettings.EnableIndexing {
 			go esInterface.DeletePost(post)
 		}
 
@@ -503,7 +503,7 @@ func SearchPostsInTeam(terms string, userId string, teamId string, isOrSearch bo
 	paramsList := model.ParseSearchParams(terms)
 
 	esInterface := einterfaces.GetElasticsearchInterface()
-	if esInterface != nil && *utils.Cfg.ElasticSearchSettings.EnableSearching && utils.IsLicensed && *utils.License.Features.Elasticsearch {
+	if esInterface != nil && *utils.Cfg.ElasticsearchSettings.EnableSearching && utils.IsLicensed && *utils.License.Features.Elasticsearch {
 		finalParamsList := []*model.SearchParams{}
 
 		for _, params := range paramsList {

--- a/config/config.json
+++ b/config/config.json
@@ -50,7 +50,7 @@
         "EnableChannelViewedMessages": true,
         "ClusterLogTimeoutMilliseconds": 2000
     },
-    "ElasticSearchSettings": {
+    "ElasticsearchSettings": {
         "ConnectionUrl": "http://dockerhost:9200",
         "Username": "elastic",
         "Password": "changeme",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3585,11 +3585,11 @@
   },
   {
     "id": "ent.elasticsearch.search_posts.disabled",
-    "translation": "ElasticSearch searching is disabled on this server"
+    "translation": "Elasticsearch searching is disabled on this server"
   },
   {
     "id": "ent.elasticsearch.generic.disabled",
-    "translation": "ElasticSearch search is not enabled on this server"
+    "translation": "Elasticsearch search is not enabled on this server"
   },
   {
     "id": "ent.elasticsearch.purge_indexes.delete_failed",
@@ -3605,23 +3605,23 @@
   },
   {
     "id": "ent.elasticsearch.create_client.connect_failed",
-    "translation": "Setting up ElasticSearch Client Failed"
+    "translation": "Setting up Elasticsearch Client Failed"
   },
   {
     "id": "ent.elasticsearch.create_index_if_not_exists.index_create_failed",
-    "translation": "Failed to create ElasticSearch index"
+    "translation": "Failed to create Elasticsearch index"
   },
   {
     "id": "ent.elasticsearch.create_index_if_not_exists.index_exists_failed",
-    "translation": "Failed to establish whether ElasticSearch index exists"
+    "translation": "Failed to establish whether Elasticsearch index exists"
   },
   {
     "id": "ent.elasticsearch.create_index_if_not_exists.index_mapping_failed",
-    "translation": "Failed to setup ElasticSearch index mapping"
+    "translation": "Failed to setup Elasticsearch index mapping"
   },
   {
     "id": "ent.elasticsearch.start.index_settings_failed",
-    "translation": "Failed to set ElasticSearch index settings"
+    "translation": "Failed to set Elasticsearch index settings"
   },
   {
     "id": "ent.elasticsearch.test_config.connect_failed",

--- a/jobs/workers.go
+++ b/jobs/workers.go
@@ -47,7 +47,7 @@ func (workers *Workers) Start() *Workers {
 			go workers.DataRetention.Run()
 		}
 
-		if workers.ElasticsearchIndexing != nil && *utils.Cfg.ElasticSearchSettings.EnableIndexing {
+		if workers.ElasticsearchIndexing != nil && *utils.Cfg.ElasticsearchSettings.EnableIndexing {
 			go workers.ElasticsearchIndexing.Run()
 		}
 
@@ -69,9 +69,9 @@ func (workers *Workers) handleConfigChange(oldConfig *model.Config, newConfig *m
 	}
 
 	if workers.ElasticsearchIndexing != nil {
-		if !*oldConfig.ElasticSearchSettings.EnableIndexing && *newConfig.ElasticSearchSettings.EnableIndexing {
+		if !*oldConfig.ElasticsearchSettings.EnableIndexing && *newConfig.ElasticsearchSettings.EnableIndexing {
 			go workers.ElasticsearchIndexing.Run()
-		} else if *oldConfig.ElasticSearchSettings.EnableIndexing && !*newConfig.ElasticSearchSettings.EnableIndexing {
+		} else if *oldConfig.ElasticsearchSettings.EnableIndexing && !*newConfig.ElasticsearchSettings.EnableIndexing {
 			workers.ElasticsearchIndexing.Stop()
 		}
 	}
@@ -86,7 +86,7 @@ func (workers *Workers) Stop() *Workers {
 		workers.DataRetention.Stop()
 	}
 
-	if workers.ElasticsearchIndexing != nil && *utils.Cfg.ElasticSearchSettings.EnableIndexing {
+	if workers.ElasticsearchIndexing != nil && *utils.Cfg.ElasticsearchSettings.EnableIndexing {
 		workers.ElasticsearchIndexing.Stop()
 	}
 

--- a/model/config.go
+++ b/model/config.go
@@ -423,7 +423,7 @@ type WebrtcSettings struct {
 	TurnSharedKey       *string
 }
 
-type ElasticSearchSettings struct {
+type ElasticsearchSettings struct {
 	ConnectionUrl   *string
 	Username        *string
 	Password        *string
@@ -465,7 +465,7 @@ type Config struct {
 	MetricsSettings       MetricsSettings
 	AnalyticsSettings     AnalyticsSettings
 	WebrtcSettings        WebrtcSettings
-	ElasticSearchSettings ElasticSearchSettings
+	ElasticsearchSettings ElasticsearchSettings
 	DataRetentionSettings DataRetentionSettings
 	JobSettings           JobSettings
 }
@@ -1351,34 +1351,34 @@ func (o *Config) SetDefaults() {
 		*o.ServiceSettings.ClusterLogTimeoutMilliseconds = 2000
 	}
 
-	if o.ElasticSearchSettings.ConnectionUrl == nil {
-		o.ElasticSearchSettings.ConnectionUrl = new(string)
-		*o.ElasticSearchSettings.ConnectionUrl = ""
+	if o.ElasticsearchSettings.ConnectionUrl == nil {
+		o.ElasticsearchSettings.ConnectionUrl = new(string)
+		*o.ElasticsearchSettings.ConnectionUrl = ""
 	}
 
-	if o.ElasticSearchSettings.Username == nil {
-		o.ElasticSearchSettings.Username = new(string)
-		*o.ElasticSearchSettings.Username = ""
+	if o.ElasticsearchSettings.Username == nil {
+		o.ElasticsearchSettings.Username = new(string)
+		*o.ElasticsearchSettings.Username = ""
 	}
 
-	if o.ElasticSearchSettings.Password == nil {
-		o.ElasticSearchSettings.Password = new(string)
-		*o.ElasticSearchSettings.Password = ""
+	if o.ElasticsearchSettings.Password == nil {
+		o.ElasticsearchSettings.Password = new(string)
+		*o.ElasticsearchSettings.Password = ""
 	}
 
-	if o.ElasticSearchSettings.EnableIndexing == nil {
-		o.ElasticSearchSettings.EnableIndexing = new(bool)
-		*o.ElasticSearchSettings.EnableIndexing = false
+	if o.ElasticsearchSettings.EnableIndexing == nil {
+		o.ElasticsearchSettings.EnableIndexing = new(bool)
+		*o.ElasticsearchSettings.EnableIndexing = false
 	}
 
-	if o.ElasticSearchSettings.EnableSearching == nil {
-		o.ElasticSearchSettings.EnableSearching = new(bool)
-		*o.ElasticSearchSettings.EnableSearching = false
+	if o.ElasticsearchSettings.EnableSearching == nil {
+		o.ElasticsearchSettings.EnableSearching = new(bool)
+		*o.ElasticsearchSettings.EnableSearching = false
 	}
 
-	if o.ElasticSearchSettings.Sniff == nil {
-		o.ElasticSearchSettings.Sniff = new(bool)
-		*o.ElasticSearchSettings.Sniff = true
+	if o.ElasticsearchSettings.Sniff == nil {
+		o.ElasticsearchSettings.Sniff = new(bool)
+		*o.ElasticsearchSettings.Sniff = true
 	}
 
 	if o.DataRetentionSettings.Enable == nil {
@@ -1611,13 +1611,13 @@ func (o *Config) IsValid() *AppError {
 		return NewLocAppError("Config.IsValid", "model.config.is_valid.time_between_user_typing.app_error", nil, "")
 	}
 
-	if *o.ElasticSearchSettings.EnableIndexing {
-		if len(*o.ElasticSearchSettings.ConnectionUrl) == 0 {
+	if *o.ElasticsearchSettings.EnableIndexing {
+		if len(*o.ElasticsearchSettings.ConnectionUrl) == 0 {
 			return NewLocAppError("Config.IsValid", "model.config.is_valid.elastic_search.connection_url.app_error", nil, "")
 		}
 	}
 
-	if *o.ElasticSearchSettings.EnableSearching && !*o.ElasticSearchSettings.EnableIndexing {
+	if *o.ElasticsearchSettings.EnableSearching && !*o.ElasticsearchSettings.EnableIndexing {
 		return NewLocAppError("Config.IsValid", "model.config.is_valid.elastic_search.enable_searching.app_error", nil, "")
 	}
 
@@ -1662,7 +1662,7 @@ func (o *Config) Sanitize() {
 		o.SqlSettings.DataSourceSearchReplicas[i] = FAKE_SETTING
 	}
 
-	*o.ElasticSearchSettings.Password = FAKE_SETTING
+	*o.ElasticsearchSettings.Password = FAKE_SETTING
 }
 
 func (o *Config) defaultWebrtcSettings() {

--- a/utils/config.go
+++ b/utils/config.go
@@ -611,8 +611,8 @@ func Desanitize(cfg *model.Config) {
 		cfg.SqlSettings.AtRestEncryptKey = Cfg.SqlSettings.AtRestEncryptKey
 	}
 
-	if *cfg.ElasticSearchSettings.Password == model.FAKE_SETTING {
-		*cfg.ElasticSearchSettings.Password = *Cfg.ElasticSearchSettings.Password
+	if *cfg.ElasticsearchSettings.Password == model.FAKE_SETTING {
+		*cfg.ElasticsearchSettings.Password = *Cfg.ElasticsearchSettings.Password
 	}
 
 	for i := range cfg.SqlSettings.DataSourceReplicas {

--- a/webapp/components/admin_console/elasticsearch_settings.jsx
+++ b/webapp/components/admin_console/elasticsearch_settings.jsx
@@ -26,24 +26,24 @@ export default class ElasticsearchSettings extends AdminSettings {
     }
 
     getConfigFromState(config) {
-        config.ElasticSearchSettings.ConnectionUrl = this.state.connectionUrl;
-        config.ElasticSearchSettings.Username = this.state.username;
-        config.ElasticSearchSettings.Password = this.state.password;
-        config.ElasticSearchSettings.Sniff = this.state.sniff;
-        config.ElasticSearchSettings.EnableIndexing = this.state.enableIndexing;
-        config.ElasticSearchSettings.EnableSearching = this.state.enableSearching;
+        config.ElasticsearchSettings.ConnectionUrl = this.state.connectionUrl;
+        config.ElasticsearchSettings.Username = this.state.username;
+        config.ElasticsearchSettings.Password = this.state.password;
+        config.ElasticsearchSettings.Sniff = this.state.sniff;
+        config.ElasticsearchSettings.EnableIndexing = this.state.enableIndexing;
+        config.ElasticsearchSettings.EnableSearching = this.state.enableSearching;
 
         return config;
     }
 
     getStateFromConfig(config) {
         return {
-            connectionUrl: config.ElasticSearchSettings.ConnectionUrl,
-            username: config.ElasticSearchSettings.Username,
-            password: config.ElasticSearchSettings.Password,
-            sniff: config.ElasticSearchSettings.Sniff,
-            enableIndexing: config.ElasticSearchSettings.EnableIndexing,
-            enableSearching: config.ElasticSearchSettings.EnableSearching,
+            connectionUrl: config.ElasticsearchSettings.ConnectionUrl,
+            username: config.ElasticsearchSettings.Username,
+            password: config.ElasticsearchSettings.Password,
+            sniff: config.ElasticsearchSettings.Sniff,
+            enableIndexing: config.ElasticsearchSettings.EnableIndexing,
+            enableSearching: config.ElasticsearchSettings.EnableSearching,
             configTested: true,
             canSave: true
         };


### PR DESCRIPTION
#### Summary
Fix capitalisation of Elasticsearch in Config.

This nukes the existing ElasticSearch settings from the config. This is OK, because although those settings have been present in previous releases, they have never previously actually done anything.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7040

#### Checklist
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/168
- [x] Includes text changes and localization file updates
