### PR TITLE
PLT-7275: Configure replica/shard count for Elasticsearch indexes.

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -391,6 +391,8 @@ func trackConfig() {
 		"enable_indexing":          *utils.Cfg.ElasticsearchSettings.EnableIndexing,
 		"enable_searching":         *utils.Cfg.ElasticsearchSettings.EnableSearching,
 		"sniff":                    *utils.Cfg.ElasticsearchSettings.Sniff,
+		"post_index_replicas":      *utils.Cfg.ElasticsearchSettings.PostIndexReplicas,
+		"post_index_shards":        *utils.Cfg.ElasticsearchSettings.PostIndexShards,
 	})
 }
 

--- a/config/config.json
+++ b/config/config.json
@@ -292,7 +292,9 @@
         "Password": "changeme",
         "EnableIndexing": false,
         "EnableSearching": false,
-        "Sniff": true
+        "Sniff": true,
+        "PostIndexReplicas": 2,
+        "PostIndexShards": 1
     },
     "DataRetentionSettings": {
         "Enable": false

--- a/model/config.go
+++ b/model/config.go
@@ -119,9 +119,11 @@ const (
 	ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_COLOR      = "#f2a93b"
 	ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_TEXT_COLOR = "#333333"
 
-	ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL = ""
-	ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME       = ""
-	ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD       = ""
+	ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL      = ""
+	ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME            = ""
+	ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD            = ""
+	ELASTICSEARCH_SETTINGS_DEFAULT_POST_INDEX_REPLICAS = 2
+	ELASTICSEARCH_SETTINGS_DEFAULT_POST_INDEX_SHARDS   = 1
 )
 
 type ServiceSettings struct {
@@ -432,12 +434,14 @@ type WebrtcSettings struct {
 }
 
 type ElasticsearchSettings struct {
-	ConnectionUrl   *string
-	Username        *string
-	Password        *string
-	EnableIndexing  *bool
-	EnableSearching *bool
-	Sniff           *bool
+	ConnectionUrl     *string
+	Username          *string
+	Password          *string
+	EnableIndexing    *bool
+	EnableSearching   *bool
+	Sniff             *bool
+	PostIndexReplicas *int
+	PostIndexShards   *int
 }
 
 type DataRetentionSettings struct {
@@ -1410,6 +1414,16 @@ func (o *Config) SetDefaults() {
 	if o.ElasticsearchSettings.Sniff == nil {
 		o.ElasticsearchSettings.Sniff = new(bool)
 		*o.ElasticsearchSettings.Sniff = true
+	}
+
+	if o.ElasticsearchSettings.PostIndexReplicas == nil {
+		o.ElasticsearchSettings.PostIndexReplicas = new(int)
+		*o.ElasticsearchSettings.PostIndexReplicas = ELASTICSEARCH_SETTINGS_DEFAULT_POST_INDEX_REPLICAS
+	}
+
+	if o.ElasticsearchSettings.PostIndexShards == nil {
+		o.ElasticsearchSettings.PostIndexShards = new(int)
+		*o.ElasticsearchSettings.PostIndexShards = ELASTICSEARCH_SETTINGS_DEFAULT_POST_INDEX_SHARDS
 	}
 
 	if o.DataRetentionSettings.Enable == nil {


### PR DESCRIPTION
#### Summary
This is the "quick" part of the fix for PLT-7275. It'll be enough to get 1,000 days of search history working with Elasticsearch in it's default/AWS config. System console UI for these two settings will come in a subsequent PR.

@jasonblais this adds two new config values to the diagnostics, so requesting your review on them.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7275
