### PR TITLE
Added type check when combining user activity messages

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -936,7 +936,12 @@ func updateUserActivitySystemMessage(post *model.Post, username, otherUsername, 
 	}
 
 	if val, ok := post.Props["messages"]; ok {
-		post.Props["messages"] = append(val.([]interface{}), props)
+		if oldProps, ok := val.([]interface{}); !ok {
+			// Just ignore whatever was stored here before since it wasn't the correct type of data
+			post.Props["messages"] = []interface{}{props}
+		} else {
+			post.Props["messages"] = append(oldProps, props)
+		}
 	} else {
 		oldProps := make(model.StringInterface)
 		for key, value := range post.Props {


### PR DESCRIPTION
@debanshuk FYI, I had one small piece of feedback that I missed getting in before https://github.com/mattermost/platform/pull/5945 was merged. I think it might been possible to make the server panic by posting a message with `message.Props["message"]` set to a non-array, so I added a quick type check for it