### PR TITLE
PLT-6683 Fix teams being incorrectly marked unread across tabs

### DIFF
--- a/webapp/stores/team_store.jsx
+++ b/webapp/stores/team_store.jsx
@@ -10,6 +10,7 @@ import Constants from 'utils/constants.jsx';
 const NotificationPrefs = Constants.NotificationPrefs;
 
 import {getSiteURL} from 'utils/url.jsx';
+import {isSystemMessage, isFromWebhook} from 'utils/post_utils.jsx';
 const ActionTypes = Constants.ActionTypes;
 
 const CHANGE_EVENT = 'change';
@@ -446,6 +447,10 @@ TeamStore.dispatchToken = AppDispatcher.register((payload) => {
         break;
     case ActionTypes.RECEIVED_POST:
         if (Constants.IGNORE_POST_TYPES.indexOf(action.post.type) !== -1) {
+            return;
+        }
+
+        if (action.post.user_id === UserStore.getCurrentId() && !isSystemMessage(action.post) && !isFromWebhook(action.post)) {
             return;
         }
 


### PR DESCRIPTION
#### Summary
Fix teams being incorrectly marked unread across tabs when the logged in user posts.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6683