### PR TITLE
Added unit tests for getFile headers

### DIFF
--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -225,7 +225,7 @@ func TestGetFileHeaders(t *testing.T) {
 	t.Run("js", testHeaders(data, "test.js", "text/plain", false))
 	t.Run("go", testHeaders(data, "test.go", "application/octet-stream", false))
 	t.Run("zip", testHeaders(data, "test.zip", "application/zip", false))
-	t.Run("exe", testHeaders(data, "test.exe", "application/x-msdownload", false))
+	t.Run("exe", testHeaders(data, "test.exe", "application/x-ms", false))
 	t.Run("no extension", testHeaders(data, "test", "application/octet-stream", false))
 	t.Run("no extension 2", testHeaders([]byte("<html></html>"), "test", "application/octet-stream", false))
 }

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -186,16 +186,16 @@ func TestGetFileHeaders(t *testing.T) {
 			_, resp = Client.GetFile(fileId)
 			CheckNoError(t, resp)
 
-			if contentType := resp.Response.Header.Get("Content-Type"); !strings.HasPrefix(contentType, expectedContentType) {
+			if contentType := resp.Header.Get("Content-Type"); !strings.HasPrefix(contentType, expectedContentType) {
 				t.Fatal("returned incorrect Content-Type", contentType)
 			}
 
 			if getInline {
-				if contentDisposition := resp.Response.Header.Get("Content-Disposition"); !strings.HasPrefix(contentDisposition, "inline") {
+				if contentDisposition := resp.Header.Get("Content-Disposition"); !strings.HasPrefix(contentDisposition, "inline") {
 					t.Fatal("returned incorrect Content-Disposition", contentDisposition)
 				}
 			} else {
-				if contentDisposition := resp.Response.Header.Get("Content-Disposition"); !strings.HasPrefix(contentDisposition, "attachment") {
+				if contentDisposition := resp.Header.Get("Content-Disposition"); !strings.HasPrefix(contentDisposition, "attachment") {
 					t.Fatal("returned incorrect Content-Disposition", contentDisposition)
 				}
 			}
@@ -203,11 +203,11 @@ func TestGetFileHeaders(t *testing.T) {
 			_, resp = Client.DownloadFile(fileId, true)
 			CheckNoError(t, resp)
 
-			if contentType := resp.Response.Header.Get("Content-Type"); !strings.HasPrefix(contentType, expectedContentType) {
+			if contentType := resp.Header.Get("Content-Type"); !strings.HasPrefix(contentType, expectedContentType) {
 				t.Fatal("returned incorrect Content-Type", contentType)
 			}
 
-			if contentDisposition := resp.Response.Header.Get("Content-Disposition"); !strings.HasPrefix(contentDisposition, "attachment") {
+			if contentDisposition := resp.Header.Get("Content-Disposition"); !strings.HasPrefix(contentDisposition, "attachment") {
 				t.Fatal("returned incorrect Content-Disposition", contentDisposition)
 			}
 		}

--- a/model/client4.go
+++ b/model/client4.go
@@ -44,7 +44,7 @@ func BuildErrorResponse(r *http.Response, err *AppError) *Response {
 		header = r.Header
 	} else {
 		statusCode = 0
-		header = make(map[string][]string, 0)
+		header = make(http.Header, 0)
 	}
 
 	return &Response{

--- a/model/client4.go
+++ b/model/client4.go
@@ -336,11 +336,14 @@ func (c *Client4) DoUploadFile(url string, data []byte, contentType string) (*Fi
 
 	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
 		return nil, BuildErrorResponse(rp, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0))
-	} else if rp.StatusCode >= 300 {
-		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
 	} else {
 		defer closeBody(rp)
-		return FileUploadResponseFromJson(rp.Body), BuildResponse(rp)
+
+		if rp.StatusCode >= 300 {
+			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+		} else {
+			return FileUploadResponseFromJson(rp.Body), BuildResponse(rp)
+		}
 	}
 }
 
@@ -355,11 +358,14 @@ func (c *Client4) DoEmojiUploadFile(url string, data []byte, contentType string)
 
 	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
 		return nil, BuildErrorResponse(rp, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0))
-	} else if rp.StatusCode >= 300 {
-		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
 	} else {
 		defer closeBody(rp)
-		return EmojiFromJson(rp.Body), BuildResponse(rp)
+
+		if rp.StatusCode >= 300 {
+			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+		} else {
+			return EmojiFromJson(rp.Body), BuildResponse(rp)
+		}
 	}
 }
 
@@ -374,11 +380,14 @@ func (c *Client4) DoUploadImportTeam(url string, data []byte, contentType string
 
 	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
 		return nil, BuildErrorResponse(rp, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0))
-	} else if rp.StatusCode >= 300 {
-		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
 	} else {
 		defer closeBody(rp)
-		return MapFromJson(rp.Body), BuildResponse(rp)
+
+		if rp.StatusCode >= 300 {
+			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+		} else {
+			return MapFromJson(rp.Body), BuildResponse(rp)
+		}
 	}
 }
 
