### PR TITLE
bump mattermost-redux#e529791 at yarn.lock

### DIFF
--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -5004,7 +5004,7 @@ math-expression-evaluator@^1.2.14:
 
 mattermost-redux@mattermost/mattermost-redux#master:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/b70727e1add55a9b173afc74cada1a32bf7db122"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/e5297912f528b822b61c61a36735fb4d6699d08d"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
Bump yarn.lock to have mattermost-redux#master/e5297912f528b822b61c61a36735fb4d6699d08d
- latest commits are critical for v4.1