### PR TITLE
PLT-6079 Adding simple leader election

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -46,7 +46,7 @@ const (
 var client *analytics.Client
 
 func SendDailyDiagnostics() {
-	if *utils.Cfg.LogSettings.EnableDiagnostics {
+	if *utils.Cfg.LogSettings.EnableDiagnostics && utils.IsLeader() {
 		initDiagnostics("")
 		trackActivity()
 		trackConfig()

--- a/einterfaces/cluster.go
+++ b/einterfaces/cluster.go
@@ -14,6 +14,7 @@ type ClusterInterface interface {
 	StopInterNodeCommunication()
 	RegisterClusterMessageHandler(event string, crm ClusterMessageHandler)
 	GetClusterId() string
+	IsLeader() bool
 	GetClusterInfos() []*model.ClusterInfo
 	SendClusterMessage(cluster *model.ClusterMessage)
 	NotifyMsg(buf []byte)

--- a/model/cluster_info.go
+++ b/model/cluster_info.go
@@ -10,6 +10,7 @@ import (
 )
 
 type ClusterInfo struct {
+	Id         string `json:"id"`
 	Version    string `json:"version"`
 	ConfigHash string `json:"config_hash"`
 	IpAddress  string `json:"ipaddress"`

--- a/utils/config.go
+++ b/utils/config.go
@@ -625,3 +625,11 @@ func Desanitize(cfg *model.Config) {
 		cfg.SqlSettings.DataSourceSearchReplicas[i] = Cfg.SqlSettings.DataSourceSearchReplicas[i]
 	}
 }
+
+func IsLeader() bool {
+	if IsLicensed && *Cfg.ClusterSettings.Enable && einterfaces.GetClusterInterface() != nil {
+		return einterfaces.GetClusterInterface().IsLeader()
+	} else {
+		return true
+	}
+}


### PR DESCRIPTION
#### Summary
This adds simple leader election.  I looked at stuff like https://github.com/docker/leadership but it has a hard requirement on using Consul, etcd or Zookeeper.  I also found https://github.com/monnand/bully implementation of the https://en.wikipedia.org/wiki/Bully_algorithm, which at it's core is a pretty simple concept.

Since we don't need a strict leader election, meaning we can tolerate multiple leaders and jobs running more than once, this PR is inspired by the bully algo, but does not implement it.

Enterprise PR https://github.com/mattermost/enterprise/pull/175

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6079

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Added or updated unit tests (required for all new features)
- [X] Has enterprise changes (please link)
- [X] Touches critical sections of the codebase (auth, upgrade, etc.)
