### PR TITLE
Allow regions to be set and honored for S3 driver. (#7010)

### DIFF
--- a/api/file_test.go
+++ b/api/file_test.go
@@ -820,11 +820,19 @@ func readTestFile(name string) ([]byte, error) {
 	}
 }
 
-func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool) (*s3.Client, error) {
+// Similar to s3.New() but allows initialization of signature v2 or signature v4 client.
+// If signV2 input is false, function always returns signature v4.
+//
+// Additionally this function also takes a user defined region, if set
+// disables automatic region lookup.
+func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, region string) (*s3.Client, error) {
 	if signV2 {
 		return s3.NewV2(endpoint, accessKey, secretKey, secure)
 	}
-	return s3.NewV4(endpoint, accessKey, secretKey, secure)
+	// Region can only be configured if using signature v4, use
+	// mattermost/platform-v4.1. For v2 signature regions are
+	// not quite meaningful and should work fine without.
+	return s3.NewWithRegion(endpoint, accessKey, secretKey, secure, region)
 }
 
 func cleanupTestFile(info *model.FileInfo) error {
@@ -834,7 +842,8 @@ func cleanupTestFile(info *model.FileInfo) error {
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *utils.Cfg.FileSettings.AmazonS3SSL
 		signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2)
+		region := utils.Cfg.FileSettings.AmazonS3Region
+		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			return err
 		}

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -695,7 +695,8 @@ func TestUserCreateImage(t *testing.T) {
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *utils.Cfg.FileSettings.AmazonS3SSL
 		signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2)
+		region := utils.Cfg.FileSettings.AmazonS3Region
+		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -800,7 +801,8 @@ func TestUserUploadProfileImage(t *testing.T) {
 			secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 			secure := *utils.Cfg.FileSettings.AmazonS3SSL
 			signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-			s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2)
+			region := utils.Cfg.FileSettings.AmazonS3Region
+			s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -632,11 +632,19 @@ func readTestFile(name string) ([]byte, error) {
 	}
 }
 
-func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool) (*s3.Client, error) {
+// Similar to s3.New() but allows initialization of signature v2 or signature v4 client.
+// If signV2 input is false, function always returns signature v4.
+//
+// Additionally this function also takes a user defined region, if set
+// disables automatic region lookup.
+func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, region string) (*s3.Client, error) {
 	if signV2 {
 		return s3.NewV2(endpoint, accessKey, secretKey, secure)
 	}
-	return s3.NewV4(endpoint, accessKey, secretKey, secure)
+	// Region can only be configured if using signature v4, use
+	// mattermost/platform-v4.1. For v2 signature regions are
+	// not quite meaningful and should work fine without.
+	return s3.NewWithRegion(endpoint, accessKey, secretKey, secure, region)
 }
 
 func cleanupTestFile(info *model.FileInfo) error {
@@ -646,7 +654,8 @@ func cleanupTestFile(info *model.FileInfo) error {
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *utils.Cfg.FileSettings.AmazonS3SSL
 		signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2)
+		region := utils.Cfg.FileSettings.AmazonS3Region
+		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			return err
 		}

--- a/model/config.go
+++ b/model/config.go
@@ -513,11 +513,6 @@ func (o *Config) SetDefaults() {
 		o.FileSettings.AmazonS3Endpoint = "s3.amazonaws.com"
 	}
 
-	if o.FileSettings.AmazonS3Region == "" {
-		// Defaults to "us-east-1" region.
-		o.FileSettings.AmazonS3Region = "us-east-1"
-	}
-
 	if o.FileSettings.AmazonS3SSL == nil {
 		o.FileSettings.AmazonS3SSL = new(bool)
 		*o.FileSettings.AmazonS3SSL = true // Secure by default.


### PR DESCRIPTION
#### Summary
This is necessary for certain users where
GetBucketLocation API is disabled using IAM
policies. There is a field AmazonS3Region
which we need to re-purpose and use to support
this properly.

#### Ticket Link
Fixes https://github.com/mattermost/platform/issues/6999

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
