### PR TITLE
PLT-7261 Fixed incorrect content type for preview and thumbnail images

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -16,6 +16,11 @@ import (
 	"github.com/mattermost/platform/utils"
 )
 
+const (
+	PREVIEW_IMAGE_TYPE   = "image/jpeg"
+	THUMBNAIL_IMAGE_TYPE = "image/jpeg"
+)
+
 var UNSAFE_CONTENT_TYPES = [...]string{
 	"application/javascript",
 	"application/ecmascript",
@@ -116,7 +121,7 @@ func getFileThumbnail(c *Context, w http.ResponseWriter, r *http.Request) {
 	if data, err := app.ReadFile(info.ThumbnailPath); err != nil {
 		c.Err = err
 		c.Err.StatusCode = http.StatusNotFound
-	} else if err := writeFileResponse(info.Name, "", data, w, r); err != nil {
+	} else if err := writeFileResponse(info.Name, THUMBNAIL_IMAGE_TYPE, data, w, r); err != nil {
 		c.Err = err
 		return
 	}
@@ -138,7 +143,7 @@ func getFilePreview(c *Context, w http.ResponseWriter, r *http.Request) {
 	if data, err := app.ReadFile(info.PreviewPath); err != nil {
 		c.Err = err
 		c.Err.StatusCode = http.StatusNotFound
-	} else if err := writeFileResponse(info.Name, "", data, w, r); err != nil {
+	} else if err := writeFileResponse(info.Name, PREVIEW_IMAGE_TYPE, data, w, r); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/file.go
+++ b/api4/file.go
@@ -17,6 +17,9 @@ import (
 
 const (
 	FILE_TEAM_ID = "noteam"
+
+	PREVIEW_IMAGE_TYPE   = "image/jpeg"
+	THUMBNAIL_IMAGE_TYPE = "image/jpeg"
 )
 
 var UNSAFE_CONTENT_TYPES = [...]string{
@@ -165,7 +168,7 @@ func getFileThumbnail(c *Context, w http.ResponseWriter, r *http.Request) {
 	if data, err := app.ReadFile(info.ThumbnailPath); err != nil {
 		c.Err = err
 		c.Err.StatusCode = http.StatusNotFound
-	} else if err := writeFileResponse(info.Name, info.MimeType, data, forceDownload, w, r); err != nil {
+	} else if err := writeFileResponse(info.Name, THUMBNAIL_IMAGE_TYPE, data, forceDownload, w, r); err != nil {
 		c.Err = err
 		return
 	}
@@ -237,7 +240,7 @@ func getFilePreview(c *Context, w http.ResponseWriter, r *http.Request) {
 	if data, err := app.ReadFile(info.PreviewPath); err != nil {
 		c.Err = err
 		c.Err.StatusCode = http.StatusNotFound
-	} else if err := writeFileResponse(info.Name, info.MimeType, data, forceDownload, w, r); err != nil {
+	} else if err := writeFileResponse(info.Name, PREVIEW_IMAGE_TYPE, data, forceDownload, w, r); err != nil {
 		c.Err = err
 		return
 	}


### PR DESCRIPTION
As it turns out, IE11 refuses to display images when the `X-Content-Type-Options` header is set to `nosniff` and their content type header doesn't match the actual type of the file.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7261