### PR TITLE
RN-152 Updated createGroupChannel's return value to match createDirectChannel

### DIFF
--- a/webapp/actions/channel_actions.jsx
+++ b/webapp/actions/channel_actions.jsx
@@ -181,14 +181,13 @@ export function openDirectChannelToUser(userId, success, error) {
 
 export function openGroupChannelToUsers(userIds, success, error) {
     ChannelActions.createGroupChannel(userIds)(dispatch, getState).then(
-        (data) => {
+        (result) => {
             loadProfilesForSidebar();
-            if (data && success) {
-                success(data, false);
-            } else if (data == null && error) {
+            if (result.data && success) {
+                success(result.data, false);
+            } else if (result.error && error) {
                 browserHistory.push(TeamStore.getCurrentTeamUrl());
-                const serverError = getState().requests.channels.createChannel.error;
-                error({id: serverError.server_error_id, ...serverError});
+                error({id: result.error.server_error_id, ...result.error});
             }
         }
     );

--- a/webapp/actions/global_actions.jsx
+++ b/webapp/actions/global_actions.jsx
@@ -45,9 +45,11 @@ export function emitChannelClickEvent(channel) {
         const currentUserId = UserStore.getCurrentId();
         const otherUserId = Utils.getUserIdFromChannelName(chan);
         createDirectChannel(currentUserId, otherUserId)(dispatch, getState).then(
-            (data) => {
-                if (data) {
-                    success(data);
+            (result) => {
+                const receivedChannel = result.data;
+
+                if (receivedChannel) {
+                    success(receivedChannel);
                 } else {
                     fail();
                 }

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -5004,7 +5004,7 @@ math-expression-evaluator@^1.2.14:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/f8d106e6fde0d8633bf5d13c1ca1aaec61b0b8bb"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/9797cb8bd8fa61252336a7c6150bd364f7ca28b1"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
This change is needed for error handling on the RN app. The web app also wasn't handling how `createDirectChannel` returned data correctly, so I fixed that as well

mattermost-redux PR: https://github.com/mattermost/mattermost-redux/pull/207

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-152