### PR TITLE
Add a + next to direct message on sidebar to open 'Direct Messages' modal

### DIFF
--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -779,7 +779,7 @@ export default class Sidebar extends React.Component {
                 <a
                     className='add-channel-btn'
                     href='#'
-                    onClick={this.showMoreDirectChannelsModal}
+                    onClick={this.handleOpenMoreDirectChannelsModal}
                 >
                     {'+'}
                 </a>

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -700,6 +700,18 @@ export default class Sidebar extends React.Component {
             </Tooltip>
         );
 
+        const createDirectMessageTooltip = (
+            <Tooltip
+                id='new-group-tooltip'
+                className='hidden-xs'
+            >
+                <FormattedMessage
+                    id='sidebar.createDirectMessage'
+                    defaultMessage='Create new direct message'
+                />
+            </Tooltip>
+        );
+
         const above = (
             <FormattedMessage
                 id='sidebar.unreads'
@@ -756,6 +768,23 @@ export default class Sidebar extends React.Component {
         if (!ChannelUtils.showCreateOption(Constants.OPEN_CHANNEL, isTeamAdmin, isSystemAdmin)) {
             createPublicChannelIcon = null;
         }
+
+        const createDirectMessageIcon = (
+            <OverlayTrigger
+                className='hidden-xs'
+                delayShow={500}
+                placement='top'
+                overlay={createDirectMessageTooltip}
+            >
+                <a
+                    className='add-channel-btn'
+                    href='#'
+                    onClick={this.showMoreDirectChannelsModal}
+                >
+                    {'+'}
+                </a>
+            </OverlayTrigger>
+        );
 
         if (!ChannelUtils.showCreateOption(Constants.PRIVATE_CHANNEL, isTeamAdmin, isSystemAdmin)) {
             createPrivateChannelIcon = null;
@@ -894,6 +923,7 @@ export default class Sidebar extends React.Component {
                                     id='sidebar.direct'
                                     defaultMessage='DIRECT MESSAGES'
                                 />
+                                {createDirectMessageIcon}
                             </h4>
                         </li>
                         {directMessageItems}


### PR DESCRIPTION
#### Summary
Add + link next to 'DIRECT MESSAGES' title in the LHS that behaves just like clicking the `More...` link at the bottom. 
![add nexttodirectmessageonsidebar](https://user-images.githubusercontent.com/160621/29095434-619c9448-7c56-11e7-993f-cf0d9c808613.png)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
