### PR TITLE
PLT-7230: fix some webhook attachments not truncating, limit short text to 300 chars

### DIFF
--- a/webapp/components/post_view/post_attachment.jsx
+++ b/webapp/components/post_view/post_attachment.jsx
@@ -72,8 +72,9 @@ export default class PostAttachment extends React.PureComponent {
         let text = this.props.attachment.text || '';
         if ((text.match(/\n/g) || []).length >= 5) {
             text = text.split('\n').splice(0, 5).join('\n');
-        } else if (text.length > 700) {
-            text = text.substr(0, 700);
+        }
+        if (text.length > 300) {
+            text = text.substr(0, 300);
         }
 
         return TextFormatting.formatText(text) + `<div><a class="attachment-link-more" href="#">${localizeMessage('post_attachment.more', 'Show more...')}</a></div>`;


### PR DESCRIPTION
#### Summary
Previously, webhooks would get truncated to 5 lines _or_ 700 characters. Now they get truncated to 5 lines _and 300_ characters.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7230
https://mattermost.atlassian.net/browse/PLT-7263

#### Checklist
- [x] Has UI changes
