### PR TITLE
PLT-7216: CLI Command to move channels between teams.

### DIFF
--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -64,3 +64,46 @@ func TestPermanentDeleteChannel(t *testing.T) {
 		t.Error("outgoing webhook wasn't deleted")
 	}
 }
+
+func TestMoveChannel(t *testing.T) {
+	th := Setup().InitBasic()
+
+	sourceTeam := th.CreateTeam()
+	targetTeam := th.CreateTeam()
+	channel1 := th.CreateChannel(sourceTeam)
+	defer func() {
+		PermanentDeleteChannel(channel1)
+		PermanentDeleteTeam(sourceTeam)
+		PermanentDeleteTeam(targetTeam)
+	}()
+
+	if _, err := AddUserToTeam(sourceTeam.Id, th.BasicUser.Id, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AddUserToTeam(sourceTeam.Id, th.BasicUser2.Id, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := AddUserToTeam(targetTeam.Id, th.BasicUser.Id, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := AddUserToChannel(th.BasicUser, channel1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AddUserToChannel(th.BasicUser2, channel1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MoveChannel(targetTeam, channel1); err == nil {
+		t.Fatal("Should have failed due to mismatched members.")
+	}
+
+	if _, err := AddUserToTeam(targetTeam.Id, th.BasicUser2.Id, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MoveChannel(targetTeam, channel1); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3168,6 +3168,10 @@
     "translation": "Must specify the team ID to create a channel"
   },
   {
+    "id": "app.channel.move_channel.members_do_not_match.error",
+    "translation": "Cannot move a channel unless all its members are already members of the destination team."
+  },
+  {
     "id": "app.channel.post_update_channel_purpose_message.post.error",
     "translation": "Failed to post channel purpose message"
   },


### PR DESCRIPTION
#### Summary
Adds a CLI command to move channels between teams.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7216

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
