### PR TITLE
PLT-7137 Show flagged posts consistently throughout the UI

### DIFF
--- a/webapp/components/post_view/post_info/index.js
+++ b/webapp/components/post_view/post_info/index.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {removePost, addReaction} from 'mattermost-redux/actions/posts';
 
-import {getBool} from 'mattermost-redux/selectors/entities/preferences';
+import {get, getBool} from 'mattermost-redux/selectors/entities/preferences';
 
 import {Preferences} from 'utils/constants.jsx';
 
@@ -15,7 +15,7 @@ function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
         useMilitaryTime: getBool(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.USE_MILITARY_TIME, false),
-        isFlagged: getBool(state, Preferences.CATEGORY_FLAGGED_POST, ownProps.post.id)
+        isFlagged: get(state, Preferences.CATEGORY_FLAGGED_POST, ownProps.post.id, null) != null
     };
 }
 

--- a/webapp/components/rhs_thread/rhs_thread.jsx
+++ b/webapp/components/rhs_thread/rhs_thread.jsx
@@ -343,7 +343,7 @@ export default class RhsThread extends React.Component {
 
         let isRootFlagged = false;
         if (this.state.flaggedPosts) {
-            isRootFlagged = this.state.flaggedPosts.get(selected.id) === 'true';
+            isRootFlagged = this.state.flaggedPosts.get(selected.id) != null;
         }
 
         let rootStatus = 'offline';
@@ -367,7 +367,7 @@ export default class RhsThread extends React.Component {
 
             let isFlagged = false;
             if (this.state.flaggedPosts) {
-                isFlagged = this.state.flaggedPosts.get(comPost.id) === 'true';
+                isFlagged = this.state.flaggedPosts.get(comPost.id) != null;
             }
 
             let status = 'offline';

--- a/webapp/components/search_results.jsx
+++ b/webapp/components/search_results.jsx
@@ -284,7 +284,7 @@ export default class SearchResults extends React.Component {
 
                 let isFlagged = false;
                 if (this.state.flaggedPosts) {
-                    isFlagged = this.state.flaggedPosts.get(post.id) === 'true';
+                    isFlagged = this.state.flaggedPosts.get(post.id) != null;
                 }
 
                 const reverseCount = arr.length - idx - 1;


### PR DESCRIPTION
#### Summary
Consider the existence of a flagged post preference as indicating a post is flagged, regardless of the preference value.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7137
#6715 