### PR TITLE
PLT-7214: make cli team / channel delete operations also delete webhooks and slash commands

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1184,6 +1184,14 @@ func PermanentDeleteChannel(channel *model.Channel) *model.AppError {
 		return result.Err
 	}
 
+	if result := <-Srv.Store.Webhook().PermanentDeleteIncomingByChannel(channel.Id); result.Err != nil {
+		return result.Err
+	}
+
+	if result := <-Srv.Store.Webhook().PermanentDeleteOutgoingByChannel(channel.Id); result.Err != nil {
+		return result.Err
+	}
+
 	if result := <-Srv.Store.Channel().PermanentDelete(channel.Id); result.Err != nil {
 		return result.Err
 	}

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
+)
+
+func TestPermanentDeleteChannel(t *testing.T) {
+	th := Setup().InitBasic()
+
+	incomingWasEnabled := utils.Cfg.ServiceSettings.EnableIncomingWebhooks
+	outgoingWasEnabled := utils.Cfg.ServiceSettings.EnableOutgoingWebhooks
+	utils.Cfg.ServiceSettings.EnableIncomingWebhooks = true
+	utils.Cfg.ServiceSettings.EnableOutgoingWebhooks = true
+	defer func() {
+		utils.Cfg.ServiceSettings.EnableIncomingWebhooks = incomingWasEnabled
+		utils.Cfg.ServiceSettings.EnableOutgoingWebhooks = outgoingWasEnabled
+	}()
+
+	channel, err := CreateChannel(&model.Channel{DisplayName: "deletion-test", Name: "deletion-test", Type: model.CHANNEL_OPEN, TeamId: th.BasicTeam.Id}, false)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer func() {
+		PermanentDeleteChannel(channel)
+	}()
+
+	incoming, err := CreateIncomingWebhookForChannel(th.BasicUser.Id, channel, &model.IncomingWebhook{ChannelId: channel.Id})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer DeleteIncomingWebhook(incoming.Id)
+
+	if incoming, err = GetIncomingWebhook(incoming.Id); incoming == nil || err != nil {
+		t.Fatal("unable to get new incoming webhook")
+	}
+
+	outgoing, err := CreateOutgoingWebhook(&model.OutgoingWebhook{
+		ChannelId:    channel.Id,
+		TeamId:       channel.TeamId,
+		CreatorId:    th.BasicUser.Id,
+		CallbackURLs: []string{"http://foo"},
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer DeleteOutgoingWebhook(outgoing.Id)
+
+	if outgoing, err = GetOutgoingWebhook(outgoing.Id); outgoing == nil || err != nil {
+		t.Fatal("unable to get new outgoing webhook")
+	}
+
+	if err := PermanentDeleteChannel(channel); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if incoming, err = GetIncomingWebhook(incoming.Id); incoming != nil || err == nil {
+		t.Error("incoming webhook wasn't deleted")
+	}
+
+	if outgoing, err = GetOutgoingWebhook(outgoing.Id); outgoing != nil || err == nil {
+		t.Error("outgoing webhook wasn't deleted")
+	}
+}

--- a/app/team.go
+++ b/app/team.go
@@ -629,7 +629,7 @@ func InviteNewUsersToTeam(emailList []string, teamId, senderId string) *model.Ap
 	var invalidEmailList []string
 
 	for _, email := range emailList {
-		if ! isTeamEmailAddressAllowed(email) {
+		if !isTeamEmailAddressAllowed(email) {
 			invalidEmailList = append(invalidEmailList, email)
 		}
 	}
@@ -735,6 +735,10 @@ func PermanentDeleteTeam(team *model.Team) *model.AppError {
 	}
 
 	if result := <-Srv.Store.Team().RemoveAllMembersByTeam(team.Id); result.Err != nil {
+		return result.Err
+	}
+
+	if result := <-Srv.Store.Command().PermanentDeleteByTeam(team.Id); result.Err != nil {
 		return result.Err
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6216,7 +6216,15 @@
     "translation": "We couldn't delete the webhook"
   },
   {
+    "id": "store.sql_webhooks.permanent_delete_incoming_by_channel.app_error",
+    "translation": "We couldn't delete the webhook"
+  },
+  {
     "id": "store.sql_webhooks.permanent_delete_outgoing_by_user.app_error",
+    "translation": "We couldn't delete the webhook"
+  },
+  {
+    "id": "store.sql_webhooks.permanent_delete_outgoing_by_channel.app_error",
     "translation": "We couldn't delete the webhook"
   },
   {

--- a/store/sql_command_store.go
+++ b/store/sql_command_store.go
@@ -134,6 +134,24 @@ func (s SqlCommandStore) Delete(commandId string, time int64) StoreChannel {
 	return storeChannel
 }
 
+func (s SqlCommandStore) PermanentDeleteByTeam(teamId string) StoreChannel {
+	storeChannel := make(StoreChannel, 1)
+
+	go func() {
+		result := StoreResult{}
+
+		_, err := s.GetMaster().Exec("DELETE FROM Commands WHERE TeamId = :TeamId", map[string]interface{}{"TeamId": teamId})
+		if err != nil {
+			result.Err = model.NewLocAppError("SqlCommandStore.DeleteByTeam", "store.sql_command.save.delete_perm.app_error", nil, "id="+teamId+", err="+err.Error())
+		}
+
+		storeChannel <- result
+		close(storeChannel)
+	}()
+
+	return storeChannel
+}
+
 func (s SqlCommandStore) PermanentDeleteByUser(userId string) StoreChannel {
 	storeChannel := make(StoreChannel, 1)
 

--- a/store/sql_command_store_test.go
+++ b/store/sql_command_store_test.go
@@ -111,6 +111,36 @@ func TestCommandStoreDelete(t *testing.T) {
 	}
 }
 
+func TestCommandStoreDeleteByTeam(t *testing.T) {
+	Setup()
+
+	o1 := &model.Command{}
+	o1.CreatorId = model.NewId()
+	o1.Method = model.COMMAND_METHOD_POST
+	o1.TeamId = model.NewId()
+	o1.URL = "http://nowhere.com/"
+	o1.Trigger = "trigger"
+
+	o1 = (<-store.Command().Save(o1)).Data.(*model.Command)
+
+	if r1 := <-store.Command().Get(o1.Id); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		if r1.Data.(*model.Command).CreateAt != o1.CreateAt {
+			t.Fatal("invalid returned command")
+		}
+	}
+
+	if r2 := <-store.Command().PermanentDeleteByTeam(o1.TeamId); r2.Err != nil {
+		t.Fatal(r2.Err)
+	}
+
+	if r3 := (<-store.Command().Get(o1.Id)); r3.Err == nil {
+		t.Log(r3.Data)
+		t.Fatal("Missing id should have failed")
+	}
+}
+
 func TestCommandStoreDeleteByUser(t *testing.T) {
 	Setup()
 

--- a/store/sql_webhook_store_test.go
+++ b/store/sql_webhook_store_test.go
@@ -157,7 +157,29 @@ func TestWebhookStoreDeleteIncoming(t *testing.T) {
 		t.Fatal(r2.Err)
 	}
 
-	ClearWebhookCaches()
+	if r3 := (<-store.Webhook().GetIncoming(o1.Id, true)); r3.Err == nil {
+		t.Log(r3.Data)
+		t.Fatal("Missing id should have failed")
+	}
+}
+
+func TestWebhookStoreDeleteIncomingByChannel(t *testing.T) {
+	Setup()
+	o1 := buildIncomingWebhook()
+
+	o1 = (<-store.Webhook().SaveIncoming(o1)).Data.(*model.IncomingWebhook)
+
+	if r1 := <-store.Webhook().GetIncoming(o1.Id, true); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		if r1.Data.(*model.IncomingWebhook).CreateAt != o1.CreateAt {
+			t.Fatal("invalid returned webhook")
+		}
+	}
+
+	if r2 := <-store.Webhook().PermanentDeleteIncomingByChannel(o1.ChannelId); r2.Err != nil {
+		t.Fatal(r2.Err)
+	}
 
 	if r3 := (<-store.Webhook().GetIncoming(o1.Id, true)); r3.Err == nil {
 		t.Log(r3.Data)
@@ -182,8 +204,6 @@ func TestWebhookStoreDeleteIncomingByUser(t *testing.T) {
 	if r2 := <-store.Webhook().PermanentDeleteIncomingByUser(o1.UserId); r2.Err != nil {
 		t.Fatal(r2.Err)
 	}
-
-	ClearWebhookCaches()
 
 	if r3 := (<-store.Webhook().GetIncoming(o1.Id, true)); r3.Err == nil {
 		t.Log(r3.Data)
@@ -371,6 +391,35 @@ func TestWebhookStoreDeleteOutgoing(t *testing.T) {
 	}
 
 	if r2 := <-store.Webhook().DeleteOutgoing(o1.Id, model.GetMillis()); r2.Err != nil {
+		t.Fatal(r2.Err)
+	}
+
+	if r3 := (<-store.Webhook().GetOutgoing(o1.Id)); r3.Err == nil {
+		t.Log(r3.Data)
+		t.Fatal("Missing id should have failed")
+	}
+}
+
+func TestWebhookStoreDeleteOutgoingByChannel(t *testing.T) {
+	Setup()
+
+	o1 := &model.OutgoingWebhook{}
+	o1.ChannelId = model.NewId()
+	o1.CreatorId = model.NewId()
+	o1.TeamId = model.NewId()
+	o1.CallbackURLs = []string{"http://nowhere.com/"}
+
+	o1 = (<-store.Webhook().SaveOutgoing(o1)).Data.(*model.OutgoingWebhook)
+
+	if r1 := <-store.Webhook().GetOutgoing(o1.Id); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		if r1.Data.(*model.OutgoingWebhook).CreateAt != o1.CreateAt {
+			t.Fatal("invalid returned webhook")
+		}
+	}
+
+	if r2 := <-store.Webhook().PermanentDeleteOutgoingByChannel(o1.ChannelId); r2.Err != nil {
 		t.Fatal(r2.Err)
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -296,6 +296,7 @@ type WebhookStore interface {
 	UpdateIncoming(webhook *model.IncomingWebhook) StoreChannel
 	GetIncomingByChannel(channelId string) StoreChannel
 	DeleteIncoming(webhookId string, time int64) StoreChannel
+	PermanentDeleteIncomingByChannel(channelId string) StoreChannel
 	PermanentDeleteIncomingByUser(userId string) StoreChannel
 
 	SaveOutgoing(webhook *model.OutgoingWebhook) StoreChannel
@@ -304,6 +305,7 @@ type WebhookStore interface {
 	GetOutgoingByChannel(channelId string, offset, limit int) StoreChannel
 	GetOutgoingByTeam(teamId string, offset, limit int) StoreChannel
 	DeleteOutgoing(webhookId string, time int64) StoreChannel
+	PermanentDeleteOutgoingByChannel(channelId string) StoreChannel
 	PermanentDeleteOutgoingByUser(userId string) StoreChannel
 	UpdateOutgoing(hook *model.OutgoingWebhook) StoreChannel
 
@@ -317,6 +319,7 @@ type CommandStore interface {
 	Get(id string) StoreChannel
 	GetByTeam(teamId string) StoreChannel
 	Delete(commandId string, time int64) StoreChannel
+	PermanentDeleteByTeam(teamId string) StoreChannel
 	PermanentDeleteByUser(userId string) StoreChannel
 	Update(hook *model.Command) StoreChannel
 	AnalyticsCommandCount(teamId string) StoreChannel


### PR DESCRIPTION
#### Summary
When doing a PermanentDelete of a team using the CLI, it removed members, channels and posts, but not Commands and Webhooks. Now it removes those too.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7214
https://mattermost.atlassian.net/browse/PLT-7215

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates