### PR TITLE
PLT-7283 Fix out-of-channel mentions for usernames with dashes/periods

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -727,12 +727,14 @@ func GetExplicitMentions(message string, keywords map[string][]string) (map[stri
 				// Case-sensitive check for first name
 				if ids, match := keywords[splitWord]; match {
 					addMentionedUsers(ids)
-				} else if _, ok := systemMentions[word]; !ok && strings.HasPrefix(word, "@") {
-					username := word[1:len(splitWord)]
+				} else if _, ok := systemMentions[splitWord]; !ok && strings.HasPrefix(splitWord, "@") {
+					username := splitWord[1:]
 					potentialOthersMentioned = append(potentialOthersMentioned, username)
 				}
 			}
-		} else if _, ok := systemMentions[word]; !ok && strings.HasPrefix(word, "@") {
+		}
+
+		if _, ok := systemMentions[word]; !ok && strings.HasPrefix(word, "@") {
 			username := word[1:]
 			potentialOthersMentioned = append(potentialOthersMentioned, username)
 		}


### PR DESCRIPTION
#### Summary
Here is a summary of some mention cases, with the two cases I changed marked.

**Note: All dashes can be replaced with periods and the same behavior will occur **

**tim in channel, tim-test not in channel**
1. message: `@tim-test `
results:
    - **(NEW BEHAVIOR) tim-test not in channel ephemeral message posted**
    - notification sent to tim
2. message: `tim-test `
results:
    - notification sent to tim

**tim and tim-test in channel**
1. message: `@tim-test `
results:
    - notification sent to tim-test
2. message: `tim-test `
results:
    - notification sent to tim-test 

**tim and tim-test not in channel**
1. message: `@tim-test `
results:
    - **(OLD BEHAVIOR) tim not in channel ephemeral message posted**
    - **(NEW BEHAVIOR) tim and tim-test not in channel ephemeral message posted**
2. message: `tim-test `
results:
    - none

**tim in channel, bill not in channel**
1. message: `@tim-bill `
results:
    - notification sent to tim
2. message: `@tim-@bill `
results:
    - notification sent to tim
    - bill not in channel ephemeral message posted

**tim and bill in channel**
1. message: `@tim-bill `
results:
    - notification sent to tim & bill
2. message: `@tim-@bill `
results:
    - notification sent to tim & bill
2. message: `tim-bill `
results:
    - notification sent to tim & bill

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7283