### PR TITLE
PLT-7249 Do not show non-autocomplete commands for system admins

### DIFF
--- a/webapp/actions/integration_actions.jsx
+++ b/webapp/actions/integration_actions.jsx
@@ -213,8 +213,12 @@ export function regenCommandToken(id) {
 export function getSuggestedCommands(command, suggestionId, component) {
     Client4.getCommandsList(TeamStore.getCurrentId()).then(
         (data) => {
-            var matches = [];
+            let matches = [];
             data.forEach((cmd) => {
+                if (!cmd.auto_complete) {
+                    return;
+                }
+
                 if (cmd.trigger !== 'shortcuts' || !UserAgent.isMobile()) {
                     if (('/' + cmd.trigger).indexOf(command) === 0) {
                         const s = '/' + cmd.trigger;


### PR DESCRIPTION
#### Summary
Do not show non-autocomplete commands for system admins (and other users too but the server won't return them for those users anyways).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7249