### PR TITLE
Allowing Paperclip icon to show mouse pointer as a hand

### DIFF
--- a/webapp/sass/components/_inputs.scss
+++ b/webapp/sass/components/_inputs.scss
@@ -46,6 +46,10 @@ input {
     }
 }
 
+input::-webkit-file-upload-button {
+    display: none
+}
+
 ::-webkit-input-placeholder { /* Chrome/Opera/Safari */
     color: inherit;
     opacity: 0.5;


### PR DESCRIPTION

#### Summary
Changing an automatic browser shadow DOM element's display style to none in order to have the paperclip icon show a finger pointer instead of a default cursor.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6303

#### Checklist
- [x] Has UI changes
