### PR TITLE
[PLT-7231/PLT-7306] Fix GitLab SSO failure with non-English locale and make config locales more forgiving

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6136,16 +6136,20 @@
     "translation": "An error occurred while saving the file to {{.Filename}}"
   },
   {
+    "id": "utils.config.add_client_locale.app_error",
+    "translation": "Unable to load mattermost configuration file:  Adding DefaultClientLocale to AvailableLocales."
+  },
+  {
     "id": "utils.config.supported_available_locales.app_error",
-    "translation": "Unable to load mattermost configuration file:  AvailableLocales must include DefaultClientLocale. Set AvailableLocales to empty string as default value."
+    "translation": "Unable to load mattermost configuration file:  AvailableLocales must include DefaultClientLocale. Setting AvailableLocales to all locales as default value."
   },
   {
     "id": "utils.config.supported_client_locale.app_error",
-    "translation": "Unable to load mattermost configuration file:  DefaultClientLocale must be one of the supported locales. Set DefaultClientLocale to en as default value."
+    "translation": "Unable to load mattermost configuration file:  DefaultClientLocale must be one of the supported locales. Setting DefaultClientLocale to en as default value."
   },
   {
     "id": "utils.config.supported_server_locale.app_error",
-    "translation": "Unable to load mattermost configuration file:  DefaultServerLocale must be one of the supported locales. Set DefaultServerLocale to en as default value."
+    "translation": "Unable to load mattermost configuration file:  DefaultServerLocale must be one of the supported locales. Setting DefaultServerLocale to en as default value."
   },
   {
     "id": "utils.config.validate_locale.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6137,7 +6137,7 @@
   },
   {
     "id": "utils.config.supported_available_locales.app_error",
-    "translation": "Unable to load mattermost configuration file:  AvailableLocales must include all of the supported locales. Set AvailableLocales to empty string as default value."
+    "translation": "Unable to load mattermost configuration file:  AvailableLocales must include DefaultClientLocale. Set AvailableLocales to empty string as default value."
   },
   {
     "id": "utils.config.supported_client_locale.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6136,12 +6136,16 @@
     "translation": "An error occurred while saving the file to {{.Filename}}"
   },
   {
+    "id": "utils.config.supported_available_locales.app_error",
+    "translation": "Unable to load mattermost configuration file:  AvailableLocales must include all of the supported locales. Set AvailableLocales to empty string as default value."
+  },
+  {
     "id": "utils.config.supported_client_locale.app_error",
-    "translation": "Unable to load mattermost configuration file:  DefaultClientLocale must be one of the supported locales"
+    "translation": "Unable to load mattermost configuration file:  DefaultClientLocale must be one of the supported locales. Set DefaultClientLocale to en as default value."
   },
   {
     "id": "utils.config.supported_server_locale.app_error",
-    "translation": "Unable to load mattermost configuration file:  DefaultServerLocale must be one of the supported locales"
+    "translation": "Unable to load mattermost configuration file:  DefaultServerLocale must be one of the supported locales. Set DefaultServerLocale to en as default value."
   },
   {
     "id": "utils.config.validate_locale.app_error",

--- a/utils/config.go
+++ b/utils/config.go
@@ -568,7 +568,8 @@ func ValidateLdapFilter(cfg *model.Config) *model.AppError {
 	return nil
 }
 
-func ValidateLocales(cfg *model.Config) (err *model.AppError) {
+func ValidateLocales(cfg *model.Config) *model.AppError {
+	var err *model.AppError
 	locales := GetSupportedLocales()
 	if _, ok := locales[*cfg.LocalizationSettings.DefaultServerLocale]; !ok {
 		*cfg.LocalizationSettings.DefaultServerLocale = model.DEFAULT_LOCALE
@@ -581,19 +582,15 @@ func ValidateLocales(cfg *model.Config) (err *model.AppError) {
 	}
 
 	if len(*cfg.LocalizationSettings.AvailableLocales) > 0 {
-		isDefaultServerLocaleInAvailableLocales := false
 		isDefaultClientLocaleInAvailableLocales := false
 		for _, word := range strings.Split(*cfg.LocalizationSettings.AvailableLocales, ",") {
 			if _, ok := locales[word]; !ok {
 				*cfg.LocalizationSettings.AvailableLocales = ""
-				isDefaultServerLocaleInAvailableLocales = true
 				isDefaultClientLocaleInAvailableLocales = true
 				err = model.NewLocAppError("ValidateLocales", "utils.config.supported_available_locales.app_error", nil, "")
 				break
 			}
-			if word == *cfg.LocalizationSettings.DefaultServerLocale {
-				isDefaultServerLocaleInAvailableLocales = true
-			}
+
 			if word == *cfg.LocalizationSettings.DefaultClientLocale {
 				isDefaultClientLocaleInAvailableLocales = true
 			}
@@ -601,14 +598,9 @@ func ValidateLocales(cfg *model.Config) (err *model.AppError) {
 
 		availableLocales := *cfg.LocalizationSettings.AvailableLocales
 
-		if !isDefaultServerLocaleInAvailableLocales {
-			availableLocales += "," + *cfg.LocalizationSettings.DefaultServerLocale
-			err = model.NewLocAppError("ValidateLocales", "utils.config.validate_locale.app_error", nil, "")
-		}
-
-		if !isDefaultClientLocaleInAvailableLocales && *cfg.LocalizationSettings.DefaultServerLocale != *cfg.LocalizationSettings.DefaultClientLocale {
+		if !isDefaultClientLocaleInAvailableLocales {
 			availableLocales += "," + *cfg.LocalizationSettings.DefaultClientLocale
-			err = model.NewLocAppError("ValidateLocales", "utils.config.validate_locale.app_error", nil, "")
+			err = model.NewLocAppError("ValidateLocales", "utils.config.add_client_locale.app_error", nil, "")
 		}
 
 		*cfg.LocalizationSettings.AvailableLocales = strings.Join(RemoveDuplicatesFromStringArray(strings.Split(availableLocales, ",")), ",")

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -155,5 +156,125 @@ func TestConfigListener(t *testing.T) {
 		t.Fatal("listener should've been called")
 	} else if !listener2Called {
 		t.Fatal("listener 2 should've been called")
+	}
+}
+
+func TestValidateLocales(t *testing.T) {
+	TranslationsPreInit()
+	LoadConfig("config.json")
+
+	defaultServerLocale := *Cfg.LocalizationSettings.DefaultServerLocale
+	defaultClientLocale := *Cfg.LocalizationSettings.DefaultClientLocale
+	availableLocales := *Cfg.LocalizationSettings.AvailableLocales
+
+	defer func() {
+		*Cfg.LocalizationSettings.DefaultClientLocale = defaultClientLocale
+		*Cfg.LocalizationSettings.DefaultServerLocale = defaultServerLocale
+		*Cfg.LocalizationSettings.AvailableLocales = availableLocales
+	}()
+
+	*Cfg.LocalizationSettings.DefaultServerLocale = "en"
+	*Cfg.LocalizationSettings.DefaultClientLocale = "en"
+	*Cfg.LocalizationSettings.AvailableLocales = ""
+
+	// t.Logf("*Cfg.LocalizationSettings.DefaultClientLocale: %+v", *Cfg.LocalizationSettings.DefaultClientLocale)
+	if err := ValidateLocales(Cfg); err != nil {
+		t.Fatal("Should have not returned an error")
+	}
+
+	// validate DefaultServerLocale
+	*Cfg.LocalizationSettings.DefaultServerLocale = "junk"
+	if err := ValidateLocales(Cfg); err != nil {
+		if *Cfg.LocalizationSettings.DefaultServerLocale != "en" {
+			t.Fatal("DefaultServerLocale should have assigned to en as a default value")
+		}
+	} else {
+
+		t.Fatal("Should have returned an error validating DefaultServerLocale")
+	}
+
+	*Cfg.LocalizationSettings.DefaultServerLocale = ""
+	if err := ValidateLocales(Cfg); err != nil {
+		if *Cfg.LocalizationSettings.DefaultServerLocale != "en" {
+			t.Fatal("DefaultServerLocale should have assigned to en as a default value")
+		}
+	} else {
+		t.Fatal("Should have returned an error validating DefaultServerLocale")
+	}
+
+	*Cfg.LocalizationSettings.AvailableLocales = "en"
+	*Cfg.LocalizationSettings.DefaultServerLocale = "de"
+	if err := ValidateLocales(Cfg); err != nil {
+		if !strings.Contains(*Cfg.LocalizationSettings.AvailableLocales, *Cfg.LocalizationSettings.DefaultServerLocale) {
+			t.Fatal("DefaultServerLocale should have added to AvailableLocales")
+		}
+	} else {
+		t.Fatal("Should have returned an error validating DefaultServerLocale")
+	}
+
+	// validate DefaultClientLocale
+	*Cfg.LocalizationSettings.AvailableLocales = ""
+	*Cfg.LocalizationSettings.DefaultClientLocale = "junk"
+	if err := ValidateLocales(Cfg); err != nil {
+		if *Cfg.LocalizationSettings.DefaultClientLocale != "en" {
+			t.Fatal("DefaultClientLocale should have assigned to en as a default value")
+		}
+	} else {
+
+		t.Fatal("Should have returned an error validating DefaultClientLocale")
+	}
+
+	*Cfg.LocalizationSettings.DefaultClientLocale = ""
+	if err := ValidateLocales(Cfg); err != nil {
+		if *Cfg.LocalizationSettings.DefaultClientLocale != "en" {
+			t.Fatal("DefaultClientLocale should have assigned to en as a default value")
+		}
+	} else {
+		t.Fatal("Should have returned an error validating DefaultClientLocale")
+	}
+
+	*Cfg.LocalizationSettings.AvailableLocales = "en"
+	*Cfg.LocalizationSettings.DefaultClientLocale = "de"
+	if err := ValidateLocales(Cfg); err != nil {
+		if !strings.Contains(*Cfg.LocalizationSettings.AvailableLocales, *Cfg.LocalizationSettings.DefaultClientLocale) {
+			t.Fatal("DefaultClientLocale should have added to AvailableLocales")
+		}
+	} else {
+		t.Fatal("Should have returned an error validating DefaultClientLocale")
+	}
+
+	// validate AvailableLocales
+	*Cfg.LocalizationSettings.DefaultServerLocale = "en"
+	*Cfg.LocalizationSettings.DefaultClientLocale = "en"
+	*Cfg.LocalizationSettings.AvailableLocales = "junk"
+	if err := ValidateLocales(Cfg); err != nil {
+		if *Cfg.LocalizationSettings.AvailableLocales != "" {
+			t.Fatal("AvailableLocales should have assigned to empty string as a default value")
+		}
+	} else {
+		t.Fatal("Should have returned an error validating AvailableLocales")
+	}
+
+	*Cfg.LocalizationSettings.AvailableLocales = "en,de,junk"
+	if err := ValidateLocales(Cfg); err != nil {
+		if *Cfg.LocalizationSettings.AvailableLocales != "" {
+			t.Fatal("AvailableLocales should have assigned to empty string as a default value")
+		}
+	} else {
+		t.Fatal("Should have returned an error validating AvailableLocales")
+	}
+
+	*Cfg.LocalizationSettings.DefaultServerLocale = "fr"
+	*Cfg.LocalizationSettings.DefaultClientLocale = "de"
+	*Cfg.LocalizationSettings.AvailableLocales = "en"
+	if err := ValidateLocales(Cfg); err != nil {
+		if !strings.Contains(*Cfg.LocalizationSettings.AvailableLocales, *Cfg.LocalizationSettings.DefaultServerLocale) {
+			t.Fatal("AvailableLocales should have assigned to empty string as a default value")
+		}
+		if !strings.Contains(*Cfg.LocalizationSettings.AvailableLocales, *Cfg.LocalizationSettings.DefaultClientLocale) {
+			t.Fatal("AvailableLocales should have assigned to empty string as a default value")
+		}
+	} else {
+		t.Fatal("Should have returned an error validating AvailableLocales")
 	}
 }

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -205,11 +205,10 @@ func TestValidateLocales(t *testing.T) {
 	*Cfg.LocalizationSettings.AvailableLocales = "en"
 	*Cfg.LocalizationSettings.DefaultServerLocale = "de"
 	if err := ValidateLocales(Cfg); err != nil {
-		if !strings.Contains(*Cfg.LocalizationSettings.AvailableLocales, *Cfg.LocalizationSettings.DefaultServerLocale) {
-			t.Fatal("DefaultServerLocale should have added to AvailableLocales")
+		if strings.Contains(*Cfg.LocalizationSettings.AvailableLocales, *Cfg.LocalizationSettings.DefaultServerLocale) {
+			t.Fatal("DefaultServerLocale should not be added to AvailableLocales")
 		}
-	} else {
-		t.Fatal("Should have returned an error validating DefaultServerLocale")
+		t.Fatal("Should have not returned an error validating DefaultServerLocale")
 	}
 
 	// validate DefaultClientLocale
@@ -268,11 +267,11 @@ func TestValidateLocales(t *testing.T) {
 	*Cfg.LocalizationSettings.DefaultClientLocale = "de"
 	*Cfg.LocalizationSettings.AvailableLocales = "en"
 	if err := ValidateLocales(Cfg); err != nil {
-		if !strings.Contains(*Cfg.LocalizationSettings.AvailableLocales, *Cfg.LocalizationSettings.DefaultServerLocale) {
-			t.Fatal("AvailableLocales should have assigned to empty string as a default value")
+		if strings.Contains(*Cfg.LocalizationSettings.AvailableLocales, *Cfg.LocalizationSettings.DefaultServerLocale) {
+			t.Fatal("DefaultServerLocale should not be added to AvailableLocales")
 		}
 		if !strings.Contains(*Cfg.LocalizationSettings.AvailableLocales, *Cfg.LocalizationSettings.DefaultClientLocale) {
-			t.Fatal("AvailableLocales should have assigned to empty string as a default value")
+			t.Fatal("DefaultClientLocale should have added to AvailableLocales")
 		}
 	} else {
 		t.Fatal("Should have returned an error validating AvailableLocales")


### PR DESCRIPTION
#### Summary

Make MM config locales more forgiving by assigning default values
- if `DefaultServerLocale` is set to empty string or unsupported language/unknown string, it will be set to `en` as default value.
- if `DefaultClientLocale` is set to empty string or unsupported language/unknown string, it will be set to `en` as default value.
- if `AvailableLocales` has unsupported language/unknown string included, it will be set to empty string ("") as default value which means set to all available language supported by MM.
- `DefaultServerLocale` will be added to `AvailableLocales` when not available.
- `DefaultClientLocale` will be added to `AvailableLocales` when not available.

#### Ticket Link
Jira ticket: [PLT-7306](https://mattermost.atlassian.net/browse/PLT-7306) & [PLT-7231](https://mattermost.atlassian.net/browse/PLT-7231)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (config)
