### PR TITLE
PLT-6603: Don't return all posts on invalid query.

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -532,6 +532,11 @@ func SearchPostsInTeam(terms string, userId string, teamId string, isOrSearch bo
 			}
 		}
 
+		// If the processed search params are empty, return empty search results.
+		if len(finalParamsList) == 0 {
+			return model.NewPostList(), nil
+		}
+
 		// We only allow the user to search in channels they are a member of.
 		userChannels, err := GetChannelsForUser(teamId, userId)
 		if err != nil {


### PR DESCRIPTION
#### Summary
PLT-6603: Don't return all posts on invalid query.

If the query contains only * or invalid punctuation only components,
don't return all posts - instead return no results.

This also fixes PLT-6608

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6603
https://mattermost.atlassian.net/browse/PLT-6608