@@ -591,10 +600,14 @@ func (c *Client4) AutocompleteUsers(username string, etag string) (*UserAutocomp
 func (c *Client4) GetProfileImage(userId, etag string) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/image", etag); err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetProfileImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	} else {
-		return data, BuildResponse(r)
+		defer closeBody(r)
+
+		if data, err := ioutil.ReadAll(r.Body); err != nil {
+			return nil, BuildErrorResponse(r, NewAppError("GetProfileImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		} else {
+			return data, BuildResponse(r)
+		}
 	}
 }
 
@@ -960,11 +973,14 @@ func (c *Client4) SetProfileImage(userId string, data []byte) (bool, *Response) 
 	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
 		// set to http.StatusForbidden(403)
 		return false, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.GetUserRoute(userId)+"/image", "model.client.connecting.app_error", nil, err.Error(), 403)}
-	} else if rp.StatusCode >= 300 {
-		return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
 	} else {
 		defer closeBody(rp)
-		return CheckStatusOK(rp), BuildResponse(rp)
+
+		if rp.StatusCode >= 300 {
+			return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+		} else {
+			return CheckStatusOK(rp), BuildResponse(rp)
+		}
 	}
 }
 
@@ -1812,10 +1828,14 @@ func (c *Client4) UploadFile(data []byte, channelId string, filename string) (*F
 func (c *Client4) GetFile(fileId string) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetFileRoute(fileId), ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetFile", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	} else {
-		return data, BuildResponse(r)
+		defer closeBody(r)
+
+		if data, err := ioutil.ReadAll(r.Body); err != nil {
+			return nil, BuildErrorResponse(r, NewAppError("GetFile", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		} else {
+			return data, BuildResponse(r)
+		}
 	}
 }
 
@@ -1823,10 +1843,14 @@ func (c *Client4) GetFile(fileId string) ([]byte, *Response) {
 func (c *Client4) DownloadFile(fileId string, download bool) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+fmt.Sprintf("?download=%v", download), ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetFile", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	} else {
-		return data, BuildResponse(r)
+		defer closeBody(r)
+
+		if data, err := ioutil.ReadAll(r.Body); err != nil {
+			return nil, BuildErrorResponse(r, NewAppError("DownloadFile", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		} else {
+			return data, BuildResponse(r)
+		}
 	}
 }
 
@@ -1834,10 +1858,14 @@ func (c *Client4) DownloadFile(fileId string, download bool) ([]byte, *Response)
 func (c *Client4) GetFileThumbnail(fileId string) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+"/thumbnail", ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetFileThumbnail", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	} else {
-		return data, BuildResponse(r)
+		defer closeBody(r)
+
+		if data, err := ioutil.ReadAll(r.Body); err != nil {
+			return nil, BuildErrorResponse(r, NewAppError("GetFileThumbnail", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		} else {
+			return data, BuildResponse(r)
+		}
 	}
 }
 
@@ -1845,10 +1873,14 @@ func (c *Client4) GetFileThumbnail(fileId string) ([]byte, *Response) {
 func (c *Client4) DownloadFileThumbnail(fileId string, download bool) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+fmt.Sprintf("/thumbnail?download=%v", download), ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetFileThumbnail", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	} else {
-		return data, BuildResponse(r)
+		defer closeBody(r)
+
+		if data, err := ioutil.ReadAll(r.Body); err != nil {
+			return nil, BuildErrorResponse(r, NewAppError("DownloadFileThumbnail", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		} else {
+			return data, BuildResponse(r)
+		}
 	}
 }
 
@@ -1857,6 +1889,8 @@ func (c *Client4) GetFileLink(fileId string) (string, *Response) {
 	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+"/link", ""); err != nil {
 		return "", BuildErrorResponse(r, err)
 	} else {
+		defer closeBody(r)
+
 		return MapFromJson(r.Body)["link"], BuildResponse(r)
 	}
 }
@@ -1865,10 +1899,14 @@ func (c *Client4) GetFileLink(fileId string) (string, *Response) {
 func (c *Client4) GetFilePreview(fileId string) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+"/preview", ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetFilePreview", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	} else {
-		return data, BuildResponse(r)
+		defer closeBody(r)
+
+		if data, err := ioutil.ReadAll(r.Body); err != nil {
+			return nil, BuildErrorResponse(r, NewAppError("GetFilePreview", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		} else {
+			return data, BuildResponse(r)
+		}
 	}
 }
 
@@ -1876,10 +1914,14 @@ func (c *Client4) GetFilePreview(fileId string) ([]byte, *Response) {
 func (c *Client4) DownloadFilePreview(fileId string, download bool) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+fmt.Sprintf("/preview?download=%v", download), ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetFilePreview", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	} else {
-		return data, BuildResponse(r)
+		defer closeBody(r)
+
+		if data, err := ioutil.ReadAll(r.Body); err != nil {
+			return nil, BuildErrorResponse(r, NewAppError("DownloadFilePreview", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		} else {
+			return data, BuildResponse(r)
+		}
 	}
 }
 
@@ -2025,11 +2067,14 @@ func (c *Client4) UploadLicenseFile(data []byte) (bool, *Response) {
 
 	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
 		return false, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.GetLicenseRoute(), "model.client.connecting.app_error", nil, err.Error(), http.StatusForbidden)}
-	} else if rp.StatusCode >= 300 {
-		return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
 	} else {
 		defer closeBody(rp)
-		return CheckStatusOK(rp), BuildResponse(rp)
+
+		if rp.StatusCode >= 300 {
+			return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+		} else {
+			return CheckStatusOK(rp), BuildResponse(rp)
+		}
 	}
 }
 
@@ -2410,15 +2455,16 @@ func (c *Client4) DownloadComplianceReport(reportId string) ([]byte, *Response) 
 
 	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
 		return nil, &Response{Error: NewAppError("DownloadComplianceReport", "model.client.connecting.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if rp.StatusCode >= 300 {
-		defer rp.Body.Close()
-		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-	} else if data, err := ioutil.ReadAll(rp.Body); err != nil {
-		defer closeBody(rp)
-		return nil, BuildErrorResponse(rp, NewAppError("DownloadComplianceReport", "model.client.read_file.app_error", nil, err.Error(), rp.StatusCode))
 	} else {
 		defer closeBody(rp)
-		return data, BuildResponse(rp)
+
+		if rp.StatusCode >= 300 {
+			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+		} else if data, err := ioutil.ReadAll(rp.Body); err != nil {
+			return nil, BuildErrorResponse(rp, NewAppError("DownloadComplianceReport", "model.client.read_file.app_error", nil, err.Error(), rp.StatusCode))
+		} else {
+			return data, BuildResponse(rp)
+		}
 	}
 }
 
@@ -2476,10 +2522,16 @@ func (c *Client4) GetAudits(page int, perPage int, etag string) (Audits, *Respon
 func (c *Client4) GetBrandImage() ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetBrandRoute()+"/image", ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetBrandImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	} else {
-		return data, BuildResponse(r)
+		defer closeBody(r)
+
+		if r.StatusCode >= 300 {
+			return nil, BuildErrorResponse(r, AppErrorFromJson(r.Body))
+		} else if data, err := ioutil.ReadAll(r.Body); err != nil {
+			return nil, BuildErrorResponse(r, NewAppError("GetBrandImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		} else {
+			return data, BuildResponse(r)
+		}
 	}
 }
 
@@ -2508,11 +2560,14 @@ func (c *Client4) UploadBrandImage(data []byte) (bool, *Response) {
 
 	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
 		return false, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.GetBrandRoute()+"/image", "model.client.connecting.app_error", nil, err.Error(), http.StatusForbidden)}
-	} else if rp.StatusCode >= 300 {
-		return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
 	} else {
 		defer closeBody(rp)
-		return CheckStatusOK(rp), BuildResponse(rp)
+
+		if rp.StatusCode >= 300 {
+			return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+		} else {
+			return CheckStatusOK(rp), BuildResponse(rp)
+		}
 	}
 }
 
