### PR TITLE
PLT-7238: In channel member dropdown list, only show the name (fullname/nickname/username) used elsewhere in the UI

### DIFF
--- a/webapp/components/popover_list_members/popover_list_members.jsx
+++ b/webapp/components/popover_list_members/popover_list_members.jsx
@@ -112,7 +112,7 @@ export default class PopoverListMembers extends React.Component {
 
                 let name = '';
                 if (teamMembers[m.username]) {
-                    name = Utils.displayEntireNameForUser(teamMembers[m.username]);
+                    name = Utils.displayUsernameForUser(teamMembers[m.username]);
                 }
 
                 if (name) {


### PR DESCRIPTION
#### Summary
Modified channel member dropdown list to show user name, as defined by display settings, rather than full name

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7238

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes