### PR TITLE
PLT-7288: Allow CLI to delete teams with no channels.

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -735,7 +735,9 @@ func PermanentDeleteTeam(team *model.Team) *model.AppError {
 	}
 
 	if result := <-Srv.Store.Channel().GetTeamChannels(team.Id); result.Err != nil {
-		return result.Err
+		if result.Err.Id != "store.sql_channel.get_channels.not_found.app_error" {
+			return result.Err
+		}
 	} else {
 		channels := result.Data.(*model.ChannelList)
 		for _, c := range *channels {

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -152,4 +152,24 @@ func TestPermanentDeleteTeam(t *testing.T) {
 	if command, err = GetCommand(command.Id); command != nil || err == nil {
 		t.Fatal("command wasn't deleted")
 	}
+
+	// Test deleting a team with no channels.
+	team = th.CreateTeam()
+	defer func() {
+		PermanentDeleteTeam(team)
+	}()
+
+	if channels, err := GetPublicChannelsForTeam(team.Id, 0, 1000); err != nil {
+		t.Fatal(err)
+	} else {
+		for _, channel := range *channels {
+			if err2 := PermanentDeleteChannel(channel); err2 != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	if err := PermanentDeleteTeam(team); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
#### Summary
Allow deleting of teams with no channels through CLI.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7288