@@ -2840,10 +2895,14 @@ func (c *Client4) GetEmoji(emojiId string) (*Emoji, *Response) {
 func (c *Client4) GetEmojiImage(emojiId string) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetEmojiRoute(emojiId)+"/image", ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetEmojiImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	} else {
-		return data, BuildResponse(r)
+		defer closeBody(r)
+
+		if data, err := ioutil.ReadAll(r.Body); err != nil {
+			return nil, BuildErrorResponse(r, NewAppError("GetEmojiImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		} else {
+			return data, BuildResponse(r)
+		}
 	}
 }
 

--- a/model/client4.go
+++ b/model/client4.go
@@ -21,7 +21,7 @@ type Response struct {
 	RequestId     string
 	Etag          string
 	ServerVersion string
-	Response      *http.Response
+	Header        http.Header
 }
 
 type Client4 struct {
@@ -37,15 +37,20 @@ func NewAPIv4Client(url string) *Client4 {
 }
 
 func BuildErrorResponse(r *http.Response, err *AppError) *Response {
-	statusCode := 0
+	var statusCode int
+	var header http.Header
 	if r != nil {
 		statusCode = r.StatusCode
+		header = r.Header
+	} else {
+		statusCode = 0
+		header = make(map[string][]string, 0)
 	}
 
 	return &Response{
 		StatusCode: statusCode,
 		Error:      err,
-		Response:   r,
+		Header:     header,
 	}
 }
 
@@ -55,7 +60,7 @@ func BuildResponse(r *http.Response) *Response {
 		RequestId:     r.Header.Get(HEADER_REQUEST_ID),
 		Etag:          r.Header.Get(HEADER_ETAG_SERVER),
 		ServerVersion: r.Header.Get(HEADER_VERSION_ID),
-		Response:      r,
+		Header:        r.Header,
 	}
 }
 


### PR DESCRIPTION
These are the unit tests I wrote a while back for https://mattermost.atlassian.net/browse/PLT-7125. It adds a field to the `model.Response` object in `model/client4.go` containing the original `http.Response` so that we can check the headers.

#### Checklist
- Added or updated unit tests (required for all new features)