### PR TITLE
PLT-6994 Fix TestCreateOAuthUser unit test

### DIFF
--- a/app/user_test.go
+++ b/app/user_test.go
@@ -67,7 +67,7 @@ func TestCheckUserDomain(t *testing.T) {
 func TestCreateOAuthUser(t *testing.T) {
 	th := Setup().InitBasic()
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	glUser := oauthgitlab.GitLabUser{Id: int64(r.Intn(1000)), Username: model.NewId(), Email: model.NewId() + "@simulator.amazonses.com", Name: "Joram Wilander"}
+	glUser := oauthgitlab.GitLabUser{Id: int64(r.Intn(1000)) + 1, Username: "o" + model.NewId(), Email: model.NewId() + "@simulator.amazonses.com", Name: "Joram Wilander"}
 
 	json := glUser.ToJson()
 	user, err := CreateOAuthUser(model.USER_AUTH_SERVICE_GITLAB, strings.NewReader(json), th.BasicTeam.Id)


### PR DESCRIPTION
#### Summary
Fix TestCreateOAuthUser unit test. If the random int was 0 then the test would fail.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6994