### PR TITLE
PLT-6961: Add elasticsearch settings to diagnostics.

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -16,27 +16,28 @@ import (
 const (
 	SEGMENT_KEY = "fwb7VPbFeQ7SKp3wHm1RzFUuXZudqVok"
 
-	TRACK_CONFIG_SERVICE      = "config_service"
-	TRACK_CONFIG_TEAM         = "config_team"
-	TRACK_CONFIG_SQL          = "config_sql"
-	TRACK_CONFIG_LOG          = "config_log"
-	TRACK_CONFIG_FILE         = "config_file"
-	TRACK_CONFIG_RATE         = "config_rate"
-	TRACK_CONFIG_EMAIL        = "config_email"
-	TRACK_CONFIG_PRIVACY      = "config_privacy"
-	TRACK_CONFIG_OAUTH        = "config_oauth"
-	TRACK_CONFIG_LDAP         = "config_ldap"
-	TRACK_CONFIG_COMPLIANCE   = "config_compliance"
-	TRACK_CONFIG_LOCALIZATION = "config_localization"
-	TRACK_CONFIG_SAML         = "config_saml"
-	TRACK_CONFIG_PASSWORD     = "config_password"
-	TRACK_CONFIG_CLUSTER      = "config_cluster"
-	TRACK_CONFIG_METRICS      = "config_metrics"
-	TRACK_CONFIG_WEBRTC       = "config_webrtc"
-	TRACK_CONFIG_SUPPORT      = "config_support"
-	TRACK_CONFIG_NATIVEAPP    = "config_nativeapp"
-	TRACK_CONFIG_ANALYTICS    = "config_analytics"
-	TRACK_CONFIG_ANNOUNCEMENT = "config_announcement"
+	TRACK_CONFIG_SERVICE       = "config_service"
+	TRACK_CONFIG_TEAM          = "config_team"
+	TRACK_CONFIG_SQL           = "config_sql"
+	TRACK_CONFIG_LOG           = "config_log"
+	TRACK_CONFIG_FILE          = "config_file"
+	TRACK_CONFIG_RATE          = "config_rate"
+	TRACK_CONFIG_EMAIL         = "config_email"
+	TRACK_CONFIG_PRIVACY       = "config_privacy"
+	TRACK_CONFIG_OAUTH         = "config_oauth"
+	TRACK_CONFIG_LDAP          = "config_ldap"
+	TRACK_CONFIG_COMPLIANCE    = "config_compliance"
+	TRACK_CONFIG_LOCALIZATION  = "config_localization"
+	TRACK_CONFIG_SAML          = "config_saml"
+	TRACK_CONFIG_PASSWORD      = "config_password"
+	TRACK_CONFIG_CLUSTER       = "config_cluster"
+	TRACK_CONFIG_METRICS       = "config_metrics"
+	TRACK_CONFIG_WEBRTC        = "config_webrtc"
+	TRACK_CONFIG_SUPPORT       = "config_support"
+	TRACK_CONFIG_NATIVEAPP     = "config_nativeapp"
+	TRACK_CONFIG_ANALYTICS     = "config_analytics"
+	TRACK_CONFIG_ANNOUNCEMENT  = "config_announcement"
+	TRACK_CONFIG_ELASTICSEARCH = "config_elasticsearch"
 
 	TRACK_ACTIVITY = "activity"
 	TRACK_LICENSE  = "license"
@@ -381,6 +382,15 @@ func trackConfig() {
 		"isdefault_banner_color":      isDefault(*utils.Cfg.AnnouncementSettings.BannerColor, model.ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_COLOR),
 		"isdefault_banner_text_color": isDefault(*utils.Cfg.AnnouncementSettings.BannerTextColor, model.ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_TEXT_COLOR),
 		"allow_banner_dismissal":      *utils.Cfg.AnnouncementSettings.AllowBannerDismissal,
+	})
+
+	SendDiagnostic(TRACK_CONFIG_ELASTICSEARCH, map[string]interface{}{
+		"isdefault_connection_url": isDefault(*utils.Cfg.ElasticsearchSettings.ConnectionUrl, model.ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL),
+		"isdefault_username":       isDefault(*utils.Cfg.ElasticsearchSettings.Username, model.ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME),
+		"isdefault_password":       isDefault(*utils.Cfg.ElasticsearchSettings.Password, model.ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD),
+		"enable_indexing":          *utils.Cfg.ElasticsearchSettings.EnableIndexing,
+		"enable_searching":         *utils.Cfg.ElasticsearchSettings.EnableSearching,
+		"sniff":                    *utils.Cfg.ElasticsearchSettings.Sniff,
 	})
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -118,6 +118,10 @@ const (
 
 	ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_COLOR      = "#f2a93b"
 	ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_TEXT_COLOR = "#333333"
+
+	ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL = ""
+	ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME       = ""
+	ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD       = ""
 )
 
 type ServiceSettings struct {
@@ -1353,17 +1357,17 @@ func (o *Config) SetDefaults() {
 
 	if o.ElasticsearchSettings.ConnectionUrl == nil {
 		o.ElasticsearchSettings.ConnectionUrl = new(string)
-		*o.ElasticsearchSettings.ConnectionUrl = ""
+		*o.ElasticsearchSettings.ConnectionUrl = ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL
 	}
 
 	if o.ElasticsearchSettings.Username == nil {
 		o.ElasticsearchSettings.Username = new(string)
-		*o.ElasticsearchSettings.Username = ""
+		*o.ElasticsearchSettings.Username = ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME
 	}
 
 	if o.ElasticsearchSettings.Password == nil {
 		o.ElasticsearchSettings.Password = new(string)
-		*o.ElasticsearchSettings.Password = ""
+		*o.ElasticsearchSettings.Password = ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD
 	}
 
 	if o.ElasticsearchSettings.EnableIndexing == nil {


### PR DESCRIPTION
#### Summary
Add elasticsearch settings to diagnostics.

PR also has changes from PLT-7040 included in it until that is merged, so just ignore them.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6961