### PR TITLE
[PLT-7020] Prevent ViewImageModal to re-render when file count is unchanged

### DIFF
--- a/webapp/components/view_image.jsx
+++ b/webapp/components/view_image.jsx
@@ -100,7 +100,7 @@ export default class ViewImageModal extends React.Component {
             this.onModalHidden();
         }
 
-        if (this.props.fileInfos !== nextProps.fileInfos) {
+        if (this.props.fileInfos.length !== nextProps.fileInfos.length) {
             this.setState({
                 loaded: Utils.fillArray(false, nextProps.fileInfos.length),
                 progress: Utils.fillArray(0, nextProps.fileInfos.length)


### PR DESCRIPTION
#### Summary
Prevent ViewImageModal to re-render when file count is unchanged. This addresses the issue of: 
- Image preview modal switches to loading gif if post finishes sending with modal open

#### Ticket Link
Jira ticket: [PLT-7020](https://mattermost.atlassian.net/browse/PLT-7020)

#### Checklist
- [x] Has UI changes
