### PR TITLE
PLT-7324: reset post attachments on post prop change

### DIFF
--- a/webapp/components/post_view/post_body_additional_content.jsx
+++ b/webapp/components/post_view/post_body_additional_content.jsx
@@ -78,6 +78,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent {
         return (
             <PostAttachmentList
                 attachments={attachments}
+                key={this.props.post.id}
             />
         );
     }


### PR DESCRIPTION
#### Summary
> 1) Go to the "Bugs" channel on pre-release
> 2) Find a post from the "Jira" account containing a message attachment
> 3) Hit the reply arrow to open a reply thread. Note the message attachment on the right-hand sidebar
> 4) Find another post from the "Jira" account and hit the reply arrow to open the right-hand sidebar.
>
> Observed: Message attachment from step 2 & 3) still shown on the right-hand sidebar. The attachment author and title change, but not the body.
> Expected: Message attachment from step 4 shown.

Post attachments store a few things in their state that are not reset when their attachment prop changes. An easy fix is to reset the attachment list when the post body component is re-used.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7324

#### Checklist
N/A