### PR TITLE
[PLT-7236] Fix JS error on handleViewAction due to missing POST_UPDATED constant for socket events

### DIFF
--- a/webapp/utils/constants.jsx
+++ b/webapp/utils/constants.jsx
@@ -68,6 +68,7 @@ export const ActionTypes = keyMirror({
     CREATE_POST: null,
     CREATE_COMMENT: null,
     POST_DELETED: null,
+    POST_UPDATED: null,
     REMOVE_POST: null,
 
     RECEIVED_CHANNELS: null,
@@ -222,6 +223,7 @@ export const SocketEvents = {
     POSTED: 'posted',
     POST_EDITED: 'post_edited',
     POST_DELETED: 'post_deleted',
+    POST_UPDATED: 'post_updated',
     CHANNEL_CREATED: 'channel_created',
     CHANNEL_DELETED: 'channel_deleted',
     CHANNEL_UPDATED: 'channel_updated',
@@ -416,6 +418,7 @@ export const Constants = {
     POST_LOADING: 'loading',
     POST_FAILED: 'failed',
     POST_DELETED: 'deleted',
+    POST_UPDATED: 'updated',
     SYSTEM_MESSAGE_PREFIX: 'system_',
     SYSTEM_MESSAGE_PROFILE_IMAGE: logoImage,
     RESERVED_TEAM_NAMES: [


### PR DESCRIPTION
#### Summary
Fix JS error on handleViewAction due to missing POST_UPDATED constant for socket events
- that should have been added to this commit https://github.com/mattermost/platform/commit/58c6a70d3e225fcc423d4f0ee9316150e097b2c2 
- such socket event is used to propagate changes (to center view) when post is edited at RHS's search results

#### Ticket Link
Jira ticket: [PLT-7236](https://mattermost.atlassian.net/browse/PLT-7236)
