### PR TITLE
PLT-7301: JS error when current language setting of a user is removed from system's available languages

### DIFF
--- a/webapp/components/user_settings/manage_languages.jsx
+++ b/webapp/components/user_settings/manage_languages.jsx
@@ -16,18 +16,14 @@ export default class ManageLanguage extends React.Component {
     constructor(props) {
         super(props);
 
-        this.setupInitialState = this.setupInitialState.bind(this);
         this.setLanguage = this.setLanguage.bind(this);
         this.changeLanguage = this.changeLanguage.bind(this);
         this.submitUser = this.submitUser.bind(this);
-        this.state = this.setupInitialState(props);
-    }
-    setupInitialState(props) {
-        var user = props.user;
-        return {
-            locale: user.locale
+        this.state = {
+            locale: props.locale
         };
     }
+
     setLanguage(e) {
         this.setState({locale: e.target.value});
     }
@@ -134,5 +130,6 @@ export default class ManageLanguage extends React.Component {
 
 ManageLanguage.propTypes = {
     user: PropTypes.object.isRequired,
+    locale: PropTypes.string.isRequired,
     updateSection: PropTypes.func.isRequired
 };

--- a/webapp/components/user_settings/user_settings_display.jsx
+++ b/webapp/components/user_settings/user_settings_display.jsx
@@ -555,14 +555,15 @@ export default class UserSettingsDisplay extends React.Component {
             );
         }
 
-        const userLocale = this.props.user.locale;
+        let userLocale = this.props.user.locale;
         if (this.props.activeSection === 'languages') {
             if (!I18n.isLanguageAvailable(userLocale)) {
-                this.props.user.locale = global.window.mm_config.DefaultClientLocale;
+                userLocale = global.window.mm_config.DefaultClientLocale;
             }
             languagesSection = (
                 <ManageLanguages
                     user={this.props.user}
+                    locale={userLocale}
                     updateSection={(e) => {
                         this.updateSection('');
                         e.preventDefault();


### PR DESCRIPTION
#### Summary
Removed props mutation that was causing JS error, now passing locale as a prop directly instead of fetching it out of the user object

**Testing Steps**
* Create a second account for testing using an invite link, open this account in an incognito window
* In the primary browser window, use System Console > General > Localization to set the only two available languages on the server to English and French
* In the incognito window, use Account Settings > Display > Language to set the language for the account to French
* Confirm that all on-screen text changes to French
* In the primary browser window, use System Console > General > Localization to remove French as a language option, leaving English as the only available option
* Back in the incognito window, open Account Settings > Display > Language and notice that no Javascript error occurs. The user should be able to switch back to English with no issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7301

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
