### PR TITLE
Use Constants.MAX_CHANNELNAME_LENGTH where a fixed number like 22 or 64 is used for max length of channel names.

### DIFF
--- a/webapp/components/change_url_modal.jsx
+++ b/webapp/components/change_url_modal.jsx
@@ -191,7 +191,7 @@ export default class ChangeUrlModal extends React.Component {
                                         type='text'
                                         ref='urlinput'
                                         className='form-control'
-                                        maxLength='22'
+                                        maxLength={Constants.MAX_CHANNELNAME_LENGTH}
                                         onChange={this.onURLChanged}
                                         value={this.state.currentURL}
                                         autoFocus={true}

--- a/webapp/components/rename_channel_modal.jsx
+++ b/webapp/components/rename_channel_modal.jsx
@@ -21,7 +21,7 @@ const holders = defineMessages({
     },
     maxLength: {
         id: 'rename_channel.maxLength',
-        defaultMessage: 'This field must be less than 22 characters'
+        defaultMessage: 'This field must be less than {maxLength, number} characters'
     },
     lowercase: {
         id: 'rename_channel.lowercase',
@@ -136,8 +136,8 @@ export class RenameChannelModal extends React.Component {
         if (!channel.display_name) {
             state.displayNameError = formatMessage(holders.required);
             state.invalid = true;
-        } else if (channel.display_name.length > 22) {
-            state.displayNameError = formatMessage(holders.maxLength);
+        } else if (channel.display_name.length > Constants.MAX_CHANNELNAME_LENGTH) {
+            state.displayNameError = formatMessage(holders.maxLength, {maxLength: Constants.MAX_CHANNELNAME_LENGTH});
             state.invalid = true;
         } else {
             state.displayNameError = '';
@@ -147,8 +147,8 @@ export class RenameChannelModal extends React.Component {
         if (!channel.name) {
             state.nameError = formatMessage(holders.required);
             state.invalid = true;
-        } else if (channel.name.length > 22) {
-            state.nameError = formatMessage(holders.maxLength);
+        } else if (channel.name.length > Constants.MAX_CHANNELNAME_LENGTH) {
+            state.nameError = formatMessage(holders.maxLength, {maxLength: Constants.MAX_CHANNELNAME_LENGTH});
             state.invalid = true;
         } else {
             const cleanedName = cleanUpUrlable(channel.name);
@@ -264,7 +264,7 @@ export class RenameChannelModal extends React.Component {
                                 className='form-control'
                                 placeholder={formatMessage(holders.displayNameHolder)}
                                 value={this.state.displayName}
-                                maxLength='64'
+                                maxLength={Constants.MAX_CHANNELNAME_LENGTH}
                             />
                             {displayNameError}
                         </div>
@@ -287,7 +287,7 @@ export class RenameChannelModal extends React.Component {
                                     ref='channelName'
                                     placeholder={formatMessage(holders.handleHolder)}
                                     value={this.state.channelName}
-                                    maxLength='64'
+                                    maxLength={Constants.MAX_CHANNELNAME_LENGTH}
                                     readOnly={readOnlyHandleInput}
                                 />
                             </div>

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1951,7 +1951,7 @@
   "rename_channel.displayNameHolder": "Enter display name",
   "rename_channel.handleHolder": "lowercase alphanumeric characters",
   "rename_channel.lowercase": "Must be lowercase alphanumeric characters",
-  "rename_channel.maxLength": "This field must be less than 22 characters",
+  "rename_channel.maxLength": "This field must be less than {maxLength, number} characters",
   "rename_channel.required": "This field is required",
   "rename_channel.save": "Save",
   "rename_channel.title": "Rename Channel",

--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+/* eslint-disable no-magic-numbers */
+
 import keyMirror from 'key-mirror';
 
 import audioIcon from 'images/icons/audio.png';


### PR DESCRIPTION
#### Summary
When creating a new channel it allows only 22 characters but when editing it allows to enter 64:

<img width="1030" alt="screen shot 2017-07-26 at 3 39 44 pm" src="https://user-images.githubusercontent.com/160621/28683927-0ffdcee6-72c8-11e7-9c88-9713b4b972bb.png">
<img width="1007" alt="screen shot 2017-07-26 at 3 33 56 pm" src="https://user-images.githubusercontent.com/160621/28683958-39e0ab52-72c8-11e7-8ea6-ffb24f789cb4.png">

Channel name length restrictions are enforced right now with fixed values like 22 or 64 in files like:
webapp/components/change_url_modal.jsx
webapp/components/rename_channel_modal.jsx
webapp/i18n/en.json

Also it's not consistent between files. It should use constant `Constants.MAX_CHANNELNAME_LENGTH` that is set to 22 (Confirmed with @jasonblais that it's right).

#### Ticket Link

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes
- [ ] Has UI changes
- [ ] Includes text changes and localization file
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
