### PR TITLE
PLT-7311 Don't allow empty search in searchbar.

### DIFF
--- a/webapp/components/search_bar.jsx
+++ b/webapp/components/search_bar.jsx
@@ -173,6 +173,10 @@ export default class SearchBar extends React.Component {
         e.preventDefault();
         const terms = this.state.searchTerm.trim();
 
+        if (terms.length === 0) {
+            return;
+        }
+
         AppDispatcher.handleServerAction({
             type: ActionTypes.RECEIVED_SEARCH_TERM,
             term: terms,


### PR DESCRIPTION
#### Summary
If the search submitted is empty, don't start the animation in the searchbar.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7311