### PR TITLE
PLT-7227: fix away/offline/online commands repeating user message

### DIFF
--- a/app/command_away.go
+++ b/app/command_away.go
@@ -33,11 +33,7 @@ func (me *AwayProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *AwayProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	rmsg := args.T("api.command_away.success")
-	if len(message) > 0 {
-		rmsg = message + " " + rmsg
-	}
 	SetStatusAwayIfNeeded(args.UserId, true)
 
-	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: rmsg}
+	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_away.success")}
 }

--- a/app/command_offline.go
+++ b/app/command_offline.go
@@ -33,11 +33,7 @@ func (me *OfflineProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *OfflineProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	rmsg := args.T("api.command_offline.success")
-	if len(message) > 0 {
-		rmsg = message + " " + rmsg
-	}
 	SetStatusOffline(args.UserId, true)
 
-	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: rmsg}
+	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_offline.success")}
 }

--- a/app/command_online.go
+++ b/app/command_online.go
@@ -33,11 +33,7 @@ func (me *OnlineProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *OnlineProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	rmsg := args.T("api.command_online.success")
-	if len(message) > 0 {
-		rmsg = message + " " + rmsg
-	}
 	SetStatusOnline(args.UserId, args.Session.Id, true)
 
-	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: rmsg}
+	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_online.success")}
 }


### PR DESCRIPTION
#### Summary
Repro steps:
1) Type `/away asdf`
Observed: The ephemeral message posted is "asdf You are now away". This also happens for `/online` and `/offline`
Expected: The remaining text is not added to the beginning of the ephemeral message

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7227