### PR TITLE
Create App type to carry our state and eliminate global Srv references

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -67,7 +67,7 @@ func getClusterStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getAllAudits(c *Context, w http.ResponseWriter, r *http.Request) {
-	if audits, err := app.GetAudits("", 200); err != nil {
+	if audits, err := c.App.GetAudits("", 200); err != nil {
 		c.Err = err
 		return
 	} else if HandleEtag(audits.Etag(), "Get All Audits", w, r) {
@@ -96,7 +96,7 @@ func reloadConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func invalidateAllCaches(c *Context, w http.ResponseWriter, r *http.Request) {
-	err := app.InvalidateAllCaches()
+	err := c.App.InvalidateAllCaches()
 	if err != nil {
 		c.Err = err
 		return
@@ -124,7 +124,7 @@ func saveConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func recycleDatabaseConnection(c *Context, w http.ResponseWriter, r *http.Request) {
-	app.RecycleDatabaseConnection()
+	c.App.RecycleDatabaseConnection()
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	ReturnStatusOK(w)
 }
@@ -136,7 +136,7 @@ func testEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := app.TestEmail(c.Session.UserId, cfg)
+	err := c.App.TestEmail(c.Session.UserId, cfg)
 	if err != nil {
 		c.Err = err
 		return
@@ -148,7 +148,7 @@ func testEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getComplianceReports(c *Context, w http.ResponseWriter, r *http.Request) {
-	crs, err := app.GetComplianceReports(0, 10000)
+	crs, err := c.App.GetComplianceReports(0, 10000)
 	if err != nil {
 		c.Err = err
 		return
@@ -165,7 +165,7 @@ func saveComplianceReport(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	job.UserId = c.Session.UserId
 
-	rjob, err := app.SaveComplianceReport(job)
+	rjob, err := c.App.SaveComplianceReport(job)
 	if err != nil {
 		c.Err = err
 		return
@@ -184,7 +184,7 @@ func downloadComplianceReport(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	job, err := app.GetComplianceReport(id)
+	job, err := c.App.GetComplianceReport(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -221,7 +221,7 @@ func getAnalytics(c *Context, w http.ResponseWriter, r *http.Request) {
 	teamId := params["id"]
 	name := params["name"]
 
-	rows, err := app.GetAnalytics(name, teamId)
+	rows, err := c.App.GetAnalytics(name, teamId)
 	if err != nil {
 		c.Err = err
 		return
@@ -316,7 +316,7 @@ func adminResetPassword(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.UpdatePasswordByUserIdSendEmail(userId, newPassword, c.T("api.user.reset_password.method")); err != nil {
+	if err := c.App.UpdatePasswordByUserIdSendEmail(userId, newPassword, c.T("api.user.reset_password.method")); err != nil {
 		c.Err = err
 		return
 	}
@@ -412,7 +412,7 @@ func samlCertificateStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getRecentlyActiveUsers(c *Context, w http.ResponseWriter, r *http.Request) {
-	if profiles, err := app.GetRecentlyActiveUsersForTeam(c.TeamId); err != nil {
+	if profiles, err := c.App.GetRecentlyActiveUsersForTeam(c.TeamId); err != nil {
 		c.Err = err
 		return
 	} else {

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
 	"github.com/mattermost/platform/utils"
@@ -597,7 +596,7 @@ func TestAdminResetPassword(t *testing.T) {
 	user := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	if _, err := Client.AdminResetPassword("", "newpwd1"); err == nil {
 		t.Fatal("Should have errored - empty user id")
@@ -619,7 +618,7 @@ func TestAdminResetPassword(t *testing.T) {
 	user2 := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", AuthData: &authData, AuthService: "random"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	LinkUserToTeam(user2, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user2.Id))
 
 	if _, err := Client.AdminResetPassword(user.Id, "newpwd1"); err != nil {
 		t.Fatal(err)

--- a/api/api.go
+++ b/api/api.go
@@ -60,14 +60,14 @@ type Routes struct {
 var BaseRoutes *Routes
 
 func InitRouter() {
-	app.Srv.Router = mux.NewRouter()
-	app.Srv.Router.NotFoundHandler = http.HandlerFunc(Handle404)
+	app.Global().Srv.Router = mux.NewRouter()
+	app.Global().Srv.Router.NotFoundHandler = http.HandlerFunc(Handle404)
 }
 
 func InitApi() {
 	BaseRoutes = &Routes{}
-	BaseRoutes.Root = app.Srv.Router
-	BaseRoutes.ApiRoot = app.Srv.Router.PathPrefix(model.API_URL_SUFFIX_V3).Subrouter()
+	BaseRoutes.Root = app.Global().Srv.Router
+	BaseRoutes.ApiRoot = app.Global().Srv.Router.PathPrefix(model.API_URL_SUFFIX_V3).Subrouter()
 	BaseRoutes.Users = BaseRoutes.ApiRoot.PathPrefix("/users").Subrouter()
 	BaseRoutes.NeedUser = BaseRoutes.Users.PathPrefix("/{user_id:[A-Za-z0-9]+}").Subrouter()
 	BaseRoutes.Teams = BaseRoutes.ApiRoot.PathPrefix("/teams").Subrouter()
@@ -111,7 +111,7 @@ func InitApi() {
 	InitDeprecated()
 
 	// 404 on any api route before web.go has a chance to serve it
-	app.Srv.Router.Handle("/api/{anything:.*}", http.HandlerFunc(Handle404))
+	app.Global().Srv.Router.Handle("/api/{anything:.*}", http.HandlerFunc(Handle404))
 
 	utils.InitHTML()
 

--- a/api/channel.go
+++ b/api/channel.go
@@ -69,7 +69,7 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if sc, err := app.CreateChannelWithUser(channel, c.Session.UserId); err != nil {
+	if sc, err := c.App.CreateChannelWithUser(channel, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -92,7 +92,7 @@ func createDirectChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if sc, err := app.CreateDirectChannel(c.Session.UserId, userId); err != nil {
+	if sc, err := c.App.CreateDirectChannel(c.Session.UserId, userId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -124,7 +124,7 @@ func createGroupChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		userIds = append(userIds, c.Session.UserId)
 	}
 
-	if sc, err := app.CreateGroupChannel(userIds, c.Session.UserId); err != nil {
+	if sc, err := c.App.CreateGroupChannel(userIds, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -133,12 +133,12 @@ func createGroupChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func CanManageChannel(c *Context, channel *model.Channel) bool {
-	if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES)
 		return false
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_PRIVATE && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES)
 		return false
 	}
@@ -157,12 +157,12 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var oldChannel *model.Channel
 	var err *model.AppError
-	if oldChannel, err = app.GetChannel(channel.Id); err != nil {
+	if oldChannel, err = c.App.GetChannel(channel.Id); err != nil {
 		c.Err = err
 		return
 	}
 
-	if _, err = app.GetChannelMember(channel.Id, c.Session.UserId); err != nil {
+	if _, err = c.App.GetChannelMember(channel.Id, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	}
@@ -200,12 +200,12 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		oldChannel.Type = channel.Type
 	}
 
-	if _, err := app.UpdateChannel(oldChannel); err != nil {
+	if _, err := c.App.UpdateChannel(oldChannel); err != nil {
 		c.Err = err
 		return
 	} else {
 		if oldChannelDisplayName != channel.DisplayName {
-			if err := app.PostUpdateChannelDisplayNameMessage(c.Session.UserId, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
+			if err := c.App.PostUpdateChannelDisplayNameMessage(c.Session.UserId, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
 				l4g.Error(err.Error())
 			}
 		}
@@ -232,12 +232,12 @@ func updateChannelHeader(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(channelId); err != nil {
+	if channel, err = c.App.GetChannel(channelId); err != nil {
 		c.Err = err
 		return
 	}
 
-	if _, err = app.GetChannelMember(channelId, c.Session.UserId); err != nil {
+	if _, err = c.App.GetChannelMember(channelId, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	}
@@ -249,11 +249,11 @@ func updateChannelHeader(c *Context, w http.ResponseWriter, r *http.Request) {
 	oldChannelHeader := channel.Header
 	channel.Header = channelHeader
 
-	if _, err := app.UpdateChannel(channel); err != nil {
+	if _, err := c.App.UpdateChannel(channel); err != nil {
 		c.Err = err
 		return
 	} else {
-		if err := app.PostUpdateChannelHeaderMessage(c.Session.UserId, channel, oldChannelHeader, channelHeader); err != nil {
+		if err := c.App.PostUpdateChannelHeaderMessage(c.Session.UserId, channel, oldChannelHeader, channelHeader); err != nil {
 			l4g.Error(err.Error())
 		}
 		c.LogAudit("name=" + channel.Name)
@@ -278,12 +278,12 @@ func updateChannelPurpose(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(channelId); err != nil {
+	if channel, err = c.App.GetChannel(channelId); err != nil {
 		c.Err = err
 		return
 	}
 
-	if _, err = app.GetChannelMember(channelId, c.Session.UserId); err != nil {
+	if _, err = c.App.GetChannelMember(channelId, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	}
@@ -295,11 +295,11 @@ func updateChannelPurpose(c *Context, w http.ResponseWriter, r *http.Request) {
 	oldChannelPurpose := channel.Purpose
 	channel.Purpose = channelPurpose
 
-	if _, err := app.UpdateChannel(channel); err != nil {
+	if _, err := c.App.UpdateChannel(channel); err != nil {
 		c.Err = err
 		return
 	} else {
-		if err := app.PostUpdateChannelPurposeMessage(c.Session.UserId, channel, oldChannelPurpose, channelPurpose); err != nil {
+		if err := c.App.PostUpdateChannelPurposeMessage(c.Session.UserId, channel, oldChannelPurpose, channelPurpose); err != nil {
 			l4g.Error(err.Error())
 		}
 		c.LogAudit("name=" + channel.Name)
@@ -315,10 +315,10 @@ func getChannels(c *Context, w http.ResponseWriter, r *http.Request) {
 	// user is already in the team
 	// Get's all channels the user is a member of
 
-	if channels, err := app.GetChannelsForUser(c.TeamId, c.Session.UserId); err != nil {
+	if channels, err := c.App.GetChannelsForUser(c.TeamId, c.Session.UserId); err != nil {
 		if err.Id == "store.sql_channel.get_channels.not_found.app_error" {
 			// lets make sure the user is valid
-			if _, err := app.GetUser(c.Session.UserId); err != nil {
+			if _, err := c.App.GetUser(c.Session.UserId); err != nil {
 				c.Err = err
 				c.RemoveSessionCookie(w, r)
 				l4g.Error(utils.T("api.channel.get_channels.error"), c.Session.UserId)
@@ -356,7 +356,7 @@ func getMoreChannelsPage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if channels, err := app.GetChannelsUserNotIn(c.TeamId, c.Session.UserId, offset, limit); err != nil {
+	if channels, err := c.App.GetChannelsUserNotIn(c.TeamId, c.Session.UserId, offset, limit); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -369,7 +369,7 @@ func getChannelCounts(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// user is already in the team
 
-	if counts, err := app.GetChannelCounts(c.TeamId, c.Session.UserId); err != nil {
+	if counts, err := c.App.GetChannelCounts(c.TeamId, c.Session.UserId); err != nil {
 		c.Err = model.NewAppError("getChannelCounts", "api.channel.get_channel_counts.app_error", nil, err.Message, http.StatusInternalServerError)
 		return
 	} else if HandleEtag(counts.Etag(), "Get Channel Counts", w, r) {
@@ -389,9 +389,9 @@ func join(c *Context, w http.ResponseWriter, r *http.Request) {
 	var channel *model.Channel
 	var err *model.AppError
 	if channelId != "" {
-		channel, err = app.GetChannel(channelId)
+		channel, err = c.App.GetChannel(channelId)
 	} else if channelName != "" {
-		channel, err = app.GetChannelByName(channelName, c.TeamId)
+		channel, err = c.App.GetChannelByName(channelName, c.TeamId)
 	} else {
 		c.SetInvalidParam("join", "channel_id, channel_name")
 		return
@@ -409,7 +409,7 @@ func join(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err = app.JoinChannel(channel, c.Session.UserId); err != nil {
+	if err = c.App.JoinChannel(channel, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	}
@@ -422,7 +422,7 @@ func leave(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	id := params["channel_id"]
 
-	err := app.LeaveChannel(id, c.Session.UserId)
+	err := c.App.LeaveChannel(id, c.Session.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -440,22 +440,22 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(id); err != nil {
+	if channel, err = c.App.GetChannel(id); err != nil {
 		c.Err = err
 		return
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
+	if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_DELETE_PUBLIC_CHANNEL)
 		return
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
+	if channel.Type == model.CHANNEL_PRIVATE && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_DELETE_PRIVATE_CHANNEL)
 		return
 	}
 
-	err = app.DeleteChannel(channel, c.Session.UserId)
+	err = c.App.DeleteChannel(channel, c.Session.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -474,7 +474,7 @@ func getChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(id); err != nil {
+	if channel, err = c.App.GetChannel(id); err != nil {
 		c.Err = err
 		return
 	}
@@ -485,7 +485,7 @@ func getChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	var member *model.ChannelMember
-	if member, err = app.GetChannelMember(id, c.Session.UserId); err != nil {
+	if member, err = c.App.GetChannelMember(id, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	}
@@ -506,11 +506,11 @@ func getChannelByName(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	channelName := params["channel_name"]
 
-	if channel, err := app.GetChannelByName(channelName, c.TeamId); err != nil {
+	if channel, err := c.App.GetChannelByName(channelName, c.TeamId); err != nil {
 		c.Err = err
 		return
 	} else {
-		if !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
+		if !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
 			c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 			return
 		}
@@ -535,7 +535,7 @@ func getChannelStats(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(id); err != nil {
+	if channel, err = c.App.GetChannel(id); err != nil {
 		c.Err = err
 		return
 	}
@@ -545,12 +545,12 @@ func getChannelStats(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if memberCount, err := app.GetChannelMemberCount(id); err != nil {
+	if memberCount, err := c.App.GetChannelMemberCount(id); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -564,12 +564,12 @@ func getChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	channelId := params["channel_id"]
 	userId := params["user_id"]
 
-	if !app.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if member, err := app.GetChannelMember(channelId, userId); err != nil {
+	if member, err := c.App.GetChannelMember(channelId, userId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -578,7 +578,7 @@ func getChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getMyChannelMembers(c *Context, w http.ResponseWriter, r *http.Request) {
-	if members, err := app.GetChannelMembersForUser(c.TeamId, c.Session.UserId); err != nil {
+	if members, err := c.App.GetChannelMembersForUser(c.TeamId, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -590,7 +590,7 @@ func getPinnedPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	channelId := params["channel_id"]
 
-	if result := <-app.Srv.Store.Channel().GetPinnedPosts(channelId); result.Err != nil {
+	if result := <-c.App.Srv.Store.Channel().GetPinnedPosts(channelId); result.Err != nil {
 		c.Err = result.Err
 		return
 	} else {
@@ -614,28 +614,28 @@ func addMember(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(id); err != nil {
+	if channel, err = c.App.GetChannel(id); err != nil {
 		c.Err = err
 		return
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
+	if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS)
 		return
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
+	if channel.Type == model.CHANNEL_PRIVATE && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS)
 		return
 	}
 
 	var nUser *model.User
-	if nUser, err = app.GetUser(userId); err != nil {
+	if nUser, err = c.App.GetUser(userId); err != nil {
 		c.Err = model.NewAppError("addMember", "api.channel.add_member.find_user.app_error", nil, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	cm, err := app.AddUserToChannel(nUser, channel)
+	cm, err := c.App.AddUserToChannel(nUser, channel)
 	if err != nil {
 		c.Err = err
 		return
@@ -644,14 +644,14 @@ func addMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.LogAudit("name=" + channel.Name + " user_id=" + userId)
 
 	var oUser *model.User
-	if oUser, err = app.GetUser(c.Session.UserId); err != nil {
+	if oUser, err = c.App.GetUser(c.Session.UserId); err != nil {
 		c.Err = model.NewAppError("addMember", "api.channel.add_member.user_adding.app_error", nil, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	go app.PostAddToChannelMessage(oUser, nUser, channel)
+	go c.App.PostAddToChannelMessage(oUser, nUser, channel)
 
-	app.UpdateChannelLastViewedAt([]string{id}, oUser.Id)
+	c.App.UpdateChannelLastViewedAt([]string{id}, oUser.Id)
 	w.Write([]byte(cm.ToJson()))
 }
 
@@ -669,22 +669,22 @@ func removeMember(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(channelId); err != nil {
+	if channel, err = c.App.GetChannel(channelId); err != nil {
 		c.Err = err
 		return
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
+	if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS)
 		return
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
+	if channel.Type == model.CHANNEL_PRIVATE && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS)
 		return
 	}
 
-	if err = app.RemoveUserFromChannel(userIdToRemove, c.Session.UserId, channel); err != nil {
+	if err = c.App.RemoveUserFromChannel(userIdToRemove, c.Session.UserId, channel); err != nil {
 		c.Err = err
 		return
 	}
@@ -717,7 +717,7 @@ func updateNotifyProps(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	member, err := app.UpdateChannelMemberNotifyProps(data, channelId, userId)
+	member, err := c.App.UpdateChannelMemberNotifyProps(data, channelId, userId)
 	if err != nil {
 		c.Err = err
 		return
@@ -745,7 +745,7 @@ func searchMoreChannels(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if channels, err := app.SearchChannelsUserNotIn(c.TeamId, c.Session.UserId, props.Term); err != nil {
+	if channels, err := c.App.SearchChannelsUserNotIn(c.TeamId, c.Session.UserId, props.Term); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -763,7 +763,7 @@ func autocompleteChannels(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if channels, err := app.SearchChannels(c.TeamId, term); err != nil {
+	if channels, err := c.App.SearchChannels(c.TeamId, term); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -779,7 +779,7 @@ func viewChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.ViewChannel(view, c.Session.UserId, !c.Session.IsMobileApp()); err != nil {
+	if err := c.App.ViewChannel(view, c.Session.UserId, !c.Session.IsMobileApp()); err != nil {
 		c.Err = err
 		return
 	}
@@ -797,12 +797,12 @@ func getChannelMembersByIds(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if members, err := app.GetChannelMembersByIds(channelId, userIds); err != nil {
+	if members, err := c.App.GetChannelMembersByIds(channelId, userIds); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -822,7 +822,7 @@ func updateChannelMemberRoles(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_MANAGE_CHANNEL_ROLES) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_MANAGE_CHANNEL_ROLES) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_CHANNEL_ROLES)
 		return
 	}
@@ -833,7 +833,7 @@ func updateChannelMemberRoles(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if _, err := app.UpdateChannelMemberRoles(channelId, userId, newRoles); err != nil {
+	if _, err := c.App.UpdateChannelMemberRoles(channelId, userId, newRoles); err != nil {
 		c.Err = err
 		return
 	}

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
 	"github.com/mattermost/platform/utils"
@@ -404,7 +403,7 @@ func TestUpdateChannel(t *testing.T) {
 	}
 
 	UpdateUserToTeamAdmin(th.BasicUser, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	if _, err := Client.UpdateChannel(channel2); err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +411,7 @@ func TestUpdateChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 	UpdateUserToNonTeamAdmin(th.BasicUser, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 
 	MakeUserChannelAdmin(th.BasicUser, channel2)
 	MakeUserChannelAdmin(th.BasicUser, channel3)
@@ -1188,7 +1187,7 @@ func TestJoinChannelByNameDisabledUser(t *testing.T) {
 
 	Client.Must(th.BasicClient.RemoveUserFromTeam(th.BasicTeam.Id, th.BasicUser.Id))
 
-	if _, err := app.AddUserToChannel(th.BasicUser, channel1); err == nil {
+	if _, err := th.App.AddUserToChannel(th.BasicUser, channel1); err == nil {
 		t.Fatal("shoudn't be able to join channel")
 	} else {
 		if err.Id != "api.channel.add_user.to.channel.failed.deleted.app_error" {
@@ -1406,7 +1405,7 @@ func TestDeleteChannel(t *testing.T) {
 	UpdateUserToTeamAdmin(th.BasicUser, team)
 
 	Client.Login(th.BasicUser.Email, th.BasicUser.Password)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 
 	if _, err := Client.DeleteChannel(channel2.Id); err != nil {
 		t.Fatal(err)
@@ -1416,7 +1415,7 @@ func TestDeleteChannel(t *testing.T) {
 	}
 
 	UpdateUserToNonTeamAdmin(th.BasicUser, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
@@ -1634,7 +1633,7 @@ func TestAddChannelMember(t *testing.T) {
 	}
 
 	MakeUserChannelAdmin(user1, channel5)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -1659,7 +1658,7 @@ func TestAddChannelMember(t *testing.T) {
 	}
 
 	UpdateUserToTeamAdmin(user1, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -1810,7 +1809,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	}
 
 	MakeUserChannelAdmin(user1, channel5)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -1835,7 +1834,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	}
 
 	UpdateUserToTeamAdmin(user1, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -2255,7 +2254,7 @@ func TestGetChannelByName(t *testing.T) {
 
 	user2 := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Jabba the Hutt", Password: "passwd1"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
-	store.Must(app.Srv.Store.User().VerifyEmail(user2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user2.Id))
 
 	Client.SetTeamId(th.BasicTeam.Id)
 
@@ -2314,7 +2313,7 @@ func TestViewChannel(t *testing.T) {
 func TestGetChannelMembersByIds(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if _, err := app.AddUserToChannel(th.BasicUser2, th.BasicChannel); err != nil {
+	if _, err := th.App.AddUserToChannel(th.BasicUser2, th.BasicChannel); err != nil {
 		t.Fatal("Could not add second user to channel")
 	}
 

--- a/api/cli_test.go
+++ b/api/cli_test.go
@@ -107,7 +107,7 @@ func TestCliCreateUserWithoutTeam(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if result := <-app.Srv.Store.User().GetByEmail(email); result.Err != nil {
+	if result := <-app.Global().Srv.Store.User().GetByEmail(email); result.Err != nil {
 		t.Fatal()
 	} else {
 		user := result.Data.(*model.User)
@@ -131,7 +131,7 @@ func TestCliAssignRole(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if result := <-app.Srv.Store.User().GetByEmail(th.BasicUser.Email); result.Err != nil {
+	if result := <-th.App.Srv.Store.User().GetByEmail(th.BasicUser.Email); result.Err != nil {
 		t.Fatal()
 	} else {
 		user := result.Data.(*model.User)
@@ -369,7 +369,7 @@ func TestCliLeaveTeam(t *testing.T) {
 		t.Fatal("profile should not be on team")
 	}
 
-	if result := <-app.Srv.Store.Team().GetTeamsByUserId(th.BasicUser.Id); result.Err != nil {
+	if result := <-th.App.Srv.Store.Team().GetTeamsByUserId(th.BasicUser.Id); result.Err != nil {
 		teamMembers := result.Data.([]*model.TeamMember)
 		if len(teamMembers) > 0 {
 			t.Fatal("Shouldn't be in team")

--- a/api/command.go
+++ b/api/command.go
@@ -34,7 +34,7 @@ func InitCommand() {
 }
 
 func listCommands(c *Context, w http.ResponseWriter, r *http.Request) {
-	commands, err := app.ListAutocompleteCommands(c.TeamId, c.T)
+	commands, err := c.App.ListAutocompleteCommands(c.TeamId, c.T)
 	if err != nil {
 		c.Err = err
 		return
@@ -56,7 +56,7 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(commandArgs.ChannelId) > 0 {
-		if !app.SessionHasPermissionToChannel(c.Session, commandArgs.ChannelId, model.PERMISSION_USE_SLASH_COMMANDS) {
+		if !c.App.SessionHasPermissionToChannel(c.Session, commandArgs.ChannelId, model.PERMISSION_USE_SLASH_COMMANDS) {
 			c.SetPermissionError(model.PERMISSION_USE_SLASH_COMMANDS)
 			return
 		}
@@ -68,7 +68,7 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	commandArgs.Session = c.Session
 	commandArgs.SiteURL = c.GetSiteURLHeader()
 
-	response, err := app.ExecuteCommand(commandArgs)
+	response, err := c.App.ExecuteCommand(commandArgs)
 	if err != nil {
 		c.Err = err
 		return
@@ -95,7 +95,7 @@ func createCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	cmd.CreatorId = c.Session.UserId
 	cmd.TeamId = c.TeamId
 
-	rcmd, err := app.CreateCommand(cmd)
+	rcmd, err := c.App.CreateCommand(cmd)
 	if err != nil {
 		c.Err = err
 		return
@@ -115,7 +115,7 @@ func updateCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("attempt")
 
-	oldCmd, err := app.GetCommand(cmd.Id)
+	oldCmd, err := c.App.GetCommand(cmd.Id)
 	if err != nil {
 		c.Err = err
 		return
@@ -138,7 +138,7 @@ func updateCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rcmd, err := app.UpdateCommand(oldCmd, cmd)
+	rcmd, err := c.App.UpdateCommand(oldCmd, cmd)
 	if err != nil {
 		c.Err = err
 		return
@@ -155,7 +155,7 @@ func listTeamCommands(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cmds, err := app.ListTeamCommands(c.TeamId)
+	cmds, err := c.App.ListTeamCommands(c.TeamId)
 	if err != nil {
 		c.Err = err
 		return
@@ -175,7 +175,7 @@ func regenCommandToken(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("attempt")
 
-	cmd, err := app.GetCommand(id)
+	cmd, err := c.App.GetCommand(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -198,7 +198,7 @@ func regenCommandToken(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rcmd, err := app.RegenCommandToken(cmd)
+	rcmd, err := c.App.RegenCommandToken(cmd)
 	if err != nil {
 		c.Err = err
 		return
@@ -218,7 +218,7 @@ func deleteCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("attempt")
 
-	cmd, err := app.GetCommand(id)
+	cmd, err := c.App.GetCommand(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -241,7 +241,7 @@ func deleteCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = app.DeleteCommand(cmd.Id)
+	err = c.App.DeleteCommand(cmd.Id)
 	if err != nil {
 		c.Err = err
 		return

--- a/api/command_help_test.go
+++ b/api/command_help_test.go
@@ -4,9 +4,10 @@
 package api
 
 import (
+	"testing"
+
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"testing"
 )
 
 func TestHelpCommand(t *testing.T) {

--- a/api/command_msg_test.go
+++ b/api/command_msg_test.go
@@ -4,9 +4,10 @@
 package api
 
 import (
-	"github.com/mattermost/platform/model"
 	"strings"
 	"testing"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestMsgCommands(t *testing.T) {

--- a/api/emoji.go
+++ b/api/emoji.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"strings"
 
+	"image/color/palette"
+
 	l4g "github.com/alecthomas/log4go"
 	"github.com/disintegration/imaging"
 	"github.com/gorilla/mux"
@@ -17,7 +19,6 @@ import (
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"image/color/palette"
 )
 
 func InitEmoji() {
@@ -35,7 +36,7 @@ func getEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	listEmoji, err := app.GetEmojiList(0, 100000)
+	listEmoji, err := c.App.GetEmojiList(0, 100000)
 	if err != nil {
 		c.Err = err
 		return
@@ -97,7 +98,7 @@ func createEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if result := <-app.Srv.Store.Emoji().GetByName(emoji.Name); result.Err == nil && result.Data != nil {
+	if result := <-c.App.Srv.Store.Emoji().GetByName(emoji.Name); result.Err == nil && result.Data != nil {
 		c.Err = model.NewAppError("createEmoji", "api.emoji.create.duplicate.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
@@ -110,7 +111,7 @@ func createEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if result := <-app.Srv.Store.Emoji().Save(emoji); result.Err != nil {
+	if result := <-c.App.Srv.Store.Emoji().Save(emoji); result.Err != nil {
 		c.Err = result.Err
 		return
 	} else {
@@ -141,7 +142,7 @@ func deleteEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	emoji, err := app.GetEmoji(id)
+	emoji, err := c.App.GetEmoji(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -152,7 +153,7 @@ func deleteEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = app.DeleteEmoji(emoji)
+	err = c.App.DeleteEmoji(emoji)
 	if err != nil {
 		c.Err = err
 		return
@@ -180,7 +181,7 @@ func getEmojiImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	image, imageType, err := app.GetEmojiImage(id)
+	image, imageType, err := c.App.GetEmojiImage(id)
 	if err != nil {
 		c.Err = err
 		return

--- a/api/emoji_test.go
+++ b/api/emoji_test.go
@@ -42,11 +42,11 @@ func TestGetEmoji(t *testing.T) {
 	}
 
 	for i, emoji := range emojis {
-		emojis[i] = store.Must(app.Srv.Store.Emoji().Save(emoji)).(*model.Emoji)
+		emojis[i] = store.Must(th.App.Srv.Store.Emoji().Save(emoji)).(*model.Emoji)
 	}
 	defer func() {
 		for _, emoji := range emojis {
-			store.Must(app.Srv.Store.Emoji().Delete(emoji.Id, time.Now().Unix()))
+			store.Must(th.App.Srv.Store.Emoji().Delete(emoji.Id, time.Now().Unix()))
 		}
 	}()
 
@@ -74,7 +74,7 @@ func TestGetEmoji(t *testing.T) {
 		Name:      model.NewId(),
 		DeleteAt:  1,
 	}
-	deleted = store.Must(app.Srv.Store.Emoji().Save(deleted)).(*model.Emoji)
+	deleted = store.Must(th.App.Srv.Store.Emoji().Save(deleted)).(*model.Emoji)
 
 	if returnedEmojis, err := Client.ListEmoji(); err != nil {
 		t.Fatal(err)
@@ -264,10 +264,10 @@ func TestDeleteEmoji(t *testing.T) {
 }
 
 func createTestEmoji(t *testing.T, emoji *model.Emoji, imageData []byte) *model.Emoji {
-	emoji = store.Must(app.Srv.Store.Emoji().Save(emoji)).(*model.Emoji)
+	emoji = store.Must(app.Global().Srv.Store.Emoji().Save(emoji)).(*model.Emoji)
 
 	if err := utils.WriteFile(imageData, "emoji/"+emoji.Id+"/image"); err != nil {
-		store.Must(app.Srv.Store.Emoji().Delete(emoji.Id, time.Now().Unix()))
+		store.Must(app.Global().Srv.Store.Emoji().Delete(emoji.Id, time.Now().Unix()))
 		t.Fatalf("failed to write image: %v", err.Error())
 	}
 

--- a/api/file.go
+++ b/api/file.go
@@ -74,12 +74,12 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_UPLOAD_FILE) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_UPLOAD_FILE) {
 		c.SetPermissionError(model.PERMISSION_UPLOAD_FILE)
 		return
 	}
 
-	resStruct, err := app.UploadFiles(c.TeamId, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"])
+	resStruct, err := c.App.UploadFiles(c.TeamId, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"])
 	if err != nil {
 		c.Err = err
 		return
@@ -205,7 +205,7 @@ func getFileInfoForRequest(c *Context, r *http.Request, requireFileVisible bool)
 		return nil, NewInvalidParamError("getFileInfoForRequest", "file_id")
 	}
 
-	info, err := app.GetFileInfo(fileId)
+	info, err := c.App.GetFileInfo(fileId)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func getFileInfoForRequest(c *Context, r *http.Request, requireFileVisible bool)
 		}
 
 		if requireFileVisible {
-			if !app.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
+			if !c.App.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
 				c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 				return nil, c.Err
 			}
@@ -261,7 +261,7 @@ func getPublicFileOld(c *Context, w http.ResponseWriter, r *http.Request) {
 	path := "teams/" + teamId + "/channels/" + channelId + "/users/" + userId + "/" + filename
 
 	var info *model.FileInfo
-	if result := <-app.Srv.Store.FileInfo().GetByPath(path); result.Err != nil {
+	if result := <-c.App.Srv.Store.FileInfo().GetByPath(path); result.Err != nil {
 		c.Err = result.Err
 		return
 	} else {

--- a/api/file_test.go
+++ b/api/file_test.go
@@ -61,7 +61,7 @@ func TestUploadFile(t *testing.T) {
 	}
 
 	var info *model.FileInfo
-	if result := <-app.Srv.Store.FileInfo().Get(uploadInfo.Id); result.Err != nil {
+	if result := <-th.App.Srv.Store.FileInfo().Get(uploadInfo.Id); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		info = result.Data.(*model.FileInfo)
@@ -170,7 +170,7 @@ func TestGetFileInfo(t *testing.T) {
 	}
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
 
 	// Other user shouldn't be able to get file info for this file if they're not in the channel for it
 	if _, err := Client.GetFileInfo(fileId); err == nil {
@@ -186,7 +186,7 @@ func TestGetFileInfo(t *testing.T) {
 		t.Fatal("other user got incorrect file")
 	}
 
-	if err := cleanupTestFile(store.Must(app.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
+	if err := cleanupTestFile(store.Must(th.App.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -239,7 +239,7 @@ func TestGetFile(t *testing.T) {
 	}
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
 
 	// Other user shouldn't be able to get file for this file if they're not in the channel for it
 	if _, err := Client.GetFile(fileId); err == nil {
@@ -268,7 +268,7 @@ func TestGetFile(t *testing.T) {
 		body.Close()
 	}
 
-	if err := cleanupTestFile(store.Must(app.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
+	if err := cleanupTestFile(store.Must(th.App.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -308,7 +308,7 @@ func TestGetFileThumbnail(t *testing.T) {
 	}
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
 
 	// Other user shouldn't be able to get thumbnail for this file if they're not in the channel for it
 	if _, err := Client.GetFileThumbnail(fileId); err == nil {
@@ -324,7 +324,7 @@ func TestGetFileThumbnail(t *testing.T) {
 		body.Close()
 	}
 
-	if err := cleanupTestFile(store.Must(app.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
+	if err := cleanupTestFile(store.Must(th.App.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -364,7 +364,7 @@ func TestGetFilePreview(t *testing.T) {
 	}
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
 
 	// Other user shouldn't be able to get preview for this file if they're not in the channel for it
 	if _, err := Client.GetFilePreview(fileId); err == nil {
@@ -380,7 +380,7 @@ func TestGetFilePreview(t *testing.T) {
 		body.Close()
 	}
 
-	if err := cleanupTestFile(store.Must(app.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
+	if err := cleanupTestFile(store.Must(th.App.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -413,7 +413,7 @@ func TestGetPublicFile(t *testing.T) {
 	}
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
 
 	link := Client.MustGeneric(Client.GetPublicLink(fileId)).(string)
 
@@ -447,7 +447,7 @@ func TestGetPublicFile(t *testing.T) {
 		t.Fatal("should've failed to get image with public link after salt changed")
 	}
 
-	if err := cleanupTestFile(store.Must(app.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
+	if err := cleanupTestFile(store.Must(th.App.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -483,12 +483,12 @@ func TestGetPublicFileOld(t *testing.T) {
 			CreatorId: th.BasicUser.Id,
 			Path:      fmt.Sprintf("teams/%s/channels/%s/users/%s/%s/%s", th.BasicTeam.Id, channel.Id, th.BasicUser.Id, fileId, "test.png"),
 		}
-		store.Must(app.Srv.Store.FileInfo().Save(&fileInfo))
+		store.Must(th.App.Srv.Store.FileInfo().Save(&fileInfo))
 		uploadFileOld(t, data, fmt.Sprintf("data/teams/%s/channels/%s/users/%s/%s", th.BasicTeam.Id, channel.Id, th.BasicUser.Id, fileId), "test.png")
 	}
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
 
 	// reconstruct old style of link
 	siteURL := *utils.Cfg.ServiceSettings.SiteURL
@@ -526,7 +526,7 @@ func TestGetPublicFileOld(t *testing.T) {
 		t.Fatal("should've failed to get image with public link after salt changed")
 	}
 
-	if err := cleanupTestFile(store.Must(app.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
+	if err := cleanupTestFile(store.Must(th.App.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -565,7 +565,7 @@ func TestGetPublicLink(t *testing.T) {
 	}
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
 
 	utils.Cfg.FileSettings.EnablePublicLink = false
 
@@ -600,7 +600,7 @@ func TestGetPublicLink(t *testing.T) {
 	// Wait a bit for files to ready
 	time.Sleep(2 * time.Second)
 
-	if err := cleanupTestFile(store.Must(app.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
+	if err := cleanupTestFile(store.Must(th.App.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -635,7 +635,7 @@ func TestMigrateFilenamesToFileInfos(t *testing.T) {
 	}
 
 	// Bypass the Client whenever possible since we're trying to simulate a pre-3.5 post
-	post1 := store.Must(app.Srv.Store.Post().Save(&model.Post{
+	post1 := store.Must(th.App.Srv.Store.Post().Save(&model.Post{
 		UserId:    user1.Id,
 		ChannelId: channel1.Id,
 		Message:   "test",
@@ -757,20 +757,20 @@ func TestFindTeamIdForFilename(t *testing.T) {
 	}
 
 	// Bypass the Client whenever possible since we're trying to simulate a pre-3.5 post
-	post1 := store.Must(app.Srv.Store.Post().Save(&model.Post{
+	post1 := store.Must(th.App.Srv.Store.Post().Save(&model.Post{
 		UserId:    user1.Id,
 		ChannelId: channel1.Id,
 		Message:   "test",
 		Filenames: []string{fmt.Sprintf("/%s/%s/%s/%s", channel1.Id, user1.Id, fileId1, "test.png")},
 	})).(*model.Post)
 
-	if teamId := app.FindTeamIdForFilename(post1, post1.Filenames[0]); teamId != team1.Id {
+	if teamId := th.App.FindTeamIdForFilename(post1, post1.Filenames[0]); teamId != team1.Id {
 		t.Log(teamId)
 		t.Fatal("file should've been found under team1")
 	}
 
 	Client.SetTeamId(team2.Id)
-	post2 := store.Must(app.Srv.Store.Post().Save(&model.Post{
+	post2 := store.Must(th.App.Srv.Store.Post().Save(&model.Post{
 		UserId:    user1.Id,
 		ChannelId: channel2.Id,
 		Message:   "test",
@@ -778,7 +778,7 @@ func TestFindTeamIdForFilename(t *testing.T) {
 	})).(*model.Post)
 	Client.SetTeamId(team1.Id)
 
-	if teamId := app.FindTeamIdForFilename(post2, post2.Filenames[0]); teamId != team2.Id {
+	if teamId := th.App.FindTeamIdForFilename(post2, post2.Filenames[0]); teamId != team2.Id {
 		t.Fatal("file should've been found under team2")
 	}
 }
@@ -808,13 +808,13 @@ func TestGetInfoForFilename(t *testing.T) {
 	} else {
 		fileId1 = Client.MustGeneric(Client.UploadPostAttachment(data, channel1.Id, "test.png")).(*model.FileUploadResponse).FileInfos[0].Id
 		uploadFileOld(t, data, fmt.Sprintf("data/teams/%s/channels/%s/users/%s/%s", team1.Id, channel1.Id, user1.Id, fileId1), "test.png")
-		path = store.Must(app.Srv.Store.FileInfo().Get(fileId1)).(*model.FileInfo).Path
-		thumbnailPath = store.Must(app.Srv.Store.FileInfo().Get(fileId1)).(*model.FileInfo).ThumbnailPath
-		previewPath = store.Must(app.Srv.Store.FileInfo().Get(fileId1)).(*model.FileInfo).PreviewPath
+		path = store.Must(th.App.Srv.Store.FileInfo().Get(fileId1)).(*model.FileInfo).Path
+		thumbnailPath = store.Must(th.App.Srv.Store.FileInfo().Get(fileId1)).(*model.FileInfo).ThumbnailPath
+		previewPath = store.Must(th.App.Srv.Store.FileInfo().Get(fileId1)).(*model.FileInfo).PreviewPath
 	}
 
 	// Bypass the Client whenever possible since we're trying to simulate a pre-3.5 post
-	post1 := store.Must(app.Srv.Store.Post().Save(&model.Post{
+	post1 := store.Must(th.App.Srv.Store.Post().Save(&model.Post{
 		UserId:    user1.Id,
 		ChannelId: channel1.Id,
 		Message:   "test",

--- a/api/license.go
+++ b/api/license.go
@@ -55,7 +55,7 @@ func addLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 	buf := bytes.NewBuffer(nil)
 	io.Copy(buf, file)
 
-	if license, err := app.SaveLicense(buf.Bytes()); err != nil {
+	if license, err := c.App.SaveLicense(buf.Bytes()); err != nil {
 		if err.Id == model.EXPIRED_LICENSE_ERROR {
 			c.LogAudit("failed - expired or non-started license")
 		} else if err.Id == model.INVALID_LICENSE_ERROR {
@@ -74,7 +74,7 @@ func addLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 func removeLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.LogAudit("")
 
-	if err := app.RemoveLicense(); err != nil {
+	if err := c.App.RemoveLicense(); err != nil {
 		c.Err = err
 		return
 	}

--- a/api/license_test.go
+++ b/api/license_test.go
@@ -4,8 +4,9 @@
 package api
 
 import (
-	"github.com/mattermost/platform/utils"
 	"testing"
+
+	"github.com/mattermost/platform/utils"
 )
 
 func TestGetLicenceConfig(t *testing.T) {

--- a/api/oauth.go
+++ b/api/oauth.go
@@ -43,7 +43,7 @@ func registerOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	oauthApp.CreatorId = c.Session.UserId
 
-	rapp, err := app.CreateOAuthApp(oauthApp)
+	rapp, err := c.App.CreateOAuthApp(oauthApp)
 
 	if err != nil {
 		c.Err = err
@@ -63,9 +63,9 @@ func getOAuthApps(c *Context, w http.ResponseWriter, r *http.Request) {
 	var apps []*model.OAuthApp
 	var err *model.AppError
 	if app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM_WIDE_OAUTH) {
-		apps, err = app.GetOAuthApps(0, 100000)
+		apps, err = c.App.GetOAuthApps(0, 100000)
 	} else {
-		apps, err = app.GetOAuthAppsByCreator(c.Session.UserId, 0, 100000)
+		apps, err = c.App.GetOAuthAppsByCreator(c.Session.UserId, 0, 100000)
 	}
 
 	if err != nil {
@@ -80,7 +80,7 @@ func getOAuthAppInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	clientId := params["client_id"]
 
-	oauthApp, err := app.GetOAuthApp(clientId)
+	oauthApp, err := c.App.GetOAuthApp(clientId)
 
 	if err != nil {
 		c.Err = err
@@ -123,7 +123,7 @@ func allowOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		State:        state,
 	}
 
-	redirectUrl, err := app.AllowOAuthAppAccessToUser(c.Session.UserId, authRequest)
+	redirectUrl, err := c.App.AllowOAuthAppAccessToUser(c.Session.UserId, authRequest)
 
 	if err != nil {
 		c.Err = err
@@ -136,7 +136,7 @@ func allowOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getAuthorizedApps(c *Context, w http.ResponseWriter, r *http.Request) {
-	apps, err := app.GetAuthorizedAppsForUser(c.Session.UserId, 0, 10000)
+	apps, err := c.App.GetAuthorizedAppsForUser(c.Session.UserId, 0, 10000)
 	if err != nil {
 		c.Err = err
 		return
@@ -151,13 +151,13 @@ func loginWithOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	loginHint := r.URL.Query().Get("login_hint")
 	redirectTo := r.URL.Query().Get("redirect_to")
 
-	teamId, err := app.GetTeamIdFromQuery(r.URL.Query())
+	teamId, err := c.App.GetTeamIdFromQuery(r.URL.Query())
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	if authUrl, err := app.GetOAuthLoginEndpoint(w, r, service, teamId, model.OAUTH_ACTION_LOGIN, redirectTo, loginHint); err != nil {
+	if authUrl, err := c.App.GetOAuthLoginEndpoint(w, r, service, teamId, model.OAUTH_ACTION_LOGIN, redirectTo, loginHint); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -174,13 +174,13 @@ func signupWithOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	teamId, err := app.GetTeamIdFromQuery(r.URL.Query())
+	teamId, err := c.App.GetTeamIdFromQuery(r.URL.Query())
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	if authUrl, err := app.GetOAuthSignupEndpoint(w, r, service, teamId); err != nil {
+	if authUrl, err := c.App.GetOAuthSignupEndpoint(w, r, service, teamId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -204,7 +204,7 @@ func deleteOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	oauthApp, err := app.GetOAuthApp(id)
+	oauthApp, err := c.App.GetOAuthApp(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -216,7 +216,7 @@ func deleteOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = app.DeleteOAuthApp(id)
+	err = c.App.DeleteOAuthApp(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -230,7 +230,7 @@ func deauthorizeOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	id := params["id"]
 
-	err := app.DeauthorizeOAuthAppForUser(c.Session.UserId, id)
+	err := c.App.DeauthorizeOAuthAppForUser(c.Session.UserId, id)
 	if err != nil {
 		c.Err = err
 		return
@@ -244,7 +244,7 @@ func regenerateOAuthSecret(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	id := params["id"]
 
-	oauthApp, err := app.GetOAuthApp(id)
+	oauthApp, err := c.App.GetOAuthApp(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -255,7 +255,7 @@ func regenerateOAuthSecret(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	oauthApp, err = app.RegenerateOAuthAppSecret(oauthApp)
+	oauthApp, err = c.App.RegenerateOAuthAppSecret(oauthApp)
 	if err != nil {
 		c.Err = err
 		return

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
@@ -77,7 +76,7 @@ func TestOAuthRegisterApp(t *testing.T) {
 	user := &model.User{Email: strings.ToLower("test+"+model.NewId()) + "@simulator.amazonses.com", Password: "hello1", Username: "n" + model.NewId(), EmailVerified: true}
 
 	ruser := Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
-	app.UpdateUserRoles(ruser.Id, "")
+	th.App.UpdateUserRoles(ruser.Id, "")
 
 	Client.Logout()
 	Client.Login(user.Email, user.Password)
@@ -233,7 +232,7 @@ func TestOAuthGetAppsByUser(t *testing.T) {
 
 	user := &model.User{Email: strings.ToLower("test+"+model.NewId()) + "@simulator.amazonses.com", Password: "hello1", Username: "n" + model.NewId(), EmailVerified: true}
 	ruser := Client.Must(AdminClient.CreateUser(user, "")).Data.(*model.User)
-	app.UpdateUserRoles(ruser.Id, "")
+	th.App.UpdateUserRoles(ruser.Id, "")
 
 	Client.Logout()
 	Client.Login(user.Email, user.Password)
@@ -338,7 +337,7 @@ func TestOAuthDeauthorizeApp(t *testing.T) {
 	a1.RefreshToken = model.NewId()
 	a1.ExpiresAt = model.GetMillis()
 	a1.RedirectUri = "http://example.com"
-	<-app.Srv.Store.OAuth().SaveAccessData(&a1)
+	<-th.App.Srv.Store.OAuth().SaveAccessData(&a1)
 
 	if err := Client.OAuthDeauthorizeApp(oauthApp.Id); err != nil {
 		t.Fatal(err)
@@ -446,7 +445,7 @@ func TestOAuthDeleteApp(t *testing.T) {
 
 	user := &model.User{Email: strings.ToLower("test+"+model.NewId()) + "@simulator.amazonses.com", Password: "hello1", Username: "n" + model.NewId(), EmailVerified: true}
 	ruser := Client.Must(AdminClient.CreateUser(user, "")).Data.(*model.User)
-	app.UpdateUserRoles(ruser.Id, "")
+	th.App.UpdateUserRoles(ruser.Id, "")
 
 	Client.Logout()
 	Client.Login(user.Email, user.Password)
@@ -675,7 +674,7 @@ func TestOAuthAccessToken(t *testing.T) {
 	}
 
 	authData := &model.AuthData{ClientId: oauthApp.Id, RedirectUri: oauthApp.CallbackUrls[0], UserId: th.BasicUser.Id, Code: model.NewId(), ExpiresIn: -1}
-	<-app.Srv.Store.OAuth().SaveAuthData(authData)
+	<-th.App.Srv.Store.OAuth().SaveAuthData(authData)
 
 	data.Set("grant_type", model.ACCESS_TOKEN_GRANT_TYPE)
 	data.Set("client_id", oauthApp.Id)
@@ -688,7 +687,7 @@ func TestOAuthAccessToken(t *testing.T) {
 	}
 
 	authData = &model.AuthData{ClientId: oauthApp.Id, RedirectUri: oauthApp.CallbackUrls[0], UserId: th.BasicUser.Id, Code: model.NewId(), ExpiresIn: model.AUTHCODE_EXPIRE_TIME}
-	<-app.Srv.Store.OAuth().SaveAuthData(authData)
+	<-th.App.Srv.Store.OAuth().SaveAuthData(authData)
 
 	data.Set("code", authData.Code)
 	if _, err := Client.GetAccessToken(data); err == nil {
@@ -787,7 +786,7 @@ func TestOAuthComplete(t *testing.T) {
 		closeBody(r)
 	}
 
-	if result := <-app.Srv.Store.User().UpdateAuthData(
+	if result := <-th.App.Srv.Store.User().UpdateAuthData(
 		th.BasicUser.Id, model.SERVICE_GITLAB, &th.BasicUser.Email, th.BasicUser.Email, true); result.Err != nil {
 		t.Fatal(result.Err)
 	}

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -142,7 +142,7 @@ func TestCreatePost(t *testing.T) {
 	} else if rpost9 := resp.Data.(*model.Post); len(rpost9.FileIds) != 3 {
 		t.Fatal("post should have 3 files")
 	} else {
-		infos := store.Must(app.Srv.Store.FileInfo().GetForPost(rpost9.Id, true, true)).([]*model.FileInfo)
+		infos := store.Must(adm.App.Srv.Store.FileInfo().GetForPost(rpost9.Id, true, true)).([]*model.FileInfo)
 
 		if len(infos) != 3 {
 			t.Fatal("should've attached all 3 files to post")
@@ -164,7 +164,7 @@ func TestCreatePost(t *testing.T) {
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
 
-	defaultChannel := store.Must(app.Srv.Store.Channel().GetByName(team.Id, model.DEFAULT_CHANNEL, true)).(*model.Channel)
+	defaultChannel := store.Must(adm.App.Srv.Store.Channel().GetByName(team.Id, model.DEFAULT_CHANNEL, true)).(*model.Channel)
 	defaultPost := &model.Post{
 		ChannelId: defaultChannel.Id,
 		Message:   "Default Channel Post",
@@ -173,7 +173,7 @@ func TestCreatePost(t *testing.T) {
 		t.Fatal("should have failed -- ExperimentalTownSquareIsReadOnly is true and it's a read only channel")
 	}
 
-	adminDefaultChannel := store.Must(app.Srv.Store.Channel().GetByName(adminTeam.Id, model.DEFAULT_CHANNEL, true)).(*model.Channel)
+	adminDefaultChannel := store.Must(adm.App.Srv.Store.Channel().GetByName(adminTeam.Id, model.DEFAULT_CHANNEL, true)).(*model.Channel)
 	adminDefaultPost := &model.Post{
 		ChannelId: adminDefaultChannel.Id,
 		Message:   "Admin Default Channel Post",
@@ -1085,7 +1085,7 @@ func TestEmailMention(t *testing.T) {
 	data["comments"] = "any"
 	Client.Must(Client.UpdateUserNotify(data))
 
-	store.Must(app.Srv.Store.Preference().Save(&model.Preferences{{
+	store.Must(th.App.Srv.Store.Preference().Save(&model.Preferences{{
 		UserId:   th.BasicUser2.Id,
 		Category: model.PREFERENCE_CATEGORY_NOTIFICATIONS,
 		Name:     model.PREFERENCE_NAME_EMAIL_INTERVAL,
@@ -1189,28 +1189,28 @@ func TestGetFlaggedPosts(t *testing.T) {
 func TestGetMessageForNotification(t *testing.T) {
 	Setup().InitBasic()
 
-	testPng := store.Must(app.Srv.Store.FileInfo().Save(&model.FileInfo{
+	testPng := store.Must(app.Global().Srv.Store.FileInfo().Save(&model.FileInfo{
 		CreatorId: model.NewId(),
 		Path:      "test1.png",
 		Name:      "test1.png",
 		MimeType:  "image/png",
 	})).(*model.FileInfo)
 
-	testJpg1 := store.Must(app.Srv.Store.FileInfo().Save(&model.FileInfo{
+	testJpg1 := store.Must(app.Global().Srv.Store.FileInfo().Save(&model.FileInfo{
 		CreatorId: model.NewId(),
 		Path:      "test2.jpg",
 		Name:      "test2.jpg",
 		MimeType:  "image/jpeg",
 	})).(*model.FileInfo)
 
-	testFile := store.Must(app.Srv.Store.FileInfo().Save(&model.FileInfo{
+	testFile := store.Must(app.Global().Srv.Store.FileInfo().Save(&model.FileInfo{
 		CreatorId: model.NewId(),
 		Path:      "test1.go",
 		Name:      "test1.go",
 		MimeType:  "text/plain",
 	})).(*model.FileInfo)
 
-	testJpg2 := store.Must(app.Srv.Store.FileInfo().Save(&model.FileInfo{
+	testJpg2 := store.Must(app.Global().Srv.Store.FileInfo().Save(&model.FileInfo{
 		CreatorId: model.NewId(),
 		Path:      "test3.jpg",
 		Name:      "test3.jpg",
@@ -1224,39 +1224,39 @@ func TestGetMessageForNotification(t *testing.T) {
 		Message: "test",
 	}
 
-	if app.GetMessageForNotification(post, translateFunc) != "test" {
+	if app.Global().GetMessageForNotification(post, translateFunc) != "test" {
 		t.Fatal("should've returned message text")
 	}
 
 	post.FileIds = model.StringArray{testPng.Id}
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(testPng.Id, post.Id))
-	if app.GetMessageForNotification(post, translateFunc) != "test" {
+	store.Must(app.Global().Srv.Store.FileInfo().AttachToPost(testPng.Id, post.Id))
+	if app.Global().GetMessageForNotification(post, translateFunc) != "test" {
 		t.Fatal("should've returned message text, even with attachments")
 	}
 
 	post.Message = ""
-	if message := app.GetMessageForNotification(post, translateFunc); message != "1 image sent: test1.png" {
+	if message := app.Global().GetMessageForNotification(post, translateFunc); message != "1 image sent: test1.png" {
 		t.Fatal("should've returned number of images:", message)
 	}
 
 	post.FileIds = model.StringArray{testPng.Id, testJpg1.Id}
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(testJpg1.Id, post.Id))
-	app.Srv.Store.FileInfo().InvalidateFileInfosForPostCache(post.Id)
-	if message := app.GetMessageForNotification(post, translateFunc); message != "2 images sent: test1.png, test2.jpg" && message != "2 images sent: test2.jpg, test1.png" {
+	store.Must(app.Global().Srv.Store.FileInfo().AttachToPost(testJpg1.Id, post.Id))
+	app.Global().Srv.Store.FileInfo().InvalidateFileInfosForPostCache(post.Id)
+	if message := app.Global().GetMessageForNotification(post, translateFunc); message != "2 images sent: test1.png, test2.jpg" && message != "2 images sent: test2.jpg, test1.png" {
 		t.Fatal("should've returned number of images:", message)
 	}
 
 	post.Id = model.NewId()
 	post.FileIds = model.StringArray{testFile.Id}
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(testFile.Id, post.Id))
-	if message := app.GetMessageForNotification(post, translateFunc); message != "1 file sent: test1.go" {
+	store.Must(app.Global().Srv.Store.FileInfo().AttachToPost(testFile.Id, post.Id))
+	if message := app.Global().GetMessageForNotification(post, translateFunc); message != "1 file sent: test1.go" {
 		t.Fatal("should've returned number of files:", message)
 	}
 
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(testJpg2.Id, post.Id))
-	app.Srv.Store.FileInfo().InvalidateFileInfosForPostCache(post.Id)
+	store.Must(app.Global().Srv.Store.FileInfo().AttachToPost(testJpg2.Id, post.Id))
+	app.Global().Srv.Store.FileInfo().InvalidateFileInfosForPostCache(post.Id)
 	post.FileIds = model.StringArray{testFile.Id, testJpg2.Id}
-	if message := app.GetMessageForNotification(post, translateFunc); message != "2 files sent: test1.go, test3.jpg" && message != "2 files sent: test3.jpg, test1.go" {
+	if message := app.Global().GetMessageForNotification(post, translateFunc); message != "2 files sent: test1.go, test3.jpg" && message != "2 files sent: test3.jpg, test1.go" {
 		t.Fatal("should've returned number of mixed files:", message)
 	}
 }

--- a/api/preference.go
+++ b/api/preference.go
@@ -4,12 +4,12 @@
 package api
 
 import (
+	"net/http"
+
 	l4g "github.com/alecthomas/log4go"
 	"github.com/gorilla/mux"
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"net/http"
 )
 
 func InitPreference() {
@@ -23,7 +23,7 @@ func InitPreference() {
 }
 
 func getAllPreferences(c *Context, w http.ResponseWriter, r *http.Request) {
-	if result := <-app.Srv.Store.Preference().GetAll(c.Session.UserId); result.Err != nil {
+	if result := <-c.App.Srv.Store.Preference().GetAll(c.Session.UserId); result.Err != nil {
 		c.Err = result.Err
 	} else {
 		data := result.Data.(model.Preferences)
@@ -39,7 +39,7 @@ func savePreferences(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.UpdatePreferences(c.Session.UserId, preferences); err != nil {
+	if err := c.App.UpdatePreferences(c.Session.UserId, preferences); err != nil {
 		c.Err = err
 		return
 	}
@@ -51,7 +51,7 @@ func getPreferenceCategory(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	category := params["category"]
 
-	if result := <-app.Srv.Store.Preference().GetCategory(c.Session.UserId, category); result.Err != nil {
+	if result := <-c.App.Srv.Store.Preference().GetCategory(c.Session.UserId, category); result.Err != nil {
 		c.Err = result.Err
 	} else {
 		data := result.Data.(model.Preferences)
@@ -65,7 +65,7 @@ func getPreference(c *Context, w http.ResponseWriter, r *http.Request) {
 	category := params["category"]
 	name := params["name"]
 
-	if result := <-app.Srv.Store.Preference().Get(c.Session.UserId, category, name); result.Err != nil {
+	if result := <-c.App.Srv.Store.Preference().Get(c.Session.UserId, category, name); result.Err != nil {
 		c.Err = result.Err
 	} else {
 		data := result.Data.(model.Preference)
@@ -80,7 +80,7 @@ func deletePreferences(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.DeletePreferences(c.Session.UserId, preferences); err != nil {
+	if err := c.App.DeletePreferences(c.Session.UserId, preferences); err != nil {
 		c.Err = err
 		return
 	}

--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -4,8 +4,9 @@
 package api
 
 import (
-	"github.com/mattermost/platform/model"
 	"testing"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestGetAllPreferences(t *testing.T) {

--- a/api/status.go
+++ b/api/status.go
@@ -33,7 +33,7 @@ func getStatusesByIdsHttp(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	statusMap, err := app.GetStatusesByIds(userIds)
+	statusMap, err := c.App.GetStatusesByIds(userIds)
 	if err != nil {
 		c.Err = err
 		return

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
 	"github.com/mattermost/platform/utils"
@@ -35,12 +34,12 @@ func TestStatuses(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
 	LinkUserToTeam(ruser, rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Id))
 
 	user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser2 := Client.Must(Client.CreateUser(&user2, "")).Data.(*model.User)
 	LinkUserToTeam(ruser2, rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser2.Id))
 
 	Client.Login(user.Email, user.Password)
 	Client.SetTeamId(team.Id)
@@ -138,7 +137,7 @@ func TestStatuses(t *testing.T) {
 
 	WebSocketClient2.Close()
 
-	app.SetStatusAwayIfNeeded(th.BasicUser.Id, false)
+	th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, false)
 
 	awayTimeout := *utils.Cfg.TeamSettings.UserStatusAwayTimeout
 	defer func() {
@@ -148,8 +147,8 @@ func TestStatuses(t *testing.T) {
 
 	time.Sleep(1500 * time.Millisecond)
 
-	app.SetStatusAwayIfNeeded(th.BasicUser.Id, false)
-	app.SetStatusOnline(th.BasicUser.Id, "junk", false)
+	th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, false)
+	th.App.SetStatusOnline(th.BasicUser.Id, "junk", false)
 
 	time.Sleep(1500 * time.Millisecond)
 

--- a/api/team.go
+++ b/api/team.go
@@ -61,7 +61,7 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rteam, err := app.CreateTeamWithUser(team, c.Session.UserId)
+	rteam, err := c.App.CreateTeamWithUser(team, c.Session.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -74,7 +74,7 @@ func GetAllTeamListings(c *Context, w http.ResponseWriter, r *http.Request) {
 	var teams []*model.Team
 	var err *model.AppError
 
-	if teams, err = app.GetAllOpenTeams(); err != nil {
+	if teams, err = c.App.GetAllOpenTeams(); err != nil {
 		c.Err = err
 		return
 	}
@@ -96,10 +96,10 @@ func getAll(c *Context, w http.ResponseWriter, r *http.Request) {
 	var teams []*model.Team
 	var err *model.AppError
 
-	if app.HasPermissionTo(c.Session.UserId, model.PERMISSION_MANAGE_SYSTEM) {
-		teams, err = app.GetAllTeams()
+	if c.App.HasPermissionTo(c.Session.UserId, model.PERMISSION_MANAGE_SYSTEM) {
+		teams, err = c.App.GetAllTeams()
 	} else {
-		teams, err = app.GetTeamsForUser(c.Session.UserId)
+		teams, err = c.App.GetTeamsForUser(c.Session.UserId)
 	}
 
 	if err != nil {
@@ -130,7 +130,7 @@ func inviteMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.InviteNewUsersToTeam(invites.ToEmailList(), c.TeamId, c.Session.UserId); err != nil {
+	if err := c.App.InviteNewUsersToTeam(invites.ToEmailList(), c.TeamId, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	}
@@ -152,7 +152,7 @@ func addUserToTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := app.AddUserToTeam(c.TeamId, userId, ""); err != nil {
+	if _, err := c.App.AddUserToTeam(c.TeamId, userId, ""); err != nil {
 		c.Err = err
 		return
 	}
@@ -176,7 +176,7 @@ func removeUserFromTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := app.RemoveUserFromTeam(c.TeamId, userId); err != nil {
+	if err := c.App.RemoveUserFromTeam(c.TeamId, userId); err != nil {
 		c.Err = err
 		return
 	}
@@ -194,9 +194,9 @@ func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request)
 	var err *model.AppError
 
 	if len(hash) > 0 {
-		team, err = app.AddUserToTeamByHash(c.Session.UserId, hash, data)
+		team, err = c.App.AddUserToTeamByHash(c.Session.UserId, hash, data)
 	} else if len(inviteId) > 0 {
-		team, err = app.AddUserToTeamByInviteId(inviteId, c.Session.UserId)
+		team, err = c.App.AddUserToTeamByInviteId(inviteId, c.Session.UserId)
 	} else {
 		c.Err = model.NewAppError("addUserToTeamFromInvite", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest)
 		return
@@ -217,7 +217,7 @@ func findTeamByName(c *Context, w http.ResponseWriter, r *http.Request) {
 	m := model.MapFromJson(r.Body)
 	name := strings.ToLower(strings.TrimSpace(m["name"]))
 
-	found := app.FindTeamByName(name)
+	found := c.App.FindTeamByName(name)
 
 	if found {
 		w.Write([]byte("true"))
@@ -230,7 +230,7 @@ func getTeamByName(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	teamname := params["team_name"]
 
-	if team, err := app.GetTeamByName(teamname); err != nil {
+	if team, err := c.App.GetTeamByName(teamname); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -250,7 +250,7 @@ func getMyTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 	if len(c.Session.TeamMembers) > 0 {
 		w.Write([]byte(model.TeamMembersToJson(c.Session.TeamMembers)))
 	} else {
-		if members, err := app.GetTeamMembersForUser(c.Session.UserId); err != nil {
+		if members, err := c.App.GetTeamMembersForUser(c.Session.UserId); err != nil {
 			c.Err = err
 			return
 		} else {
@@ -262,7 +262,7 @@ func getMyTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 func getMyTeamsUnread(c *Context, w http.ResponseWriter, r *http.Request) {
 	teamId := r.URL.Query().Get("id")
 
-	if unreads, err := app.GetTeamsUnreadForUser(teamId, c.Session.UserId); err != nil {
+	if unreads, err := c.App.GetTeamsUnreadForUser(teamId, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -288,7 +288,7 @@ func updateTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	var err *model.AppError
 	var updatedTeam *model.Team
 
-	updatedTeam, err = app.UpdateTeam(team)
+	updatedTeam, err = c.App.UpdateTeam(team)
 	if err != nil {
 		c.Err = err
 		return
@@ -319,7 +319,7 @@ func updateMemberRoles(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := app.UpdateTeamMemberRoles(teamId, userId, newRoles); err != nil {
+	if _, err := c.App.UpdateTeamMemberRoles(teamId, userId, newRoles); err != nil {
 		c.Err = err
 		return
 	}
@@ -335,7 +335,7 @@ func getMyTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if team, err := app.GetTeam(c.TeamId); err != nil {
+	if team, err := c.App.GetTeam(c.TeamId); err != nil {
 		c.Err = err
 		return
 	} else if HandleEtag(team.Etag(), "Get My Team", w, r) {
@@ -355,7 +355,7 @@ func getTeamStats(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	stats, err := app.GetTeamStats(c.TeamId)
+	stats, err := c.App.GetTeamStats(c.TeamId)
 	if err != nil {
 		c.Err = err
 		return
@@ -414,7 +414,7 @@ func importTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	switch importFrom {
 	case "slack":
 		var err *model.AppError
-		if err, log = app.SlackImport(fileData, fileSize, c.TeamId); err != nil {
+		if err, log = c.App.SlackImport(fileData, fileSize, c.TeamId); err != nil {
 			c.Err = err
 			c.Err.StatusCode = http.StatusBadRequest
 		}
@@ -433,7 +433,7 @@ func getInviteInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 	m := model.MapFromJson(r.Body)
 	inviteId := m["invite_id"]
 
-	if team, err := app.GetTeamByInviteId(inviteId); err != nil {
+	if team, err := c.App.GetTeamByInviteId(inviteId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -473,7 +473,7 @@ func getTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if members, err := app.GetTeamMembers(c.TeamId, offset, limit); err != nil {
+	if members, err := c.App.GetTeamMembers(c.TeamId, offset, limit); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -498,7 +498,7 @@ func getTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if member, err := app.GetTeamMember(c.TeamId, userId); err != nil {
+	if member, err := c.App.GetTeamMember(c.TeamId, userId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -521,7 +521,7 @@ func getTeamMembersByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if members, err := app.GetTeamMembersByIds(c.TeamId, userIds); err != nil {
+	if members, err := c.App.GetTeamMembersByIds(c.TeamId, userIds); err != nil {
 		c.Err = err
 		return
 	} else {

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -6,7 +6,6 @@ package api
 import (
 	"testing"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
 	"github.com/mattermost/platform/utils"
@@ -25,7 +24,7 @@ func TestCreateTeam(t *testing.T) {
 	user := &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	Client.Login(user.Email, "passwd1")
 	Client.SetTeamId(rteam.Data.(*model.Team).Id)
@@ -128,7 +127,7 @@ func TestAddUserToTeam(t *testing.T) {
 
 	// Should work as team admin.
 	UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	*utils.Cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
@@ -219,7 +218,7 @@ func TestGetAllTeams(t *testing.T) {
 	user := &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	Client.Login(user.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -258,7 +257,7 @@ func TestGetAllTeamListings(t *testing.T) {
 	user := &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	Client.Login(user.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -275,7 +274,7 @@ func TestGetAllTeamListings(t *testing.T) {
 		}
 	}
 
-	app.UpdateUserRoles(user.Id, model.ROLE_SYSTEM_ADMIN.Id)
+	th.App.UpdateUserRoles(user.Id, model.ROLE_SYSTEM_ADMIN.Id)
 
 	Client.Login(user.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -305,7 +304,7 @@ func TestTeamPermDelete(t *testing.T) {
 	user1 := &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	LinkUserToTeam(user1, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user1.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user1.Id))
 
 	Client.Login(user1.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -329,7 +328,7 @@ func TestTeamPermDelete(t *testing.T) {
 	c.RequestId = model.NewId()
 	c.IpAddress = "test"
 
-	err := app.PermanentDeleteTeam(team)
+	err := th.App.PermanentDeleteTeam(team)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,7 +349,7 @@ func TestInviteMembers(t *testing.T) {
 	user := &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	Client.Login(user.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -437,7 +436,7 @@ func TestUpdateTeamDisplayName(t *testing.T) {
 	user2 := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	LinkUserToTeam(user2, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user2.Id))
 
 	Client.Login(user2.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -498,7 +497,7 @@ func TestGetMyTeam(t *testing.T) {
 	user := model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser, _ := Client.CreateUser(&user, "")
 	LinkUserToTeam(ruser.Data.(*model.User), rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
 	Client.Login(user.Email, user.Password)
 	Client.SetTeamId(team.Id)
@@ -743,7 +742,7 @@ func TestGetTeamStats(t *testing.T) {
 
 	user := model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser, _ := Client.CreateUser(&user, "")
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
 	Client.Login(user.Email, user.Password)
 
@@ -764,7 +763,7 @@ func TestUpdateTeamDescription(t *testing.T) {
 	user2 := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Jabba the Hutt", Password: "passwd1"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	LinkUserToTeam(user2, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user2.Id))
 
 	Client.Login(user2.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -817,7 +816,7 @@ func TestGetTeamByName(t *testing.T) {
 
 	user2 := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Jabba the Hutt", Password: "passwd1"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
-	store.Must(app.Srv.Store.User().VerifyEmail(user2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user2.Id))
 
 	Client.Login(user2.Email, "passwd1")
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -109,7 +109,7 @@ func TestLogin(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Username: "corey" + model.NewId(), Password: "passwd1"}
 	ruser, _ := Client.CreateUser(&user, "")
 	LinkUserToTeam(ruser.Data.(*model.User), rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
 	if result, err := Client.LoginById(ruser.Data.(*model.User).Id, user.Password); err != nil {
 		t.Fatal(err)
@@ -203,7 +203,7 @@ func TestLogin(t *testing.T) {
 		AuthService: model.USER_AUTH_SERVICE_LDAP,
 	}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
-	store.Must(app.Srv.Store.User().VerifyEmail(user3.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user3.Id))
 
 	if _, err := Client.Login(user3.Id, user3.Password); err == nil {
 		t.Fatal("AD/LDAP user should not be able to log in with AD/LDAP disabled")
@@ -222,7 +222,7 @@ func TestLoginByLdap(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Username: "corey" + model.NewId(), Password: "passwd1"}
 	ruser, _ := Client.CreateUser(&user, "")
 	LinkUserToTeam(ruser.Data.(*model.User), rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
 	if _, err := Client.LoginByLdap(ruser.Data.(*model.User).Id, user.Password); err == nil {
 		t.Fatal("should have failed to log in with non AD/LDAP user")
@@ -249,7 +249,7 @@ func TestLoginWithDeviceId(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if sresult := <-app.Srv.Store.Session().Get(sessions[0].Id); sresult.Err == nil {
+			if sresult := <-th.App.Srv.Store.Session().Get(sessions[0].Id); sresult.Err == nil {
 				t.Fatal("session should have been removed")
 			}
 		}
@@ -355,17 +355,17 @@ func TestGetUser(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser, _ := Client.CreateUser(&user, "")
 	LinkUserToTeam(ruser.Data.(*model.User), rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
 	user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1", FirstName: "Corey", LastName: "Hulen"}
 	ruser2, _ := Client.CreateUser(&user2, "")
 	LinkUserToTeam(ruser2.Data.(*model.User), rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser2.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser2.Data.(*model.User).Id))
 
 	user3 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser3, _ := Client.CreateUser(&user3, "")
 	LinkUserToTeam(ruser3.Data.(*model.User), rteam2.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser3.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser3.Data.(*model.User).Id))
 
 	Client.Login(user.Email, user.Password)
 
@@ -488,7 +488,7 @@ func TestGetUser(t *testing.T) {
 		t.Fatal("shouldn't have accss")
 	}
 
-	app.UpdateUserRoles(ruser.Data.(*model.User).Id, model.ROLE_SYSTEM_ADMIN.Id)
+	th.App.UpdateUserRoles(ruser.Data.(*model.User).Id, model.ROLE_SYSTEM_ADMIN.Id)
 
 	Client.Login(user.Email, "passwd1")
 
@@ -620,7 +620,7 @@ func TestGetAudits(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser, _ := Client.CreateUser(&user, "")
 	LinkUserToTeam(ruser.Data.(*model.User), rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -675,7 +675,7 @@ func TestUserCreateImage(t *testing.T) {
 	user := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	Client.Login(user.Email, "passwd1")
 
@@ -724,7 +724,7 @@ func TestUserUploadProfileImage(t *testing.T) {
 	user := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	if *utils.Cfg.FileSettings.DriverName != "" {
 
@@ -837,7 +837,7 @@ func TestUserUpdate(t *testing.T) {
 	user := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1", Roles: ""}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	if _, err := Client.UpdateUser(user); err == nil {
 		t.Fatal("Should have errored")
@@ -867,7 +867,7 @@ func TestUserUpdate(t *testing.T) {
 	user2 := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	LinkUserToTeam(user2, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user2.Id))
 
 	Client.Login(user2.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -892,7 +892,7 @@ func TestUserUpdatePassword(t *testing.T) {
 	user := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	if _, err := Client.UpdateUserPassword(user.Id, "passwd1", "newpasswd1"); err == nil {
 		t.Fatal("Should have errored")
@@ -976,12 +976,12 @@ func TestUserUpdateRoles(t *testing.T) {
 	user := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	user2 := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	LinkUserToTeam(user2, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user2.Id))
 
 	if _, err := Client.UpdateUserRoles(user.Id, ""); err == nil {
 		t.Fatal("Should have errored, not logged in")
@@ -1000,7 +1000,7 @@ func TestUserUpdateRoles(t *testing.T) {
 	user3 := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 	LinkUserToTeam(user3, team2)
-	store.Must(app.Srv.Store.User().VerifyEmail(user3.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user3.Id))
 
 	Client.Login(user3.Email, "passwd1")
 	Client.SetTeamId(team2.Id)
@@ -1095,7 +1095,7 @@ func TestUserUpdateDeviceId(t *testing.T) {
 	user := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	Client.Login(user.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -1105,7 +1105,7 @@ func TestUserUpdateDeviceId(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if result := <-app.Srv.Store.Session().GetSessions(user.Id); result.Err != nil {
+	if result := <-th.App.Srv.Store.Session().GetSessions(user.Id); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		sessions := result.Data.([]*model.Session)
@@ -1126,7 +1126,7 @@ func TestUserUpdateDeviceId2(t *testing.T) {
 	user := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	Client.Login(user.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -1136,7 +1136,7 @@ func TestUserUpdateDeviceId2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if result := <-app.Srv.Store.Session().GetSessions(user.Id); result.Err != nil {
+	if result := <-th.App.Srv.Store.Session().GetSessions(user.Id); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		sessions := result.Data.([]*model.Session)
@@ -1163,12 +1163,12 @@ func TestUserUpdateActive(t *testing.T) {
 	user := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	user2 := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	LinkUserToTeam(user2, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user2.Id))
 
 	if _, err := Client.UpdateActive(user.Id, false); err == nil {
 		t.Fatal("Should have errored, not logged in")
@@ -1186,7 +1186,7 @@ func TestUserUpdateActive(t *testing.T) {
 	user3 := &model.User{Email: "success+" + model.NewId() + "@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
 	LinkUserToTeam(user2, team2)
-	store.Must(app.Srv.Store.User().VerifyEmail(user3.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user3.Id))
 
 	Client.Login(user3.Email, "passwd1")
 	Client.SetTeamId(team2.Id)
@@ -1206,13 +1206,13 @@ func TestUserUpdateActive(t *testing.T) {
 		t.Fatal("Should have errored, bad id")
 	}
 
-	app.SetStatusOnline(user3.Id, "", false)
+	th.App.SetStatusOnline(user3.Id, "", false)
 
 	if _, err := SystemAdminClient.UpdateActive(user3.Id, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if status, err := app.GetStatus(user3.Id); err != nil {
+	if status, err := th.App.GetStatus(user3.Id); err != nil {
 		t.Fatal(err)
 	} else if status.Status != model.STATUS_OFFLINE {
 		t.Fatal("status should have been set to offline")
@@ -1229,7 +1229,7 @@ func TestUserPermDelete(t *testing.T) {
 	user1 := &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user1 = Client.Must(Client.CreateUser(user1, "")).Data.(*model.User)
 	LinkUserToTeam(user1, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user1.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user1.Id))
 
 	Client.Login(user1.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -1253,7 +1253,7 @@ func TestUserPermDelete(t *testing.T) {
 	c.RequestId = model.NewId()
 	c.IpAddress = "test"
 
-	err := app.PermanentDeleteUser(user1)
+	err := th.App.PermanentDeleteUser(user1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1271,7 +1271,7 @@ func TestSendPasswordReset(t *testing.T) {
 	user := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	Client.Logout()
 
@@ -1296,7 +1296,7 @@ func TestSendPasswordReset(t *testing.T) {
 	user2 := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", AuthData: &authData, AuthService: "random"}
 	user2 = Client.Must(Client.CreateUser(user2, "")).Data.(*model.User)
 	LinkUserToTeam(user2, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user2.Id))
 
 	if _, err := Client.SendPasswordReset(user2.Email); err == nil {
 		t.Fatal("should have errored - SSO user can't send reset password link")
@@ -1311,7 +1311,7 @@ func TestResetPassword(t *testing.T) {
 	user := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	//Delete all the messages before check the reset password
 	utils.DeleteMailBox(user.Email)
@@ -1350,7 +1350,7 @@ func TestResetPassword(t *testing.T) {
 	}
 
 	var recoveryToken *model.Token
-	if result := <-app.Srv.Store.Token().GetByToken(recoveryTokenString); result.Err != nil {
+	if result := <-th.App.Srv.Store.Token().GetByToken(recoveryTokenString); result.Err != nil {
 		t.Log(recoveryTokenString)
 		t.Fatal(result.Err)
 	} else {
@@ -1412,7 +1412,7 @@ func TestUserUpdateNotify(t *testing.T) {
 	user := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1", Roles: ""}
 	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
 	LinkUserToTeam(user, team)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(user.Id))
 
 	data := make(map[string]string)
 	data["user_id"] = user.Id
@@ -1527,7 +1527,7 @@ func TestEmailToOAuth(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
 	LinkUserToTeam(ruser, rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Id))
 
 	m := map[string]string{}
 	if _, err := Client.EmailToOAuth(m); err == nil {
@@ -1580,12 +1580,12 @@ func TestOAuthToEmail(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
 	LinkUserToTeam(ruser, rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Id))
 
 	user2 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser2 := Client.Must(Client.CreateUser(&user2, "")).Data.(*model.User)
 	LinkUserToTeam(ruser2, rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser2.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser2.Id))
 
 	m := map[string]string{}
 	if _, err := Client.OAuthToEmail(m); err == nil {
@@ -1631,7 +1631,7 @@ func TestLDAPToEmail(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
 	LinkUserToTeam(ruser, rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Id))
 
 	Client.Login(user.Email, user.Password)
 
@@ -1684,7 +1684,7 @@ func TestEmailToLDAP(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
 	LinkUserToTeam(ruser, rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Id))
 
 	Client.Login(user.Email, user.Password)
 
@@ -1815,7 +1815,7 @@ func TestGenerateMfaSecret(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser, _ := Client.CreateUser(&user, "")
 	LinkUserToTeam(ruser.Data.(*model.User), rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
 	Client.Logout()
 
@@ -1856,7 +1856,7 @@ func TestUpdateMfa(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser, _ := Client.CreateUser(&user, "")
 	LinkUserToTeam(ruser.Data.(*model.User), rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
 	Client.Logout()
 
@@ -1897,7 +1897,7 @@ func TestCheckMfa(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	ruser, _ := Client.CreateUser(&user, "")
 	LinkUserToTeam(ruser.Data.(*model.User), rteam.Data.(*model.Team))
-	store.Must(app.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser.Data.(*model.User).Id))
 
 	if result, err := Client.CheckMfa(user.Email); err != nil {
 		t.Fatal(err)

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -34,7 +34,7 @@ func createIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	channel, err := app.GetChannel(hook.ChannelId)
+	channel, err := c.App.GetChannel(hook.ChannelId)
 	if err != nil {
 		c.Err = err
 		return
@@ -47,13 +47,13 @@ func createIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if channel.Type != model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
+	if channel.Type != model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
 		c.LogAudit("fail - bad channel permissions")
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if incomingHook, err := app.CreateIncomingWebhookForChannel(c.Session.UserId, channel, hook); err != nil {
+	if incomingHook, err := c.App.CreateIncomingWebhookForChannel(c.Session.UserId, channel, hook); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -73,7 +73,7 @@ func updateIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("attempt")
 
-	oldHook, err := app.GetIncomingWebhook(hook.Id)
+	oldHook, err := c.App.GetIncomingWebhook(hook.Id)
 	if err != nil {
 		c.Err = err
 		return
@@ -95,19 +95,19 @@ func updateIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	channel, err := app.GetChannel(hook.ChannelId)
+	channel, err := c.App.GetChannel(hook.ChannelId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	if channel.Type != model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
+	if channel.Type != model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
 		c.LogAudit("fail - bad channel permissions")
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	rhook, err := app.UpdateIncomingWebhook(oldHook, hook)
+	rhook, err := c.App.UpdateIncomingWebhook(oldHook, hook)
 	if err != nil {
 		c.Err = err
 		return
@@ -126,7 +126,7 @@ func deleteIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hook, err := app.GetIncomingWebhook(id)
+	hook, err := c.App.GetIncomingWebhook(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -145,7 +145,7 @@ func deleteIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.DeleteIncomingWebhook(id); err != nil {
+	if err := c.App.DeleteIncomingWebhook(id); err != nil {
 		c.LogAudit("fail")
 		c.Err = err
 		return
@@ -161,7 +161,7 @@ func getIncomingHooks(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if hooks, err := app.GetIncomingWebhooksForTeamPage(c.TeamId, 0, 100); err != nil {
+	if hooks, err := c.App.GetIncomingWebhooksForTeamPage(c.TeamId, 0, 100); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -186,7 +186,7 @@ func createOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if rhook, err := app.CreateOutgoingWebhook(hook); err != nil {
+	if rhook, err := c.App.CreateOutgoingWebhook(hook); err != nil {
 		c.LogAudit("fail")
 		c.Err = err
 		return
@@ -202,7 +202,7 @@ func getOutgoingHooks(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if hooks, err := app.GetOutgoingWebhooksForTeamPage(c.TeamId, 0, 100); err != nil {
+	if hooks, err := c.App.GetOutgoingWebhooksForTeamPage(c.TeamId, 0, 100); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -220,7 +220,7 @@ func updateOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	oldHook, err := app.GetOutgoingWebhook(hook.Id)
+	oldHook, err := c.App.GetOutgoingWebhook(hook.Id)
 	if err != nil {
 		c.Err = err
 		return
@@ -243,7 +243,7 @@ func updateOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rhook, err := app.UpdateOutgoingWebhook(oldHook, hook)
+	rhook, err := c.App.UpdateOutgoingWebhook(oldHook, hook)
 	if err != nil {
 		c.Err = err
 		return
@@ -269,7 +269,7 @@ func deleteOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hook, err := app.GetOutgoingWebhook(id)
+	hook, err := c.App.GetOutgoingWebhook(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -281,7 +281,7 @@ func deleteOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.DeleteOutgoingWebhook(id); err != nil {
+	if err := c.App.DeleteOutgoingWebhook(id); err != nil {
 		c.LogAudit("fail")
 		c.Err = err
 		return
@@ -300,7 +300,7 @@ func regenOutgoingHookToken(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	hook, err := app.GetOutgoingWebhook(id)
+	hook, err := c.App.GetOutgoingWebhook(id)
 	if err != nil {
 		c.Err = err
 		return
@@ -324,7 +324,7 @@ func regenOutgoingHookToken(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if rhook, err := app.RegenOutgoingWebhookToken(hook); err != nil {
+	if rhook, err := c.App.RegenOutgoingWebhookToken(hook); err != nil {
 		c.Err = err
 		return
 	} else {

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -34,7 +34,7 @@ func connect(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wc := app.NewWebConn(ws, c.Session, c.T, c.Locale)
+	wc := c.App.NewWebConn(ws, c.Session, c.T, c.Locale)
 
 	if len(c.Session.UserId) > 0 {
 		app.HubRegister(wc)

--- a/api4/api.go
+++ b/api4/api.go
@@ -106,14 +106,14 @@ type Routes struct {
 var BaseRoutes *Routes
 
 func InitRouter() {
-	app.Srv.Router = mux.NewRouter()
-	app.Srv.Router.NotFoundHandler = http.HandlerFunc(Handle404)
+	app.Global().Srv.Router = mux.NewRouter()
+	app.Global().Srv.Router.NotFoundHandler = http.HandlerFunc(Handle404)
 }
 
 func InitApi(full bool) {
 	BaseRoutes = &Routes{}
-	BaseRoutes.Root = app.Srv.Router
-	BaseRoutes.ApiRoot = app.Srv.Router.PathPrefix(model.API_URL_SUFFIX).Subrouter()
+	BaseRoutes.Root = app.Global().Srv.Router
+	BaseRoutes.ApiRoot = app.Global().Srv.Router.PathPrefix(model.API_URL_SUFFIX).Subrouter()
 
 	BaseRoutes.Users = BaseRoutes.ApiRoot.PathPrefix("/users").Subrouter()
 	BaseRoutes.User = BaseRoutes.ApiRoot.PathPrefix("/users/{user_id:[A-Za-z0-9]+}").Subrouter()
@@ -213,7 +213,7 @@ func InitApi(full bool) {
 	InitOpenGraph()
 	InitPlugin()
 
-	app.Srv.Router.Handle("/api/v4/{anything:.*}", http.HandlerFunc(Handle404))
+	app.Global().Srv.Router.Handle("/api/v4/{anything:.*}", http.HandlerFunc(Handle404))
 
 	// REMOVE CONDITION WHEN APIv3 REMOVED
 	if full {

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -66,7 +66,7 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if sc, err := app.CreateChannelWithUser(channel, c.Session.UserId); err != nil {
+	if sc, err := c.App.CreateChannelWithUser(channel, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -91,12 +91,12 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var oldChannel *model.Channel
 	var err *model.AppError
-	if oldChannel, err = app.GetChannel(channel.Id); err != nil {
+	if oldChannel, err = c.App.GetChannel(channel.Id); err != nil {
 		c.Err = err
 		return
 	}
 
-	if _, err = app.GetChannelMember(channel.Id, c.Session.UserId); err != nil {
+	if _, err = c.App.GetChannelMember(channel.Id, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	}
@@ -134,12 +134,12 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		oldChannel.Type = channel.Type
 	}
 
-	if _, err := app.UpdateChannel(oldChannel); err != nil {
+	if _, err := c.App.UpdateChannel(oldChannel); err != nil {
 		c.Err = err
 		return
 	} else {
 		if oldChannelDisplayName != channel.DisplayName {
-			if err := app.PostUpdateChannelDisplayNameMessage(c.Session.UserId, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
+			if err := c.App.PostUpdateChannelDisplayNameMessage(c.Session.UserId, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
 				l4g.Error(err.Error())
 			}
 		}
@@ -160,7 +160,7 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	oldChannel, err := app.GetChannel(c.Params.ChannelId)
+	oldChannel, err := c.App.GetChannel(c.Params.ChannelId)
 	if err != nil {
 		c.Err = err
 		return
@@ -170,7 +170,7 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if rchannel, err := app.PatchChannel(oldChannel, patch, c.Session.UserId); err != nil {
+	if rchannel, err := c.App.PatchChannel(oldChannel, patch, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -187,7 +187,7 @@ func restoreChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(c.Params.ChannelId); err != nil {
+	if channel, err = c.App.GetChannel(c.Params.ChannelId); err != nil {
 		c.Err = err
 		return
 	}
@@ -198,7 +198,7 @@ func restoreChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	channel, err = app.RestoreChannel(channel)
+	channel, err = c.App.RestoreChannel(channel)
 	if err != nil {
 		c.Err = err
 		return
@@ -210,12 +210,12 @@ func restoreChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func CanManageChannel(c *Context, channel *model.Channel) bool {
-	if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES)
 		return false
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_PRIVATE && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES)
 		return false
 	}
@@ -252,7 +252,7 @@ func createDirectChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if sc, err := app.CreateDirectChannel(userIds[0], userIds[1]); err != nil {
+	if sc, err := c.App.CreateDirectChannel(userIds[0], userIds[1]); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -289,7 +289,7 @@ func createGroupChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if groupChannel, err := app.CreateGroupChannel(userIds, c.Session.UserId); err != nil {
+	if groupChannel, err := c.App.CreateGroupChannel(userIds, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -304,7 +304,7 @@ func getChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	channel, err := app.GetChannel(c.Params.ChannelId)
+	channel, err := c.App.GetChannel(c.Params.ChannelId)
 	if err != nil {
 		c.Err = err
 		return
@@ -316,7 +316,7 @@ func getChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		if !app.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
+		if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
 			c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 			return
 		}
@@ -337,12 +337,12 @@ func getChannelUnread(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	channelUnread, err := app.GetChannelUnread(c.Params.ChannelId, c.Params.UserId)
+	channelUnread, err := c.App.GetChannelUnread(c.Params.ChannelId, c.Params.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -357,12 +357,12 @@ func getChannelStats(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	memberCount, err := app.GetChannelMemberCount(c.Params.ChannelId)
+	memberCount, err := c.App.GetChannelMemberCount(c.Params.ChannelId)
 
 	if err != nil {
 		c.Err = err
@@ -379,12 +379,12 @@ func getPinnedPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if posts, err := app.GetPinnedPosts(c.Params.ChannelId); err != nil {
+	if posts, err := c.App.GetPinnedPosts(c.Params.ChannelId); err != nil {
 		c.Err = err
 		return
 	} else if HandleEtag(posts.Etag(), "Get Pinned Posts", w, r) {
@@ -406,7 +406,7 @@ func getPublicChannelsForTeam(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if channels, err := app.GetPublicChannelsForTeam(c.Params.TeamId, c.Params.Page*c.Params.PerPage, c.Params.PerPage); err != nil {
+	if channels, err := c.App.GetPublicChannelsForTeam(c.Params.TeamId, c.Params.Page*c.Params.PerPage, c.Params.PerPage); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -426,7 +426,7 @@ func getDeletedChannelsForTeam(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if channels, err := app.GetDeletedChannels(c.Params.TeamId, c.Params.Page*c.Params.PerPage, c.Params.PerPage); err != nil {
+	if channels, err := c.App.GetDeletedChannels(c.Params.TeamId, c.Params.Page*c.Params.PerPage, c.Params.PerPage); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -459,7 +459,7 @@ func getPublicChannelsByIdsForTeam(c *Context, w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if channels, err := app.GetPublicChannelsByIdsForTeam(c.Params.TeamId, channelIds); err != nil {
+	if channels, err := c.App.GetPublicChannelsByIdsForTeam(c.Params.TeamId, channelIds); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -483,7 +483,7 @@ func getChannelsForTeamForUser(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if channels, err := app.GetChannelsForUser(c.Params.TeamId, c.Params.UserId); err != nil {
+	if channels, err := c.App.GetChannelsForUser(c.Params.TeamId, c.Params.UserId); err != nil {
 		c.Err = err
 		return
 	} else if HandleEtag(channels.Etag(), "Get Channels", w, r) {
@@ -511,7 +511,7 @@ func searchChannelsForTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if channels, err := app.SearchChannels(c.Params.TeamId, props.Term); err != nil {
+	if channels, err := c.App.SearchChannels(c.Params.TeamId, props.Term); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -527,22 +527,22 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(c.Params.ChannelId); err != nil {
+	if channel, err = c.App.GetChannel(c.Params.ChannelId); err != nil {
 		c.Err = err
 		return
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
+	if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_DELETE_PUBLIC_CHANNEL)
 		return
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
+	if channel.Type == model.CHANNEL_PRIVATE && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PRIVATE_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_DELETE_PRIVATE_CHANNEL)
 		return
 	}
 
-	err = app.DeleteChannel(channel, c.Session.UserId)
+	err = c.App.DeleteChannel(channel, c.Session.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -562,7 +562,7 @@ func getChannelByName(c *Context, w http.ResponseWriter, r *http.Request) {
 	var channel *model.Channel
 	var err *model.AppError
 
-	if channel, err = app.GetChannelByName(c.Params.ChannelName, c.Params.TeamId); err != nil {
+	if channel, err = c.App.GetChannelByName(c.Params.ChannelName, c.Params.TeamId); err != nil {
 		c.Err = err
 		return
 	}
@@ -573,7 +573,7 @@ func getChannelByName(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		if !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
+		if !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
 			c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 			return
 		}
@@ -591,12 +591,12 @@ func getChannelByNameForTeamName(c *Context, w http.ResponseWriter, r *http.Requ
 	var channel *model.Channel
 	var err *model.AppError
 
-	if channel, err = app.GetChannelByNameForTeamName(c.Params.ChannelName, c.Params.TeamName); err != nil {
+	if channel, err = c.App.GetChannelByNameForTeamName(c.Params.ChannelName, c.Params.TeamName); err != nil {
 		c.Err = err
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
@@ -611,12 +611,12 @@ func getChannelMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if members, err := app.GetChannelMembersPage(c.Params.ChannelId, c.Params.Page, c.Params.PerPage); err != nil {
+	if members, err := c.App.GetChannelMembersPage(c.Params.ChannelId, c.Params.Page, c.Params.PerPage); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -636,12 +636,12 @@ func getChannelMembersByIds(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if members, err := app.GetChannelMembersByIds(c.Params.ChannelId, userIds); err != nil {
+	if members, err := c.App.GetChannelMembersByIds(c.Params.ChannelId, userIds); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -655,12 +655,12 @@ func getChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if member, err := app.GetChannelMember(c.Params.ChannelId, c.Params.UserId); err != nil {
+	if member, err := c.App.GetChannelMember(c.Params.ChannelId, c.Params.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -684,7 +684,7 @@ func getChannelMembersForUser(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if members, err := app.GetChannelMembersForUser(c.Params.TeamId, c.Params.UserId); err != nil {
+	if members, err := c.App.GetChannelMembersForUser(c.Params.TeamId, c.Params.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -709,7 +709,7 @@ func viewChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.ViewChannel(view, c.Params.UserId, !c.Session.IsMobileApp()); err != nil {
+	if err := c.App.ViewChannel(view, c.Params.UserId, !c.Session.IsMobileApp()); err != nil {
 		c.Err = err
 		return
 	}
@@ -731,12 +731,12 @@ func updateChannelMemberRoles(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_MANAGE_CHANNEL_ROLES) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_MANAGE_CHANNEL_ROLES) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_CHANNEL_ROLES)
 		return
 	}
 
-	if _, err := app.UpdateChannelMemberRoles(c.Params.ChannelId, c.Params.UserId, newRoles); err != nil {
+	if _, err := c.App.UpdateChannelMemberRoles(c.Params.ChannelId, c.Params.UserId, newRoles); err != nil {
 		c.Err = err
 		return
 	}
@@ -761,7 +761,7 @@ func updateChannelMemberNotifyProps(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	_, err := app.UpdateChannelMemberNotifyProps(props, c.Params.ChannelId, c.Params.UserId)
+	_, err := c.App.UpdateChannelMemberNotifyProps(props, c.Params.ChannelId, c.Params.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -791,7 +791,7 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(member.ChannelId); err != nil {
+	if channel, err = c.App.GetChannel(member.ChannelId); err != nil {
 		c.Err = err
 		return
 	}
@@ -799,24 +799,24 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	// Check join permission if adding yourself, otherwise check manage permission
 	if channel.Type == model.CHANNEL_OPEN {
 		if member.UserId == c.Session.UserId {
-			if !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_JOIN_PUBLIC_CHANNELS) {
+			if !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_JOIN_PUBLIC_CHANNELS) {
 				c.SetPermissionError(model.PERMISSION_JOIN_PUBLIC_CHANNELS)
 				return
 			}
 		} else {
-			if !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
+			if !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
 				c.SetPermissionError(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS)
 				return
 			}
 		}
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
+	if channel.Type == model.CHANNEL_PRIVATE && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS)
 		return
 	}
 
-	if cm, err := app.AddChannelMember(member.UserId, channel, c.Session.UserId); err != nil {
+	if cm, err := c.App.AddChannelMember(member.UserId, channel, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -834,24 +834,24 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var channel *model.Channel
 	var err *model.AppError
-	if channel, err = app.GetChannel(c.Params.ChannelId); err != nil {
+	if channel, err = c.App.GetChannel(c.Params.ChannelId); err != nil {
 		c.Err = err
 		return
 	}
 
 	if c.Params.UserId != c.Session.UserId {
-		if channel.Type == model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
+		if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS)
 			return
 		}
 
-		if channel.Type == model.CHANNEL_PRIVATE && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
+		if channel.Type == model.CHANNEL_PRIVATE && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS)
 			return
 		}
 	}
 
-	if err = app.RemoveUserFromChannel(c.Params.UserId, c.Session.UserId, channel); err != nil {
+	if err = c.App.RemoveUserFromChannel(c.Params.UserId, c.Session.UserId, channel); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
 	"github.com/mattermost/platform/utils"
@@ -390,7 +389,7 @@ func TestCreateGroupChannel(t *testing.T) {
 		t.Fatal("should have created a channel of group type")
 	}
 
-	m, _ := app.GetChannelMembersPage(rgc.Id, 0, 10)
+	m, _ := th.App.GetChannelMembersPage(rgc.Id, 0, 10)
 	if len(*m) != 3 {
 		t.Fatal("should have 3 channel members")
 	}
@@ -403,7 +402,7 @@ func TestCreateGroupChannel(t *testing.T) {
 		t.Fatal("should have returned existing channel")
 	}
 
-	m2, _ := app.GetChannelMembersPage(rgc2.Id, 0, 10)
+	m2, _ := th.App.GetChannelMembersPage(rgc2.Id, 0, 10)
 	if !reflect.DeepEqual(*m, *m2) {
 		t.Fatal("should be equal")
 	}
@@ -798,9 +797,9 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal("should have passed")
 	}
 
-	if ch, err := app.GetChannel(publicChannel1.Id); err == nil && ch.DeleteAt == 0 {
+	if ch, err := th.App.GetChannel(publicChannel1.Id); err == nil && ch.DeleteAt == 0 {
 		t.Fatal("should have failed to get deleted channel")
-	} else if err := app.JoinChannel(ch, user2.Id); err == nil {
+	} else if err := th.App.JoinChannel(ch, user2.Id); err == nil {
 		t.Fatal("should have failed to join deleted channel")
 	}
 
@@ -816,7 +815,7 @@ func TestDeleteChannel(t *testing.T) {
 
 	// successful delete of channel with multiple members
 	publicChannel3 := th.CreatePublicChannel()
-	app.AddUserToChannel(user2, publicChannel3)
+	th.App.AddUserToChannel(user2, publicChannel3)
 	_, resp = Client.DeleteChannel(publicChannel3.Id)
 	CheckNoError(t, resp)
 
@@ -827,7 +826,7 @@ func TestDeleteChannel(t *testing.T) {
 	CheckNoError(t, resp)
 
 	// default channel cannot be deleted.
-	defaultChannel, _ := app.GetChannelByName(model.DEFAULT_CHANNEL, team.Id)
+	defaultChannel, _ := th.App.GetChannelByName(model.DEFAULT_CHANNEL, team.Id)
 	pass, resp = Client.DeleteChannel(defaultChannel.Id)
 	CheckBadRequestStatus(t, resp)
 
@@ -904,9 +903,9 @@ func TestDeleteChannel(t *testing.T) {
 	// channels created by SystemAdmin
 	publicChannel6 := th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
 	privateChannel7 := th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	app.AddUserToChannel(user, publicChannel6)
-	app.AddUserToChannel(user, privateChannel7)
-	app.AddUserToChannel(user2, privateChannel7)
+	th.App.AddUserToChannel(user, publicChannel6)
+	th.App.AddUserToChannel(user, privateChannel7)
+	th.App.AddUserToChannel(user2, privateChannel7)
 
 	// successful delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -922,9 +921,9 @@ func TestDeleteChannel(t *testing.T) {
 	// channels created by SystemAdmin
 	publicChannel6 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
 	privateChannel7 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	app.AddUserToChannel(user, publicChannel6)
-	app.AddUserToChannel(user, privateChannel7)
-	app.AddUserToChannel(user2, privateChannel7)
+	th.App.AddUserToChannel(user, publicChannel6)
+	th.App.AddUserToChannel(user, privateChannel7)
+	th.App.AddUserToChannel(user2, privateChannel7)
 
 	// cannot delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -947,13 +946,13 @@ func TestDeleteChannel(t *testing.T) {
 	// // channels created by SystemAdmin
 	publicChannel6 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
 	privateChannel7 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	app.AddUserToChannel(user, publicChannel6)
-	app.AddUserToChannel(user, privateChannel7)
-	app.AddUserToChannel(user2, privateChannel7)
+	th.App.AddUserToChannel(user, publicChannel6)
+	th.App.AddUserToChannel(user, privateChannel7)
+	th.App.AddUserToChannel(user2, privateChannel7)
 
 	// successful delete by team admin
 	UpdateUserToTeamAdmin(user, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -968,7 +967,7 @@ func TestDeleteChannel(t *testing.T) {
 	*utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetDefaultRolesBasedOnConfig()
 	UpdateUserToNonTeamAdmin(user, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -976,9 +975,9 @@ func TestDeleteChannel(t *testing.T) {
 	// channels created by SystemAdmin
 	publicChannel6 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
 	privateChannel7 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	app.AddUserToChannel(user, publicChannel6)
-	app.AddUserToChannel(user, privateChannel7)
-	app.AddUserToChannel(user2, privateChannel7)
+	th.App.AddUserToChannel(user, publicChannel6)
+	th.App.AddUserToChannel(user, privateChannel7)
+	th.App.AddUserToChannel(user2, privateChannel7)
 
 	// cannot delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -1000,7 +999,7 @@ func TestDeleteChannel(t *testing.T) {
 
 	// successful delete by team admin
 	UpdateUserToTeamAdmin(th.BasicUser, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -1018,9 +1017,9 @@ func TestDeleteChannel(t *testing.T) {
 	// channels created by SystemAdmin
 	publicChannel6 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
 	privateChannel7 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	app.AddUserToChannel(user, publicChannel6)
-	app.AddUserToChannel(user, privateChannel7)
-	app.AddUserToChannel(user2, privateChannel7)
+	th.App.AddUserToChannel(user, publicChannel6)
+	th.App.AddUserToChannel(user, privateChannel7)
+	th.App.AddUserToChannel(user2, privateChannel7)
 
 	// cannot delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -1042,7 +1041,7 @@ func TestDeleteChannel(t *testing.T) {
 
 	// cannot delete by team admin
 	UpdateUserToTeamAdmin(th.BasicUser, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -1560,7 +1559,7 @@ func TestUpdateChannelRoles(t *testing.T) {
 	channel := th.CreatePublicChannel()
 
 	// Adds User 2 to the channel, making them a channel member by default.
-	app.AddUserToChannel(th.BasicUser2, channel)
+	th.App.AddUserToChannel(th.BasicUser2, channel)
 
 	// User 1 promotes User 2
 	pass, resp := Client.UpdateChannelRoles(channel.Id, th.BasicUser2.Id, CHANNEL_ADMIN)
@@ -1643,7 +1642,7 @@ func TestUpdateChannelNotifyProps(t *testing.T) {
 		t.Fatal("should have passed")
 	}
 
-	member, err := app.GetChannelMember(th.BasicChannel.Id, th.BasicUser.Id)
+	member, err := th.App.GetChannelMember(th.BasicChannel.Id, th.BasicUser.Id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1838,7 +1837,7 @@ func TestAddChannelMember(t *testing.T) {
 	Client.Logout()
 
 	MakeUserChannelAdmin(user, privateChannel)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -1868,7 +1867,7 @@ func TestAddChannelMember(t *testing.T) {
 	Client.Logout()
 
 	UpdateUserToTeamAdmin(user, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -1932,7 +1931,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	_, resp = Client.RemoveUserFromChannel(th.BasicChannel.Id, th.BasicUser.Id)
 	CheckForbiddenStatus(t, resp)
 
-	app.AddUserToChannel(th.BasicUser2, th.BasicChannel)
+	th.App.AddUserToChannel(th.BasicUser2, th.BasicChannel)
 	_, resp = Client.RemoveUserFromChannel(th.BasicChannel.Id, th.BasicUser2.Id)
 	CheckNoError(t, resp)
 
@@ -1944,7 +1943,7 @@ func TestRemoveChannelMember(t *testing.T) {
 
 	th.LoginBasic()
 	private := th.CreatePrivateChannel()
-	app.AddUserToChannel(th.BasicUser2, private)
+	th.App.AddUserToChannel(th.BasicUser2, private)
 
 	_, resp = Client.RemoveUserFromChannel(private.Id, th.BasicUser2.Id)
 	CheckNoError(t, resp)
@@ -1958,7 +1957,7 @@ func TestRemoveChannelMember(t *testing.T) {
 
 	th.LoginBasic()
 	UpdateUserToNonTeamAdmin(user1, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 
 	// Test policy does not apply to TE.
 	restrictPrivateChannel := *utils.Cfg.TeamSettings.RestrictPrivateChannelManageMembers
@@ -2018,7 +2017,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	MakeUserChannelAdmin(user1, privateChannel)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -2043,7 +2042,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	UpdateUserToTeamAdmin(user1, team)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()

--- a/api4/command.go
+++ b/api4/command.go
@@ -48,7 +48,7 @@ func createCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	cmd.CreatorId = c.Session.UserId
 
-	rcmd, err := app.CreateCommand(cmd)
+	rcmd, err := c.App.CreateCommand(cmd)
 	if err != nil {
 		c.Err = err
 		return
@@ -73,7 +73,7 @@ func updateCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("attempt")
 
-	oldCmd, err := app.GetCommand(c.Params.CommandId)
+	oldCmd, err := c.App.GetCommand(c.Params.CommandId)
 	if err != nil {
 		c.Err = err
 		return
@@ -96,7 +96,7 @@ func updateCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rcmd, err := app.UpdateCommand(oldCmd, cmd)
+	rcmd, err := c.App.UpdateCommand(oldCmd, cmd)
 	if err != nil {
 		c.Err = err
 		return
@@ -115,7 +115,7 @@ func deleteCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("attempt")
 
-	cmd, err := app.GetCommand(c.Params.CommandId)
+	cmd, err := c.App.GetCommand(c.Params.CommandId)
 	if err != nil {
 		c.Err = err
 		return
@@ -133,7 +133,7 @@ func deleteCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = app.DeleteCommand(cmd.Id)
+	err = c.App.DeleteCommand(cmd.Id)
 	if err != nil {
 		c.Err = err
 		return
@@ -164,7 +164,7 @@ func listCommands(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_SLASH_COMMANDS)
 			return
 		}
-		commands, err = app.ListTeamCommands(teamId)
+		commands, err = c.App.ListTeamCommands(teamId)
 		if err != nil {
 			c.Err = err
 			return
@@ -172,13 +172,13 @@ func listCommands(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		//User with no permission should see only system commands
 		if !app.SessionHasPermissionToTeam(c.Session, teamId, model.PERMISSION_MANAGE_SLASH_COMMANDS) {
-			commands, err = app.ListAutocompleteCommands(teamId, c.T)
+			commands, err = c.App.ListAutocompleteCommands(teamId, c.T)
 			if err != nil {
 				c.Err = err
 				return
 			}
 		} else {
-			commands, err = app.ListAllCommands(teamId, c.T)
+			commands, err = c.App.ListAllCommands(teamId, c.T)
 			if err != nil {
 				c.Err = err
 				return
@@ -201,12 +201,12 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, commandArgs.ChannelId, model.PERMISSION_USE_SLASH_COMMANDS) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, commandArgs.ChannelId, model.PERMISSION_USE_SLASH_COMMANDS) {
 		c.SetPermissionError(model.PERMISSION_USE_SLASH_COMMANDS)
 		return
 	}
 
-	channel, err := app.GetChannel(commandArgs.ChannelId)
+	channel, err := c.App.GetChannel(commandArgs.ChannelId)
 	if err != nil {
 		c.Err = err
 		return
@@ -224,7 +224,7 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	commandArgs.Session = c.Session
 	commandArgs.SiteURL = c.GetSiteURLHeader()
 
-	response, err := app.ExecuteCommand(commandArgs)
+	response, err := c.App.ExecuteCommand(commandArgs)
 	if err != nil {
 		c.Err = err
 		return
@@ -244,7 +244,7 @@ func listAutocompleteCommands(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	commands, err := app.ListAutocompleteCommands(c.Params.TeamId, c.T)
+	commands, err := c.App.ListAutocompleteCommands(c.Params.TeamId, c.T)
 	if err != nil {
 		c.Err = err
 		return
@@ -260,7 +260,7 @@ func regenCommandToken(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.LogAudit("attempt")
-	cmd, err := app.GetCommand(c.Params.CommandId)
+	cmd, err := c.App.GetCommand(c.Params.CommandId)
 	if err != nil {
 		c.Err = err
 		return
@@ -278,7 +278,7 @@ func regenCommandToken(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rcmd, err := app.RegenCommandToken(cmd)
+	rcmd, err := c.App.RegenCommandToken(cmd)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/command_help_test.go
+++ b/api4/command_help_test.go
@@ -4,9 +4,10 @@
 package api4
 
 import (
+	"testing"
+
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"testing"
 )
 
 func TestHelpCommand(t *testing.T) {

--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 )
@@ -82,7 +81,7 @@ func TestUpdateCommand(t *testing.T) {
 		Trigger:   "trigger1",
 	}
 
-	cmd1, _ = app.CreateCommand(cmd1)
+	cmd1, _ = th.App.CreateCommand(cmd1)
 
 	cmd2 := &model.Command{
 		CreatorId: GenerateTestId(),
@@ -168,7 +167,7 @@ func TestDeleteCommand(t *testing.T) {
 		Trigger:   "trigger1",
 	}
 
-	rcmd1, _ := app.CreateCommand(cmd1)
+	rcmd1, _ := th.App.CreateCommand(cmd1)
 
 	ok, resp := Client.DeleteCommand(rcmd1.Id)
 	CheckNoError(t, resp)
@@ -177,7 +176,7 @@ func TestDeleteCommand(t *testing.T) {
 		t.Fatal("should have returned true")
 	}
 
-	rcmd1, _ = app.GetCommand(rcmd1.Id)
+	rcmd1, _ = th.App.GetCommand(rcmd1.Id)
 	if rcmd1 != nil {
 		t.Fatal("should be nil")
 	}
@@ -200,7 +199,7 @@ func TestDeleteCommand(t *testing.T) {
 		Trigger:   "trigger2",
 	}
 
-	rcmd2, _ := app.CreateCommand(cmd2)
+	rcmd2, _ := th.App.CreateCommand(cmd2)
 
 	_, resp = th.Client.DeleteCommand(rcmd2.Id)
 	CheckForbiddenStatus(t, resp)
@@ -405,7 +404,7 @@ func TestExecuteCommand(t *testing.T) {
 		Trigger:   "postcommand",
 	}
 
-	if _, err := app.CreateCommand(postCmd); err != nil {
+	if _, err := th.App.CreateCommand(postCmd); err != nil {
 		t.Fatal("failed to create post command")
 	}
 
@@ -416,7 +415,7 @@ func TestExecuteCommand(t *testing.T) {
 		t.Fatal("command response should have returned")
 	}
 
-	posts, err := app.GetPostsPage(channel.Id, 0, 10)
+	posts, err := th.App.GetPostsPage(channel.Id, 0, 10)
 	if err != nil || posts == nil || len(posts.Order) != 3 {
 		t.Fatal("Test command failed to send")
 	}
@@ -441,7 +440,7 @@ func TestExecuteCommand(t *testing.T) {
 		Trigger:   "getcommand",
 	}
 
-	if _, err := app.CreateCommand(getCmd); err != nil {
+	if _, err := th.App.CreateCommand(getCmd); err != nil {
 		t.Fatal("failed to create get command")
 	}
 
@@ -452,7 +451,7 @@ func TestExecuteCommand(t *testing.T) {
 		t.Fatal("command response should have returned")
 	}
 
-	posts, err = app.GetPostsPage(channel.Id, 0, 10)
+	posts, err = th.App.GetPostsPage(channel.Id, 0, 10)
 	if err != nil || posts == nil || len(posts.Order) != 4 {
 		t.Fatal("Test command failed to send")
 	}

--- a/api4/compliance.go
+++ b/api4/compliance.go
@@ -37,7 +37,7 @@ func createComplianceReport(c *Context, w http.ResponseWriter, r *http.Request) 
 
 	job.UserId = c.Session.UserId
 
-	rjob, err := app.SaveComplianceReport(job)
+	rjob, err := c.App.SaveComplianceReport(job)
 	if err != nil {
 		c.Err = err
 		return
@@ -54,7 +54,7 @@ func getComplianceReports(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	crs, err := app.GetComplianceReports(c.Params.Page, c.Params.PerPage)
+	crs, err := c.App.GetComplianceReports(c.Params.Page, c.Params.PerPage)
 	if err != nil {
 		c.Err = err
 		return
@@ -74,7 +74,7 @@ func getComplianceReport(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	job, err := app.GetComplianceReport(c.Params.ReportId)
+	job, err := c.App.GetComplianceReport(c.Params.ReportId)
 	if err != nil {
 		c.Err = err
 		return
@@ -94,7 +94,7 @@ func downloadComplianceReport(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	job, err := app.GetComplianceReport(c.Params.ReportId)
+	job, err := c.App.GetComplianceReport(c.Params.ReportId)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/emoji.go
+++ b/api4/emoji.go
@@ -66,7 +66,7 @@ func createEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newEmoji, err := app.CreateEmoji(c.Session.UserId, emoji, m)
+	newEmoji, err := c.App.CreateEmoji(c.Session.UserId, emoji, m)
 	if err != nil {
 		c.Err = err
 		return
@@ -81,7 +81,7 @@ func getEmojiList(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	listEmoji, err := app.GetEmojiList(c.Params.Page, c.Params.PerPage)
+	listEmoji, err := c.App.GetEmojiList(c.Params.Page, c.Params.PerPage)
 	if err != nil {
 		c.Err = err
 		return
@@ -96,7 +96,7 @@ func deleteEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	emoji, err := app.GetEmoji(c.Params.EmojiId)
+	emoji, err := c.App.GetEmoji(c.Params.EmojiId)
 	if err != nil {
 		c.Err = err
 		return
@@ -107,7 +107,7 @@ func deleteEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = app.DeleteEmoji(emoji)
+	err = c.App.DeleteEmoji(emoji)
 	if err != nil {
 		c.Err = err
 		return
@@ -127,7 +127,7 @@ func getEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	emoji, err := app.GetEmoji(c.Params.EmojiId)
+	emoji, err := c.App.GetEmoji(c.Params.EmojiId)
 	if err != nil {
 		c.Err = err
 		return
@@ -152,7 +152,7 @@ func getEmojiImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	image, imageType, err := app.GetEmojiImage(c.Params.EmojiId)
+	image, imageType, err := c.App.GetEmojiImage(c.Params.EmojiId)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/file.go
+++ b/api4/file.go
@@ -86,12 +86,12 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_UPLOAD_FILE) {
+	if !c.App.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_UPLOAD_FILE) {
 		c.SetPermissionError(model.PERMISSION_UPLOAD_FILE)
 		return
 	}
 
-	resStruct, err := app.UploadFiles(FILE_TEAM_ID, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"])
+	resStruct, err := c.App.UploadFiles(FILE_TEAM_ID, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"])
 	if err != nil {
 		c.Err = err
 		return
@@ -112,13 +112,13 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		forceDownload = false
 	}
 
-	info, err := app.GetFileInfo(c.Params.FileId)
+	info, err := c.App.GetFileInfo(c.Params.FileId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	if info.CreatorId != c.Session.UserId && !app.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
+	if info.CreatorId != c.Session.UserId && !c.App.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
@@ -148,13 +148,13 @@ func getFileThumbnail(c *Context, w http.ResponseWriter, r *http.Request) {
 		forceDownload = false
 	}
 
-	info, err := app.GetFileInfo(c.Params.FileId)
+	info, err := c.App.GetFileInfo(c.Params.FileId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	if info.CreatorId != c.Session.UserId && !app.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
+	if info.CreatorId != c.Session.UserId && !c.App.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
@@ -184,13 +184,13 @@ func getFileLink(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info, err := app.GetFileInfo(c.Params.FileId)
+	info, err := c.App.GetFileInfo(c.Params.FileId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	if info.CreatorId != c.Session.UserId && !app.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
+	if info.CreatorId != c.Session.UserId && !c.App.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
@@ -217,13 +217,13 @@ func getFilePreview(c *Context, w http.ResponseWriter, r *http.Request) {
 		forceDownload = false
 	}
 
-	info, err := app.GetFileInfo(c.Params.FileId)
+	info, err := c.App.GetFileInfo(c.Params.FileId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	if info.CreatorId != c.Session.UserId && !app.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
+	if info.CreatorId != c.Session.UserId && !c.App.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
@@ -248,13 +248,13 @@ func getFileInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info, err := app.GetFileInfo(c.Params.FileId)
+	info, err := c.App.GetFileInfo(c.Params.FileId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	if info.CreatorId != c.Session.UserId && !app.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
+	if info.CreatorId != c.Session.UserId && !c.App.SessionHasPermissionToChannelByPost(c.Session, info.PostId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
@@ -274,7 +274,7 @@ func getPublicFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info, err := app.GetFileInfo(c.Params.FileId)
+	info, err := c.App.GetFileInfo(c.Params.FileId)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -51,7 +51,7 @@ func TestUploadFile(t *testing.T) {
 	}
 
 	var info *model.FileInfo
-	if result := <-app.Srv.Store.FileInfo().Get(uploadInfo.Id); result.Err != nil {
+	if result := <-th.App.Srv.Store.FileInfo().Get(uploadInfo.Id); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		info = result.Data.(*model.FileInfo)
@@ -317,7 +317,7 @@ func TestGetFileLink(t *testing.T) {
 	CheckBadRequestStatus(t, resp)
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
 
 	utils.Cfg.FileSettings.EnablePublicLink = false
 	_, resp = Client.GetFileLink(fileId)
@@ -352,7 +352,7 @@ func TestGetFileLink(t *testing.T) {
 	_, resp = th.SystemAdminClient.GetFileLink(fileId)
 	CheckNoError(t, resp)
 
-	if result := <-app.Srv.Store.FileInfo().Get(fileId); result.Err != nil {
+	if result := <-th.App.Srv.Store.FileInfo().Get(fileId); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		cleanupTestFile(result.Data.(*model.FileInfo))
@@ -508,9 +508,9 @@ func TestGetPublicFile(t *testing.T) {
 	}
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(app.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
 
-	result := <-app.Srv.Store.FileInfo().Get(fileId)
+	result := <-th.App.Srv.Store.FileInfo().Get(fileId)
 	info := result.Data.(*model.FileInfo)
 	link := app.GeneratePublicLink(Client.Url, info)
 
@@ -543,7 +543,7 @@ func TestGetPublicFile(t *testing.T) {
 		t.Fatal("should've failed to get image with public link after salt changed")
 	}
 
-	if err := cleanupTestFile(store.Must(app.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
+	if err := cleanupTestFile(store.Must(th.App.Srv.Store.FileInfo().Get(fileId)).(*model.FileInfo)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api4/job.go
+++ b/api4/job.go
@@ -32,7 +32,7 @@ func getJob(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if job, err := app.GetJob(c.Params.JobId); err != nil {
+	if job, err := c.App.GetJob(c.Params.JobId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -71,7 +71,7 @@ func getJobs(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if jobs, err := app.GetJobsPage(c.Params.Page, c.Params.PerPage); err != nil {
+	if jobs, err := c.App.GetJobsPage(c.Params.Page, c.Params.PerPage); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -90,7 +90,7 @@ func getJobsByType(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if jobs, err := app.GetJobsByTypePage(c.Params.JobType, c.Params.Page, c.Params.PerPage); err != nil {
+	if jobs, err := c.App.GetJobsByTypePage(c.Params.JobType, c.Params.Page, c.Params.PerPage); err != nil {
 		c.Err = err
 		return
 	} else {

--- a/api4/job_test.go
+++ b/api4/job_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
 )
@@ -26,7 +25,7 @@ func TestCreateJob(t *testing.T) {
 	received, resp := th.SystemAdminClient.CreateJob(job)
 	CheckNoError(t, resp)
 
-	defer app.Srv.Store.Job().Delete(received.Id)
+	defer th.App.Srv.Store.Job().Delete(received.Id)
 
 	job = &model.Job{
 		Type: model.NewId(),
@@ -47,11 +46,11 @@ func TestGetJob(t *testing.T) {
 		Id:     model.NewId(),
 		Status: model.JOB_STATUS_PENDING,
 	}
-	if result := <-app.Srv.Store.Job().Save(job); result.Err != nil {
+	if result := <-th.App.Srv.Store.Job().Save(job); result.Err != nil {
 		t.Fatal(result.Err)
 	}
 
-	defer app.Srv.Store.Job().Delete(job.Id)
+	defer th.App.Srv.Store.Job().Delete(job.Id)
 
 	received, resp := th.SystemAdminClient.GetJob(job.Id)
 	CheckNoError(t, resp)
@@ -95,8 +94,8 @@ func TestGetJobs(t *testing.T) {
 	}
 
 	for _, job := range jobs {
-		store.Must(app.Srv.Store.Job().Save(job))
-		defer app.Srv.Store.Job().Delete(job.Id)
+		store.Must(th.App.Srv.Store.Job().Save(job))
+		defer th.App.Srv.Store.Job().Delete(job.Id)
 	}
 
 	received, resp := th.SystemAdminClient.GetJobs(0, 2)
@@ -151,8 +150,8 @@ func TestGetJobsByType(t *testing.T) {
 	}
 
 	for _, job := range jobs {
-		store.Must(app.Srv.Store.Job().Save(job))
-		defer app.Srv.Store.Job().Delete(job.Id)
+		store.Must(th.App.Srv.Store.Job().Save(job))
+		defer th.App.Srv.Store.Job().Delete(job.Id)
 	}
 
 	received, resp := th.SystemAdminClient.GetJobsByType(jobType, 0, 2)
@@ -208,8 +207,8 @@ func TestCancelJob(t *testing.T) {
 	}
 
 	for _, job := range jobs {
-		store.Must(app.Srv.Store.Job().Save(job))
-		defer app.Srv.Store.Job().Delete(job.Id)
+		store.Must(th.App.Srv.Store.Job().Save(job))
+		defer th.App.Srv.Store.Job().Delete(job.Id)
 	}
 
 	_, resp := th.Client.CancelJob(jobs[0].Id)

--- a/api4/plugin.go
+++ b/api4/plugin.go
@@ -63,7 +63,7 @@ func uploadPlugin(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	manifest, unpackErr := app.UnpackAndActivatePlugin(file)
+	manifest, unpackErr := c.App.UnpackAndActivatePlugin(file)
 
 	if unpackErr != nil {
 		c.Err = unpackErr
@@ -85,7 +85,7 @@ func getPlugins(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	manifests, err := app.GetActivePluginManifests()
+	manifests, err := c.App.GetActivePluginManifests()
 	if err != nil {
 		c.Err = err
 		return
@@ -110,7 +110,7 @@ func removePlugin(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := app.RemovePlugin(c.Params.PluginId)
+	err := c.App.RemovePlugin(c.Params.PluginId)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +29,7 @@ func TestPlugin(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer TearDown()
 
-	app.StartupPlugins(pluginDir, webappDir)
+	th.App.StartupPlugins(pluginDir, webappDir)
 
 	enablePlugins := *utils.Cfg.PluginSettings.Enable
 	defer func() {
@@ -111,5 +110,5 @@ func TestPlugin(t *testing.T) {
 	_, resp = th.SystemAdminClient.RemovePlugin("bad.id")
 	CheckNotFoundStatus(t, resp)
 
-	app.Srv.PluginEnv = nil
+	th.App.Srv.PluginEnv = nil
 }

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -277,8 +277,8 @@ func TestCreatePostPublic(t *testing.T) {
 	_, resp = Client.CreatePost(post)
 	CheckForbiddenStatus(t, resp)
 
-	app.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_POST_ALL_PUBLIC.Id)
-	app.InvalidateAllCaches()
+	th.App.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_POST_ALL_PUBLIC.Id)
+	th.App.InvalidateAllCaches()
 
 	Client.Login(user.Email, user.Password)
 
@@ -289,10 +289,10 @@ func TestCreatePostPublic(t *testing.T) {
 	_, resp = Client.CreatePost(post)
 	CheckForbiddenStatus(t, resp)
 
-	app.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id)
-	app.JoinUserToTeam(th.BasicTeam, ruser, "")
-	app.UpdateTeamMemberRoles(th.BasicTeam.Id, ruser.Id, model.ROLE_TEAM_USER.Id+" "+model.ROLE_TEAM_POST_ALL_PUBLIC.Id)
-	app.InvalidateAllCaches()
+	th.App.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id)
+	th.App.JoinUserToTeam(th.BasicTeam, ruser, "")
+	th.App.UpdateTeamMemberRoles(th.BasicTeam.Id, ruser.Id, model.ROLE_TEAM_USER.Id+" "+model.ROLE_TEAM_POST_ALL_PUBLIC.Id)
+	th.App.InvalidateAllCaches()
 
 	Client.Login(user.Email, user.Password)
 
@@ -314,7 +314,7 @@ func TestCreatePostAll(t *testing.T) {
 
 	user := model.User{Email: GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_USER.Id}
 
-	directChannel, _ := app.CreateDirectChannel(th.BasicUser.Id, th.BasicUser2.Id)
+	directChannel, _ := th.App.CreateDirectChannel(th.BasicUser.Id, th.BasicUser2.Id)
 
 	ruser, resp := Client.CreateUser(&user)
 	CheckNoError(t, resp)
@@ -324,8 +324,8 @@ func TestCreatePostAll(t *testing.T) {
 	_, resp = Client.CreatePost(post)
 	CheckForbiddenStatus(t, resp)
 
-	app.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_POST_ALL.Id)
-	app.InvalidateAllCaches()
+	th.App.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_POST_ALL.Id)
+	th.App.InvalidateAllCaches()
 
 	Client.Login(user.Email, user.Password)
 
@@ -340,10 +340,10 @@ func TestCreatePostAll(t *testing.T) {
 	_, resp = Client.CreatePost(post)
 	CheckNoError(t, resp)
 
-	app.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id)
-	app.JoinUserToTeam(th.BasicTeam, ruser, "")
-	app.UpdateTeamMemberRoles(th.BasicTeam.Id, ruser.Id, model.ROLE_TEAM_USER.Id+" "+model.ROLE_TEAM_POST_ALL.Id)
-	app.InvalidateAllCaches()
+	th.App.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id)
+	th.App.JoinUserToTeam(th.BasicTeam, ruser, "")
+	th.App.UpdateTeamMemberRoles(th.BasicTeam.Id, ruser.Id, model.ROLE_TEAM_USER.Id+" "+model.ROLE_TEAM_POST_ALL.Id)
+	th.App.InvalidateAllCaches()
 
 	Client.Login(user.Email, user.Password)
 
@@ -557,7 +557,7 @@ func TestPinPost(t *testing.T) {
 		t.Fatal("should have passed")
 	}
 
-	if rpost, err := app.GetSinglePost(post.Id); err != nil && rpost.IsPinned != true {
+	if rpost, err := th.App.GetSinglePost(post.Id); err != nil && rpost.IsPinned != true {
 		t.Fatal("failed to pin post")
 	}
 
@@ -592,7 +592,7 @@ func TestUnpinPost(t *testing.T) {
 		t.Fatal("should have passed")
 	}
 
-	if rpost, err := app.GetSinglePost(pinnedPost.Id); err != nil && rpost.IsPinned != false {
+	if rpost, err := th.App.GetSinglePost(pinnedPost.Id); err != nil && rpost.IsPinned != false {
 		t.Fatal("failed to pin post")
 	}
 
@@ -1297,8 +1297,8 @@ func TestSearchPostsFromUser(t *testing.T) {
 	th.LoginTeamAdmin()
 	user := th.CreateUser()
 	LinkUserToTeam(user, th.BasicTeam)
-	app.AddUserToChannel(user, th.BasicChannel)
-	app.AddUserToChannel(user, th.BasicChannel2)
+	th.App.AddUserToChannel(user, th.BasicChannel)
+	th.App.AddUserToChannel(user, th.BasicChannel2)
 
 	message := "sgtitlereview with space"
 	_ = th.CreateMessagePost(message)

--- a/api4/preference.go
+++ b/api4/preference.go
@@ -33,7 +33,7 @@ func getPreferences(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if preferences, err := app.GetPreferencesForUser(c.Params.UserId); err != nil {
+	if preferences, err := c.App.GetPreferencesForUser(c.Params.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -53,7 +53,7 @@ func getPreferencesByCategory(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if preferences, err := app.GetPreferenceByCategoryForUser(c.Params.UserId, c.Params.Category); err != nil {
+	if preferences, err := c.App.GetPreferenceByCategoryForUser(c.Params.UserId, c.Params.Category); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -73,7 +73,7 @@ func getPreferenceByCategoryAndName(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if preferences, err := app.GetPreferenceByCategoryAndNameForUser(c.Params.UserId, c.Params.Category, c.Params.PreferenceName); err != nil {
+	if preferences, err := c.App.GetPreferenceByCategoryAndNameForUser(c.Params.UserId, c.Params.Category, c.Params.PreferenceName); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -99,7 +99,7 @@ func updatePreferences(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.UpdatePreferences(c.Params.UserId, preferences); err != nil {
+	if err := c.App.UpdatePreferences(c.Params.UserId, preferences); err != nil {
 		c.Err = err
 		return
 	}
@@ -124,7 +124,7 @@ func deletePreferences(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.DeletePreferences(c.Params.UserId, preferences); err != nil {
+	if err := c.App.DeletePreferences(c.Params.UserId, preferences); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/reaction.go
+++ b/api4/reaction.go
@@ -37,12 +37,12 @@ func saveReaction(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannelByPost(c.Session, reaction.PostId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannelByPost(c.Session, reaction.PostId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if reaction, err := app.SaveReactionForPost(reaction); err != nil {
+	if reaction, err := c.App.SaveReactionForPost(reaction); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -57,12 +57,12 @@ func getReactions(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannelByPost(c.Session, c.Params.PostId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannelByPost(c.Session, c.Params.PostId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if reactions, err := app.GetReactionsForPost(c.Params.PostId); err != nil {
+	if reactions, err := c.App.GetReactionsForPost(c.Params.PostId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -87,7 +87,7 @@ func deleteReaction(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !app.SessionHasPermissionToChannelByPost(c.Session, c.Params.PostId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannelByPost(c.Session, c.Params.PostId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
@@ -103,7 +103,7 @@ func deleteReaction(c *Context, w http.ResponseWriter, r *http.Request) {
 		EmojiName: c.Params.EmojiName,
 	}
 
-	err := app.DeleteReactionForPost(reaction)
+	err := c.App.DeleteReactionForPost(reaction)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/reaction_test.go
+++ b/api4/reaction_test.go
@@ -9,7 +9,6 @@ import (
 
 	"reflect"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 )
 
@@ -45,7 +44,7 @@ func TestSaveReaction(t *testing.T) {
 		t.Fatal("CreateAt should exist")
 	}
 
-	if reactions, err := app.GetReactionsForPost(postId); err != nil && len(reactions) != 1 {
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil && len(reactions) != 1 {
 		t.Fatal("didn't save reaction correctly")
 	}
 
@@ -53,7 +52,7 @@ func TestSaveReaction(t *testing.T) {
 	rr, resp = Client.SaveReaction(reaction)
 	CheckNoError(t, resp)
 
-	if reactions, err := app.GetReactionsForPost(postId); err != nil && len(reactions) != 1 {
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil && len(reactions) != 1 {
 		t.Fatal("should have not save duplicated reaction")
 	}
 
@@ -66,7 +65,7 @@ func TestSaveReaction(t *testing.T) {
 		t.Fatal("EmojiName did not match")
 	}
 
-	if reactions, err := app.GetReactionsForPost(postId); err != nil && len(reactions) != 2 {
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil && len(reactions) != 2 {
 		t.Fatal("should have save multiple reactions")
 	}
 
@@ -80,7 +79,7 @@ func TestSaveReaction(t *testing.T) {
 		t.Fatal("EmojiName did not match")
 	}
 
-	if reactions, err := app.GetReactionsForPost(postId); err != nil && len(reactions) != 3 {
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil && len(reactions) != 3 {
 		t.Fatal("should have save multiple reactions")
 	}
 
@@ -171,7 +170,7 @@ func TestGetReactions(t *testing.T) {
 	var reactions []*model.Reaction
 
 	for _, userReaction := range userReactions {
-		if result := <-app.Srv.Store.Reaction().Save(userReaction); result.Err != nil {
+		if result := <-th.App.Srv.Store.Reaction().Save(userReaction); result.Err != nil {
 			t.Fatal(result.Err)
 		} else {
 			reactions = append(reactions, result.Data.(*model.Reaction))
@@ -222,8 +221,8 @@ func TestDeleteReaction(t *testing.T) {
 		EmojiName: "smile",
 	}
 
-	app.SaveReactionForPost(r1)
-	if reactions, err := app.GetReactionsForPost(postId); err != nil || len(reactions) != 1 {
+	th.App.SaveReactionForPost(r1)
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil || len(reactions) != 1 {
 		t.Fatal("didn't save reaction correctly")
 	}
 
@@ -234,7 +233,7 @@ func TestDeleteReaction(t *testing.T) {
 		t.Fatal("should have returned true")
 	}
 
-	if reactions, err := app.GetReactionsForPost(postId); err != nil || len(reactions) != 0 {
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil || len(reactions) != 0 {
 		t.Fatal("should have deleted reaction")
 	}
 
@@ -245,16 +244,16 @@ func TestDeleteReaction(t *testing.T) {
 		EmojiName: "smile-",
 	}
 
-	app.SaveReactionForPost(r1)
-	app.SaveReactionForPost(r2)
-	if reactions, err := app.GetReactionsForPost(postId); err != nil || len(reactions) != 2 {
+	th.App.SaveReactionForPost(r1)
+	th.App.SaveReactionForPost(r2)
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil || len(reactions) != 2 {
 		t.Fatal("didn't save reactions correctly")
 	}
 
 	_, resp = Client.DeleteReaction(r2)
 	CheckNoError(t, resp)
 
-	if reactions, err := app.GetReactionsForPost(postId); err != nil || len(reactions) != 1 || *reactions[0] != *r1 {
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil || len(reactions) != 1 || *reactions[0] != *r1 {
 		t.Fatal("should have deleted 1 reaction only")
 	}
 
@@ -265,15 +264,15 @@ func TestDeleteReaction(t *testing.T) {
 		EmojiName: "+1",
 	}
 
-	app.SaveReactionForPost(r3)
-	if reactions, err := app.GetReactionsForPost(postId); err != nil || len(reactions) != 2 {
+	th.App.SaveReactionForPost(r3)
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil || len(reactions) != 2 {
 		t.Fatal("didn't save reactions correctly")
 	}
 
 	_, resp = Client.DeleteReaction(r3)
 	CheckNoError(t, resp)
 
-	if reactions, err := app.GetReactionsForPost(postId); err != nil || len(reactions) != 1 || *reactions[0] != *r1 {
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil || len(reactions) != 1 || *reactions[0] != *r1 {
 		t.Fatal("should have deleted 1 reaction only")
 	}
 
@@ -285,8 +284,8 @@ func TestDeleteReaction(t *testing.T) {
 	}
 
 	th.LoginBasic2()
-	app.SaveReactionForPost(r4)
-	if reactions, err := app.GetReactionsForPost(postId); err != nil || len(reactions) != 2 {
+	th.App.SaveReactionForPost(r4)
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil || len(reactions) != 2 {
 		t.Fatal("didn't save reaction correctly")
 	}
 
@@ -299,7 +298,7 @@ func TestDeleteReaction(t *testing.T) {
 		t.Fatal("should have returned false")
 	}
 
-	if reactions, err := app.GetReactionsForPost(postId); err != nil || len(reactions) != 2 {
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil || len(reactions) != 2 {
 		t.Fatal("should have not deleted a reaction")
 	}
 
@@ -346,7 +345,7 @@ func TestDeleteReaction(t *testing.T) {
 	_, resp = th.SystemAdminClient.DeleteReaction(r4)
 	CheckNoError(t, resp)
 
-	if reactions, err := app.GetReactionsForPost(postId); err != nil || len(reactions) != 0 {
+	if reactions, err := th.App.GetReactionsForPost(postId); err != nil || len(reactions) != 0 {
 		t.Fatal("should have deleted both reactions")
 	}
 }

--- a/api4/status.go
+++ b/api4/status.go
@@ -29,7 +29,7 @@ func getUserStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// No permission check required
 
-	if statusMap, err := app.GetUserStatusesByIds([]string{c.Params.UserId}); err != nil {
+	if statusMap, err := c.App.GetUserStatusesByIds([]string{c.Params.UserId}); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -52,7 +52,7 @@ func getUserStatusesByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// No permission check required
 
-	if statusMap, err := app.GetUserStatusesByIds(userIds); err != nil {
+	if statusMap, err := c.App.GetUserStatusesByIds(userIds); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -79,11 +79,11 @@ func updateUserStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	switch status.Status {
 	case "online":
-		app.SetStatusOnline(c.Params.UserId, "", true)
+		c.App.SetStatusOnline(c.Params.UserId, "", true)
 	case "offline":
-		app.SetStatusOffline(c.Params.UserId, true)
+		c.App.SetStatusOffline(c.Params.UserId, true)
 	case "away":
-		app.SetStatusAwayIfNeeded(c.Params.UserId, true)
+		c.App.SetStatusAwayIfNeeded(c.Params.UserId, true)
 	default:
 		c.SetInvalidParam("status")
 		return

--- a/api4/status_test.go
+++ b/api4/status_test.go
@@ -3,7 +3,6 @@ package api4
 import (
 	"testing"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 )
 
@@ -18,21 +17,21 @@ func TestGetUserStatus(t *testing.T) {
 		t.Fatal("Should return offline status")
 	}
 
-	app.SetStatusOnline(th.BasicUser.Id, "", true)
+	th.App.SetStatusOnline(th.BasicUser.Id, "", true)
 	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
 	CheckNoError(t, resp)
 	if userStatus.Status != "online" {
 		t.Fatal("Should return online status")
 	}
 
-	app.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
+	th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
 	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
 	CheckNoError(t, resp)
 	if userStatus.Status != "away" {
 		t.Fatal("Should return away status")
 	}
 
-	app.SetStatusOffline(th.BasicUser.Id, true)
+	th.App.SetStatusOffline(th.BasicUser.Id, true)
 	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
 	CheckNoError(t, resp)
 	if userStatus.Status != "offline" {
@@ -70,8 +69,8 @@ func TestGetUsersStatusesByIds(t *testing.T) {
 		}
 	}
 
-	app.SetStatusOnline(th.BasicUser.Id, "", true)
-	app.SetStatusOnline(th.BasicUser2.Id, "", true)
+	th.App.SetStatusOnline(th.BasicUser.Id, "", true)
+	th.App.SetStatusOnline(th.BasicUser2.Id, "", true)
 	usersStatuses, resp = Client.GetUsersStatusesByIds(usersIds)
 	CheckNoError(t, resp)
 	for _, userStatus := range usersStatuses {
@@ -80,8 +79,8 @@ func TestGetUsersStatusesByIds(t *testing.T) {
 		}
 	}
 
-	app.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
-	app.SetStatusAwayIfNeeded(th.BasicUser2.Id, true)
+	th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
+	th.App.SetStatusAwayIfNeeded(th.BasicUser2.Id, true)
 	usersStatuses, resp = Client.GetUsersStatusesByIds(usersIds)
 	CheckNoError(t, resp)
 	for _, userStatus := range usersStatuses {

--- a/api4/system.go
+++ b/api4/system.go
@@ -79,7 +79,7 @@ func testEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := app.TestEmail(c.Session.UserId, cfg)
+	err := c.App.TestEmail(c.Session.UserId, cfg)
 	if err != nil {
 		c.Err = err
 		return
@@ -144,7 +144,7 @@ func getAudits(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	audits, err := app.GetAuditsPage("", c.Params.Page, c.Params.PerPage)
+	audits, err := c.App.GetAuditsPage("", c.Params.Page, c.Params.PerPage)
 
 	if err != nil {
 		c.Err = err
@@ -161,7 +161,7 @@ func databaseRecycle(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.RecycleDatabaseConnection()
+	c.App.RecycleDatabaseConnection()
 
 	ReturnStatusOK(w)
 }
@@ -172,7 +172,7 @@ func invalidateCaches(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := app.InvalidateAllCaches()
+	err := c.App.InvalidateAllCaches()
 	if err != nil {
 		c.Err = err
 		return
@@ -243,8 +243,8 @@ func getClientConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		respCfg[k] = v
 	}
 
-	respCfg["NoAccounts"] = strconv.FormatBool(app.IsFirstUserAccount())
-	respCfg["Plugins"] = app.GetPluginsForClientConfig()
+	respCfg["NoAccounts"] = strconv.FormatBool(c.App.IsFirstUserAccount())
+	respCfg["Plugins"] = c.App.GetPluginsForClientConfig()
 
 	w.Write([]byte(model.MapToJson(respCfg)))
 }
@@ -318,7 +318,7 @@ func addLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 	buf := bytes.NewBuffer(nil)
 	io.Copy(buf, file)
 
-	if license, err := app.SaveLicense(buf.Bytes()); err != nil {
+	if license, err := c.App.SaveLicense(buf.Bytes()); err != nil {
 		if err.Id == model.EXPIRED_LICENSE_ERROR {
 			c.LogAudit("failed - expired or non-started license")
 		} else if err.Id == model.INVALID_LICENSE_ERROR {
@@ -342,7 +342,7 @@ func removeLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.RemoveLicense(); err != nil {
+	if err := c.App.RemoveLicense(); err != nil {
 		c.Err = err
 		return
 	}
@@ -364,7 +364,7 @@ func getAnalytics(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := app.GetAnalytics(name, teamId)
+	rows, err := c.App.GetAnalytics(name, teamId)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/team.go
+++ b/api4/team.go
@@ -65,7 +65,7 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rteam, err := app.CreateTeamWithUser(team, c.Session.UserId)
+	rteam, err := c.App.CreateTeamWithUser(team, c.Session.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -81,7 +81,7 @@ func getTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if team, err := app.GetTeam(c.Params.TeamId); err != nil {
+	if team, err := c.App.GetTeam(c.Params.TeamId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -101,7 +101,7 @@ func getTeamByName(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if team, err := app.GetTeamByName(c.Params.TeamName); err != nil {
+	if team, err := c.App.GetTeamByName(c.Params.TeamName); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -135,7 +135,7 @@ func updateTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedTeam, err := app.UpdateTeam(team)
+	updatedTeam, err := c.App.UpdateTeam(team)
 
 	if err != nil {
 		c.Err = err
@@ -163,7 +163,7 @@ func patchTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	patchedTeam, err := app.PatchTeam(c.Params.TeamId, team)
+	patchedTeam, err := c.App.PatchTeam(c.Params.TeamId, team)
 
 	if err != nil {
 		c.Err = err
@@ -187,9 +187,9 @@ func deleteTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var err *model.AppError
 	if c.Params.Permanent {
-		err = app.PermanentDeleteTeamId(c.Params.TeamId)
+		err = c.App.PermanentDeleteTeamId(c.Params.TeamId)
 	} else {
-		err = app.SoftDeleteTeam(c.Params.TeamId)
+		err = c.App.SoftDeleteTeam(c.Params.TeamId)
 	}
 
 	if err != nil {
@@ -211,7 +211,7 @@ func getTeamsForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if teams, err := app.GetTeamsForUser(c.Params.UserId); err != nil {
+	if teams, err := c.App.GetTeamsForUser(c.Params.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -233,7 +233,7 @@ func getTeamsUnreadForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	// optional team id to be excluded from the result
 	teamId := r.URL.Query().Get("exclude_team")
 
-	unreadTeamsList, err := app.GetTeamsUnreadForUser(teamId, c.Params.UserId)
+	unreadTeamsList, err := c.App.GetTeamsUnreadForUser(teamId, c.Params.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -253,7 +253,7 @@ func getTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if team, err := app.GetTeamMember(c.Params.TeamId, c.Params.UserId); err != nil {
+	if team, err := c.App.GetTeamMember(c.Params.TeamId, c.Params.UserId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -273,7 +273,7 @@ func getTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if members, err := app.GetTeamMembers(c.Params.TeamId, c.Params.Page, c.Params.PerPage); err != nil {
+	if members, err := c.App.GetTeamMembers(c.Params.TeamId, c.Params.Page, c.Params.PerPage); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -293,7 +293,7 @@ func getTeamMembersForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	members, err := app.GetTeamMembersForUser(c.Params.UserId)
+	members, err := c.App.GetTeamMembersForUser(c.Params.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -320,7 +320,7 @@ func getTeamMembersByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	members, err := app.GetTeamMembersByIds(c.Params.TeamId, userIds)
+	members, err := c.App.GetTeamMembersByIds(c.Params.TeamId, userIds)
 	if err != nil {
 		c.Err = err
 		return
@@ -352,7 +352,7 @@ func addTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	member, err = app.AddTeamMember(member.TeamId, member.UserId)
+	member, err = c.App.AddTeamMember(member.TeamId, member.UserId)
 
 	if err != nil {
 		c.Err = err
@@ -372,9 +372,9 @@ func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request)
 	var err *model.AppError
 
 	if len(hash) > 0 && len(data) > 0 {
-		member, err = app.AddTeamMemberByHash(c.Session.UserId, hash, data)
+		member, err = c.App.AddTeamMemberByHash(c.Session.UserId, hash, data)
 	} else if len(inviteId) > 0 {
-		member, err = app.AddTeamMemberByInviteId(inviteId, c.Session.UserId)
+		member, err = c.App.AddTeamMemberByInviteId(inviteId, c.Session.UserId)
 	} else {
 		err = model.NewAppError("addTeamMember", "api.team.add_user_to_team.missing_parameter.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -422,7 +422,7 @@ func addTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	members, err = app.AddTeamMembers(c.Params.TeamId, userIds, c.Session.UserId)
+	members, err = c.App.AddTeamMembers(c.Params.TeamId, userIds, c.Session.UserId)
 
 	if err != nil {
 		c.Err = err
@@ -446,7 +446,7 @@ func removeTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := app.RemoveUserFromTeam(c.Params.TeamId, c.Params.UserId); err != nil {
+	if err := c.App.RemoveUserFromTeam(c.Params.TeamId, c.Params.UserId); err != nil {
 		c.Err = err
 		return
 	}
@@ -470,7 +470,7 @@ func getTeamUnread(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	unreadTeam, err := app.GetTeamUnread(c.Params.TeamId, c.Params.UserId)
+	unreadTeam, err := c.App.GetTeamUnread(c.Params.TeamId, c.Params.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -490,7 +490,7 @@ func getTeamStats(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if stats, err := app.GetTeamStats(c.Params.TeamId); err != nil {
+	if stats, err := c.App.GetTeamStats(c.Params.TeamId); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -518,7 +518,7 @@ func updateTeamMemberRoles(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := app.UpdateTeamMemberRoles(c.Params.TeamId, c.Params.UserId, newRoles); err != nil {
+	if _, err := c.App.UpdateTeamMemberRoles(c.Params.TeamId, c.Params.UserId, newRoles); err != nil {
 		c.Err = err
 		return
 	}
@@ -531,9 +531,9 @@ func getAllTeams(c *Context, w http.ResponseWriter, r *http.Request) {
 	var err *model.AppError
 
 	if app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
-		teams, err = app.GetAllTeamsPage(c.Params.Page, c.Params.PerPage)
+		teams, err = c.App.GetAllTeamsPage(c.Params.Page, c.Params.PerPage)
 	} else {
-		teams, err = app.GetAllOpenTeamsPage(c.Params.Page, c.Params.PerPage)
+		teams, err = c.App.GetAllOpenTeamsPage(c.Params.Page, c.Params.PerPage)
 	}
 
 	if err != nil {
@@ -560,9 +560,9 @@ func searchTeams(c *Context, w http.ResponseWriter, r *http.Request) {
 	var err *model.AppError
 
 	if app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
-		teams, err = app.SearchAllTeams(props.Term)
+		teams, err = c.App.SearchAllTeams(props.Term)
 	} else {
-		teams, err = app.SearchOpenTeams(props.Term)
+		teams, err = c.App.SearchOpenTeams(props.Term)
 	}
 
 	if err != nil {
@@ -581,7 +581,7 @@ func teamExists(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	resp := make(map[string]bool)
 
-	if _, err := app.GetTeamByName(c.Params.TeamName); err != nil {
+	if _, err := c.App.GetTeamByName(c.Params.TeamName); err != nil {
 		resp["exists"] = false
 	} else {
 		resp["exists"] = true
@@ -646,7 +646,7 @@ func importTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	switch importFrom {
 	case "slack":
 		var err *model.AppError
-		if err, log = app.SlackImport(fileData, fileSize, c.Params.TeamId); err != nil {
+		if err, log = c.App.SlackImport(fileData, fileSize, c.Params.TeamId); err != nil {
 			c.Err = err
 			c.Err.StatusCode = http.StatusBadRequest
 		}
@@ -683,7 +683,7 @@ func inviteUsersToTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := app.InviteNewUsersToTeam(emailList, c.Params.TeamId, c.Session.UserId)
+	err := c.App.InviteNewUsersToTeam(emailList, c.Params.TeamId, c.Session.UserId)
 	if err != nil {
 		c.Err = err
 		return
@@ -698,7 +698,7 @@ func getInviteInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if team, err := app.GetTeamByInviteId(c.Params.InviteId); err != nil {
+	if team, err := c.App.GetTeamByInviteId(c.Params.InviteId); err != nil {
 		c.Err = err
 		return
 	} else {

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -14,7 +14,6 @@ import (
 
 	"encoding/base64"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 )
@@ -346,7 +345,7 @@ func TestSoftDeleteTeam(t *testing.T) {
 		t.Fatal("should have returned true")
 	}
 
-	rteam, err := app.GetTeam(team.Id)
+	rteam, err := th.App.GetTeam(team.Id)
 	if err != nil {
 		t.Fatal("should have returned archived team")
 	}
@@ -390,7 +389,7 @@ func TestPermanentDeleteTeam(t *testing.T) {
 
 	// The team is deleted in the background, its only soft deleted at this
 	// time
-	rteam, err := app.GetTeam(team.Id)
+	rteam, err := th.App.GetTeam(team.Id)
 	if err != nil {
 		t.Fatal("should have returned archived team")
 	}
@@ -515,7 +514,7 @@ func TestSearchAllTeams(t *testing.T) {
 	oTeam := th.BasicTeam
 	oTeam.AllowOpenInvite = true
 
-	updatedTeam, _ := app.UpdateTeam(oTeam)
+	updatedTeam, _ := th.App.UpdateTeam(oTeam)
 	oTeam.UpdateAt = updatedTeam.UpdateAt
 
 	pTeam := &model.Team{DisplayName: "PName", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_INVITE}
@@ -803,7 +802,7 @@ func TestAddTeamMember(t *testing.T) {
 	team := th.BasicTeam
 	otherUser := th.CreateUser()
 
-	if err := app.RemoveUserFromTeam(th.BasicTeam.Id, th.BasicUser2.Id); err != nil {
+	if err := th.App.RemoveUserFromTeam(th.BasicTeam.Id, th.BasicUser2.Id); err != nil {
 		t.Fatalf(err.Error())
 	}
 
@@ -887,7 +886,7 @@ func TestAddTeamMember(t *testing.T) {
 
 	// Update user to team admin
 	UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	*utils.Cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
@@ -913,7 +912,7 @@ func TestAddTeamMember(t *testing.T) {
 
 	// Change permission level to All
 	UpdateUserToNonTeamAdmin(th.BasicUser, th.BasicTeam)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	*utils.Cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_ALL
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
@@ -1019,7 +1018,7 @@ func TestAddTeamMembers(t *testing.T) {
 		otherUser.Id,
 	}
 
-	if err := app.RemoveUserFromTeam(th.BasicTeam.Id, th.BasicUser2.Id); err != nil {
+	if err := th.App.RemoveUserFromTeam(th.BasicTeam.Id, th.BasicUser2.Id); err != nil {
 		t.Fatalf(err.Error())
 	}
 
@@ -1101,7 +1100,7 @@ func TestAddTeamMembers(t *testing.T) {
 
 	// Update user to team admin
 	UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	*utils.Cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
@@ -1127,7 +1126,7 @@ func TestAddTeamMembers(t *testing.T) {
 
 	// Change permission level to All
 	UpdateUserToNonTeamAdmin(th.BasicUser, th.BasicTeam)
-	app.InvalidateAllCaches()
+	th.App.InvalidateAllCaches()
 	*utils.Cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_ALL
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
@@ -1493,7 +1492,7 @@ func TestInviteUsersToTeam(t *testing.T) {
 	}()
 	utils.Cfg.TeamSettings.RestrictCreationToDomains = "@example.com"
 
-	err := app.InviteNewUsersToTeam(emailList, th.BasicTeam.Id, th.BasicUser.Id)
+	err := th.App.InviteNewUsersToTeam(emailList, th.BasicTeam.Id, th.BasicUser.Id)
 
 	if err == nil {
 		t.Fatal("Adding users with non-restricted domains was allowed")

--- a/api4/webhook.go
+++ b/api4/webhook.go
@@ -45,7 +45,7 @@ func createIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	channel, err := app.GetChannel(hook.ChannelId)
+	channel, err := c.App.GetChannel(hook.ChannelId)
 	if err != nil {
 		c.Err = err
 		return
@@ -58,13 +58,13 @@ func createIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if channel.Type != model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
+	if channel.Type != model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
 		c.LogAudit("fail - bad channel permissions")
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if incomingHook, err := app.CreateIncomingWebhookForChannel(c.Session.UserId, channel, hook); err != nil {
+	if incomingHook, err := c.App.CreateIncomingWebhookForChannel(c.Session.UserId, channel, hook); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -90,7 +90,7 @@ func updateIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("attempt")
 
-	oldHook, err := app.GetIncomingWebhook(hookId)
+	oldHook, err := c.App.GetIncomingWebhook(hookId)
 	if err != nil {
 		c.Err = err
 		return
@@ -116,19 +116,19 @@ func updateIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	channel, err := app.GetChannel(updatedHook.ChannelId)
+	channel, err := c.App.GetChannel(updatedHook.ChannelId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	if channel.Type != model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
+	if channel.Type != model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
 		c.LogAudit("fail - bad channel permissions")
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
 
-	if incomingHook, err := app.UpdateIncomingWebhook(oldHook, updatedHook); err != nil {
+	if incomingHook, err := c.App.UpdateIncomingWebhook(oldHook, updatedHook); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -150,14 +150,14 @@ func getIncomingHooks(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		hooks, err = app.GetIncomingWebhooksForTeamPage(teamId, c.Params.Page, c.Params.PerPage)
+		hooks, err = c.App.GetIncomingWebhooksForTeamPage(teamId, c.Params.Page, c.Params.PerPage)
 	} else {
 		if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_WEBHOOKS) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_WEBHOOKS)
 			return
 		}
 
-		hooks, err = app.GetIncomingWebhooksPage(c.Params.Page, c.Params.PerPage)
+		hooks, err = c.App.GetIncomingWebhooksPage(c.Params.Page, c.Params.PerPage)
 	}
 
 	if err != nil {
@@ -180,18 +180,18 @@ func getIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 	var hook *model.IncomingWebhook
 	var channel *model.Channel
 
-	if hook, err = app.GetIncomingWebhook(hookId); err != nil {
+	if hook, err = c.App.GetIncomingWebhook(hookId); err != nil {
 		c.Err = err
 		return
 	} else {
-		channel, err = app.GetChannel(hook.ChannelId)
+		channel, err = c.App.GetChannel(hook.ChannelId)
 		if err != nil {
 			c.Err = err
 			return
 		}
 
 		if !app.SessionHasPermissionToTeam(c.Session, hook.TeamId, model.PERMISSION_MANAGE_WEBHOOKS) ||
-			(channel.Type != model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, hook.ChannelId, model.PERMISSION_READ_CHANNEL)) {
+			(channel.Type != model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, hook.ChannelId, model.PERMISSION_READ_CHANNEL)) {
 			c.LogAudit("fail - bad permissions")
 			c.SetPermissionError(model.PERMISSION_MANAGE_WEBHOOKS)
 			return
@@ -214,23 +214,23 @@ func deleteIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 	var hook *model.IncomingWebhook
 	var channel *model.Channel
 
-	if hook, err = app.GetIncomingWebhook(hookId); err != nil {
+	if hook, err = c.App.GetIncomingWebhook(hookId); err != nil {
 		c.Err = err
 		return
 	} else {
-		channel, err = app.GetChannel(hook.ChannelId)
+		channel, err = c.App.GetChannel(hook.ChannelId)
 		if err != nil {
 			c.Err = err
 			return
 		}
 
 		if !app.SessionHasPermissionToTeam(c.Session, hook.TeamId, model.PERMISSION_MANAGE_WEBHOOKS) ||
-			(channel.Type != model.CHANNEL_OPEN && !app.SessionHasPermissionToChannel(c.Session, hook.ChannelId, model.PERMISSION_READ_CHANNEL)) {
+			(channel.Type != model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, hook.ChannelId, model.PERMISSION_READ_CHANNEL)) {
 			c.LogAudit("fail - bad permissions")
 			c.SetPermissionError(model.PERMISSION_MANAGE_WEBHOOKS)
 			return
 		} else {
-			if err = app.DeleteIncomingWebhook(hookId); err != nil {
+			if err = c.App.DeleteIncomingWebhook(hookId); err != nil {
 				c.Err = err
 				return
 			}
@@ -261,7 +261,7 @@ func updateOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	oldHook, err := app.GetOutgoingWebhook(toUpdateHook.Id)
+	oldHook, err := c.App.GetOutgoingWebhook(toUpdateHook.Id)
 	if err != nil {
 		c.Err = err
 		return
@@ -273,7 +273,7 @@ func updateOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rhook, err := app.UpdateOutgoingWebhook(oldHook, toUpdateHook)
+	rhook, err := c.App.UpdateOutgoingWebhook(oldHook, toUpdateHook)
 	if err != nil {
 		c.Err = err
 		return
@@ -299,7 +299,7 @@ func createOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if rhook, err := app.CreateOutgoingWebhook(hook); err != nil {
+	if rhook, err := c.App.CreateOutgoingWebhook(hook); err != nil {
 		c.LogAudit("fail")
 		c.Err = err
 		return
@@ -318,26 +318,26 @@ func getOutgoingHooks(c *Context, w http.ResponseWriter, r *http.Request) {
 	var err *model.AppError
 
 	if len(channelId) > 0 {
-		if !app.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_MANAGE_WEBHOOKS) {
+		if !c.App.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_MANAGE_WEBHOOKS) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_WEBHOOKS)
 			return
 		}
 
-		hooks, err = app.GetOutgoingWebhooksForChannelPage(channelId, c.Params.Page, c.Params.PerPage)
+		hooks, err = c.App.GetOutgoingWebhooksForChannelPage(channelId, c.Params.Page, c.Params.PerPage)
 	} else if len(teamId) > 0 {
 		if !app.SessionHasPermissionToTeam(c.Session, teamId, model.PERMISSION_MANAGE_WEBHOOKS) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_WEBHOOKS)
 			return
 		}
 
-		hooks, err = app.GetOutgoingWebhooksForTeamPage(teamId, c.Params.Page, c.Params.PerPage)
+		hooks, err = c.App.GetOutgoingWebhooksForTeamPage(teamId, c.Params.Page, c.Params.PerPage)
 	} else {
 		if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_WEBHOOKS) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_WEBHOOKS)
 			return
 		}
 
-		hooks, err = app.GetOutgoingWebhooksPage(c.Params.Page, c.Params.PerPage)
+		hooks, err = c.App.GetOutgoingWebhooksPage(c.Params.Page, c.Params.PerPage)
 	}
 
 	if err != nil {
@@ -354,7 +354,7 @@ func getOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hook, err := app.GetOutgoingWebhook(c.Params.HookId)
+	hook, err := c.App.GetOutgoingWebhook(c.Params.HookId)
 	if err != nil {
 		c.Err = err
 		return
@@ -383,7 +383,7 @@ func regenOutgoingHookToken(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	hook, err := app.GetOutgoingWebhook(c.Params.HookId)
+	hook, err := c.App.GetOutgoingWebhook(c.Params.HookId)
 	if err != nil {
 		c.Err = err
 		return
@@ -402,7 +402,7 @@ func regenOutgoingHookToken(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if rhook, err := app.RegenOutgoingWebhookToken(hook); err != nil {
+	if rhook, err := c.App.RegenOutgoingWebhookToken(hook); err != nil {
 		c.Err = err
 		return
 	} else {
@@ -416,7 +416,7 @@ func deleteOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hook, err := app.GetOutgoingWebhook(c.Params.HookId)
+	hook, err := c.App.GetOutgoingWebhook(c.Params.HookId)
 	if err != nil {
 		c.Err = err
 		return
@@ -435,7 +435,7 @@ func deleteOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.DeleteOutgoingWebhook(hook.Id); err != nil {
+	if err := c.App.DeleteOutgoingWebhook(hook.Id); err != nil {
 		c.LogAudit("fail")
 		c.Err = err
 		return
@@ -478,7 +478,7 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := app.HandleIncomingWebhook(id, parsedRequest)
+	err := c.App.HandleIncomingWebhook(id, parsedRequest)
 	if err != nil {
 		c.Err = err
 		return
@@ -494,7 +494,7 @@ func commandWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	response := model.CommandResponseFromHTTPBody(r.Header.Get("Content-Type"), r.Body)
 
-	err := app.HandleCommandWebhook(id, response)
+	err := c.App.HandleCommandWebhook(id, response)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/webhook_test.go
+++ b/api4/webhook_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 )
@@ -914,7 +913,7 @@ func TestCommandWebhooks(t *testing.T) {
 		UserId:    th.BasicUser.Id,
 		ChannelId: th.BasicChannel.Id,
 	}
-	hook, err := app.CreateCommandWebhook(cmd.Id, args)
+	hook, err := th.App.CreateCommandWebhook(cmd.Id, args)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api4/websocket.go
+++ b/api4/websocket.go
@@ -35,7 +35,7 @@ func connectWebSocket(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wc := app.NewWebConn(ws, c.Session, c.T, "")
+	wc := c.App.NewWebConn(ws, c.Session, c.T, "")
 
 	if len(c.Session.UserId) > 0 {
 		app.HubRegister(wc)

--- a/app/app.go
+++ b/app/app.go
@@ -8,6 +8,16 @@ import (
 	"net/http"
 )
 
+type App struct {
+	Srv *Server
+}
+
+var globalApp App
+
+func Global() *App {
+	return &globalApp
+}
+
 func CloseBody(r *http.Response) {
 	if r.Body != nil {
 		ioutil.ReadAll(r.Body)

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -20,8 +20,8 @@ type TestHelper struct {
 	BasicPost    *model.Post
 }
 
-func SetupEnterprise() *TestHelper {
-	if Srv == nil {
+func (a *App) SetupEnterprise() *TestHelper {
+	if a.Srv == nil {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
@@ -29,12 +29,12 @@ func SetupEnterprise() *TestHelper {
 		*utils.Cfg.RateLimitSettings.Enable = false
 		utils.DisableDebugLogForTest()
 		utils.License().Features.SetDefaults()
-		NewServer()
-		InitStores()
-		StartServer()
+		a.NewServer()
+		a.InitStores()
+		a.StartServer()
 		utils.InitHTML()
 		utils.EnableDebugLogForTest()
-		Srv.Store.MarkSystemRanUnitTests()
+		a.Srv.Store.MarkSystemRanUnitTests()
 
 		*utils.Cfg.TeamSettings.EnableOpenServer = true
 	}
@@ -42,20 +42,20 @@ func SetupEnterprise() *TestHelper {
 	return &TestHelper{}
 }
 
-func Setup() *TestHelper {
-	if Srv == nil {
+func (a *App) Setup() *TestHelper {
+	if a.Srv == nil {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
 		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 		*utils.Cfg.RateLimitSettings.Enable = false
 		utils.DisableDebugLogForTest()
-		NewServer()
-		InitStores()
-		StartServer()
+		a.NewServer()
+		a.InitStores()
+		a.StartServer()
 		utils.InitHTML()
 		utils.EnableDebugLogForTest()
-		Srv.Store.MarkSystemRanUnitTests()
+		a.Srv.Store.MarkSystemRanUnitTests()
 
 		*utils.Cfg.TeamSettings.EnableOpenServer = true
 	}
@@ -66,9 +66,9 @@ func Setup() *TestHelper {
 func (me *TestHelper) InitBasic() *TestHelper {
 	me.BasicTeam = me.CreateTeam()
 	me.BasicUser = me.CreateUser()
-	LinkUserToTeam(me.BasicUser, me.BasicTeam)
+	Global().LinkUserToTeam(me.BasicUser, me.BasicTeam)
 	me.BasicUser2 = me.CreateUser()
-	LinkUserToTeam(me.BasicUser2, me.BasicTeam)
+	Global().LinkUserToTeam(me.BasicUser2, me.BasicTeam)
 	me.BasicChannel = me.CreateChannel(me.BasicTeam)
 	me.BasicPost = me.CreatePost(me.BasicChannel)
 
@@ -94,7 +94,7 @@ func (me *TestHelper) CreateTeam() *model.Team {
 
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
-	if team, err = CreateTeam(team); err != nil {
+	if team, err = Global().CreateTeam(team); err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()
 		time.Sleep(time.Second)
@@ -117,7 +117,7 @@ func (me *TestHelper) CreateUser() *model.User {
 
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
-	if user, err = CreateUser(user); err != nil {
+	if user, err = Global().CreateUser(user); err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()
 		time.Sleep(time.Second)
@@ -148,7 +148,7 @@ func (me *TestHelper) createChannel(team *model.Team, channelType string) *model
 
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
-	if channel, err = CreateChannel(channel, true); err != nil {
+	if channel, err = Global().CreateChannel(channel, true); err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()
 		time.Sleep(time.Second)
@@ -169,7 +169,7 @@ func (me *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
-	if post, err = CreatePost(post, channel, false); err != nil {
+	if post, err = Global().CreatePost(post, channel, false); err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()
 		time.Sleep(time.Second)
@@ -179,10 +179,10 @@ func (me *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 	return post
 }
 
-func LinkUserToTeam(user *model.User, team *model.Team) {
+func (a *App) LinkUserToTeam(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	err := JoinUserToTeam(team, user, "")
+	err := a.JoinUserToTeam(team, user, "")
 	if err != nil {
 		l4g.Error(err.Error())
 		l4g.Close()
@@ -193,8 +193,8 @@ func LinkUserToTeam(user *model.User, team *model.Team) {
 	utils.EnableDebugLogForTest()
 }
 
-func TearDown() {
-	if Srv != nil {
-		StopServer()
+func (a *App) TearDown() {
+	if a.Srv != nil {
+		a.StopServer()
 	}
 }

--- a/app/audit.go
+++ b/app/audit.go
@@ -7,16 +7,16 @@ import (
 	"github.com/mattermost/platform/model"
 )
 
-func GetAudits(userId string, limit int) (model.Audits, *model.AppError) {
-	if result := <-Srv.Store.Audit().Get(userId, 0, limit); result.Err != nil {
+func (a *App) GetAudits(userId string, limit int) (model.Audits, *model.AppError) {
+	if result := <-a.Srv.Store.Audit().Get(userId, 0, limit); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(model.Audits), nil
 	}
 }
 
-func GetAuditsPage(userId string, page int, perPage int) (model.Audits, *model.AppError) {
-	if result := <-Srv.Store.Audit().Get(userId, page*perPage, perPage); result.Err != nil {
+func (a *App) GetAuditsPage(userId string, page int, perPage int) (model.Audits, *model.AppError) {
+	if result := <-a.Srv.Store.Audit().Get(userId, page*perPage, perPage); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(model.Audits), nil

--- a/app/authorization_test.go
+++ b/app/authorization_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestCheckIfRolesGrantPermission(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 
 	cases := []struct {
 		roles        []string

--- a/app/auto_environment.go
+++ b/app/auto_environment.go
@@ -4,10 +4,11 @@
 package app
 
 import (
-	"github.com/mattermost/platform/model"
-	"github.com/mattermost/platform/utils"
 	"math/rand"
 	"time"
+
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
 )
 
 type TestEnvironment struct {

--- a/app/auto_posts.go
+++ b/app/auto_posts.go
@@ -5,10 +5,11 @@ package app
 
 import (
 	"bytes"
-	"github.com/mattermost/platform/model"
-	"github.com/mattermost/platform/utils"
 	"io"
 	"os"
+
+	"github.com/mattermost/platform/model"
+	"github.com/mattermost/platform/utils"
 )
 
 type AutoPostCreator struct {

--- a/app/auto_users.go
+++ b/app/auto_users.go
@@ -34,7 +34,7 @@ func NewAutoUserCreator(client *model.Client, team *model.Team) *AutoUserCreator
 }
 
 // Basic test team and user so you always know one
-func CreateBasicUser(client *model.Client) *model.AppError {
+func (a *App) CreateBasicUser(client *model.Client) *model.AppError {
 	result, _ := client.FindTeamByName(BTEST_TEAM_NAME)
 	if result.Data.(bool) == false {
 		newteam := &model.Team{DisplayName: BTEST_TEAM_DISPLAY_NAME, Name: BTEST_TEAM_NAME, Email: BTEST_TEAM_EMAIL, Type: BTEST_TEAM_TYPE}
@@ -49,8 +49,8 @@ func CreateBasicUser(client *model.Client) *model.AppError {
 			return err
 		}
 		ruser := result.Data.(*model.User)
-		store.Must(Srv.Store.User().VerifyEmail(ruser.Id))
-		store.Must(Srv.Store.Team().SaveMember(&model.TeamMember{TeamId: basicteam.Id, UserId: ruser.Id}))
+		store.Must(a.Srv.Store.User().VerifyEmail(ruser.Id))
+		store.Must(a.Srv.Store.Team().SaveMember(&model.TeamMember{TeamId: basicteam.Id, UserId: ruser.Id}))
 	}
 	return nil
 }
@@ -81,14 +81,14 @@ func (cfg *AutoUserCreator) createRandomUser() (*model.User, bool) {
 	ruser := result.Data.(*model.User)
 
 	status := &model.Status{UserId: ruser.Id, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: model.GetMillis(), ActiveChannel: ""}
-	if result := <-Srv.Store.Status().SaveOrUpdate(status); result.Err != nil {
+	if result := <-Global().Srv.Store.Status().SaveOrUpdate(status); result.Err != nil {
 		result.Err.Translate(utils.T)
 		l4g.Error(result.Err.Error())
 		return nil, false
 	}
 
 	// We need to cheat to verify the user's email
-	store.Must(Srv.Store.User().VerifyEmail(ruser.Id))
+	store.Must(Global().Srv.Store.User().VerifyEmail(ruser.Id))
 
 	return result.Data.(*model.User), true
 }

--- a/app/channel.go
+++ b/app/channel.go
@@ -15,16 +15,16 @@ import (
 	"github.com/mattermost/platform/utils"
 )
 
-func CreateDefaultChannels(teamId string) ([]*model.Channel, *model.AppError) {
+func (a *App) CreateDefaultChannels(teamId string) ([]*model.Channel, *model.AppError) {
 	townSquare := &model.Channel{DisplayName: utils.T("api.channel.create_default_channels.town_square"), Name: "town-square", Type: model.CHANNEL_OPEN, TeamId: teamId}
 
-	if _, err := CreateChannel(townSquare, false); err != nil {
+	if _, err := a.CreateChannel(townSquare, false); err != nil {
 		return nil, err
 	}
 
 	offTopic := &model.Channel{DisplayName: utils.T("api.channel.create_default_channels.off_topic"), Name: "off-topic", Type: model.CHANNEL_OPEN, TeamId: teamId}
 
-	if _, err := CreateChannel(offTopic, false); err != nil {
+	if _, err := a.CreateChannel(offTopic, false); err != nil {
 		return nil, err
 	}
 
@@ -32,19 +32,19 @@ func CreateDefaultChannels(teamId string) ([]*model.Channel, *model.AppError) {
 	return channels, nil
 }
 
-func JoinDefaultChannels(teamId string, user *model.User, channelRole string, userRequestorId string) *model.AppError {
+func (a *App) JoinDefaultChannels(teamId string, user *model.User, channelRole string, userRequestorId string) *model.AppError {
 	var err *model.AppError = nil
 
 	var requestor *model.User
 	if userRequestorId != "" {
-		if u := <-Srv.Store.User().Get(userRequestorId); u.Err != nil {
+		if u := <-a.Srv.Store.User().Get(userRequestorId); u.Err != nil {
 			return u.Err
 		} else {
 			requestor = u.Data.(*model.User)
 		}
 	}
 
-	if result := <-Srv.Store.Channel().GetByName(teamId, "town-square", true); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().GetByName(teamId, "town-square", true); result.Err != nil {
 		err = result.Err
 	} else {
 		townSquare := result.Data.(*model.Channel)
@@ -52,24 +52,24 @@ func JoinDefaultChannels(teamId string, user *model.User, channelRole string, us
 		cm := &model.ChannelMember{ChannelId: townSquare.Id, UserId: user.Id,
 			Roles: channelRole, NotifyProps: model.GetDefaultChannelNotifyProps()}
 
-		if cmResult := <-Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
+		if cmResult := <-a.Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
 			err = cmResult.Err
 		}
 
 		if requestor == nil {
-			if err := postJoinChannelMessage(user, townSquare); err != nil {
+			if err := a.postJoinChannelMessage(user, townSquare); err != nil {
 				l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 			}
 		} else {
-			if err := PostAddToChannelMessage(requestor, user, townSquare); err != nil {
+			if err := a.PostAddToChannelMessage(requestor, user, townSquare); err != nil {
 				l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 			}
 		}
 
-		InvalidateCacheForChannelMembers(result.Data.(*model.Channel).Id)
+		a.InvalidateCacheForChannelMembers(result.Data.(*model.Channel).Id)
 	}
 
-	if result := <-Srv.Store.Channel().GetByName(teamId, "off-topic", true); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().GetByName(teamId, "off-topic", true); result.Err != nil {
 		err = result.Err
 	} else {
 		offTopic := result.Data.(*model.Channel)
@@ -77,27 +77,27 @@ func JoinDefaultChannels(teamId string, user *model.User, channelRole string, us
 		cm := &model.ChannelMember{ChannelId: offTopic.Id, UserId: user.Id,
 			Roles: channelRole, NotifyProps: model.GetDefaultChannelNotifyProps()}
 
-		if cmResult := <-Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
+		if cmResult := <-a.Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
 			err = cmResult.Err
 		}
 
 		if requestor == nil {
-			if err := postJoinChannelMessage(user, offTopic); err != nil {
+			if err := a.postJoinChannelMessage(user, offTopic); err != nil {
 				l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 			}
 		} else {
-			if err := PostAddToChannelMessage(requestor, user, offTopic); err != nil {
+			if err := a.PostAddToChannelMessage(requestor, user, offTopic); err != nil {
 				l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 			}
 		}
 
-		InvalidateCacheForChannelMembers(result.Data.(*model.Channel).Id)
+		a.InvalidateCacheForChannelMembers(result.Data.(*model.Channel).Id)
 	}
 
 	return err
 }
 
-func CreateChannelWithUser(channel *model.Channel, userId string) (*model.Channel, *model.AppError) {
+func (a *App) CreateChannelWithUser(channel *model.Channel, userId string) (*model.Channel, *model.AppError) {
 	if channel.IsGroupOrDirect() {
 		return nil, model.NewAppError("CreateChannelWithUser", "api.channel.create_channel.direct_channel.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -111,7 +111,7 @@ func CreateChannelWithUser(channel *model.Channel, userId string) (*model.Channe
 	}
 
 	// Get total number of channels on current team
-	if count, err := GetNumberOfChannelsOnTeam(channel.TeamId); err != nil {
+	if count, err := a.GetNumberOfChannelsOnTeam(channel.TeamId); err != nil {
 		return nil, err
 	} else {
 		if int64(count+1) > *utils.Cfg.TeamSettings.MaxChannelsPerTeam {
@@ -121,17 +121,17 @@ func CreateChannelWithUser(channel *model.Channel, userId string) (*model.Channe
 
 	channel.CreatorId = userId
 
-	rchannel, err := CreateChannel(channel, true)
+	rchannel, err := a.CreateChannel(channel, true)
 	if err != nil {
 		return nil, err
 	}
 
 	var user *model.User
-	if user, err = GetUser(userId); err != nil {
+	if user, err = a.GetUser(userId); err != nil {
 		return nil, err
 	}
 
-	postJoinChannelMessage(user, channel)
+	a.postJoinChannelMessage(user, channel)
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_CREATED, "", "", userId, nil)
 	message.Add("channel_id", channel.Id)
@@ -141,8 +141,8 @@ func CreateChannelWithUser(channel *model.Channel, userId string) (*model.Channe
 	return rchannel, nil
 }
 
-func CreateChannel(channel *model.Channel, addMember bool) (*model.Channel, *model.AppError) {
-	if result := <-Srv.Store.Channel().Save(channel); result.Err != nil {
+func (a *App) CreateChannel(channel *model.Channel, addMember bool) (*model.Channel, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().Save(channel); result.Err != nil {
 		return nil, result.Err
 	} else {
 		sc := result.Data.(*model.Channel)
@@ -155,29 +155,29 @@ func CreateChannel(channel *model.Channel, addMember bool) (*model.Channel, *mod
 				NotifyProps: model.GetDefaultChannelNotifyProps(),
 			}
 
-			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
+			if cmresult := <-a.Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				return nil, cmresult.Err
 			}
 
-			InvalidateCacheForUser(channel.CreatorId)
+			a.InvalidateCacheForUser(channel.CreatorId)
 		}
 
 		return sc, nil
 	}
 }
 
-func CreateDirectChannel(userId string, otherUserId string) (*model.Channel, *model.AppError) {
-	if channel, err := createDirectChannel(userId, otherUserId); err != nil {
+func (a *App) CreateDirectChannel(userId string, otherUserId string) (*model.Channel, *model.AppError) {
+	if channel, err := a.createDirectChannel(userId, otherUserId); err != nil {
 		if err.Id == store.CHANNEL_EXISTS_ERROR {
 			return channel, nil
 		} else {
 			return nil, err
 		}
 	} else {
-		WaitForChannelMembership(channel.Id, userId)
+		a.WaitForChannelMembership(channel.Id, userId)
 
-		InvalidateCacheForUser(userId)
-		InvalidateCacheForUser(otherUserId)
+		a.InvalidateCacheForUser(userId)
+		a.InvalidateCacheForUser(otherUserId)
 
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_DIRECT_ADDED, "", channel.Id, "", nil)
 		message.Add("teammate_id", otherUserId)
@@ -187,9 +187,9 @@ func CreateDirectChannel(userId string, otherUserId string) (*model.Channel, *mo
 	}
 }
 
-func createDirectChannel(userId string, otherUserId string) (*model.Channel, *model.AppError) {
-	uc1 := Srv.Store.User().Get(userId)
-	uc2 := Srv.Store.User().Get(otherUserId)
+func (a *App) createDirectChannel(userId string, otherUserId string) (*model.Channel, *model.AppError) {
+	uc1 := a.Srv.Store.User().Get(userId)
+	uc2 := a.Srv.Store.User().Get(otherUserId)
 
 	if result := <-uc1; result.Err != nil {
 		return nil, model.NewAppError("CreateDirectChannel", "api.channel.create_direct_channel.invalid_user.app_error", nil, userId, http.StatusBadRequest)
@@ -199,7 +199,7 @@ func createDirectChannel(userId string, otherUserId string) (*model.Channel, *mo
 		return nil, model.NewAppError("CreateDirectChannel", "api.channel.create_direct_channel.invalid_user.app_error", nil, otherUserId, http.StatusBadRequest)
 	}
 
-	if result := <-Srv.Store.Channel().CreateDirectChannel(userId, otherUserId); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().CreateDirectChannel(userId, otherUserId); result.Err != nil {
 		if result.Err.Id == store.CHANNEL_EXISTS_ERROR {
 			return result.Data.(*model.Channel), result.Err
 		} else {
@@ -211,7 +211,7 @@ func createDirectChannel(userId string, otherUserId string) (*model.Channel, *mo
 	}
 }
 
-func WaitForChannelMembership(channelId string, userId string) {
+func (a *App) WaitForChannelMembership(channelId string, userId string) {
 	if len(utils.Cfg.SqlSettings.DataSourceReplicas) > 0 {
 		now := model.GetMillis()
 
@@ -219,7 +219,7 @@ func WaitForChannelMembership(channelId string, userId string) {
 
 			time.Sleep(100 * time.Millisecond)
 
-			result := <-Srv.Store.Channel().GetMember(channelId, userId)
+			result := <-a.Srv.Store.Channel().GetMember(channelId, userId)
 
 			// If the membership was found then return
 			if result.Err == nil {
@@ -236,8 +236,8 @@ func WaitForChannelMembership(channelId string, userId string) {
 	}
 }
 
-func CreateGroupChannel(userIds []string, creatorId string) (*model.Channel, *model.AppError) {
-	if channel, err := createGroupChannel(userIds, creatorId); err != nil {
+func (a *App) CreateGroupChannel(userIds []string, creatorId string) (*model.Channel, *model.AppError) {
+	if channel, err := a.createGroupChannel(userIds, creatorId); err != nil {
 		if err.Id == store.CHANNEL_EXISTS_ERROR {
 			return channel, nil
 		} else {
@@ -246,10 +246,10 @@ func CreateGroupChannel(userIds []string, creatorId string) (*model.Channel, *mo
 	} else {
 		for _, userId := range userIds {
 			if userId == creatorId {
-				WaitForChannelMembership(channel.Id, creatorId)
+				a.WaitForChannelMembership(channel.Id, creatorId)
 			}
 
-			InvalidateCacheForUser(userId)
+			a.InvalidateCacheForUser(userId)
 		}
 
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_GROUP_ADDED, "", channel.Id, "", nil)
@@ -260,13 +260,13 @@ func CreateGroupChannel(userIds []string, creatorId string) (*model.Channel, *mo
 	}
 }
 
-func createGroupChannel(userIds []string, creatorId string) (*model.Channel, *model.AppError) {
+func (a *App) createGroupChannel(userIds []string, creatorId string) (*model.Channel, *model.AppError) {
 	if len(userIds) > model.CHANNEL_GROUP_MAX_USERS || len(userIds) < model.CHANNEL_GROUP_MIN_USERS {
 		return nil, model.NewAppError("CreateGroupChannel", "api.channel.create_group.bad_size.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	var users []*model.User
-	if result := <-Srv.Store.User().GetProfileByIds(userIds, true); result.Err != nil {
+	if result := <-a.Srv.Store.User().GetProfileByIds(userIds, true); result.Err != nil {
 		return nil, result.Err
 	} else {
 		users = result.Data.([]*model.User)
@@ -282,7 +282,7 @@ func createGroupChannel(userIds []string, creatorId string) (*model.Channel, *mo
 		Type:        model.CHANNEL_GROUP,
 	}
 
-	if result := <-Srv.Store.Channel().Save(group); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().Save(group); result.Err != nil {
 		if result.Err.Id == store.CHANNEL_EXISTS_ERROR {
 			return result.Data.(*model.Channel), result.Err
 		} else {
@@ -299,7 +299,7 @@ func createGroupChannel(userIds []string, creatorId string) (*model.Channel, *mo
 				Roles:       model.ROLE_CHANNEL_USER.Id,
 			}
 
-			if result := <-Srv.Store.Channel().SaveMember(cm); result.Err != nil {
+			if result := <-a.Srv.Store.Channel().SaveMember(cm); result.Err != nil {
 				return nil, result.Err
 			}
 		}
@@ -308,11 +308,11 @@ func createGroupChannel(userIds []string, creatorId string) (*model.Channel, *mo
 	}
 }
 
-func UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
-	if result := <-Srv.Store.Channel().Update(channel); result.Err != nil {
+func (a *App) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().Update(channel); result.Err != nil {
 		return nil, result.Err
 	} else {
-		InvalidateCacheForChannel(channel)
+		a.InvalidateCacheForChannel(channel)
 
 		messageWs := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_UPDATED, "", channel.Id, "", nil)
 		messageWs.Add("channel", channel.ToJson())
@@ -322,39 +322,39 @@ func UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
 	}
 }
 
-func RestoreChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
-	if result := <-Srv.Store.Channel().Restore(channel.Id, model.GetMillis()); result.Err != nil {
+func (a *App) RestoreChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().Restore(channel.Id, model.GetMillis()); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return channel, nil
 	}
 }
 
-func PatchChannel(channel *model.Channel, patch *model.ChannelPatch, userId string) (*model.Channel, *model.AppError) {
+func (a *App) PatchChannel(channel *model.Channel, patch *model.ChannelPatch, userId string) (*model.Channel, *model.AppError) {
 	oldChannelDisplayName := channel.DisplayName
 	oldChannelHeader := channel.Header
 	oldChannelPurpose := channel.Purpose
 
 	channel.Patch(patch)
-	channel, err := UpdateChannel(channel)
+	channel, err := a.UpdateChannel(channel)
 	if err != nil {
 		return nil, err
 	}
 
 	if oldChannelDisplayName != channel.DisplayName {
-		if err := PostUpdateChannelDisplayNameMessage(userId, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
+		if err := a.PostUpdateChannelDisplayNameMessage(userId, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
 			l4g.Error(err.Error())
 		}
 	}
 
 	if channel.Header != oldChannelHeader {
-		if err := PostUpdateChannelHeaderMessage(userId, channel, oldChannelHeader, channel.Header); err != nil {
+		if err := a.PostUpdateChannelHeaderMessage(userId, channel, oldChannelHeader, channel.Header); err != nil {
 			l4g.Error(err.Error())
 		}
 	}
 
 	if channel.Purpose != oldChannelPurpose {
-		if err := PostUpdateChannelPurposeMessage(userId, channel, oldChannelPurpose, channel.Purpose); err != nil {
+		if err := a.PostUpdateChannelPurposeMessage(userId, channel, oldChannelPurpose, channel.Purpose); err != nil {
 			l4g.Error(err.Error())
 		}
 	}
@@ -362,27 +362,27 @@ func PatchChannel(channel *model.Channel, patch *model.ChannelPatch, userId stri
 	return channel, err
 }
 
-func UpdateChannelMemberRoles(channelId string, userId string, newRoles string) (*model.ChannelMember, *model.AppError) {
+func (a *App) UpdateChannelMemberRoles(channelId string, userId string, newRoles string) (*model.ChannelMember, *model.AppError) {
 	var member *model.ChannelMember
 	var err *model.AppError
-	if member, err = GetChannelMember(channelId, userId); err != nil {
+	if member, err = a.GetChannelMember(channelId, userId); err != nil {
 		return nil, err
 	}
 
 	member.Roles = newRoles
 
-	if result := <-Srv.Store.Channel().UpdateMember(member); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().UpdateMember(member); result.Err != nil {
 		return nil, result.Err
 	}
 
-	InvalidateCacheForUser(userId)
+	a.InvalidateCacheForUser(userId)
 	return member, nil
 }
 
-func UpdateChannelMemberNotifyProps(data map[string]string, channelId string, userId string) (*model.ChannelMember, *model.AppError) {
+func (a *App) UpdateChannelMemberNotifyProps(data map[string]string, channelId string, userId string) (*model.ChannelMember, *model.AppError) {
 	var member *model.ChannelMember
 	var err *model.AppError
-	if member, err = GetChannelMember(channelId, userId); err != nil {
+	if member, err = a.GetChannelMember(channelId, userId); err != nil {
 		return nil, err
 	}
 
@@ -403,19 +403,19 @@ func UpdateChannelMemberNotifyProps(data map[string]string, channelId string, us
 		member.NotifyProps[model.PUSH_NOTIFY_PROP] = push
 	}
 
-	if result := <-Srv.Store.Channel().UpdateMember(member); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().UpdateMember(member); result.Err != nil {
 		return nil, result.Err
 	} else {
-		InvalidateCacheForUser(userId)
-		InvalidateCacheForChannelMembersNotifyProps(channelId)
+		a.InvalidateCacheForUser(userId)
+		a.InvalidateCacheForChannelMembersNotifyProps(channelId)
 		return member, nil
 	}
 }
 
-func DeleteChannel(channel *model.Channel, userId string) *model.AppError {
-	uc := Srv.Store.User().Get(userId)
-	ihc := Srv.Store.Webhook().GetIncomingByChannel(channel.Id)
-	ohc := Srv.Store.Webhook().GetOutgoingByChannel(channel.Id, -1, -1)
+func (a *App) DeleteChannel(channel *model.Channel, userId string) *model.AppError {
+	uc := a.Srv.Store.User().Get(userId)
+	ihc := a.Srv.Store.Webhook().GetIncomingByChannel(channel.Id)
+	ohc := a.Srv.Store.Webhook().GetOutgoingByChannel(channel.Id, -1, -1)
 
 	if uresult := <-uc; uresult.Err != nil {
 		return uresult.Err
@@ -450,28 +450,28 @@ func DeleteChannel(channel *model.Channel, userId string) *model.AppError {
 			},
 		}
 
-		if _, err := CreatePost(post, channel, false); err != nil {
+		if _, err := a.CreatePost(post, channel, false); err != nil {
 			l4g.Error(utils.T("api.channel.delete_channel.failed_post.error"), err)
 		}
 
 		now := model.GetMillis()
 		for _, hook := range incomingHooks {
-			if result := <-Srv.Store.Webhook().DeleteIncoming(hook.Id, now); result.Err != nil {
+			if result := <-a.Srv.Store.Webhook().DeleteIncoming(hook.Id, now); result.Err != nil {
 				l4g.Error(utils.T("api.channel.delete_channel.incoming_webhook.error"), hook.Id)
 			}
-			InvalidateCacheForWebhook(hook.Id)
+			a.InvalidateCacheForWebhook(hook.Id)
 		}
 
 		for _, hook := range outgoingHooks {
-			if result := <-Srv.Store.Webhook().DeleteOutgoing(hook.Id, now); result.Err != nil {
+			if result := <-a.Srv.Store.Webhook().DeleteOutgoing(hook.Id, now); result.Err != nil {
 				l4g.Error(utils.T("api.channel.delete_channel.outgoing_webhook.error"), hook.Id)
 			}
 		}
 
-		if dresult := <-Srv.Store.Channel().Delete(channel.Id, model.GetMillis()); dresult.Err != nil {
+		if dresult := <-a.Srv.Store.Channel().Delete(channel.Id, model.GetMillis()); dresult.Err != nil {
 			return dresult.Err
 		}
-		InvalidateCacheForChannel(channel)
+		a.InvalidateCacheForChannel(channel)
 
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_DELETED, channel.TeamId, "", "", nil)
 		message.Add("channel_id", channel.Id)
@@ -482,7 +482,7 @@ func DeleteChannel(channel *model.Channel, userId string) *model.AppError {
 	return nil
 }
 
-func addUserToChannel(user *model.User, channel *model.Channel, teamMember *model.TeamMember) (*model.ChannelMember, *model.AppError) {
+func (a *App) addUserToChannel(user *model.User, channel *model.Channel, teamMember *model.TeamMember) (*model.ChannelMember, *model.AppError) {
 	if channel.DeleteAt > 0 {
 		return nil, model.NewAppError("AddUserToChannel", "api.channel.add_user_to_channel.deleted.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -491,7 +491,7 @@ func addUserToChannel(user *model.User, channel *model.Channel, teamMember *mode
 		return nil, model.NewAppError("AddUserToChannel", "api.channel.add_user_to_channel.type.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	cmchan := Srv.Store.Channel().GetMember(channel.Id, user.Id)
+	cmchan := a.Srv.Store.Channel().GetMember(channel.Id, user.Id)
 
 	if result := <-cmchan; result.Err != nil {
 		if result.Err.Id != store.MISSING_CHANNEL_MEMBER_ERROR {
@@ -508,21 +508,21 @@ func addUserToChannel(user *model.User, channel *model.Channel, teamMember *mode
 		NotifyProps: model.GetDefaultChannelNotifyProps(),
 		Roles:       model.ROLE_CHANNEL_USER.Id,
 	}
-	if result := <-Srv.Store.Channel().SaveMember(newMember); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().SaveMember(newMember); result.Err != nil {
 		l4g.Error("Failed to add member user_id=%v channel_id=%v err=%v", user.Id, channel.Id, result.Err)
 		return nil, model.NewAppError("AddUserToChannel", "api.channel.add_user.to.channel.failed.app_error", nil, "", http.StatusInternalServerError)
 	}
 
-	WaitForChannelMembership(channel.Id, user.Id)
+	a.WaitForChannelMembership(channel.Id, user.Id)
 
-	InvalidateCacheForUser(user.Id)
-	InvalidateCacheForChannelMembers(channel.Id)
+	a.InvalidateCacheForUser(user.Id)
+	a.InvalidateCacheForChannelMembers(channel.Id)
 
 	return newMember, nil
 }
 
-func AddUserToChannel(user *model.User, channel *model.Channel) (*model.ChannelMember, *model.AppError) {
-	tmchan := Srv.Store.Team().GetMember(channel.TeamId, user.Id)
+func (a *App) AddUserToChannel(user *model.User, channel *model.Channel) (*model.ChannelMember, *model.AppError) {
+	tmchan := a.Srv.Store.Team().GetMember(channel.TeamId, user.Id)
 	var teamMember *model.TeamMember
 
 	if result := <-tmchan; result.Err != nil {
@@ -534,7 +534,7 @@ func AddUserToChannel(user *model.User, channel *model.Channel) (*model.ChannelM
 		}
 	}
 
-	newMember, err := addUserToChannel(user, channel, teamMember)
+	newMember, err := a.addUserToChannel(user, channel, teamMember)
 	if err != nil {
 		return nil, err
 	}
@@ -547,8 +547,8 @@ func AddUserToChannel(user *model.User, channel *model.Channel) (*model.ChannelM
 	return newMember, nil
 }
 
-func AddChannelMember(userId string, channel *model.Channel, userRequestorId string) (*model.ChannelMember, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetMember(channel.Id, userId); result.Err != nil {
+func (a *App) AddChannelMember(userId string, channel *model.Channel, userRequestorId string) (*model.ChannelMember, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetMember(channel.Id, userId); result.Err != nil {
 		if result.Err.Id != store.MISSING_CHANNEL_MEMBER_ERROR {
 			return nil, result.Err
 		}
@@ -559,34 +559,34 @@ func AddChannelMember(userId string, channel *model.Channel, userRequestorId str
 	var user *model.User
 	var err *model.AppError
 
-	if user, err = GetUser(userId); err != nil {
+	if user, err = a.GetUser(userId); err != nil {
 		return nil, err
 	}
 
 	var userRequestor *model.User
-	if userRequestor, err = GetUser(userRequestorId); err != nil {
+	if userRequestor, err = a.GetUser(userRequestorId); err != nil {
 		return nil, err
 	}
 
-	cm, err := AddUserToChannel(user, channel)
+	cm, err := a.AddUserToChannel(user, channel)
 	if err != nil {
 		return nil, err
 	}
 
 	if userId == userRequestorId {
-		postJoinChannelMessage(user, channel)
+		a.postJoinChannelMessage(user, channel)
 	} else {
-		go PostAddToChannelMessage(userRequestor, user, channel)
+		go a.PostAddToChannelMessage(userRequestor, user, channel)
 	}
 
-	UpdateChannelLastViewedAt([]string{channel.Id}, userRequestor.Id)
+	a.UpdateChannelLastViewedAt([]string{channel.Id}, userRequestor.Id)
 
 	return cm, nil
 }
 
-func AddDirectChannels(teamId string, user *model.User) *model.AppError {
+func (a *App) AddDirectChannels(teamId string, user *model.User) *model.AppError {
 	var profiles []*model.User
-	if result := <-Srv.Store.User().GetProfiles(teamId, 0, 100); result.Err != nil {
+	if result := <-a.Srv.Store.User().GetProfiles(teamId, 0, 100); result.Err != nil {
 		return model.NewAppError("AddDirectChannels", "api.user.add_direct_channels_and_forget.failed.error", map[string]interface{}{"UserId": user.Id, "TeamId": teamId, "Error": result.Err.Error()}, "", http.StatusInternalServerError)
 	} else {
 		profiles = result.Data.([]*model.User)
@@ -613,15 +613,15 @@ func AddDirectChannels(teamId string, user *model.User) *model.AppError {
 		}
 	}
 
-	if result := <-Srv.Store.Preference().Save(&preferences); result.Err != nil {
+	if result := <-a.Srv.Store.Preference().Save(&preferences); result.Err != nil {
 		return model.NewAppError("AddDirectChannels", "api.user.add_direct_channels_and_forget.failed.error", map[string]interface{}{"UserId": user.Id, "TeamId": teamId, "Error": result.Err.Error()}, "", http.StatusInternalServerError)
 	}
 
 	return nil
 }
 
-func PostUpdateChannelHeaderMessage(userId string, channel *model.Channel, oldChannelHeader, newChannelHeader string) *model.AppError {
-	uc := Srv.Store.User().Get(userId)
+func (a *App) PostUpdateChannelHeaderMessage(userId string, channel *model.Channel, oldChannelHeader, newChannelHeader string) *model.AppError {
+	uc := a.Srv.Store.User().Get(userId)
 
 	if uresult := <-uc; uresult.Err != nil {
 		return model.NewAppError("PostUpdateChannelHeaderMessage", "api.channel.post_update_channel_header_message_and_forget.retrieve_user.error", nil, uresult.Err.Error(), http.StatusBadRequest)
@@ -649,7 +649,7 @@ func PostUpdateChannelHeaderMessage(userId string, channel *model.Channel, oldCh
 			},
 		}
 
-		if _, err := CreatePost(post, channel, false); err != nil {
+		if _, err := a.CreatePost(post, channel, false); err != nil {
 			return model.NewAppError("", "api.channel.post_update_channel_header_message_and_forget.post.error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
@@ -657,8 +657,8 @@ func PostUpdateChannelHeaderMessage(userId string, channel *model.Channel, oldCh
 	return nil
 }
 
-func PostUpdateChannelPurposeMessage(userId string, channel *model.Channel, oldChannelPurpose string, newChannelPurpose string) *model.AppError {
-	uc := Srv.Store.User().Get(userId)
+func (a *App) PostUpdateChannelPurposeMessage(userId string, channel *model.Channel, oldChannelPurpose string, newChannelPurpose string) *model.AppError {
+	uc := a.Srv.Store.User().Get(userId)
 
 	if uresult := <-uc; uresult.Err != nil {
 		return model.NewAppError("PostUpdateChannelPurposeMessage", "app.channel.post_update_channel_purpose_message.retrieve_user.error", nil, uresult.Err.Error(), http.StatusBadRequest)
@@ -685,7 +685,7 @@ func PostUpdateChannelPurposeMessage(userId string, channel *model.Channel, oldC
 				"new_purpose": newChannelPurpose,
 			},
 		}
-		if _, err := CreatePost(post, channel, false); err != nil {
+		if _, err := a.CreatePost(post, channel, false); err != nil {
 			return model.NewAppError("", "app.channel.post_update_channel_purpose_message.post.error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
@@ -693,8 +693,8 @@ func PostUpdateChannelPurposeMessage(userId string, channel *model.Channel, oldC
 	return nil
 }
 
-func PostUpdateChannelDisplayNameMessage(userId string, channel *model.Channel, oldChannelDisplayName, newChannelDisplayName string) *model.AppError {
-	uc := Srv.Store.User().Get(userId)
+func (a *App) PostUpdateChannelDisplayNameMessage(userId string, channel *model.Channel, oldChannelDisplayName, newChannelDisplayName string) *model.AppError {
+	uc := a.Srv.Store.User().Get(userId)
 
 	if uresult := <-uc; uresult.Err != nil {
 		return model.NewAppError("PostUpdateChannelDisplayNameMessage", "api.channel.post_update_channel_displayname_message_and_forget.retrieve_user.error", nil, uresult.Err.Error(), http.StatusBadRequest)
@@ -715,7 +715,7 @@ func PostUpdateChannelDisplayNameMessage(userId string, channel *model.Channel, 
 			},
 		}
 
-		if _, err := CreatePost(post, channel, false); err != nil {
+		if _, err := a.CreatePost(post, channel, false); err != nil {
 			return model.NewAppError("PostUpdateChannelDisplayNameMessage", "api.channel.post_update_channel_displayname_message_and_forget.create_post.error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
@@ -723,8 +723,8 @@ func PostUpdateChannelDisplayNameMessage(userId string, channel *model.Channel, 
 	return nil
 }
 
-func GetChannel(channelId string) (*model.Channel, *model.AppError) {
-	if result := <-Srv.Store.Channel().Get(channelId, true); result.Err != nil && result.Err.Id == "store.sql_channel.get.existing.app_error" {
+func (a *App) GetChannel(channelId string) (*model.Channel, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().Get(channelId, true); result.Err != nil && result.Err.Id == "store.sql_channel.get.existing.app_error" {
 		result.Err.StatusCode = http.StatusNotFound
 		return nil, result.Err
 	} else if result.Err != nil {
@@ -735,8 +735,8 @@ func GetChannel(channelId string) (*model.Channel, *model.AppError) {
 	}
 }
 
-func GetChannelByName(channelName, teamId string) (*model.Channel, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetByName(teamId, channelName, true); result.Err != nil && result.Err.Id == "store.sql_channel.get_by_name.missing.app_error" {
+func (a *App) GetChannelByName(channelName, teamId string) (*model.Channel, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetByName(teamId, channelName, true); result.Err != nil && result.Err.Id == "store.sql_channel.get_by_name.missing.app_error" {
 		result.Err.StatusCode = http.StatusNotFound
 		return nil, result.Err
 	} else if result.Err != nil {
@@ -747,17 +747,17 @@ func GetChannelByName(channelName, teamId string) (*model.Channel, *model.AppErr
 	}
 }
 
-func GetChannelByNameForTeamName(channelName, teamName string) (*model.Channel, *model.AppError) {
+func (a *App) GetChannelByNameForTeamName(channelName, teamName string) (*model.Channel, *model.AppError) {
 	var team *model.Team
 
-	if result := <-Srv.Store.Team().GetByName(teamName); result.Err != nil {
+	if result := <-a.Srv.Store.Team().GetByName(teamName); result.Err != nil {
 		result.Err.StatusCode = http.StatusNotFound
 		return nil, result.Err
 	} else {
 		team = result.Data.(*model.Team)
 	}
 
-	if result := <-Srv.Store.Channel().GetByName(team.Id, channelName, true); result.Err != nil && result.Err.Id == "store.sql_channel.get_by_name.missing.app_error" {
+	if result := <-a.Srv.Store.Channel().GetByName(team.Id, channelName, true); result.Err != nil && result.Err.Id == "store.sql_channel.get_by_name.missing.app_error" {
 		result.Err.StatusCode = http.StatusNotFound
 		return nil, result.Err
 	} else if result.Err != nil {
@@ -768,96 +768,96 @@ func GetChannelByNameForTeamName(channelName, teamName string) (*model.Channel, 
 	}
 }
 
-func GetChannelsForUser(teamId string, userId string) (*model.ChannelList, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetChannels(teamId, userId); result.Err != nil {
+func (a *App) GetChannelsForUser(teamId string, userId string) (*model.ChannelList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetChannels(teamId, userId); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelList), nil
 	}
 }
 
-func GetDeletedChannels(teamId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetDeleted(teamId, offset, limit); result.Err != nil {
+func (a *App) GetDeletedChannels(teamId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetDeleted(teamId, offset, limit); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelList), nil
 	}
 }
 
-func GetChannelsUserNotIn(teamId string, userId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetMoreChannels(teamId, userId, offset, limit); result.Err != nil {
+func (a *App) GetChannelsUserNotIn(teamId string, userId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetMoreChannels(teamId, userId, offset, limit); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelList), nil
 	}
 }
 
-func GetPublicChannelsByIdsForTeam(teamId string, channelIds []string) (*model.ChannelList, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetPublicChannelsByIdsForTeam(teamId, channelIds); result.Err != nil {
+func (a *App) GetPublicChannelsByIdsForTeam(teamId string, channelIds []string) (*model.ChannelList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetPublicChannelsByIdsForTeam(teamId, channelIds); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelList), nil
 	}
 }
 
-func GetPublicChannelsForTeam(teamId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetPublicChannelsForTeam(teamId, offset, limit); result.Err != nil {
+func (a *App) GetPublicChannelsForTeam(teamId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetPublicChannelsForTeam(teamId, offset, limit); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelList), nil
 	}
 }
 
-func GetChannelMember(channelId string, userId string) (*model.ChannelMember, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetMember(channelId, userId); result.Err != nil {
+func (a *App) GetChannelMember(channelId string, userId string) (*model.ChannelMember, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetMember(channelId, userId); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelMember), nil
 	}
 }
 
-func GetChannelMembersPage(channelId string, page, perPage int) (*model.ChannelMembers, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetMembers(channelId, page*perPage, perPage); result.Err != nil {
+func (a *App) GetChannelMembersPage(channelId string, page, perPage int) (*model.ChannelMembers, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetMembers(channelId, page*perPage, perPage); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelMembers), nil
 	}
 }
 
-func GetChannelMembersByIds(channelId string, userIds []string) (*model.ChannelMembers, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetMembersByIds(channelId, userIds); result.Err != nil {
+func (a *App) GetChannelMembersByIds(channelId string, userIds []string) (*model.ChannelMembers, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetMembersByIds(channelId, userIds); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelMembers), nil
 	}
 }
 
-func GetChannelMembersForUser(teamId string, userId string) (*model.ChannelMembers, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetMembersForUser(teamId, userId); result.Err != nil {
+func (a *App) GetChannelMembersForUser(teamId string, userId string) (*model.ChannelMembers, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetMembersForUser(teamId, userId); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelMembers), nil
 	}
 }
 
-func GetChannelMemberCount(channelId string) (int64, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetMemberCount(channelId, true); result.Err != nil {
+func (a *App) GetChannelMemberCount(channelId string) (int64, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetMemberCount(channelId, true); result.Err != nil {
 		return 0, result.Err
 	} else {
 		return result.Data.(int64), nil
 	}
 }
 
-func GetChannelCounts(teamId string, userId string) (*model.ChannelCounts, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetChannelCounts(teamId, userId); result.Err != nil {
+func (a *App) GetChannelCounts(teamId string, userId string) (*model.ChannelCounts, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetChannelCounts(teamId, userId); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelCounts), nil
 	}
 }
 
-func GetChannelUnread(channelId, userId string) (*model.ChannelUnread, *model.AppError) {
-	result := <-Srv.Store.Channel().GetChannelUnread(channelId, userId)
+func (a *App) GetChannelUnread(channelId, userId string) (*model.ChannelUnread, *model.AppError) {
+	result := <-a.Srv.Store.Channel().GetChannelUnread(channelId, userId)
 	if result.Err != nil {
 		return nil, result.Err
 	}
@@ -870,13 +870,13 @@ func GetChannelUnread(channelId, userId string) (*model.ChannelUnread, *model.Ap
 	return channelUnread, nil
 }
 
-func JoinChannel(channel *model.Channel, userId string) *model.AppError {
+func (a *App) JoinChannel(channel *model.Channel, userId string) *model.AppError {
 	if channel.DeleteAt > 0 {
 		return model.NewAppError("JoinChannel", "api.channel.join_channel.already_deleted.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	userChan := Srv.Store.User().Get(userId)
-	memberChan := Srv.Store.Channel().GetMember(channel.Id, userId)
+	userChan := a.Srv.Store.User().Get(userId)
+	memberChan := a.Srv.Store.Channel().GetMember(channel.Id, userId)
 
 	if uresult := <-userChan; uresult.Err != nil {
 		return uresult.Err
@@ -887,11 +887,11 @@ func JoinChannel(channel *model.Channel, userId string) *model.AppError {
 		user := uresult.Data.(*model.User)
 
 		if channel.Type == model.CHANNEL_OPEN {
-			if _, err := AddUserToChannel(user, channel); err != nil {
+			if _, err := a.AddUserToChannel(user, channel); err != nil {
 				return err
 			}
 
-			if err := postJoinChannelMessage(user, channel); err != nil {
+			if err := a.postJoinChannelMessage(user, channel); err != nil {
 				return err
 			}
 		} else {
@@ -902,7 +902,7 @@ func JoinChannel(channel *model.Channel, userId string) *model.AppError {
 	return nil
 }
 
-func postJoinChannelMessage(user *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postJoinChannelMessage(user *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(utils.T("api.channel.join_channel.post_and_forget"), user.Username),
@@ -913,17 +913,17 @@ func postJoinChannelMessage(user *model.User, channel *model.Channel) *model.App
 		},
 	}
 
-	if _, err := CreatePost(post, channel, false); err != nil {
+	if _, err := a.CreatePost(post, channel, false); err != nil {
 		return model.NewAppError("postJoinChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	return nil
 }
 
-func LeaveChannel(channelId string, userId string) *model.AppError {
-	sc := Srv.Store.Channel().Get(channelId, true)
-	uc := Srv.Store.User().Get(userId)
-	ccm := Srv.Store.Channel().GetMemberCount(channelId, false)
+func (a *App) LeaveChannel(channelId string, userId string) *model.AppError {
+	sc := a.Srv.Store.Channel().Get(channelId, true)
+	uc := a.Srv.Store.User().Get(userId)
+	ccm := a.Srv.Store.Channel().GetMemberCount(channelId, false)
 
 	if cresult := <-sc; cresult.Err != nil {
 		return cresult.Err
@@ -946,17 +946,17 @@ func LeaveChannel(channelId string, userId string) *model.AppError {
 			return err
 		}
 
-		if err := removeUserFromChannel(userId, userId, channel); err != nil {
+		if err := a.removeUserFromChannel(userId, userId, channel); err != nil {
 			return err
 		}
 
-		go postLeaveChannelMessage(user, channel)
+		go a.postLeaveChannelMessage(user, channel)
 	}
 
 	return nil
 }
 
-func postLeaveChannelMessage(user *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postLeaveChannelMessage(user *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(utils.T("api.channel.leave.left"), user.Username),
@@ -967,14 +967,14 @@ func postLeaveChannelMessage(user *model.User, channel *model.Channel) *model.Ap
 		},
 	}
 
-	if _, err := CreatePost(post, channel, false); err != nil {
+	if _, err := a.CreatePost(post, channel, false); err != nil {
 		return model.NewAppError("postLeaveChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	return nil
 }
 
-func PostAddToChannelMessage(user *model.User, addedUser *model.User, channel *model.Channel) *model.AppError {
+func (a *App) PostAddToChannelMessage(user *model.User, addedUser *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(utils.T("api.channel.add_member.added"), addedUser.Username, user.Username),
@@ -986,14 +986,14 @@ func PostAddToChannelMessage(user *model.User, addedUser *model.User, channel *m
 		},
 	}
 
-	if _, err := CreatePost(post, channel, false); err != nil {
+	if _, err := a.CreatePost(post, channel, false); err != nil {
 		return model.NewAppError("postAddToChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	return nil
 }
 
-func PostRemoveFromChannelMessage(removerUserId string, removedUser *model.User, channel *model.Channel) *model.AppError {
+func (a *App) PostRemoveFromChannelMessage(removerUserId string, removedUser *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(utils.T("api.channel.remove_member.removed"), removedUser.Username),
@@ -1004,14 +1004,14 @@ func PostRemoveFromChannelMessage(removerUserId string, removedUser *model.User,
 		},
 	}
 
-	if _, err := CreatePost(post, channel, false); err != nil {
+	if _, err := a.CreatePost(post, channel, false); err != nil {
 		return model.NewAppError("postRemoveFromChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	return nil
 }
 
-func removeUserFromChannel(userIdToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
+func (a *App) removeUserFromChannel(userIdToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
 	if channel.DeleteAt > 0 {
 		err := model.NewAppError("RemoveUserFromChannel", "api.channel.remove_user_from_channel.deleted.app_error", nil, "", http.StatusBadRequest)
 		return err
@@ -1021,12 +1021,12 @@ func removeUserFromChannel(userIdToRemove string, removerUserId string, channel 
 		return model.NewAppError("RemoveUserFromChannel", "api.channel.remove.default.app_error", map[string]interface{}{"Channel": model.DEFAULT_CHANNEL}, "", http.StatusBadRequest)
 	}
 
-	if cmresult := <-Srv.Store.Channel().RemoveMember(channel.Id, userIdToRemove); cmresult.Err != nil {
+	if cmresult := <-a.Srv.Store.Channel().RemoveMember(channel.Id, userIdToRemove); cmresult.Err != nil {
 		return cmresult.Err
 	}
 
-	InvalidateCacheForUser(userIdToRemove)
-	InvalidateCacheForChannelMembers(channel.Id)
+	a.InvalidateCacheForUser(userIdToRemove)
+	a.InvalidateCacheForChannelMembers(channel.Id)
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_REMOVED, "", channel.Id, "", nil)
 	message.Add("user_id", userIdToRemove)
@@ -1042,37 +1042,37 @@ func removeUserFromChannel(userIdToRemove string, removerUserId string, channel 
 	return nil
 }
 
-func RemoveUserFromChannel(userIdToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
+func (a *App) RemoveUserFromChannel(userIdToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
 	var err *model.AppError
-	if err = removeUserFromChannel(userIdToRemove, removerUserId, channel); err != nil {
+	if err = a.removeUserFromChannel(userIdToRemove, removerUserId, channel); err != nil {
 		return err
 	}
 
 	var user *model.User
-	if user, err = GetUser(userIdToRemove); err != nil {
+	if user, err = a.GetUser(userIdToRemove); err != nil {
 		return err
 	}
 
 	if userIdToRemove == removerUserId {
-		postLeaveChannelMessage(user, channel)
+		a.postLeaveChannelMessage(user, channel)
 	} else {
-		go PostRemoveFromChannelMessage(removerUserId, user, channel)
+		go a.PostRemoveFromChannelMessage(removerUserId, user, channel)
 	}
 
 	return nil
 }
 
-func GetNumberOfChannelsOnTeam(teamId string) (int, *model.AppError) {
+func (a *App) GetNumberOfChannelsOnTeam(teamId string) (int, *model.AppError) {
 	// Get total number of channels on current team
-	if result := <-Srv.Store.Channel().GetTeamChannels(teamId); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().GetTeamChannels(teamId); result.Err != nil {
 		return 0, result.Err
 	} else {
 		return len(*result.Data.(*model.ChannelList)), nil
 	}
 }
 
-func SetActiveChannel(userId string, channelId string) *model.AppError {
-	status, err := GetStatus(userId)
+func (a *App) SetActiveChannel(userId string, channelId string) *model.AppError {
+	status, err := a.GetStatus(userId)
 
 	oldStatus := model.STATUS_OFFLINE
 
@@ -1096,8 +1096,8 @@ func SetActiveChannel(userId string, channelId string) *model.AppError {
 	return nil
 }
 
-func UpdateChannelLastViewedAt(channelIds []string, userId string) *model.AppError {
-	if result := <-Srv.Store.Channel().UpdateLastViewedAt(channelIds, userId); result.Err != nil {
+func (a *App) UpdateChannelLastViewedAt(channelIds []string, userId string) *model.AppError {
+	if result := <-a.Srv.Store.Channel().UpdateLastViewedAt(channelIds, userId); result.Err != nil {
 		return result.Err
 	}
 
@@ -1112,24 +1112,24 @@ func UpdateChannelLastViewedAt(channelIds []string, userId string) *model.AppErr
 	return nil
 }
 
-func SearchChannels(teamId string, term string) (*model.ChannelList, *model.AppError) {
-	if result := <-Srv.Store.Channel().SearchInTeam(teamId, term); result.Err != nil {
+func (a *App) SearchChannels(teamId string, term string) (*model.ChannelList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().SearchInTeam(teamId, term); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelList), nil
 	}
 }
 
-func SearchChannelsUserNotIn(teamId string, userId string, term string) (*model.ChannelList, *model.AppError) {
-	if result := <-Srv.Store.Channel().SearchMore(userId, teamId, term); result.Err != nil {
+func (a *App) SearchChannelsUserNotIn(teamId string, userId string, term string) (*model.ChannelList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().SearchMore(userId, teamId, term); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.ChannelList), nil
 	}
 }
 
-func ViewChannel(view *model.ChannelView, userId string, clearPushNotifications bool) *model.AppError {
-	if err := SetActiveChannel(userId, view.ChannelId); err != nil {
+func (a *App) ViewChannel(view *model.ChannelView, userId string, clearPushNotifications bool) *model.AppError {
+	if err := a.SetActiveChannel(userId, view.ChannelId); err != nil {
 		return err
 	}
 
@@ -1144,7 +1144,7 @@ func ViewChannel(view *model.ChannelView, userId string, clearPushNotifications 
 		channelIds = append(channelIds, view.PrevChannelId)
 
 		if *utils.Cfg.EmailSettings.SendPushNotifications && clearPushNotifications && len(view.ChannelId) > 0 {
-			pchan = Srv.Store.User().GetUnreadCountForChannel(userId, view.ChannelId)
+			pchan = a.Srv.Store.User().GetUnreadCountForChannel(userId, view.ChannelId)
 		}
 	}
 
@@ -1152,14 +1152,14 @@ func ViewChannel(view *model.ChannelView, userId string, clearPushNotifications 
 		return nil
 	}
 
-	uchan := Srv.Store.Channel().UpdateLastViewedAt(channelIds, userId)
+	uchan := a.Srv.Store.Channel().UpdateLastViewedAt(channelIds, userId)
 
 	if pchan != nil {
 		if result := <-pchan; result.Err != nil {
 			return result.Err
 		} else {
 			if result.Data.(int64) > 0 {
-				ClearPushNotification(userId, view.ChannelId)
+				a.ClearPushNotification(userId, view.ChannelId)
 			}
 		}
 	}
@@ -1177,24 +1177,24 @@ func ViewChannel(view *model.ChannelView, userId string, clearPushNotifications 
 	return nil
 }
 
-func PermanentDeleteChannel(channel *model.Channel) *model.AppError {
-	if result := <-Srv.Store.Post().PermanentDeleteByChannel(channel.Id); result.Err != nil {
+func (a *App) PermanentDeleteChannel(channel *model.Channel) *model.AppError {
+	if result := <-a.Srv.Store.Post().PermanentDeleteByChannel(channel.Id); result.Err != nil {
 		return result.Err
 	}
 
-	if result := <-Srv.Store.Channel().PermanentDeleteMembersByChannel(channel.Id); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().PermanentDeleteMembersByChannel(channel.Id); result.Err != nil {
 		return result.Err
 	}
 
-	if result := <-Srv.Store.Webhook().PermanentDeleteIncomingByChannel(channel.Id); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().PermanentDeleteIncomingByChannel(channel.Id); result.Err != nil {
 		return result.Err
 	}
 
-	if result := <-Srv.Store.Webhook().PermanentDeleteOutgoingByChannel(channel.Id); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().PermanentDeleteOutgoingByChannel(channel.Id); result.Err != nil {
 		return result.Err
 	}
 
-	if result := <-Srv.Store.Channel().PermanentDelete(channel.Id); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().PermanentDelete(channel.Id); result.Err != nil {
 		return result.Err
 	}
 
@@ -1203,9 +1203,9 @@ func PermanentDeleteChannel(channel *model.Channel) *model.AppError {
 
 // This function is intended for use from the CLI. It is not robust against people joining the channel while the move
 // is in progress, and therefore should not be used from the API without first fixing this potential race condition.
-func MoveChannel(team *model.Team, channel *model.Channel) *model.AppError {
+func (a *App) MoveChannel(team *model.Team, channel *model.Channel) *model.AppError {
 	// Check that all channel members are in the destination team.
-	if channelMembers, err := GetChannelMembersPage(channel.Id, 0, 10000000); err != nil {
+	if channelMembers, err := a.GetChannelMembersPage(channel.Id, 0, 10000000); err != nil {
 		return err
 	} else {
 		channelMemberIds := []string{}
@@ -1213,7 +1213,7 @@ func MoveChannel(team *model.Team, channel *model.Channel) *model.AppError {
 			channelMemberIds = append(channelMemberIds, channelMember.UserId)
 		}
 
-		if teamMembers, err2 := GetTeamMembersByIds(team.Id, channelMemberIds); err != nil {
+		if teamMembers, err2 := a.GetTeamMembersByIds(team.Id, channelMemberIds); err != nil {
 			return err2
 		} else {
 			if len(teamMembers) != len(*channelMembers) {
@@ -1224,30 +1224,30 @@ func MoveChannel(team *model.Team, channel *model.Channel) *model.AppError {
 
 	// Change the Team ID of the channel.
 	channel.TeamId = team.Id
-	if result := <-Srv.Store.Channel().Update(channel); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().Update(channel); result.Err != nil {
 		return result.Err
 	}
 
 	return nil
 }
 
-func GetPinnedPosts(channelId string) (*model.PostList, *model.AppError) {
-	if result := <-Srv.Store.Channel().GetPinnedPosts(channelId); result.Err != nil {
+func (a *App) GetPinnedPosts(channelId string) (*model.PostList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetPinnedPosts(channelId); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.PostList), nil
 	}
 }
 
-func GetDirectChannel(userId1, userId2 string) (*model.Channel, *model.AppError) {
-	result := <-Srv.Store.Channel().GetByName("", model.GetDMNameFromIds(userId1, userId2), true)
+func (a *App) GetDirectChannel(userId1, userId2 string) (*model.Channel, *model.AppError) {
+	result := <-a.Srv.Store.Channel().GetByName("", model.GetDMNameFromIds(userId1, userId2), true)
 	if result.Err != nil && result.Err.Id == store.MISSING_CHANNEL_ERROR {
-		result := <-Srv.Store.Channel().CreateDirectChannel(userId1, userId2)
+		result := <-a.Srv.Store.Channel().CreateDirectChannel(userId1, userId2)
 		if result.Err != nil {
 			return nil, model.NewAppError("GetOrCreateDMChannel", "web.incoming_webhook.channel.app_error", nil, "err="+result.Err.Message, http.StatusBadRequest)
 		}
-		InvalidateCacheForUser(userId1)
-		InvalidateCacheForUser(userId2)
+		a.InvalidateCacheForUser(userId1)
+		a.InvalidateCacheForUser(userId2)
 		return result.Data.(*model.Channel), nil
 	} else if result.Err != nil {
 		return nil, model.NewAppError("GetOrCreateDMChannel", "web.incoming_webhook.channel.app_error", nil, "err="+result.Err.Message, result.Err.StatusCode)

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestPermanentDeleteChannel(t *testing.T) {
-	th := Setup().InitBasic()
+	a := Global()
+	th := a.Setup().InitBasic()
 
 	incomingWasEnabled := utils.Cfg.ServiceSettings.EnableIncomingWebhooks
 	outgoingWasEnabled := utils.Cfg.ServiceSettings.EnableOutgoingWebhooks
@@ -19,25 +20,25 @@ func TestPermanentDeleteChannel(t *testing.T) {
 		utils.Cfg.ServiceSettings.EnableOutgoingWebhooks = outgoingWasEnabled
 	}()
 
-	channel, err := CreateChannel(&model.Channel{DisplayName: "deletion-test", Name: "deletion-test", Type: model.CHANNEL_OPEN, TeamId: th.BasicTeam.Id}, false)
+	channel, err := a.CreateChannel(&model.Channel{DisplayName: "deletion-test", Name: "deletion-test", Type: model.CHANNEL_OPEN, TeamId: th.BasicTeam.Id}, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	defer func() {
-		PermanentDeleteChannel(channel)
+		a.PermanentDeleteChannel(channel)
 	}()
 
-	incoming, err := CreateIncomingWebhookForChannel(th.BasicUser.Id, channel, &model.IncomingWebhook{ChannelId: channel.Id})
+	incoming, err := a.CreateIncomingWebhookForChannel(th.BasicUser.Id, channel, &model.IncomingWebhook{ChannelId: channel.Id})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer DeleteIncomingWebhook(incoming.Id)
+	defer a.DeleteIncomingWebhook(incoming.Id)
 
-	if incoming, err = GetIncomingWebhook(incoming.Id); incoming == nil || err != nil {
+	if incoming, err = a.GetIncomingWebhook(incoming.Id); incoming == nil || err != nil {
 		t.Fatal("unable to get new incoming webhook")
 	}
 
-	outgoing, err := CreateOutgoingWebhook(&model.OutgoingWebhook{
+	outgoing, err := a.CreateOutgoingWebhook(&model.OutgoingWebhook{
 		ChannelId:    channel.Id,
 		TeamId:       channel.TeamId,
 		CreatorId:    th.BasicUser.Id,
@@ -46,64 +47,65 @@ func TestPermanentDeleteChannel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer DeleteOutgoingWebhook(outgoing.Id)
+	defer a.DeleteOutgoingWebhook(outgoing.Id)
 
-	if outgoing, err = GetOutgoingWebhook(outgoing.Id); outgoing == nil || err != nil {
+	if outgoing, err = a.GetOutgoingWebhook(outgoing.Id); outgoing == nil || err != nil {
 		t.Fatal("unable to get new outgoing webhook")
 	}
 
-	if err := PermanentDeleteChannel(channel); err != nil {
+	if err := a.PermanentDeleteChannel(channel); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	if incoming, err = GetIncomingWebhook(incoming.Id); incoming != nil || err == nil {
+	if incoming, err = a.GetIncomingWebhook(incoming.Id); incoming != nil || err == nil {
 		t.Error("incoming webhook wasn't deleted")
 	}
 
-	if outgoing, err = GetOutgoingWebhook(outgoing.Id); outgoing != nil || err == nil {
+	if outgoing, err = a.GetOutgoingWebhook(outgoing.Id); outgoing != nil || err == nil {
 		t.Error("outgoing webhook wasn't deleted")
 	}
 }
 
 func TestMoveChannel(t *testing.T) {
-	th := Setup().InitBasic()
+	a := Global()
+	th := a.Setup().InitBasic()
 
 	sourceTeam := th.CreateTeam()
 	targetTeam := th.CreateTeam()
 	channel1 := th.CreateChannel(sourceTeam)
 	defer func() {
-		PermanentDeleteChannel(channel1)
-		PermanentDeleteTeam(sourceTeam)
-		PermanentDeleteTeam(targetTeam)
+		a.PermanentDeleteChannel(channel1)
+		a.PermanentDeleteTeam(sourceTeam)
+		a.PermanentDeleteTeam(targetTeam)
 	}()
 
-	if _, err := AddUserToTeam(sourceTeam.Id, th.BasicUser.Id, ""); err != nil {
+	if _, err := a.AddUserToTeam(sourceTeam.Id, th.BasicUser.Id, ""); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := AddUserToTeam(sourceTeam.Id, th.BasicUser2.Id, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := AddUserToTeam(targetTeam.Id, th.BasicUser.Id, ""); err != nil {
+	if _, err := a.AddUserToTeam(sourceTeam.Id, th.BasicUser2.Id, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := AddUserToChannel(th.BasicUser, channel1); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := AddUserToChannel(th.BasicUser2, channel1); err != nil {
+	if _, err := a.AddUserToTeam(targetTeam.Id, th.BasicUser.Id, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := MoveChannel(targetTeam, channel1); err == nil {
+	if _, err := a.AddUserToChannel(th.BasicUser, channel1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.AddUserToChannel(th.BasicUser2, channel1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := a.MoveChannel(targetTeam, channel1); err == nil {
 		t.Fatal("Should have failed due to mismatched members.")
 	}
 
-	if _, err := AddUserToTeam(targetTeam.Id, th.BasicUser2.Id, ""); err != nil {
+	if _, err := a.AddUserToTeam(targetTeam.Id, th.BasicUser2.Id, ""); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := MoveChannel(targetTeam, channel1); err != nil {
+	if err := a.MoveChannel(targetTeam, channel1); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/app/cluster_discovery_test.go
+++ b/app/cluster_discovery_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestClusterDiscoveryService(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 
 	ds := NewClusterDiscoveryService()
 	ds.Type = model.CDS_TYPE_APP

--- a/app/cluster_handlers.go
+++ b/app/cluster_handlers.go
@@ -10,17 +10,17 @@ import (
 	"github.com/mattermost/platform/model"
 )
 
-func RegisterAllClusterMessageHandlers() {
+func (a *App) RegisterAllClusterMessageHandlers() {
 	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_PUBLISH, ClusterPublishHandler)
 	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_UPDATE_STATUS, ClusterUpdateStatusHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_ALL_CACHES, ClusterInvalidateAllCachesHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_WEBHOOK, ClusterInvalidateCacheForWebhookHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_POSTS, ClusterInvalidateCacheForChannelPostsHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS_NOTIFY_PROPS, ClusterInvalidateCacheForChannelMembersNotifyPropHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS, ClusterInvalidateCacheForChannelMembersHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_BY_NAME, ClusterInvalidateCacheForChannelByNameHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL, ClusterInvalidateCacheForChannelHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_USER, ClusterInvalidateCacheForUserHandler)
+	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_ALL_CACHES, a.ClusterInvalidateAllCachesHandler)
+	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_WEBHOOK, a.ClusterInvalidateCacheForWebhookHandler)
+	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_POSTS, a.ClusterInvalidateCacheForChannelPostsHandler)
+	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS_NOTIFY_PROPS, a.ClusterInvalidateCacheForChannelMembersNotifyPropHandler)
+	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS, a.ClusterInvalidateCacheForChannelMembersHandler)
+	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_BY_NAME, a.ClusterInvalidateCacheForChannelByNameHandler)
+	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL, a.ClusterInvalidateCacheForChannelHandler)
+	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_USER, a.ClusterInvalidateCacheForUserHandler)
 	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_CLEAR_SESSION_CACHE_FOR_USER, ClusterClearSessionCacheForUserHandler)
 
 }
@@ -35,36 +35,36 @@ func ClusterUpdateStatusHandler(msg *model.ClusterMessage) {
 	AddStatusCacheSkipClusterSend(status)
 }
 
-func ClusterInvalidateAllCachesHandler(msg *model.ClusterMessage) {
-	InvalidateAllCachesSkipSend()
+func (a *App) ClusterInvalidateAllCachesHandler(msg *model.ClusterMessage) {
+	a.InvalidateAllCachesSkipSend()
 }
 
-func ClusterInvalidateCacheForWebhookHandler(msg *model.ClusterMessage) {
-	InvalidateCacheForWebhookSkipClusterSend(msg.Data)
+func (a *App) ClusterInvalidateCacheForWebhookHandler(msg *model.ClusterMessage) {
+	a.InvalidateCacheForWebhookSkipClusterSend(msg.Data)
 }
 
-func ClusterInvalidateCacheForChannelPostsHandler(msg *model.ClusterMessage) {
-	InvalidateCacheForChannelPostsSkipClusterSend(msg.Data)
+func (a *App) ClusterInvalidateCacheForChannelPostsHandler(msg *model.ClusterMessage) {
+	a.InvalidateCacheForChannelPostsSkipClusterSend(msg.Data)
 }
 
-func ClusterInvalidateCacheForChannelMembersNotifyPropHandler(msg *model.ClusterMessage) {
-	InvalidateCacheForChannelMembersNotifyPropsSkipClusterSend(msg.Data)
+func (a *App) ClusterInvalidateCacheForChannelMembersNotifyPropHandler(msg *model.ClusterMessage) {
+	a.InvalidateCacheForChannelMembersNotifyPropsSkipClusterSend(msg.Data)
 }
 
-func ClusterInvalidateCacheForChannelMembersHandler(msg *model.ClusterMessage) {
-	InvalidateCacheForChannelMembersSkipClusterSend(msg.Data)
+func (a *App) ClusterInvalidateCacheForChannelMembersHandler(msg *model.ClusterMessage) {
+	a.InvalidateCacheForChannelMembersSkipClusterSend(msg.Data)
 }
 
-func ClusterInvalidateCacheForChannelByNameHandler(msg *model.ClusterMessage) {
-	InvalidateCacheForChannelByNameSkipClusterSend(msg.Props["id"], msg.Props["name"])
+func (a *App) ClusterInvalidateCacheForChannelByNameHandler(msg *model.ClusterMessage) {
+	a.InvalidateCacheForChannelByNameSkipClusterSend(msg.Props["id"], msg.Props["name"])
 }
 
-func ClusterInvalidateCacheForChannelHandler(msg *model.ClusterMessage) {
-	InvalidateCacheForChannelSkipClusterSend(msg.Data)
+func (a *App) ClusterInvalidateCacheForChannelHandler(msg *model.ClusterMessage) {
+	a.InvalidateCacheForChannelSkipClusterSend(msg.Data)
 }
 
-func ClusterInvalidateCacheForUserHandler(msg *model.ClusterMessage) {
-	InvalidateCacheForUserSkipClusterSend(msg.Data)
+func (a *App) ClusterInvalidateCacheForUserHandler(msg *model.ClusterMessage) {
+	a.InvalidateCacheForUserSkipClusterSend(msg.Data)
 }
 
 func ClusterClearSessionCacheForUserHandler(msg *model.ClusterMessage) {

--- a/app/command_away.go
+++ b/app/command_away.go
@@ -33,7 +33,7 @@ func (me *AwayProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *AwayProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	SetStatusAwayIfNeeded(args.UserId, true)
+	Global().SetStatusAwayIfNeeded(args.UserId, true)
 
 	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_away.success")}
 }

--- a/app/command_channel_header.go
+++ b/app/command_channel_header.go
@@ -35,16 +35,16 @@ func (me *HeaderProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *HeaderProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	channel, err := GetChannel(args.ChannelId)
+	channel, err := Global().GetChannel(args.ChannelId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_header.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_OPEN && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_header.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_PRIVATE && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_header.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
@@ -57,7 +57,7 @@ func (me *HeaderProvider) DoCommand(args *model.CommandArgs, message string) *mo
 	}
 	*patch.Header = message
 
-	_, err = PatchChannel(channel, patch, args.UserId)
+	_, err = Global().PatchChannel(channel, patch, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_header.update_channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_channel_purpose.go
+++ b/app/command_channel_purpose.go
@@ -34,16 +34,16 @@ func (me *PurposeProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *PurposeProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	channel, err := GetChannel(args.ChannelId)
+	channel, err := Global().GetChannel(args.ChannelId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_OPEN && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_PRIVATE && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
@@ -60,7 +60,7 @@ func (me *PurposeProvider) DoCommand(args *model.CommandArgs, message string) *m
 	}
 	*patch.Purpose = message
 
-	_, err = PatchChannel(channel, patch, args.UserId)
+	_, err = Global().PatchChannel(channel, patch, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.update_channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_channel_rename.go
+++ b/app/command_channel_rename.go
@@ -34,16 +34,16 @@ func (me *RenameProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *RenameProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	channel, err := GetChannel(args.ChannelId)
+	channel, err := Global().GetChannel(args.ChannelId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_OPEN && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_PRIVATE && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
@@ -64,7 +64,7 @@ func (me *RenameProvider) DoCommand(args *model.CommandArgs, message string) *mo
 	}
 	*patch.DisplayName = message
 
-	_, err = PatchChannel(channel, patch, args.UserId)
+	_, err = Global().PatchChannel(channel, patch, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.update_channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_channel_rename_test.go
+++ b/app/command_channel_rename_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestRenameProviderDoCommand(t *testing.T) {
-	th := Setup().InitBasic()
+	a := Global()
+	th := a.Setup().InitBasic()
 
 	rp := RenameProvider{}
 	args := &model.CommandArgs{

--- a/app/command_echo.go
+++ b/app/command_echo.go
@@ -88,7 +88,7 @@ func (me *EchoProvider) DoCommand(args *model.CommandArgs, message string) *mode
 
 		time.Sleep(time.Duration(delay) * time.Second)
 
-		if _, err := CreatePostMissingChannel(post, true); err != nil {
+		if _, err := Global().CreatePostMissingChannel(post, true); err != nil {
 			l4g.Error(args.T("api.command_echo.create.app_error"), err)
 		}
 	}()

--- a/app/command_expand_collapse.go
+++ b/app/command_expand_collapse.go
@@ -53,14 +53,14 @@ func (me *CollapseProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *ExpandProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	return setCollapsePreference(args, false)
+	return Global().setCollapsePreference(args, false)
 }
 
 func (me *CollapseProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	return setCollapsePreference(args, true)
+	return Global().setCollapsePreference(args, true)
 }
 
-func setCollapsePreference(args *model.CommandArgs, isCollapse bool) *model.CommandResponse {
+func (a *App) setCollapsePreference(args *model.CommandArgs, isCollapse bool) *model.CommandResponse {
 	pref := model.Preference{
 		UserId:   args.UserId,
 		Category: model.PREFERENCE_CATEGORY_DISPLAY_SETTINGS,
@@ -68,7 +68,7 @@ func setCollapsePreference(args *model.CommandArgs, isCollapse bool) *model.Comm
 		Value:    strconv.FormatBool(isCollapse),
 	}
 
-	if result := <-Srv.Store.Preference().Save(&model.Preferences{pref}); result.Err != nil {
+	if result := <-a.Srv.Store.Preference().Save(&model.Preferences{pref}); result.Err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_expand_collapse.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 

--- a/app/command_invite_people.go
+++ b/app/command_invite_people.go
@@ -63,7 +63,7 @@ func (me *InvitePeopleProvider) DoCommand(args *model.CommandArgs, message strin
 		return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command.invite_people.no_email")}
 	}
 
-	if err := InviteNewUsersToTeam(emailList, args.TeamId, args.UserId); err != nil {
+	if err := Global().InviteNewUsersToTeam(emailList, args.TeamId, args.UserId); err != nil {
 		l4g.Error(err.Error())
 		return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command.invite_people.fail")}
 	}

--- a/app/command_join.go
+++ b/app/command_join.go
@@ -34,14 +34,14 @@ func (me *JoinProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *JoinProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	if result := <-Srv.Store.Channel().GetByName(args.TeamId, message, true); result.Err != nil {
+	if result := <-Global().Srv.Store.Channel().GetByName(args.TeamId, message, true); result.Err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_join.list.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	} else {
 		channel := result.Data.(*model.Channel)
 
 		if channel.Name == message {
 			allowed := false
-			if (channel.Type == model.CHANNEL_PRIVATE && SessionHasPermissionToChannel(args.Session, channel.Id, model.PERMISSION_READ_CHANNEL)) || channel.Type == model.CHANNEL_OPEN {
+			if (channel.Type == model.CHANNEL_PRIVATE && Global().SessionHasPermissionToChannel(args.Session, channel.Id, model.PERMISSION_READ_CHANNEL)) || channel.Type == model.CHANNEL_OPEN {
 				allowed = true
 			}
 
@@ -49,11 +49,11 @@ func (me *JoinProvider) DoCommand(args *model.CommandArgs, message string) *mode
 				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 
-			if err := JoinChannel(channel, args.UserId); err != nil {
+			if err := Global().JoinChannel(channel, args.UserId); err != nil {
 				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 
-			team, err := GetTeam(channel.TeamId)
+			team, err := Global().GetTeam(channel.TeamId)
 			if err != nil {
 				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}

--- a/app/command_leave.go
+++ b/app/command_leave.go
@@ -35,18 +35,18 @@ func (me *LeaveProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 func (me *LeaveProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
 	var channel *model.Channel
 	var noChannelErr *model.AppError
-	if channel, noChannelErr = GetChannel(args.ChannelId); noChannelErr != nil {
+	if channel, noChannelErr = Global().GetChannel(args.ChannelId); noChannelErr != nil {
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 	if channel.Name == model.DEFAULT_CHANNEL {
 		return &model.CommandResponse{Text: args.T("api.channel.leave.default.app_error", map[string]interface{}{"Channel": model.DEFAULT_CHANNEL}), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
-	err := LeaveChannel(args.ChannelId, args.UserId)
+	err := Global().LeaveChannel(args.ChannelId, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	team, err := GetTeam(args.TeamId)
+	team, err := Global().GetTeam(args.TeamId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_loadtest.go
+++ b/app/command_loadtest.go
@@ -161,7 +161,7 @@ func (me *LoadTestProvider) SetupCommand(args *model.CommandArgs, message string
 	client := model.NewClient(args.SiteURL)
 
 	if doTeams {
-		if err := CreateBasicUser(client); err != nil {
+		if err := Global().CreateBasicUser(client); err != nil {
 			return &model.CommandResponse{Text: "Failed to create testing environment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 		client.Login(BTEST_USER_EMAIL, BTEST_USER_PASSWORD)
@@ -184,7 +184,7 @@ func (me *LoadTestProvider) SetupCommand(args *model.CommandArgs, message string
 	} else {
 
 		var team *model.Team
-		if tr := <-Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
+		if tr := <-Global().Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
 			return &model.CommandResponse{Text: "Failed to create testing environment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		} else {
 			team = tr.Data.(*model.Team)
@@ -219,7 +219,7 @@ func (me *LoadTestProvider) UsersCommand(args *model.CommandArgs, message string
 	}
 
 	var team *model.Team
-	if tr := <-Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
+	if tr := <-Global().Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
 		return &model.CommandResponse{Text: "Failed to create testing environment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	} else {
 		team = tr.Data.(*model.Team)
@@ -249,7 +249,7 @@ func (me *LoadTestProvider) ChannelsCommand(args *model.CommandArgs, message str
 	}
 
 	var team *model.Team
-	if tr := <-Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
+	if tr := <-Global().Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
 		return &model.CommandResponse{Text: "Failed to create testing environment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	} else {
 		team = tr.Data.(*model.Team)
@@ -288,7 +288,7 @@ func (me *LoadTestProvider) PostsCommand(args *model.CommandArgs, message string
 	}
 
 	var usernames []string
-	if result := <-Srv.Store.User().GetProfiles(args.TeamId, 0, 1000); result.Err == nil {
+	if result := <-Global().Srv.Store.User().GetProfiles(args.TeamId, 0, 1000); result.Err == nil {
 		profileUsers := result.Data.([]*model.User)
 		usernames = make([]string, len(profileUsers))
 		i := 0
@@ -357,7 +357,7 @@ func (me *LoadTestProvider) UrlCommand(args *model.CommandArgs, message string) 
 		post.ChannelId = args.ChannelId
 		post.UserId = args.UserId
 
-		if _, err := CreatePostMissingChannel(post, false); err != nil {
+		if _, err := Global().CreatePostMissingChannel(post, false); err != nil {
 			return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 	}
@@ -396,7 +396,7 @@ func (me *LoadTestProvider) JsonCommand(args *model.CommandArgs, message string)
 		post.Message = message
 	}
 
-	if _, err := CreatePostMissingChannel(post, false); err != nil {
+	if _, err := Global().CreatePostMissingChannel(post, false); err != nil {
 		return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 	return &model.CommandResponse{Text: "Loaded data", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}

--- a/app/command_logout.go
+++ b/app/command_logout.go
@@ -39,7 +39,7 @@ func (me *LogoutProvider) DoCommand(args *model.CommandArgs, message string) *mo
 
 	// We can't actually remove the user's cookie from here so we just dump their session and let the browser figure it out
 	if args.Session.Id != "" {
-		if err := RevokeSessionById(args.Session.Id); err != nil {
+		if err := Global().RevokeSessionById(args.Session.Id); err != nil {
 			return FAIL
 		}
 		return SUCCESS

--- a/app/command_msg.go
+++ b/app/command_msg.go
@@ -51,7 +51,7 @@ func (me *msgProvider) DoCommand(args *model.CommandArgs, message string) *model
 	targetUsername = strings.TrimPrefix(targetUsername, "@")
 
 	var userProfile *model.User
-	if result := <-Srv.Store.User().GetByUsername(targetUsername); result.Err != nil {
+	if result := <-Global().Srv.Store.User().GetByUsername(targetUsername); result.Err != nil {
 		l4g.Error(result.Err.Error())
 		return &model.CommandResponse{Text: args.T("api.command_msg.missing.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	} else {
@@ -66,9 +66,9 @@ func (me *msgProvider) DoCommand(args *model.CommandArgs, message string) *model
 	channelName := model.GetDMNameFromIds(args.UserId, userProfile.Id)
 
 	targetChannelId := ""
-	if channel := <-Srv.Store.Channel().GetByName(args.TeamId, channelName, true); channel.Err != nil {
+	if channel := <-Global().Srv.Store.Channel().GetByName(args.TeamId, channelName, true); channel.Err != nil {
 		if channel.Err.Id == "store.sql_channel.get_by_name.missing.app_error" {
-			if directChannel, err := CreateDirectChannel(args.UserId, userProfile.Id); err != nil {
+			if directChannel, err := Global().CreateDirectChannel(args.UserId, userProfile.Id); err != nil {
 				l4g.Error(err.Error())
 				return &model.CommandResponse{Text: args.T("api.command_msg.dm_fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			} else {
@@ -89,7 +89,7 @@ func (me *msgProvider) DoCommand(args *model.CommandArgs, message string) *model
 		post.Message = parsedMessage
 		post.ChannelId = targetChannelId
 		post.UserId = args.UserId
-		if _, err := CreatePostMissingChannel(post, true); err != nil {
+		if _, err := Global().CreatePostMissingChannel(post, true); err != nil {
 			return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 	}
@@ -101,7 +101,7 @@ func (me *msgProvider) DoCommand(args *model.CommandArgs, message string) *model
 		teamId = args.Session.TeamMembers[0].TeamId
 	}
 
-	team, err := GetTeam(teamId)
+	team, err := Global().GetTeam(teamId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_offline.go
+++ b/app/command_offline.go
@@ -33,7 +33,7 @@ func (me *OfflineProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *OfflineProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	SetStatusOffline(args.UserId, true)
+	Global().SetStatusOffline(args.UserId, true)
 
 	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_offline.success")}
 }

--- a/app/command_online.go
+++ b/app/command_online.go
@@ -33,7 +33,7 @@ func (me *OnlineProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *OnlineProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	SetStatusOnline(args.UserId, args.Session.Id, true)
+	Global().SetStatusOnline(args.UserId, args.Session.Id, true)
 
 	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_online.success")}
 }

--- a/app/compliance.go
+++ b/app/compliance.go
@@ -6,32 +6,33 @@ package app
 import (
 	"io/ioutil"
 
+	"net/http"
+
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"net/http"
 )
 
-func GetComplianceReports(page, perPage int) (model.Compliances, *model.AppError) {
+func (a *App) GetComplianceReports(page, perPage int) (model.Compliances, *model.AppError) {
 	if !*utils.Cfg.ComplianceSettings.Enable || !utils.IsLicensed() || !*utils.License().Features.Compliance {
 		return nil, model.NewAppError("GetComplianceReports", "ent.compliance.licence_disable.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Compliance().GetAll(page*perPage, perPage); result.Err != nil {
+	if result := <-a.Srv.Store.Compliance().GetAll(page*perPage, perPage); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(model.Compliances), nil
 	}
 }
 
-func SaveComplianceReport(job *model.Compliance) (*model.Compliance, *model.AppError) {
+func (a *App) SaveComplianceReport(job *model.Compliance) (*model.Compliance, *model.AppError) {
 	if !*utils.Cfg.ComplianceSettings.Enable || !utils.IsLicensed() || !*utils.License().Features.Compliance || einterfaces.GetComplianceInterface() == nil {
 		return nil, model.NewAppError("saveComplianceReport", "ent.compliance.licence_disable.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	job.Type = model.COMPLIANCE_TYPE_ADHOC
 
-	if result := <-Srv.Store.Compliance().Save(job); result.Err != nil {
+	if result := <-a.Srv.Store.Compliance().Save(job); result.Err != nil {
 		return nil, result.Err
 	} else {
 		job = result.Data.(*model.Compliance)
@@ -41,12 +42,12 @@ func SaveComplianceReport(job *model.Compliance) (*model.Compliance, *model.AppE
 	return job, nil
 }
 
-func GetComplianceReport(reportId string) (*model.Compliance, *model.AppError) {
+func (a *App) GetComplianceReport(reportId string) (*model.Compliance, *model.AppError) {
 	if !*utils.Cfg.ComplianceSettings.Enable || !utils.IsLicensed() || !*utils.License().Features.Compliance || einterfaces.GetComplianceInterface() == nil {
 		return nil, model.NewAppError("downloadComplianceReport", "ent.compliance.licence_disable.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Compliance().Get(reportId); result.Err != nil {
+	if result := <-a.Srv.Store.Compliance().Get(reportId); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.Compliance), nil

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -50,13 +50,13 @@ const (
 
 var client *analytics.Client
 
-func SendDailyDiagnostics() {
+func (a *App) SendDailyDiagnostics() {
 	if *utils.Cfg.LogSettings.EnableDiagnostics && utils.IsLeader() {
 		initDiagnostics("")
-		trackActivity()
+		a.trackActivity()
 		trackConfig()
 		trackLicense()
-		trackServer()
+		a.trackServer()
 	}
 }
 
@@ -108,7 +108,7 @@ func pluginSetting(plugin, key string, defaultValue interface{}) interface{} {
 	return defaultValue
 }
 
-func trackActivity() {
+func (a *App) trackActivity() {
 	var userCount int64
 	var activeUserCount int64
 	var inactiveUserCount int64
@@ -120,43 +120,43 @@ func trackActivity() {
 	var deletedPrivateChannelCount int64
 	var postsCount int64
 
-	if ucr := <-Srv.Store.User().GetTotalUsersCount(); ucr.Err == nil {
+	if ucr := <-a.Srv.Store.User().GetTotalUsersCount(); ucr.Err == nil {
 		userCount = ucr.Data.(int64)
 	}
 
-	if ucr := <-Srv.Store.Status().GetTotalActiveUsersCount(); ucr.Err == nil {
+	if ucr := <-a.Srv.Store.Status().GetTotalActiveUsersCount(); ucr.Err == nil {
 		activeUserCount = ucr.Data.(int64)
 	}
 
-	if iucr := <-Srv.Store.Status().GetTotalActiveUsersCount(); iucr.Err == nil {
+	if iucr := <-a.Srv.Store.Status().GetTotalActiveUsersCount(); iucr.Err == nil {
 		inactiveUserCount = iucr.Data.(int64)
 	}
 
-	if tcr := <-Srv.Store.Team().AnalyticsTeamCount(); tcr.Err == nil {
+	if tcr := <-a.Srv.Store.Team().AnalyticsTeamCount(); tcr.Err == nil {
 		teamCount = tcr.Data.(int64)
 	}
 
-	if ucc := <-Srv.Store.Channel().AnalyticsTypeCount("", "O"); ucc.Err == nil {
+	if ucc := <-a.Srv.Store.Channel().AnalyticsTypeCount("", "O"); ucc.Err == nil {
 		publicChannelCount = ucc.Data.(int64)
 	}
 
-	if pcc := <-Srv.Store.Channel().AnalyticsTypeCount("", "P"); pcc.Err == nil {
+	if pcc := <-a.Srv.Store.Channel().AnalyticsTypeCount("", "P"); pcc.Err == nil {
 		privateChannelCount = pcc.Data.(int64)
 	}
 
-	if dcc := <-Srv.Store.Channel().AnalyticsTypeCount("", "D"); dcc.Err == nil {
+	if dcc := <-a.Srv.Store.Channel().AnalyticsTypeCount("", "D"); dcc.Err == nil {
 		directChannelCount = dcc.Data.(int64)
 	}
 
-	if duccr := <-Srv.Store.Channel().AnalyticsDeletedTypeCount("", "O"); duccr.Err == nil {
+	if duccr := <-a.Srv.Store.Channel().AnalyticsDeletedTypeCount("", "O"); duccr.Err == nil {
 		deletedPublicChannelCount = duccr.Data.(int64)
 	}
 
-	if dpccr := <-Srv.Store.Channel().AnalyticsDeletedTypeCount("", "P"); dpccr.Err == nil {
+	if dpccr := <-a.Srv.Store.Channel().AnalyticsDeletedTypeCount("", "P"); dpccr.Err == nil {
 		deletedPrivateChannelCount = dpccr.Data.(int64)
 	}
 
-	if pcr := <-Srv.Store.Post().AnalyticsPostCount("", false, false); pcr.Err == nil {
+	if pcr := <-a.Srv.Store.Post().AnalyticsPostCount("", false, false); pcr.Err == nil {
 		postsCount = pcr.Data.(int64)
 	}
 
@@ -467,7 +467,7 @@ func trackLicense() {
 	}
 }
 
-func trackServer() {
+func (a *App) trackServer() {
 	data := map[string]interface{}{
 		"edition":          model.BuildEnterpriseReady,
 		"version":          model.CurrentVersion,
@@ -475,7 +475,7 @@ func trackServer() {
 		"operating_system": runtime.GOOS,
 	}
 
-	if scr := <-Srv.Store.User().AnalyticsGetSystemAdminCount(); scr.Err == nil {
+	if scr := <-a.Srv.Store.User().AnalyticsGetSystemAdminCount(); scr.Err == nil {
 		data["system_admins"] = scr.Data.(int64)
 	}
 

--- a/app/diagnostics_test.go
+++ b/app/diagnostics_test.go
@@ -47,7 +47,8 @@ func TestPluginSetting(t *testing.T) {
 }
 
 func TestDiagnostics(t *testing.T) {
-	Setup().InitBasic()
+	a := Global()
+	a.Setup().InitBasic()
 
 	if testing.Short() {
 		t.SkipNow()
@@ -91,7 +92,7 @@ func TestDiagnostics(t *testing.T) {
 	})
 
 	t.Run("SendDailyDiagnostics", func(t *testing.T) {
-		SendDailyDiagnostics()
+		a.SendDailyDiagnostics()
 
 		info := ""
 		// Collect the info sent.
@@ -151,7 +152,7 @@ func TestDiagnostics(t *testing.T) {
 			*utils.Cfg.LogSettings.EnableDiagnostics = oldSetting
 		}()
 
-		SendDailyDiagnostics()
+		a.SendDailyDiagnostics()
 
 		select {
 		case <-data:

--- a/app/email.go
+++ b/app/email.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"net/url"
 
+	"net/http"
+
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"net/http"
 )
 
 func SendChangeUsernameEmail(oldUsername, newUsername, email, locale, siteURL string) *model.AppError {
@@ -120,7 +121,7 @@ func SendSignInChangeEmail(email, method, locale, siteURL string) *model.AppErro
 	return nil
 }
 
-func SendWelcomeEmail(userId string, email string, verified bool, locale, siteURL string) *model.AppError {
+func (a *App) SendWelcomeEmail(userId string, email string, verified bool, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
 	rawUrl, _ := url.Parse(siteURL)
@@ -144,7 +145,7 @@ func SendWelcomeEmail(userId string, email string, verified bool, locale, siteUR
 	}
 
 	if !verified {
-		token, err := CreateVerifyEmailToken(userId)
+		token, err := a.CreateVerifyEmailToken(userId)
 		if err != nil {
 			return err
 		}

--- a/app/email_test.go
+++ b/app/email_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 func TestSendChangeUsernameEmail(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	Setup()
+	a.Setup()
 
 	var emailTo string = "test@example.com"
 	var oldUsername string = "myoldusername"
@@ -63,10 +64,11 @@ func TestSendChangeUsernameEmail(t *testing.T) {
 }
 
 func TestSendEmailChangeVerifyEmail(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	Setup()
+	a.Setup()
 
 	var newUserEmail string = "newtest@example.com"
 	var locale string = "en"
@@ -117,10 +119,11 @@ func TestSendEmailChangeVerifyEmail(t *testing.T) {
 }
 
 func TestSendEmailChangeEmail(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	Setup()
+	a.Setup()
 
 	var oldEmail string = "test@example.com"
 	var newUserEmail string = "newtest@example.com"
@@ -167,10 +170,11 @@ func TestSendEmailChangeEmail(t *testing.T) {
 }
 
 func TestSendVerifyEmail(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	Setup()
+	a.Setup()
 
 	var userEmail string = "test@example.com"
 	var locale string = "en"
@@ -221,10 +225,11 @@ func TestSendVerifyEmail(t *testing.T) {
 }
 
 func TestSendSignInChangeEmail(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	Setup()
+	a.Setup()
 
 	var email string = "test@example.com"
 	var locale string = "en"
@@ -271,10 +276,11 @@ func TestSendSignInChangeEmail(t *testing.T) {
 }
 
 func TestSendWelcomeEmail(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	Setup()
+	a.Setup()
 
 	var userId string = "32432nkjnijn432uj32"
 	var email string = "test@example.com"
@@ -287,7 +293,7 @@ func TestSendWelcomeEmail(t *testing.T) {
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(email)
 
-	if err := SendWelcomeEmail(userId, email, verified, locale, siteURL); err != nil {
+	if err := a.SendWelcomeEmail(userId, email, verified, locale, siteURL); err != nil {
 		t.Log(err)
 		t.Fatal("Should send change username email")
 	} else {
@@ -324,7 +330,7 @@ func TestSendWelcomeEmail(t *testing.T) {
 	verified = false
 	var expectedVerifyEmail string = "Please verify your email address by clicking below."
 
-	if err := SendWelcomeEmail(userId, email, verified, locale, siteURL); err != nil {
+	if err := a.SendWelcomeEmail(userId, email, verified, locale, siteURL); err != nil {
 		t.Log(err)
 		t.Fatal("Should send change username email")
 	} else {
@@ -367,10 +373,11 @@ func TestSendWelcomeEmail(t *testing.T) {
 }
 
 func TestSendPasswordChangeEmail(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	Setup()
+	a.Setup()
 
 	var email string = "test@example.com"
 	var locale string = "en"
@@ -417,10 +424,11 @@ func TestSendPasswordChangeEmail(t *testing.T) {
 }
 
 func TestSendMfaChangeEmail(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	Setup()
+	a.Setup()
 
 	var email string = "test@example.com"
 	var locale string = "en"
@@ -504,10 +512,11 @@ func TestSendMfaChangeEmail(t *testing.T) {
 }
 
 func TestSendInviteEmails(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	th := Setup().InitBasic()
+	th := a.Setup().InitBasic()
 
 	var email1 string = "test1@example.com"
 	var email2 string = "test2@example.com"
@@ -582,10 +591,11 @@ func TestSendInviteEmails(t *testing.T) {
 }
 
 func TestSendPasswordReset(t *testing.T) {
+	a := Global()
 	if testing.Short() {
 		t.SkipNow()
 	}
-	th := Setup().InitBasic()
+	th := a.Setup().InitBasic()
 
 	var siteURL string = "http://test.mattermost.io"
 	// var locale string = "en"
@@ -595,7 +605,7 @@ func TestSendPasswordReset(t *testing.T) {
 	//Delete all the messages before check the sample email
 	utils.DeleteMailBox(th.BasicUser.Email)
 
-	if _, err := SendPasswordReset(th.BasicUser.Email, siteURL); err != nil {
+	if _, err := a.SendPasswordReset(th.BasicUser.Email, siteURL); err != nil {
 		t.Log(err)
 		t.Fatal("Should send change username email")
 	} else {
@@ -620,7 +630,7 @@ func TestSendPasswordReset(t *testing.T) {
 				loc += 6
 				recoveryTokenString := resultsEmail.Body.Text[loc : loc+model.TOKEN_SIZE]
 				var recoveryToken *model.Token
-				if result := <-Srv.Store.Token().GetByToken(recoveryTokenString); result.Err != nil {
+				if result := <-a.Srv.Store.Token().GetByToken(recoveryTokenString); result.Err != nil {
 					t.Log(recoveryTokenString)
 					t.Fatal(result.Err)
 				} else {

--- a/app/file_test.go
+++ b/app/file_test.go
@@ -36,7 +36,8 @@ func TestGeneratePublicLinkHash(t *testing.T) {
 }
 
 func TestDoUploadFile(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 
 	teamId := model.NewId()
 	channelId := model.NewId()
@@ -44,12 +45,12 @@ func TestDoUploadFile(t *testing.T) {
 	filename := "test"
 	data := []byte("abcd")
 
-	info1, err := DoUploadFile(time.Date(2007, 2, 4, 1, 2, 3, 4, time.Local), teamId, channelId, userId, filename, data)
+	info1, err := a.DoUploadFile(time.Date(2007, 2, 4, 1, 2, 3, 4, time.Local), teamId, channelId, userId, filename, data)
 	if err != nil {
 		t.Fatal(err)
 	} else {
 		defer func() {
-			<-Srv.Store.FileInfo().PermanentDelete(info1.Id)
+			<-a.Srv.Store.FileInfo().PermanentDelete(info1.Id)
 			utils.RemoveFile(info1.Path)
 		}()
 	}
@@ -58,12 +59,12 @@ func TestDoUploadFile(t *testing.T) {
 		t.Fatal("stored file at incorrect path", info1.Path)
 	}
 
-	info2, err := DoUploadFile(time.Date(2007, 2, 4, 1, 2, 3, 4, time.Local), teamId, channelId, userId, filename, data)
+	info2, err := a.DoUploadFile(time.Date(2007, 2, 4, 1, 2, 3, 4, time.Local), teamId, channelId, userId, filename, data)
 	if err != nil {
 		t.Fatal(err)
 	} else {
 		defer func() {
-			<-Srv.Store.FileInfo().PermanentDelete(info2.Id)
+			<-a.Srv.Store.FileInfo().PermanentDelete(info2.Id)
 			utils.RemoveFile(info2.Path)
 		}()
 	}
@@ -72,12 +73,12 @@ func TestDoUploadFile(t *testing.T) {
 		t.Fatal("stored file at incorrect path", info2.Path)
 	}
 
-	info3, err := DoUploadFile(time.Date(2008, 3, 5, 1, 2, 3, 4, time.Local), teamId, channelId, userId, filename, data)
+	info3, err := a.DoUploadFile(time.Date(2008, 3, 5, 1, 2, 3, 4, time.Local), teamId, channelId, userId, filename, data)
 	if err != nil {
 		t.Fatal(err)
 	} else {
 		defer func() {
-			<-Srv.Store.FileInfo().PermanentDelete(info3.Id)
+			<-a.Srv.Store.FileInfo().PermanentDelete(info3.Id)
 			utils.RemoveFile(info3.Path)
 		}()
 	}

--- a/app/job.go
+++ b/app/job.go
@@ -8,32 +8,32 @@ import (
 	"github.com/mattermost/platform/model"
 )
 
-func GetJob(id string) (*model.Job, *model.AppError) {
-	if result := <-Srv.Store.Job().Get(id); result.Err != nil {
+func (a *App) GetJob(id string) (*model.Job, *model.AppError) {
+	if result := <-a.Srv.Store.Job().Get(id); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.Job), nil
 	}
 }
 
-func GetJobsPage(page int, perPage int) ([]*model.Job, *model.AppError) {
-	return GetJobs(page*perPage, perPage)
+func (a *App) GetJobsPage(page int, perPage int) ([]*model.Job, *model.AppError) {
+	return a.GetJobs(page*perPage, perPage)
 }
 
-func GetJobs(offset int, limit int) ([]*model.Job, *model.AppError) {
-	if result := <-Srv.Store.Job().GetAllPage(offset, limit); result.Err != nil {
+func (a *App) GetJobs(offset int, limit int) ([]*model.Job, *model.AppError) {
+	if result := <-a.Srv.Store.Job().GetAllPage(offset, limit); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.([]*model.Job), nil
 	}
 }
 
-func GetJobsByTypePage(jobType string, page int, perPage int) ([]*model.Job, *model.AppError) {
-	return GetJobsByType(jobType, page*perPage, perPage)
+func (a *App) GetJobsByTypePage(jobType string, page int, perPage int) ([]*model.Job, *model.AppError) {
+	return a.GetJobsByType(jobType, page*perPage, perPage)
 }
 
-func GetJobsByType(jobType string, offset int, limit int) ([]*model.Job, *model.AppError) {
-	if result := <-Srv.Store.Job().GetAllByTypePage(jobType, offset, limit); result.Err != nil {
+func (a *App) GetJobsByType(jobType string, offset int, limit int) ([]*model.Job, *model.AppError) {
+	if result := <-a.Srv.Store.Job().GetAllByTypePage(jobType, offset, limit); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.([]*model.Job), nil

--- a/app/job_test.go
+++ b/app/job_test.go
@@ -11,19 +11,20 @@ import (
 )
 
 func TestGetJob(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 
 	status := &model.Job{
 		Id:     model.NewId(),
 		Status: model.NewId(),
 	}
-	if result := <-Srv.Store.Job().Save(status); result.Err != nil {
+	if result := <-a.Srv.Store.Job().Save(status); result.Err != nil {
 		t.Fatal(result.Err)
 	}
 
-	defer Srv.Store.Job().Delete(status.Id)
+	defer a.Srv.Store.Job().Delete(status.Id)
 
-	if received, err := GetJob(status.Id); err != nil {
+	if received, err := a.GetJob(status.Id); err != nil {
 		t.Fatal(err)
 	} else if received.Id != status.Id || received.Status != status.Status {
 		t.Fatal("inccorrect job status received")
@@ -31,34 +32,35 @@ func TestGetJob(t *testing.T) {
 }
 
 func TestGetJobByType(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 
 	jobType := model.NewId()
 
 	statuses := []*model.Job{
 		{
-			Id:      model.NewId(),
-			Type:    jobType,
+			Id:       model.NewId(),
+			Type:     jobType,
 			CreateAt: 1000,
 		},
 		{
-			Id:      model.NewId(),
-			Type:    jobType,
+			Id:       model.NewId(),
+			Type:     jobType,
 			CreateAt: 999,
 		},
 		{
-			Id:      model.NewId(),
-			Type:    jobType,
+			Id:       model.NewId(),
+			Type:     jobType,
 			CreateAt: 1001,
 		},
 	}
 
 	for _, status := range statuses {
-		store.Must(Srv.Store.Job().Save(status))
-		defer Srv.Store.Job().Delete(status.Id)
+		store.Must(a.Srv.Store.Job().Save(status))
+		defer a.Srv.Store.Job().Delete(status.Id)
 	}
 
-	if received, err := GetJobsByType(jobType, 0, 2); err != nil {
+	if received, err := a.GetJobsByType(jobType, 0, 2); err != nil {
 		t.Fatal(err)
 	} else if len(received) != 2 {
 		t.Fatal("received wrong number of statuses")
@@ -68,7 +70,7 @@ func TestGetJobByType(t *testing.T) {
 		t.Fatal("should've received second newest job second")
 	}
 
-	if received, err := GetJobsByType(jobType, 2, 2); err != nil {
+	if received, err := a.GetJobsByType(jobType, 2, 2); err != nil {
 		t.Fatal(err)
 	} else if len(received) != 1 {
 		t.Fatal("received wrong number of statuses")

--- a/app/ldap.go
+++ b/app/ldap.go
@@ -38,17 +38,17 @@ func TestLdap() *model.AppError {
 	return nil
 }
 
-func SwitchEmailToLdap(email, password, code, ldapId, ldapPassword string) (string, *model.AppError) {
-	user, err := GetUserByEmail(email)
+func (a *App) SwitchEmailToLdap(email, password, code, ldapId, ldapPassword string) (string, *model.AppError) {
+	user, err := a.GetUserByEmail(email)
 	if err != nil {
 		return "", err
 	}
 
-	if err := CheckPasswordAndAllCriteria(user, password, code); err != nil {
+	if err := a.CheckPasswordAndAllCriteria(user, password, code); err != nil {
 		return "", err
 	}
 
-	if err := RevokeAllSessions(user.Id); err != nil {
+	if err := a.RevokeAllSessions(user.Id); err != nil {
 		return "", err
 	}
 
@@ -70,8 +70,8 @@ func SwitchEmailToLdap(email, password, code, ldapId, ldapPassword string) (stri
 	return "/login?extra=signin_change", nil
 }
 
-func SwitchLdapToEmail(ldapPassword, code, email, newPassword string) (string, *model.AppError) {
-	user, err := GetUserByEmail(email)
+func (a *App) SwitchLdapToEmail(ldapPassword, code, email, newPassword string) (string, *model.AppError) {
+	user, err := a.GetUserByEmail(email)
 	if err != nil {
 		return "", err
 	}
@@ -93,11 +93,11 @@ func SwitchLdapToEmail(ldapPassword, code, email, newPassword string) (string, *
 		return "", err
 	}
 
-	if err := UpdatePassword(user, newPassword); err != nil {
+	if err := a.UpdatePassword(user, newPassword); err != nil {
 		return "", err
 	}
 
-	if err := RevokeAllSessions(user.Id); err != nil {
+	if err := a.RevokeAllSessions(user.Id); err != nil {
 		return "", err
 	}
 

--- a/app/license_test.go
+++ b/app/license_test.go
@@ -5,33 +5,37 @@ package app
 
 import (
 	//"github.com/mattermost/platform/model"
-	"github.com/mattermost/platform/utils"
 	"testing"
+
+	"github.com/mattermost/platform/utils"
 )
 
 func TestLoadLicense(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 
-	LoadLicense()
+	a.LoadLicense()
 	if utils.IsLicensed() {
 		t.Fatal("shouldn't have a valid license")
 	}
 }
 
 func TestSaveLicense(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 
 	b1 := []byte("junk")
 
-	if _, err := SaveLicense(b1); err == nil {
+	if _, err := a.SaveLicense(b1); err == nil {
 		t.Fatal("shouldn't have saved license")
 	}
 }
 
 func TestRemoveLicense(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 
-	if err := RemoveLicense(); err != nil {
+	if err := a.RemoveLicense(); err != nil {
 		t.Fatal("should have removed license")
 	}
 }

--- a/app/notification.go
+++ b/app/notification.go
@@ -25,13 +25,13 @@ import (
 	"github.com/nicksnyder/go-i18n/i18n"
 )
 
-func SendNotifications(post *model.Post, team *model.Team, channel *model.Channel, sender *model.User, parentPostList *model.PostList) ([]string, *model.AppError) {
-	pchan := Srv.Store.User().GetAllProfilesInChannel(channel.Id, true)
-	cmnchan := Srv.Store.Channel().GetAllChannelMembersNotifyPropsForChannel(channel.Id, true)
+func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *model.Channel, sender *model.User, parentPostList *model.PostList) ([]string, *model.AppError) {
+	pchan := a.Srv.Store.User().GetAllProfilesInChannel(channel.Id, true)
+	cmnchan := a.Srv.Store.Channel().GetAllChannelMembersNotifyPropsForChannel(channel.Id, true)
 	var fchan store.StoreChannel
 
 	if len(post.FileIds) != 0 {
-		fchan = Srv.Store.FileInfo().GetForPost(post.Id, true, true)
+		fchan = a.Srv.Store.FileInfo().GetForPost(post.Id, true, true)
 	}
 
 	var profileMap map[string]*model.User
@@ -92,7 +92,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 		}
 
 		if len(potentialOtherMentions) > 0 {
-			if result := <-Srv.Store.User().GetProfilesByUsernames(potentialOtherMentions, team.Id); result.Err == nil {
+			if result := <-a.Srv.Store.User().GetProfilesByUsernames(potentialOtherMentions, team.Id); result.Err == nil {
 				outOfChannelMentions := result.Data.([]*model.User)
 				if channel.Type != model.CHANNEL_GROUP {
 					go sendOutOfChannelMentions(sender, post, team.Id, outOfChannelMentions)
@@ -114,7 +114,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 	mentionedUsersList := make([]string, 0, len(mentionedUserIds))
 	for id := range mentionedUserIds {
 		mentionedUsersList = append(mentionedUsersList, id)
-		updateMentionChans = append(updateMentionChans, Srv.Store.Channel().IncrementMentionCount(post.ChannelId, id))
+		updateMentionChans = append(updateMentionChans, a.Srv.Store.Channel().IncrementMentionCount(post.ChannelId, id))
 	}
 
 	senderName := ""
@@ -160,7 +160,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 
 			var status *model.Status
 			var err *model.AppError
-			if status, err = GetStatus(id); err != nil {
+			if status, err = a.GetStatus(id); err != nil {
 				status = &model.Status{
 					UserId:         id,
 					Status:         model.STATUS_OFFLINE,
@@ -171,7 +171,7 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 			}
 
 			if userAllowsEmails && status.Status != model.STATUS_ONLINE && profileMap[id].DeleteAt == 0 {
-				sendNotificationEmail(post, profileMap[id], channel, team, senderName, sender)
+				a.sendNotificationEmail(post, profileMap[id], channel, team, senderName, sender)
 			}
 		}
 	}
@@ -239,12 +239,12 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 		for _, id := range mentionedUsersList {
 			var status *model.Status
 			var err *model.AppError
-			if status, err = GetStatus(id); err != nil {
+			if status, err = a.GetStatus(id); err != nil {
 				status = &model.Status{UserId: id, Status: model.STATUS_OFFLINE, Manual: false, LastActivityAt: 0, ActiveChannel: ""}
 			}
 
 			if ShouldSendPushNotification(profileMap[id], channelMemberNotifyPropsMap[id], true, status, post) {
-				sendPushNotification(post, profileMap[id], channel, senderName, channelName, true)
+				a.sendPushNotification(post, profileMap[id], channel, senderName, channelName, true)
 			}
 		}
 
@@ -252,12 +252,12 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 			if _, ok := mentionedUserIds[id]; !ok {
 				var status *model.Status
 				var err *model.AppError
-				if status, err = GetStatus(id); err != nil {
+				if status, err = a.GetStatus(id); err != nil {
 					status = &model.Status{UserId: id, Status: model.STATUS_OFFLINE, Manual: false, LastActivityAt: 0, ActiveChannel: ""}
 				}
 
 				if ShouldSendPushNotification(profileMap[id], channelMemberNotifyPropsMap[id], false, status, post) {
-					sendPushNotification(post, profileMap[id], channel, senderName, channelName, false)
+					a.sendPushNotification(post, profileMap[id], channel, senderName, channelName, false)
 				}
 			}
 		}
@@ -297,9 +297,9 @@ func SendNotifications(post *model.Post, team *model.Team, channel *model.Channe
 	return mentionedUsersList, nil
 }
 
-func sendNotificationEmail(post *model.Post, user *model.User, channel *model.Channel, team *model.Team, senderName string, sender *model.User) *model.AppError {
+func (a *App) sendNotificationEmail(post *model.Post, user *model.User, channel *model.Channel, team *model.Team, senderName string, sender *model.User) *model.AppError {
 	if channel.IsGroupOrDirect() {
-		if result := <-Srv.Store.Team().GetTeamsByUserId(user.Id); result.Err != nil {
+		if result := <-a.Srv.Store.Team().GetTeamsByUserId(user.Id); result.Err != nil {
 			return result.Err
 		} else {
 			// if the recipient isn't in the current user's team, just pick one
@@ -323,7 +323,7 @@ func sendNotificationEmail(post *model.Post, user *model.User, channel *model.Ch
 	}
 	if *utils.Cfg.EmailSettings.EnableEmailBatching {
 		var sendBatched bool
-		if result := <-Srv.Store.Preference().Get(user.Id, model.PREFERENCE_CATEGORY_NOTIFICATIONS, model.PREFERENCE_NAME_EMAIL_INTERVAL); result.Err != nil {
+		if result := <-a.Srv.Store.Preference().Get(user.Id, model.PREFERENCE_CATEGORY_NOTIFICATIONS, model.PREFERENCE_NAME_EMAIL_INTERVAL); result.Err != nil {
 			// if the call fails, assume that the interval has not been explicitly set and batch the notifications
 			sendBatched = true
 		} else {
@@ -355,7 +355,7 @@ func sendNotificationEmail(post *model.Post, user *model.User, channel *model.Ch
 	}
 
 	teamURL := utils.GetSiteURL() + "/" + team.Name
-	var bodyText = getNotificationEmailBody(user, post, channel, senderName, team.Name, teamURL, emailNotificationContentsType, translateFunc)
+	var bodyText = a.getNotificationEmailBody(user, post, channel, senderName, team.Name, teamURL, emailNotificationContentsType, translateFunc)
 
 	go func() {
 		if err := utils.SendMail(user.Email, html.UnescapeString(subjectText), bodyText); err != nil {
@@ -403,12 +403,12 @@ func getNotificationEmailSubject(post *model.Post, translateFunc i18n.TranslateF
 /**
  * Computes the email body for notification messages
  */
-func getNotificationEmailBody(recipient *model.User, post *model.Post, channel *model.Channel, senderName string, teamName string, teamURL string, emailNotificationContentsType string, translateFunc i18n.TranslateFunc) string {
+func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, channel *model.Channel, senderName string, teamName string, teamURL string, emailNotificationContentsType string, translateFunc i18n.TranslateFunc) string {
 	// only include message contents in notification email if email notification contents type is set to full
 	var bodyPage *utils.HTMLTemplate
 	if emailNotificationContentsType == model.EMAIL_NOTIFICATION_CONTENTS_FULL {
 		bodyPage = utils.NewHTMLTemplate("post_body_full", recipient.Locale)
-		bodyPage.Props["PostMessage"] = GetMessageForNotification(post, translateFunc)
+		bodyPage.Props["PostMessage"] = a.GetMessageForNotification(post, translateFunc)
 	} else {
 		bodyPage = utils.NewHTMLTemplate("post_body_generic", recipient.Locale)
 	}
@@ -513,14 +513,14 @@ func getFormattedPostTime(post *model.Post, translateFunc i18n.TranslateFunc) fo
 	}
 }
 
-func GetMessageForNotification(post *model.Post, translateFunc i18n.TranslateFunc) string {
+func (a *App) GetMessageForNotification(post *model.Post, translateFunc i18n.TranslateFunc) string {
 	if len(strings.TrimSpace(post.Message)) != 0 || len(post.FileIds) == 0 {
 		return post.Message
 	}
 
 	// extract the filenames from their paths and determine what type of files are attached
 	var infos []*model.FileInfo
-	if result := <-Srv.Store.FileInfo().GetForPost(post.Id, true, true); result.Err != nil {
+	if result := <-a.Srv.Store.FileInfo().GetForPost(post.Id, true, true); result.Err != nil {
 		l4g.Warn(utils.T("api.post.get_message_for_notification.get_files.error"), post.Id, result.Err)
 	} else {
 		infos = result.Data.([]*model.FileInfo)
@@ -548,8 +548,8 @@ func GetMessageForNotification(post *model.Post, translateFunc i18n.TranslateFun
 	}
 }
 
-func sendPushNotification(post *model.Post, user *model.User, channel *model.Channel, senderName, channelName string, wasMentioned bool) *model.AppError {
-	sessions, err := getMobileAppSessions(user.Id)
+func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *model.Channel, senderName, channelName string, wasMentioned bool) *model.AppError {
+	sessions, err := a.getMobileAppSessions(user.Id)
 	if err != nil {
 		return err
 	}
@@ -561,7 +561,7 @@ func sendPushNotification(post *model.Post, user *model.User, channel *model.Cha
 	userLocale := utils.GetUserTranslations(user.Locale)
 
 	msg := model.PushNotification{}
-	if badge := <-Srv.Store.User().GetUnreadCount(user.Id); badge.Err != nil {
+	if badge := <-a.Srv.Store.User().GetUnreadCount(user.Id); badge.Err != nil {
 		msg.Badge = 1
 		l4g.Error(utils.T("store.sql_user.get_unread_count.app_error"), user.Id, badge.Err)
 	} else {
@@ -633,7 +633,7 @@ func sendPushNotification(post *model.Post, user *model.User, channel *model.Cha
 
 		l4g.Debug("Sending push notification to device %v for user %v with msg of '%v'", tmpMessage.DeviceId, user.Id, msg.Message)
 
-		go sendToPushProxy(tmpMessage, session)
+		go a.sendToPushProxy(tmpMessage, session)
 
 		if einterfaces.GetMetricsInterface() != nil {
 			einterfaces.GetMetricsInterface().IncrementPostSentPush()
@@ -643,8 +643,8 @@ func sendPushNotification(post *model.Post, user *model.User, channel *model.Cha
 	return nil
 }
 
-func ClearPushNotification(userId string, channelId string) *model.AppError {
-	sessions, err := getMobileAppSessions(userId)
+func (a *App) ClearPushNotification(userId string, channelId string) *model.AppError {
+	sessions, err := a.getMobileAppSessions(userId)
 	if err != nil {
 		return err
 	}
@@ -653,7 +653,7 @@ func ClearPushNotification(userId string, channelId string) *model.AppError {
 	msg.Type = model.PUSH_TYPE_CLEAR
 	msg.ChannelId = channelId
 	msg.ContentAvailable = 0
-	if badge := <-Srv.Store.User().GetUnreadCount(userId); badge.Err != nil {
+	if badge := <-a.Srv.Store.User().GetUnreadCount(userId); badge.Err != nil {
 		msg.Badge = 0
 		l4g.Error(utils.T("store.sql_user.get_unread_count.app_error"), userId, badge.Err)
 	} else {
@@ -665,13 +665,13 @@ func ClearPushNotification(userId string, channelId string) *model.AppError {
 	for _, session := range sessions {
 		tmpMessage := *model.PushNotificationFromJson(strings.NewReader(msg.ToJson()))
 		tmpMessage.SetDeviceIdAndPlatform(session.DeviceId)
-		go sendToPushProxy(tmpMessage, session)
+		go a.sendToPushProxy(tmpMessage, session)
 	}
 
 	return nil
 }
 
-func sendToPushProxy(msg model.PushNotification, session *model.Session) {
+func (a *App) sendToPushProxy(msg model.PushNotification, session *model.Session) {
 	msg.ServerId = utils.CfgDiagnosticId
 
 	request, _ := http.NewRequest("POST", *utils.Cfg.EmailSettings.PushNotificationServer+model.API_URL_SUFFIX_V1+"/send_push", strings.NewReader(msg.ToJson()))
@@ -687,7 +687,7 @@ func sendToPushProxy(msg model.PushNotification, session *model.Session) {
 
 		if pushResponse[model.PUSH_STATUS] == model.PUSH_STATUS_REMOVE {
 			l4g.Info("Device was reported as removed for UserId=%v SessionId=%v removing push for this session", session.UserId, session.Id)
-			AttachDeviceId(session.Id, "", session.ExpiresAt)
+			a.AttachDeviceId(session.Id, "", session.ExpiresAt)
 			ClearSessionCacheForUser(session.UserId)
 		}
 
@@ -697,8 +697,8 @@ func sendToPushProxy(msg model.PushNotification, session *model.Session) {
 	}
 }
 
-func getMobileAppSessions(userId string) ([]*model.Session, *model.AppError) {
-	if result := <-Srv.Store.Session().GetSessionsWithActiveDeviceIds(userId); result.Err != nil {
+func (a *App) getMobileAppSessions(userId string) ([]*model.Session, *model.AppError) {
+	if result := <-a.Srv.Store.Session().GetSessionsWithActiveDeviceIds(userId); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.([]*model.Session), nil

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 func TestSendNotifications(t *testing.T) {
-	th := Setup().InitBasic()
+	a := Global()
+	th := a.Setup().InitBasic()
 
-	AddUserToChannel(th.BasicUser2, th.BasicChannel)
+	a.AddUserToChannel(th.BasicUser2, th.BasicChannel)
 
-	post1, err := CreatePostMissingChannel(&model.Post{
+	post1, err := a.CreatePostMissingChannel(&model.Post{
 		UserId:    th.BasicUser.Id,
 		ChannelId: th.BasicChannel.Id,
 		Message:   "@" + th.BasicUser2.Username,
@@ -26,7 +27,7 @@ func TestSendNotifications(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mentions, err := SendNotifications(post1, th.BasicTeam, th.BasicChannel, th.BasicUser, nil)
+	mentions, err := a.SendNotifications(post1, th.BasicTeam, th.BasicChannel, th.BasicUser, nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if mentions == nil {
@@ -37,12 +38,12 @@ func TestSendNotifications(t *testing.T) {
 		t.Fatal("user should have been mentioned")
 	}
 
-	dm, err := CreateDirectChannel(th.BasicUser.Id, th.BasicUser2.Id)
+	dm, err := a.CreateDirectChannel(th.BasicUser.Id, th.BasicUser2.Id)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	post2, err := CreatePostMissingChannel(&model.Post{
+	post2, err := a.CreatePostMissingChannel(&model.Post{
 		UserId:    th.BasicUser.Id,
 		ChannelId: dm.Id,
 		Message:   "dm message",
@@ -52,15 +53,15 @@ func TestSendNotifications(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = SendNotifications(post2, th.BasicTeam, dm, th.BasicUser, nil)
+	_, err = a.SendNotifications(post2, th.BasicTeam, dm, th.BasicUser, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	UpdateActive(th.BasicUser2, false)
-	InvalidateAllCaches()
+	a.UpdateActive(th.BasicUser2, false)
+	a.InvalidateAllCaches()
 
-	post3, err := CreatePostMissingChannel(&model.Post{
+	post3, err := a.CreatePostMissingChannel(&model.Post{
 		UserId:    th.BasicUser.Id,
 		ChannelId: dm.Id,
 		Message:   "dm message",
@@ -70,7 +71,7 @@ func TestSendNotifications(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = SendNotifications(post3, th.BasicTeam, dm, th.BasicUser, nil)
+	_, err = a.SendNotifications(post3, th.BasicTeam, dm, th.BasicUser, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +409,8 @@ func TestRemoveCodeFromMessage(t *testing.T) {
 }
 
 func TestGetMentionKeywords(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	// user with username or custom mentions enabled
 	user1 := &model.User{
 		Id:        model.NewId(),
@@ -833,7 +835,8 @@ func TestDoesStatusAllowPushNotification(t *testing.T) {
 }
 
 func TestGetDirectMessageNotificationEmailSubject(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	expectedPrefix := "[http://localhost:8065] New Direct Message from sender on"
 	post := &model.Post{
 		CreateAt: 1501804801000,
@@ -846,7 +849,8 @@ func TestGetDirectMessageNotificationEmailSubject(t *testing.T) {
 }
 
 func TestGetNotificationEmailSubject(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	expectedPrefix := "[http://localhost:8065] Notification in team on"
 	post := &model.Post{
 		CreateAt: 1501804801000,
@@ -859,7 +863,8 @@ func TestGetNotificationEmailSubject(t *testing.T) {
 }
 
 func TestGetNotificationEmailBodyFullNotificationPublicChannel(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	recipient := &model.User{}
 	post := &model.Post{
 		Message: "This is the message",
@@ -874,7 +879,7 @@ func TestGetNotificationEmailBodyFullNotificationPublicChannel(t *testing.T) {
 	emailNotificationContentsType := model.EMAIL_NOTIFICATION_CONTENTS_FULL
 	translateFunc := utils.GetUserTranslations("en")
 
-	body := getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
+	body := a.getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
 	if !strings.Contains(body, "You have a new notification.") {
 		t.Fatal("Expected email text 'You have a new notification. Got " + body)
 	}
@@ -893,7 +898,8 @@ func TestGetNotificationEmailBodyFullNotificationPublicChannel(t *testing.T) {
 }
 
 func TestGetNotificationEmailBodyFullNotificationGroupChannel(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	recipient := &model.User{}
 	post := &model.Post{
 		Message: "This is the message",
@@ -908,7 +914,7 @@ func TestGetNotificationEmailBodyFullNotificationGroupChannel(t *testing.T) {
 	emailNotificationContentsType := model.EMAIL_NOTIFICATION_CONTENTS_FULL
 	translateFunc := utils.GetUserTranslations("en")
 
-	body := getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
+	body := a.getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
 	if !strings.Contains(body, "You have a new notification.") {
 		t.Fatal("Expected email text 'You have a new notification. Got " + body)
 	}
@@ -927,7 +933,8 @@ func TestGetNotificationEmailBodyFullNotificationGroupChannel(t *testing.T) {
 }
 
 func TestGetNotificationEmailBodyFullNotificationPrivateChannel(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	recipient := &model.User{}
 	post := &model.Post{
 		Message: "This is the message",
@@ -942,7 +949,7 @@ func TestGetNotificationEmailBodyFullNotificationPrivateChannel(t *testing.T) {
 	emailNotificationContentsType := model.EMAIL_NOTIFICATION_CONTENTS_FULL
 	translateFunc := utils.GetUserTranslations("en")
 
-	body := getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
+	body := a.getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
 	if !strings.Contains(body, "You have a new notification.") {
 		t.Fatal("Expected email text 'You have a new notification. Got " + body)
 	}
@@ -961,7 +968,8 @@ func TestGetNotificationEmailBodyFullNotificationPrivateChannel(t *testing.T) {
 }
 
 func TestGetNotificationEmailBodyFullNotificationDirectChannel(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	recipient := &model.User{}
 	post := &model.Post{
 		Message: "This is the message",
@@ -976,7 +984,7 @@ func TestGetNotificationEmailBodyFullNotificationDirectChannel(t *testing.T) {
 	emailNotificationContentsType := model.EMAIL_NOTIFICATION_CONTENTS_FULL
 	translateFunc := utils.GetUserTranslations("en")
 
-	body := getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
+	body := a.getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
 	if !strings.Contains(body, "You have a new direct message.") {
 		t.Fatal("Expected email text 'You have a new direct message. Got " + body)
 	}
@@ -993,7 +1001,8 @@ func TestGetNotificationEmailBodyFullNotificationDirectChannel(t *testing.T) {
 
 // from here
 func TestGetNotificationEmailBodyGenericNotificationPublicChannel(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	recipient := &model.User{}
 	post := &model.Post{
 		Message: "This is the message",
@@ -1008,7 +1017,7 @@ func TestGetNotificationEmailBodyGenericNotificationPublicChannel(t *testing.T) 
 	emailNotificationContentsType := model.EMAIL_NOTIFICATION_CONTENTS_GENERIC
 	translateFunc := utils.GetUserTranslations("en")
 
-	body := getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
+	body := a.getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
 	if !strings.Contains(body, "You have a new notification from "+senderName) {
 		t.Fatal("Expected email text 'You have a new notification from " + senderName + "'. Got " + body)
 	}
@@ -1024,7 +1033,8 @@ func TestGetNotificationEmailBodyGenericNotificationPublicChannel(t *testing.T) 
 }
 
 func TestGetNotificationEmailBodyGenericNotificationGroupChannel(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	recipient := &model.User{}
 	post := &model.Post{
 		Message: "This is the message",
@@ -1039,7 +1049,7 @@ func TestGetNotificationEmailBodyGenericNotificationGroupChannel(t *testing.T) {
 	emailNotificationContentsType := model.EMAIL_NOTIFICATION_CONTENTS_GENERIC
 	translateFunc := utils.GetUserTranslations("en")
 
-	body := getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
+	body := a.getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
 	if !strings.Contains(body, "You have a new notification from "+senderName) {
 		t.Fatal("Expected email text 'You have a new notification from " + senderName + "'. Got " + body)
 	}
@@ -1055,7 +1065,8 @@ func TestGetNotificationEmailBodyGenericNotificationGroupChannel(t *testing.T) {
 }
 
 func TestGetNotificationEmailBodyGenericNotificationPrivateChannel(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	recipient := &model.User{}
 	post := &model.Post{
 		Message: "This is the message",
@@ -1070,7 +1081,7 @@ func TestGetNotificationEmailBodyGenericNotificationPrivateChannel(t *testing.T)
 	emailNotificationContentsType := model.EMAIL_NOTIFICATION_CONTENTS_GENERIC
 	translateFunc := utils.GetUserTranslations("en")
 
-	body := getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
+	body := a.getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
 	if !strings.Contains(body, "You have a new notification from "+senderName) {
 		t.Fatal("Expected email text 'You have a new notification from " + senderName + "'. Got " + body)
 	}
@@ -1086,7 +1097,8 @@ func TestGetNotificationEmailBodyGenericNotificationPrivateChannel(t *testing.T)
 }
 
 func TestGetNotificationEmailBodyGenericNotificationDirectChannel(t *testing.T) {
-	Setup()
+	a := Global()
+	a.Setup()
 	recipient := &model.User{}
 	post := &model.Post{
 		Message: "This is the message",
@@ -1101,7 +1113,7 @@ func TestGetNotificationEmailBodyGenericNotificationDirectChannel(t *testing.T) 
 	emailNotificationContentsType := model.EMAIL_NOTIFICATION_CONTENTS_GENERIC
 	translateFunc := utils.GetUserTranslations("en")
 
-	body := getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
+	body := a.getNotificationEmailBody(recipient, post, channel, senderName, teamName, teamURL, emailNotificationContentsType, translateFunc)
 	if !strings.Contains(body, "You have a new direct message from "+senderName) {
 		t.Fatal("Expected email text 'You have a new direct message from " + senderName + "'. Got " + body)
 	}

--- a/app/preference.go
+++ b/app/preference.go
@@ -4,12 +4,13 @@
 package app
 
 import (
-	"github.com/mattermost/platform/model"
 	"net/http"
+
+	"github.com/mattermost/platform/model"
 )
 
-func GetPreferencesForUser(userId string) (model.Preferences, *model.AppError) {
-	if result := <-Srv.Store.Preference().GetAll(userId); result.Err != nil {
+func (a *App) GetPreferencesForUser(userId string) (model.Preferences, *model.AppError) {
+	if result := <-a.Srv.Store.Preference().GetAll(userId); result.Err != nil {
 		result.Err.StatusCode = http.StatusBadRequest
 		return nil, result.Err
 	} else {
@@ -17,8 +18,8 @@ func GetPreferencesForUser(userId string) (model.Preferences, *model.AppError) {
 	}
 }
 
-func GetPreferenceByCategoryForUser(userId string, category string) (model.Preferences, *model.AppError) {
-	if result := <-Srv.Store.Preference().GetCategory(userId, category); result.Err != nil {
+func (a *App) GetPreferenceByCategoryForUser(userId string, category string) (model.Preferences, *model.AppError) {
+	if result := <-a.Srv.Store.Preference().GetCategory(userId, category); result.Err != nil {
 		result.Err.StatusCode = http.StatusBadRequest
 		return nil, result.Err
 	} else if len(result.Data.(model.Preferences)) == 0 {
@@ -29,8 +30,8 @@ func GetPreferenceByCategoryForUser(userId string, category string) (model.Prefe
 	}
 }
 
-func GetPreferenceByCategoryAndNameForUser(userId string, category string, preferenceName string) (*model.Preference, *model.AppError) {
-	if result := <-Srv.Store.Preference().Get(userId, category, preferenceName); result.Err != nil {
+func (a *App) GetPreferenceByCategoryAndNameForUser(userId string, category string, preferenceName string) (*model.Preference, *model.AppError) {
+	if result := <-a.Srv.Store.Preference().Get(userId, category, preferenceName); result.Err != nil {
 		result.Err.StatusCode = http.StatusBadRequest
 		return nil, result.Err
 	} else {
@@ -39,7 +40,7 @@ func GetPreferenceByCategoryAndNameForUser(userId string, category string, prefe
 	}
 }
 
-func UpdatePreferences(userId string, preferences model.Preferences) *model.AppError {
+func (a *App) UpdatePreferences(userId string, preferences model.Preferences) *model.AppError {
 	for _, preference := range preferences {
 		if userId != preference.UserId {
 			return model.NewAppError("savePreferences", "api.preference.update_preferences.set.app_error", nil,
@@ -47,7 +48,7 @@ func UpdatePreferences(userId string, preferences model.Preferences) *model.AppE
 		}
 	}
 
-	if result := <-Srv.Store.Preference().Save(&preferences); result.Err != nil {
+	if result := <-a.Srv.Store.Preference().Save(&preferences); result.Err != nil {
 		result.Err.StatusCode = http.StatusBadRequest
 		return result.Err
 	}
@@ -59,7 +60,7 @@ func UpdatePreferences(userId string, preferences model.Preferences) *model.AppE
 	return nil
 }
 
-func DeletePreferences(userId string, preferences model.Preferences) *model.AppError {
+func (a *App) DeletePreferences(userId string, preferences model.Preferences) *model.AppError {
 	for _, preference := range preferences {
 		if userId != preference.UserId {
 			err := model.NewAppError("deletePreferences", "api.preference.delete_preferences.delete.app_error", nil,
@@ -69,7 +70,7 @@ func DeletePreferences(userId string, preferences model.Preferences) *model.AppE
 	}
 
 	for _, preference := range preferences {
-		if result := <-Srv.Store.Preference().Delete(userId, preference.Category, preference.Name); result.Err != nil {
+		if result := <-a.Srv.Store.Preference().Delete(userId, preference.Category, preference.Name); result.Err != nil {
 			result.Err.StatusCode = http.StatusBadRequest
 			return result.Err
 		}

--- a/app/reaction.go
+++ b/app/reaction.go
@@ -7,54 +7,54 @@ import (
 	"github.com/mattermost/platform/model"
 )
 
-func SaveReactionForPost(reaction *model.Reaction) (*model.Reaction, *model.AppError) {
-	post, err := GetSinglePost(reaction.PostId)
+func (a *App) SaveReactionForPost(reaction *model.Reaction) (*model.Reaction, *model.AppError) {
+	post, err := a.GetSinglePost(reaction.PostId)
 	if err != nil {
 		return nil, err
 	}
 
-	if result := <-Srv.Store.Reaction().Save(reaction); result.Err != nil {
+	if result := <-a.Srv.Store.Reaction().Save(reaction); result.Err != nil {
 		return nil, result.Err
 	} else {
 		reaction = result.Data.(*model.Reaction)
 
-		go sendReactionEvent(model.WEBSOCKET_EVENT_REACTION_ADDED, reaction, post)
+		go a.sendReactionEvent(model.WEBSOCKET_EVENT_REACTION_ADDED, reaction, post)
 
 		return reaction, nil
 	}
 }
 
-func GetReactionsForPost(postId string) ([]*model.Reaction, *model.AppError) {
-	if result := <-Srv.Store.Reaction().GetForPost(postId, true); result.Err != nil {
+func (a *App) GetReactionsForPost(postId string) ([]*model.Reaction, *model.AppError) {
+	if result := <-a.Srv.Store.Reaction().GetForPost(postId, true); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.([]*model.Reaction), nil
 	}
 }
 
-func DeleteReactionForPost(reaction *model.Reaction) *model.AppError {
-	post, err := GetSinglePost(reaction.PostId)
+func (a *App) DeleteReactionForPost(reaction *model.Reaction) *model.AppError {
+	post, err := a.GetSinglePost(reaction.PostId)
 	if err != nil {
 		return err
 	}
 
-	if result := <-Srv.Store.Reaction().Delete(reaction); result.Err != nil {
+	if result := <-a.Srv.Store.Reaction().Delete(reaction); result.Err != nil {
 		return result.Err
 	} else {
-		go sendReactionEvent(model.WEBSOCKET_EVENT_REACTION_REMOVED, reaction, post)
+		go a.sendReactionEvent(model.WEBSOCKET_EVENT_REACTION_REMOVED, reaction, post)
 	}
 
 	return nil
 }
 
-func sendReactionEvent(event string, reaction *model.Reaction, post *model.Post) {
+func (a *App) sendReactionEvent(event string, reaction *model.Reaction, post *model.Post) {
 	// send out that a reaction has been added/removed
 	message := model.NewWebSocketEvent(event, "", post.ChannelId, "", nil)
 	message.Add("reaction", reaction.ToJson())
 	Publish(message)
 
 	// The post is always modified since the UpdateAt always changes
-	InvalidateCacheForChannelPosts(post.ChannelId)
+	a.InvalidateCacheForChannelPosts(post.ChannelId)
 	post.HasReactions = true
 	post.UpdateAt = model.GetMillis()
 	umessage := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_EDITED, "", post.ChannelId, "", nil)

--- a/app/saml.go
+++ b/app/saml.go
@@ -9,10 +9,11 @@ import (
 	"net/http"
 	"os"
 
+	"path/filepath"
+
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"path/filepath"
 )
 
 func GetSamlMetadata() (string, *model.AppError) {

--- a/app/security_update_check.go
+++ b/app/security_update_check.go
@@ -30,9 +30,9 @@ const (
 	PROP_SECURITY_UNIT_TESTS        = "ut"
 )
 
-func DoSecurityUpdateCheck() {
+func (a *App) DoSecurityUpdateCheck() {
 	if *utils.Cfg.ServiceSettings.EnableSecurityFixAlert {
-		if result := <-Srv.Store.System().Get(); result.Err == nil {
+		if result := <-a.Srv.Store.System().Get(); result.Err == nil {
 			props := result.Data.(model.StringMap)
 			lastSecurityTime, _ := strconv.ParseInt(props[model.SYSTEM_LAST_SECURITY_TIME], 10, 0)
 			currentTime := model.GetMillis()
@@ -56,20 +56,20 @@ func DoSecurityUpdateCheck() {
 
 				systemSecurityLastTime := &model.System{Name: model.SYSTEM_LAST_SECURITY_TIME, Value: strconv.FormatInt(currentTime, 10)}
 				if lastSecurityTime == 0 {
-					<-Srv.Store.System().Save(systemSecurityLastTime)
+					<-a.Srv.Store.System().Save(systemSecurityLastTime)
 				} else {
-					<-Srv.Store.System().Update(systemSecurityLastTime)
+					<-a.Srv.Store.System().Update(systemSecurityLastTime)
 				}
 
-				if ucr := <-Srv.Store.User().GetTotalUsersCount(); ucr.Err == nil {
+				if ucr := <-a.Srv.Store.User().GetTotalUsersCount(); ucr.Err == nil {
 					v.Set(PROP_SECURITY_USER_COUNT, strconv.FormatInt(ucr.Data.(int64), 10))
 				}
 
-				if ucr := <-Srv.Store.Status().GetTotalActiveUsersCount(); ucr.Err == nil {
+				if ucr := <-a.Srv.Store.Status().GetTotalActiveUsersCount(); ucr.Err == nil {
 					v.Set(PROP_SECURITY_ACTIVE_USER_COUNT, strconv.FormatInt(ucr.Data.(int64), 10))
 				}
 
-				if tcr := <-Srv.Store.Team().AnalyticsTeamCount(); tcr.Err == nil {
+				if tcr := <-a.Srv.Store.Team().AnalyticsTeamCount(); tcr.Err == nil {
 					v.Set(PROP_SECURITY_TEAM_COUNT, strconv.FormatInt(tcr.Data.(int64), 10))
 				}
 
@@ -86,7 +86,7 @@ func DoSecurityUpdateCheck() {
 				for _, bulletin := range bulletins {
 					if bulletin.AppliesToVersion == model.CurrentVersion {
 						if props["SecurityBulletin_"+bulletin.Id] == "" {
-							if results := <-Srv.Store.User().GetSystemAdminProfiles(); results.Err != nil {
+							if results := <-a.Srv.Store.User().GetSystemAdminProfiles(); results.Err != nil {
 								l4g.Error(utils.T("mattermost.system_admins.error"))
 								return
 							} else {
@@ -112,7 +112,7 @@ func DoSecurityUpdateCheck() {
 							}
 
 							bulletinSeen := &model.System{Name: "SecurityBulletin_" + bulletin.Id, Value: bulletin.Id}
-							<-Srv.Store.System().Save(bulletinSeen)
+							<-a.Srv.Store.System().Save(bulletinSeen)
 						}
 					}
 				}

--- a/app/session_test.go
+++ b/app/session_test.go
@@ -4,8 +4,9 @@
 package app
 
 import (
-	"github.com/mattermost/platform/model"
 	"testing"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestCache(t *testing.T) {

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -176,9 +176,9 @@ func PublishSkipClusterSend(message *model.WebSocketEvent) {
 	}
 }
 
-func InvalidateCacheForChannel(channel *model.Channel) {
-	InvalidateCacheForChannelSkipClusterSend(channel.Id)
-	InvalidateCacheForChannelByNameSkipClusterSend(channel.TeamId, channel.Name)
+func (a *App) InvalidateCacheForChannel(channel *model.Channel) {
+	a.InvalidateCacheForChannelSkipClusterSend(channel.Id)
+	a.InvalidateCacheForChannelByNameSkipClusterSend(channel.TeamId, channel.Name)
 
 	if cluster := einterfaces.GetClusterInterface(); cluster != nil {
 		msg := &model.ClusterMessage{
@@ -206,12 +206,12 @@ func InvalidateCacheForChannel(channel *model.Channel) {
 	}
 }
 
-func InvalidateCacheForChannelSkipClusterSend(channelId string) {
-	Srv.Store.Channel().InvalidateChannel(channelId)
+func (a *App) InvalidateCacheForChannelSkipClusterSend(channelId string) {
+	a.Srv.Store.Channel().InvalidateChannel(channelId)
 }
 
-func InvalidateCacheForChannelMembers(channelId string) {
-	InvalidateCacheForChannelMembersSkipClusterSend(channelId)
+func (a *App) InvalidateCacheForChannelMembers(channelId string) {
+	a.InvalidateCacheForChannelMembersSkipClusterSend(channelId)
 
 	if einterfaces.GetClusterInterface() != nil {
 		msg := &model.ClusterMessage{
@@ -223,13 +223,13 @@ func InvalidateCacheForChannelMembers(channelId string) {
 	}
 }
 
-func InvalidateCacheForChannelMembersSkipClusterSend(channelId string) {
-	Srv.Store.User().InvalidateProfilesInChannelCache(channelId)
-	Srv.Store.Channel().InvalidateMemberCount(channelId)
+func (a *App) InvalidateCacheForChannelMembersSkipClusterSend(channelId string) {
+	a.Srv.Store.User().InvalidateProfilesInChannelCache(channelId)
+	a.Srv.Store.Channel().InvalidateMemberCount(channelId)
 }
 
-func InvalidateCacheForChannelMembersNotifyProps(channelId string) {
-	InvalidateCacheForChannelMembersNotifyPropsSkipClusterSend(channelId)
+func (a *App) InvalidateCacheForChannelMembersNotifyProps(channelId string) {
+	a.InvalidateCacheForChannelMembersNotifyPropsSkipClusterSend(channelId)
 
 	if einterfaces.GetClusterInterface() != nil {
 		msg := &model.ClusterMessage{
@@ -241,20 +241,20 @@ func InvalidateCacheForChannelMembersNotifyProps(channelId string) {
 	}
 }
 
-func InvalidateCacheForChannelMembersNotifyPropsSkipClusterSend(channelId string) {
-	Srv.Store.Channel().InvalidateCacheForChannelMembersNotifyProps(channelId)
+func (a *App) InvalidateCacheForChannelMembersNotifyPropsSkipClusterSend(channelId string) {
+	a.Srv.Store.Channel().InvalidateCacheForChannelMembersNotifyProps(channelId)
 }
 
-func InvalidateCacheForChannelByNameSkipClusterSend(teamId, name string) {
+func (a *App) InvalidateCacheForChannelByNameSkipClusterSend(teamId, name string) {
 	if teamId == "" {
 		teamId = "dm"
 	}
 
-	Srv.Store.Channel().InvalidateChannelByName(teamId, name)
+	a.Srv.Store.Channel().InvalidateChannelByName(teamId, name)
 }
 
-func InvalidateCacheForChannelPosts(channelId string) {
-	InvalidateCacheForChannelPostsSkipClusterSend(channelId)
+func (a *App) InvalidateCacheForChannelPosts(channelId string) {
+	a.InvalidateCacheForChannelPostsSkipClusterSend(channelId)
 
 	if einterfaces.GetClusterInterface() != nil {
 		msg := &model.ClusterMessage{
@@ -266,12 +266,12 @@ func InvalidateCacheForChannelPosts(channelId string) {
 	}
 }
 
-func InvalidateCacheForChannelPostsSkipClusterSend(channelId string) {
-	Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
+func (a *App) InvalidateCacheForChannelPostsSkipClusterSend(channelId string) {
+	a.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
 }
 
-func InvalidateCacheForUser(userId string) {
-	InvalidateCacheForUserSkipClusterSend(userId)
+func (a *App) InvalidateCacheForUser(userId string) {
+	a.InvalidateCacheForUserSkipClusterSend(userId)
 
 	if einterfaces.GetClusterInterface() != nil {
 		msg := &model.ClusterMessage{
@@ -283,18 +283,18 @@ func InvalidateCacheForUser(userId string) {
 	}
 }
 
-func InvalidateCacheForUserSkipClusterSend(userId string) {
-	Srv.Store.Channel().InvalidateAllChannelMembersForUser(userId)
-	Srv.Store.User().InvalidateProfilesInChannelCacheByUser(userId)
-	Srv.Store.User().InvalidatProfileCacheForUser(userId)
+func (a *App) InvalidateCacheForUserSkipClusterSend(userId string) {
+	a.Srv.Store.Channel().InvalidateAllChannelMembersForUser(userId)
+	a.Srv.Store.User().InvalidateProfilesInChannelCacheByUser(userId)
+	a.Srv.Store.User().InvalidatProfileCacheForUser(userId)
 
 	if len(hubs) != 0 {
 		GetHubForUserId(userId).InvalidateUser(userId)
 	}
 }
 
-func InvalidateCacheForWebhook(webhookId string) {
-	InvalidateCacheForWebhookSkipClusterSend(webhookId)
+func (a *App) InvalidateCacheForWebhook(webhookId string) {
+	a.InvalidateCacheForWebhookSkipClusterSend(webhookId)
 
 	if einterfaces.GetClusterInterface() != nil {
 		msg := &model.ClusterMessage{
@@ -306,8 +306,8 @@ func InvalidateCacheForWebhook(webhookId string) {
 	}
 }
 
-func InvalidateCacheForWebhookSkipClusterSend(webhookId string) {
-	Srv.Store.Webhook().InvalidateWebhookCache(webhookId)
+func (a *App) InvalidateCacheForWebhookSkipClusterSend(webhookId string) {
+	a.Srv.Store.Webhook().InvalidateWebhookCache(webhookId)
 }
 
 func InvalidateWebConnSessionCacheForUser(userId string) {
@@ -398,7 +398,7 @@ func (h *Hub) Start() {
 				}
 
 				if !found {
-					go SetStatusOffline(userId, false)
+					go Global().SetStatusOffline(userId, false)
 				}
 
 			case userId := <-h.invalidateUser:

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -22,7 +22,7 @@ const (
 	TRIGGERWORDS_STARTS_WITH = 1
 )
 
-func handleWebhookEvents(post *model.Post, team *model.Team, channel *model.Channel, user *model.User) *model.AppError {
+func (a *App) handleWebhookEvents(post *model.Post, team *model.Team, channel *model.Channel, user *model.User) *model.AppError {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return nil
 	}
@@ -31,7 +31,7 @@ func handleWebhookEvents(post *model.Post, team *model.Team, channel *model.Chan
 		return nil
 	}
 
-	hchan := Srv.Store.Webhook().GetOutgoingByTeam(team.Id, -1, -1)
+	hchan := a.Srv.Store.Webhook().GetOutgoingByTeam(team.Id, -1, -1)
 	result := <-hchan
 	if result.Err != nil {
 		return result.Err
@@ -80,13 +80,13 @@ func handleWebhookEvents(post *model.Post, team *model.Team, channel *model.Chan
 			TriggerWord: triggerWord,
 			FileIds:     strings.Join(post.FileIds, ","),
 		}
-		go TriggerWebhook(payload, hook, post, channel)
+		go a.TriggerWebhook(payload, hook, post, channel)
 	}
 
 	return nil
 }
 
-func TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.OutgoingWebhook, post *model.Post, channel *model.Channel) {
+func (a *App) TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.OutgoingWebhook, post *model.Post, channel *model.Channel) {
 	var body io.Reader
 	var contentType string
 	if hook.ContentType == "application/json" {
@@ -109,7 +109,7 @@ func TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.OutgoingW
 				respProps := model.MapFromJson(resp.Body)
 
 				if text, ok := respProps["text"]; ok {
-					if _, err := CreateWebhookPost(hook.CreatorId, channel, text, respProps["username"], respProps["icon_url"], post.Props, post.Type); err != nil {
+					if _, err := a.CreateWebhookPost(hook.CreatorId, channel, text, respProps["username"], respProps["icon_url"], post.Props, post.Type); err != nil {
 						l4g.Error(utils.T("api.post.handle_webhook_events_and_forget.create_post.error"), err)
 					}
 				}
@@ -118,7 +118,7 @@ func TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.OutgoingW
 	}
 }
 
-func CreateWebhookPost(userId string, channel *model.Channel, text, overrideUsername, overrideIconUrl string, props model.StringInterface, postType string) (*model.Post, *model.AppError) {
+func (a *App) CreateWebhookPost(userId string, channel *model.Channel, text, overrideUsername, overrideIconUrl string, props model.StringInterface, postType string) (*model.Post, *model.AppError) {
 	// parse links into Markdown format
 	linkWithTextRegex := regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
 	text = linkWithTextRegex.ReplaceAllString(text, "[${2}](${1})")
@@ -173,7 +173,7 @@ func CreateWebhookPost(userId string, channel *model.Channel, text, overrideUser
 		post.UpdateAt = 0
 		post.CreateAt = 0
 		post.Message = txt
-		if _, err := CreatePostMissingChannel(post, false); err != nil {
+		if _, err := a.CreatePostMissingChannel(post, false); err != nil {
 			return nil, model.NewAppError("CreateWebhookPost", "api.post.create_webhook_post.creating.app_error", nil, "err="+err.Message, http.StatusInternalServerError)
 		}
 
@@ -189,7 +189,7 @@ func CreateWebhookPost(userId string, channel *model.Channel, text, overrideUser
 	return firstPost, nil
 }
 
-func CreateIncomingWebhookForChannel(creatorId string, channel *model.Channel, hook *model.IncomingWebhook) (*model.IncomingWebhook, *model.AppError) {
+func (a *App) CreateIncomingWebhookForChannel(creatorId string, channel *model.Channel, hook *model.IncomingWebhook) (*model.IncomingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableIncomingWebhooks {
 		return nil, model.NewAppError("CreateIncomingWebhookForChannel", "api.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
@@ -197,14 +197,14 @@ func CreateIncomingWebhookForChannel(creatorId string, channel *model.Channel, h
 	hook.UserId = creatorId
 	hook.TeamId = channel.TeamId
 
-	if result := <-Srv.Store.Webhook().SaveIncoming(hook); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().SaveIncoming(hook); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.IncomingWebhook), nil
 	}
 }
 
-func UpdateIncomingWebhook(oldHook, updatedHook *model.IncomingWebhook) (*model.IncomingWebhook, *model.AppError) {
+func (a *App) UpdateIncomingWebhook(oldHook, updatedHook *model.IncomingWebhook) (*model.IncomingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableIncomingWebhooks {
 		return nil, model.NewAppError("UpdateIncomingWebhook", "api.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
@@ -216,70 +216,70 @@ func UpdateIncomingWebhook(oldHook, updatedHook *model.IncomingWebhook) (*model.
 	updatedHook.TeamId = oldHook.TeamId
 	updatedHook.DeleteAt = oldHook.DeleteAt
 
-	if result := <-Srv.Store.Webhook().UpdateIncoming(updatedHook); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().UpdateIncoming(updatedHook); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.IncomingWebhook), nil
 	}
 }
 
-func DeleteIncomingWebhook(hookId string) *model.AppError {
+func (a *App) DeleteIncomingWebhook(hookId string) *model.AppError {
 	if !utils.Cfg.ServiceSettings.EnableIncomingWebhooks {
 		return model.NewAppError("DeleteIncomingWebhook", "api.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Webhook().DeleteIncoming(hookId, model.GetMillis()); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().DeleteIncoming(hookId, model.GetMillis()); result.Err != nil {
 		return result.Err
 	}
 
-	InvalidateCacheForWebhook(hookId)
+	a.InvalidateCacheForWebhook(hookId)
 
 	return nil
 }
 
-func GetIncomingWebhook(hookId string) (*model.IncomingWebhook, *model.AppError) {
+func (a *App) GetIncomingWebhook(hookId string) (*model.IncomingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableIncomingWebhooks {
 		return nil, model.NewAppError("GetIncomingWebhook", "api.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Webhook().GetIncoming(hookId, true); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().GetIncoming(hookId, true); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.IncomingWebhook), nil
 	}
 }
 
-func GetIncomingWebhooksForTeamPage(teamId string, page, perPage int) ([]*model.IncomingWebhook, *model.AppError) {
+func (a *App) GetIncomingWebhooksForTeamPage(teamId string, page, perPage int) ([]*model.IncomingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableIncomingWebhooks {
 		return nil, model.NewAppError("GetIncomingWebhooksForTeamPage", "api.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Webhook().GetIncomingByTeam(teamId, page*perPage, perPage); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().GetIncomingByTeam(teamId, page*perPage, perPage); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.([]*model.IncomingWebhook), nil
 	}
 }
 
-func GetIncomingWebhooksPage(page, perPage int) ([]*model.IncomingWebhook, *model.AppError) {
+func (a *App) GetIncomingWebhooksPage(page, perPage int) ([]*model.IncomingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableIncomingWebhooks {
 		return nil, model.NewAppError("GetIncomingWebhooksPage", "api.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Webhook().GetIncomingList(page*perPage, perPage); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().GetIncomingList(page*perPage, perPage); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.([]*model.IncomingWebhook), nil
 	}
 }
 
-func CreateOutgoingWebhook(hook *model.OutgoingWebhook) (*model.OutgoingWebhook, *model.AppError) {
+func (a *App) CreateOutgoingWebhook(hook *model.OutgoingWebhook) (*model.OutgoingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return nil, model.NewAppError("CreateOutgoingWebhook", "api.outgoing_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	if len(hook.ChannelId) != 0 {
-		cchan := Srv.Store.Channel().Get(hook.ChannelId, true)
+		cchan := a.Srv.Store.Channel().Get(hook.ChannelId, true)
 
 		var channel *model.Channel
 		if result := <-cchan; result.Err != nil {
@@ -299,7 +299,7 @@ func CreateOutgoingWebhook(hook *model.OutgoingWebhook) (*model.OutgoingWebhook,
 		return nil, model.NewAppError("CreateOutgoingWebhook", "api.webhook.create_outgoing.triggers.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	if result := <-Srv.Store.Webhook().GetOutgoingByTeam(hook.TeamId, -1, -1); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().GetOutgoingByTeam(hook.TeamId, -1, -1); result.Err != nil {
 		return nil, result.Err
 	} else {
 		allHooks := result.Data.([]*model.OutgoingWebhook)
@@ -314,20 +314,20 @@ func CreateOutgoingWebhook(hook *model.OutgoingWebhook) (*model.OutgoingWebhook,
 		}
 	}
 
-	if result := <-Srv.Store.Webhook().SaveOutgoing(hook); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().SaveOutgoing(hook); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.OutgoingWebhook), nil
 	}
 }
 
-func UpdateOutgoingWebhook(oldHook, updatedHook *model.OutgoingWebhook) (*model.OutgoingWebhook, *model.AppError) {
+func (a *App) UpdateOutgoingWebhook(oldHook, updatedHook *model.OutgoingWebhook) (*model.OutgoingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return nil, model.NewAppError("UpdateOutgoingWebhook", "api.outgoing_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	if len(updatedHook.ChannelId) > 0 {
-		channel, err := GetChannel(updatedHook.ChannelId)
+		channel, err := a.GetChannel(updatedHook.ChannelId)
 		if err != nil {
 			return nil, err
 		}
@@ -344,7 +344,7 @@ func UpdateOutgoingWebhook(oldHook, updatedHook *model.OutgoingWebhook) (*model.
 	}
 
 	var result store.StoreResult
-	if result = <-Srv.Store.Webhook().GetOutgoingByTeam(oldHook.TeamId, -1, -1); result.Err != nil {
+	if result = <-a.Srv.Store.Webhook().GetOutgoingByTeam(oldHook.TeamId, -1, -1); result.Err != nil {
 		return nil, result.Err
 	}
 
@@ -365,93 +365,93 @@ func UpdateOutgoingWebhook(oldHook, updatedHook *model.OutgoingWebhook) (*model.
 	updatedHook.TeamId = oldHook.TeamId
 	updatedHook.UpdateAt = model.GetMillis()
 
-	if result = <-Srv.Store.Webhook().UpdateOutgoing(updatedHook); result.Err != nil {
+	if result = <-a.Srv.Store.Webhook().UpdateOutgoing(updatedHook); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.OutgoingWebhook), nil
 	}
 }
 
-func GetOutgoingWebhook(hookId string) (*model.OutgoingWebhook, *model.AppError) {
+func (a *App) GetOutgoingWebhook(hookId string) (*model.OutgoingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return nil, model.NewAppError("GetOutgoingWebhook", "api.outgoing_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Webhook().GetOutgoing(hookId); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().GetOutgoing(hookId); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.OutgoingWebhook), nil
 	}
 }
 
-func GetOutgoingWebhooksPage(page, perPage int) ([]*model.OutgoingWebhook, *model.AppError) {
+func (a *App) GetOutgoingWebhooksPage(page, perPage int) ([]*model.OutgoingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return nil, model.NewAppError("GetOutgoingWebhooksPage", "api.outgoing_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Webhook().GetOutgoingList(page*perPage, perPage); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().GetOutgoingList(page*perPage, perPage); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.([]*model.OutgoingWebhook), nil
 	}
 }
 
-func GetOutgoingWebhooksForChannelPage(channelId string, page, perPage int) ([]*model.OutgoingWebhook, *model.AppError) {
+func (a *App) GetOutgoingWebhooksForChannelPage(channelId string, page, perPage int) ([]*model.OutgoingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return nil, model.NewAppError("GetOutgoingWebhooksForChannelPage", "api.outgoing_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Webhook().GetOutgoingByChannel(channelId, page*perPage, perPage); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().GetOutgoingByChannel(channelId, page*perPage, perPage); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.([]*model.OutgoingWebhook), nil
 	}
 }
 
-func GetOutgoingWebhooksForTeamPage(teamId string, page, perPage int) ([]*model.OutgoingWebhook, *model.AppError) {
+func (a *App) GetOutgoingWebhooksForTeamPage(teamId string, page, perPage int) ([]*model.OutgoingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return nil, model.NewAppError("GetOutgoingWebhooksForTeamPage", "api.outgoing_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Webhook().GetOutgoingByTeam(teamId, page*perPage, perPage); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().GetOutgoingByTeam(teamId, page*perPage, perPage); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.([]*model.OutgoingWebhook), nil
 	}
 }
 
-func DeleteOutgoingWebhook(hookId string) *model.AppError {
+func (a *App) DeleteOutgoingWebhook(hookId string) *model.AppError {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return model.NewAppError("DeleteOutgoingWebhook", "api.outgoing_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if result := <-Srv.Store.Webhook().DeleteOutgoing(hookId, model.GetMillis()); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().DeleteOutgoing(hookId, model.GetMillis()); result.Err != nil {
 		return result.Err
 	}
 
 	return nil
 }
 
-func RegenOutgoingWebhookToken(hook *model.OutgoingWebhook) (*model.OutgoingWebhook, *model.AppError) {
+func (a *App) RegenOutgoingWebhookToken(hook *model.OutgoingWebhook) (*model.OutgoingWebhook, *model.AppError) {
 	if !utils.Cfg.ServiceSettings.EnableOutgoingWebhooks {
 		return nil, model.NewAppError("RegenOutgoingWebhookToken", "api.outgoing_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	hook.Token = model.NewId()
 
-	if result := <-Srv.Store.Webhook().UpdateOutgoing(hook); result.Err != nil {
+	if result := <-a.Srv.Store.Webhook().UpdateOutgoing(hook); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.OutgoingWebhook), nil
 	}
 }
 
-func HandleIncomingWebhook(hookId string, req *model.IncomingWebhookRequest) *model.AppError {
+func (a *App) HandleIncomingWebhook(hookId string, req *model.IncomingWebhookRequest) *model.AppError {
 	if !utils.Cfg.ServiceSettings.EnableIncomingWebhooks {
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	hchan := Srv.Store.Webhook().GetIncoming(hookId, true)
+	hchan := a.Srv.Store.Webhook().GetIncoming(hookId, true)
 
 	if req == nil {
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.parse.app_error", nil, "", http.StatusBadRequest)
@@ -493,22 +493,22 @@ func HandleIncomingWebhook(hookId string, req *model.IncomingWebhookRequest) *mo
 
 	if len(channelName) != 0 {
 		if channelName[0] == '@' {
-			if result := <-Srv.Store.User().GetByUsername(channelName[1:]); result.Err != nil {
+			if result := <-a.Srv.Store.User().GetByUsername(channelName[1:]); result.Err != nil {
 				return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.user.app_error", nil, "err="+result.Err.Message, http.StatusBadRequest)
 			} else {
-				if ch, err := GetDirectChannel(hook.UserId, result.Data.(*model.User).Id); err != nil {
+				if ch, err := a.GetDirectChannel(hook.UserId, result.Data.(*model.User).Id); err != nil {
 					return err
 				} else {
 					channel = ch
 				}
 			}
 		} else if channelName[0] == '#' {
-			cchan = Srv.Store.Channel().GetByName(hook.TeamId, channelName[1:], true)
+			cchan = a.Srv.Store.Channel().GetByName(hook.TeamId, channelName[1:], true)
 		} else {
-			cchan = Srv.Store.Channel().GetByName(hook.TeamId, channelName, true)
+			cchan = a.Srv.Store.Channel().GetByName(hook.TeamId, channelName, true)
 		}
 	} else {
-		cchan = Srv.Store.Channel().Get(hook.ChannelId, true)
+		cchan = a.Srv.Store.Channel().Get(hook.ChannelId, true)
 	}
 
 	if channel == nil {
@@ -525,21 +525,21 @@ func HandleIncomingWebhook(hookId string, req *model.IncomingWebhookRequest) *mo
 		return model.NewLocAppError("HandleIncomingWebhook", "api.post.create_post.town_square_read_only", nil, "")
 	}
 
-	if channel.Type != model.CHANNEL_OPEN && !HasPermissionToChannel(hook.UserId, channel.Id, model.PERMISSION_READ_CHANNEL) {
+	if channel.Type != model.CHANNEL_OPEN && !a.HasPermissionToChannel(hook.UserId, channel.Id, model.PERMISSION_READ_CHANNEL) {
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.permissions.app_error", nil, "", http.StatusForbidden)
 	}
 
 	overrideUsername := req.Username
 	overrideIconUrl := req.IconURL
 
-	if _, err := CreateWebhookPost(hook.UserId, channel, text, overrideUsername, overrideIconUrl, req.Props, webhookType); err != nil {
+	if _, err := a.CreateWebhookPost(hook.UserId, channel, text, overrideUsername, overrideIconUrl, req.Props, webhookType); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func CreateCommandWebhook(commandId string, args *model.CommandArgs) (*model.CommandWebhook, *model.AppError) {
+func (a *App) CreateCommandWebhook(commandId string, args *model.CommandArgs) (*model.CommandWebhook, *model.AppError) {
 	hook := &model.CommandWebhook{
 		CommandId: commandId,
 		UserId:    args.UserId,
@@ -548,27 +548,27 @@ func CreateCommandWebhook(commandId string, args *model.CommandArgs) (*model.Com
 		ParentId:  args.ParentId,
 	}
 
-	if result := <-Srv.Store.CommandWebhook().Save(hook); result.Err != nil {
+	if result := <-a.Srv.Store.CommandWebhook().Save(hook); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.CommandWebhook), nil
 	}
 }
 
-func HandleCommandWebhook(hookId string, response *model.CommandResponse) *model.AppError {
+func (a *App) HandleCommandWebhook(hookId string, response *model.CommandResponse) *model.AppError {
 	if response == nil {
 		return model.NewAppError("HandleCommandWebhook", "web.command_webhook.parse.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	var hook *model.CommandWebhook
-	if result := <-Srv.Store.CommandWebhook().Get(hookId); result.Err != nil {
+	if result := <-a.Srv.Store.CommandWebhook().Get(hookId); result.Err != nil {
 		return model.NewAppError("HandleCommandWebhook", "web.command_webhook.invalid.app_error", nil, "err="+result.Err.Message, result.Err.StatusCode)
 	} else {
 		hook = result.Data.(*model.CommandWebhook)
 	}
 
 	var cmd *model.Command
-	if result := <-Srv.Store.Command().Get(hook.CommandId); result.Err != nil {
+	if result := <-a.Srv.Store.Command().Get(hook.CommandId); result.Err != nil {
 		return model.NewAppError("HandleCommandWebhook", "web.command_webhook.command.app_error", nil, "err="+result.Err.Message, http.StatusBadRequest)
 	} else {
 		cmd = result.Data.(*model.Command)
@@ -582,10 +582,10 @@ func HandleCommandWebhook(hookId string, response *model.CommandResponse) *model
 		ParentId:  hook.ParentId,
 	}
 
-	if result := <-Srv.Store.CommandWebhook().TryUse(hook.Id, 5); result.Err != nil {
+	if result := <-a.Srv.Store.CommandWebhook().TryUse(hook.Id, 5); result.Err != nil {
 		return model.NewAppError("HandleCommandWebhook", "web.command_webhook.invalid.app_error", nil, "err="+result.Err.Message, result.Err.StatusCode)
 	}
 
-	_, err := HandleCommandResponse(cmd, args, response, false)
+	_, err := a.HandleCommandResponse(cmd, args, response, false)
 	return err
 }

--- a/app/webhook_test.go
+++ b/app/webhook_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 func TestCreateWebhookPost(t *testing.T) {
-	th := Setup().InitBasic()
-	defer TearDown()
+	a := Global()
+	th := a.Setup().InitBasic()
+	defer a.TearDown()
 
 	enableIncomingHooks := utils.Cfg.ServiceSettings.EnableIncomingWebhooks
 	defer func() {
@@ -22,13 +23,13 @@ func TestCreateWebhookPost(t *testing.T) {
 	utils.Cfg.ServiceSettings.EnableIncomingWebhooks = true
 	utils.SetDefaultRolesBasedOnConfig()
 
-	hook, err := CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &model.IncomingWebhook{ChannelId: th.BasicChannel.Id})
+	hook, err := a.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &model.IncomingWebhook{ChannelId: th.BasicChannel.Id})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer DeleteIncomingWebhook(hook.Id)
+	defer a.DeleteIncomingWebhook(hook.Id)
 
-	post, err := CreateWebhookPost(hook.UserId, th.BasicChannel, "foo", "user", "http://iconurl", model.StringInterface{
+	post, err := a.CreateWebhookPost(hook.UserId, th.BasicChannel, "foo", "user", "http://iconurl", model.StringInterface{
 		"attachments": []*model.SlackAttachment{
 			&model.SlackAttachment{
 				Text: "text",

--- a/app/websocket_router.go
+++ b/app/websocket_router.go
@@ -6,9 +6,10 @@ package app
 import (
 	l4g "github.com/alecthomas/log4go"
 
+	"net/http"
+
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"net/http"
 )
 
 type webSocketHandler interface {
@@ -53,14 +54,14 @@ func (wr *WebSocketRouter) ServeWebSocket(conn *WebConn, r *model.WebSocketReque
 			return
 		}
 
-		session, err := GetSession(token)
+		session, err := Global().GetSession(token)
 
 		if err != nil {
 			conn.WebSocket.Close()
 		} else {
 			go func() {
-				SetStatusOnline(session.UserId, session.Id, false)
-				UpdateLastActivityAtIfNeeded(*session)
+				Global().SetStatusOnline(session.UserId, session.Id, false)
+				Global().UpdateLastActivityAtIfNeeded(*session)
 			}()
 
 			conn.SetSession(session)

--- a/cmd/platform/channelargs.go
+++ b/cmd/platform/channelargs.go
@@ -42,7 +42,7 @@ func getChannelFromChannelArg(channelArg string) *model.Channel {
 			return nil
 		}
 
-		if result := <-app.Srv.Store.Channel().GetByNameIncludeDeleted(team.Id, channelPart, true); result.Err == nil {
+		if result := <-app.Global().Srv.Store.Channel().GetByNameIncludeDeleted(team.Id, channelPart, true); result.Err == nil {
 			channel = result.Data.(*model.Channel)
 		} else {
 			fmt.Println(result.Err.Error())
@@ -50,7 +50,7 @@ func getChannelFromChannelArg(channelArg string) *model.Channel {
 	}
 
 	if channel == nil {
-		if result := <-app.Srv.Store.Channel().Get(channelPart, true); result.Err == nil {
+		if result := <-app.Global().Srv.Store.Channel().Get(channelPart, true); result.Err == nil {
 			channel = result.Data.(*model.Channel)
 		}
 	}

--- a/cmd/platform/config.go
+++ b/cmd/platform/config.go
@@ -5,10 +5,11 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"os"
+
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var configCmd = &cobra.Command{

--- a/cmd/platform/import.go
+++ b/cmd/platform/import.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"fmt"
+
 	"github.com/mattermost/platform/app"
 	"github.com/spf13/cobra"
 )
@@ -70,7 +71,7 @@ func slackImportCmdF(cmd *cobra.Command, args []string) error {
 
 	CommandPrettyPrintln("Running Slack Import. This may take a long time for large teams or teams with many messages.")
 
-	app.SlackImport(fileReader, fileInfo.Size(), team.Id)
+	app.Global().SlackImport(fileReader, fileInfo.Size(), team.Id)
 
 	CommandPrettyPrintln("Finished Slack Import.")
 
@@ -120,7 +121,7 @@ func bulkImportCmdF(cmd *cobra.Command, args []string) error {
 
 	CommandPrettyPrintln("")
 
-	if err, lineNumber := app.BulkImport(fileReader, !apply, workers); err != nil {
+	if err, lineNumber := app.Global().BulkImport(fileReader, !apply, workers); err != nil {
 		CommandPrettyPrintln(err.Error())
 		if lineNumber != 0 {
 			CommandPrettyPrintln(fmt.Sprintf("Error occurred on data file line %v", lineNumber))

--- a/cmd/platform/init.go
+++ b/cmd/platform/init.go
@@ -28,10 +28,10 @@ func initDBCommandContext(configFileLocation string) error {
 
 	utils.ConfigureCmdLineLog()
 
-	app.NewServer()
-	app.InitStores()
+	app.Global().NewServer()
+	app.Global().InitStores()
 	if model.BuildEnterpriseReady == "true" {
-		app.LoadLicense()
+		app.Global().LoadLicense()
 	}
 
 	return nil

--- a/cmd/platform/license.go
+++ b/cmd/platform/license.go
@@ -42,7 +42,7 @@ func uploadLicenseCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if _, err := app.SaveLicense(fileBytes); err != nil {
+	if _, err := app.Global().SaveLicense(fileBytes); err != nil {
 		return err
 	}
 

--- a/cmd/platform/mattermost.go
+++ b/cmd/platform/mattermost.go
@@ -79,7 +79,7 @@ func resetCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	app.Srv.Store.DropAllTables()
+	app.Global().Srv.Store.DropAllTables()
 	CommandPrettyPrintln("Database sucessfully reset")
 
 	return nil

--- a/cmd/platform/roles.go
+++ b/cmd/platform/roles.go
@@ -52,7 +52,7 @@ func makeSystemAdminCmdF(cmd *cobra.Command, args []string) error {
 			return errors.New("Unable to find user '" + args[i] + "'")
 		}
 
-		if _, err := app.UpdateUserRoles(user.Id, "system_admin system_user"); err != nil {
+		if _, err := app.Global().UpdateUserRoles(user.Id, "system_admin system_user"); err != nil {
 			return err
 		}
 	}
@@ -75,7 +75,7 @@ func makeMemberCmdF(cmd *cobra.Command, args []string) error {
 			return errors.New("Unable to find user '" + args[i] + "'")
 		}
 
-		if _, err := app.UpdateUserRoles(user.Id, "system_user"); err != nil {
+		if _, err := app.Global().UpdateUserRoles(user.Id, "system_user"); err != nil {
 			return err
 		}
 	}

--- a/cmd/platform/team.go
+++ b/cmd/platform/team.go
@@ -94,7 +94,7 @@ func createTeamCmdF(cmd *cobra.Command, args []string) error {
 		Type:        teamType,
 	}
 
-	if _, err := app.CreateTeam(team); err != nil {
+	if _, err := app.Global().CreateTeam(team); err != nil {
 		return errors.New("Team creation failed: " + err.Error())
 	}
 
@@ -128,7 +128,7 @@ func removeUserFromTeam(team *model.Team, user *model.User, userArg string) {
 		CommandPrintErrorln("Can't find user '" + userArg + "'")
 		return
 	}
-	if err := app.LeaveTeam(team, user); err != nil {
+	if err := app.Global().LeaveTeam(team, user); err != nil {
 		CommandPrintErrorln("Unable to remove '" + userArg + "' from " + team.Name + ". Error: " + err.Error())
 	}
 }
@@ -160,7 +160,7 @@ func addUserToTeam(team *model.Team, user *model.User, userArg string) {
 		CommandPrintErrorln("Can't find user '" + userArg + "'")
 		return
 	}
-	if err := app.JoinUserToTeam(team, user, ""); err != nil {
+	if err := app.Global().JoinUserToTeam(team, user, ""); err != nil {
 		CommandPrintErrorln("Unable to add '" + userArg + "' to " + team.Name)
 	}
 }
@@ -207,5 +207,5 @@ func deleteTeamsCmdF(cmd *cobra.Command, args []string) error {
 }
 
 func deleteTeam(team *model.Team) *model.AppError {
-	return app.PermanentDeleteTeam(team)
+	return app.Global().PermanentDeleteTeam(team)
 }

--- a/cmd/platform/teamargs.go
+++ b/cmd/platform/teamargs.go
@@ -18,12 +18,12 @@ func getTeamsFromTeamArgs(teamArgs []string) []*model.Team {
 
 func getTeamFromTeamArg(teamArg string) *model.Team {
 	var team *model.Team
-	if result := <-app.Srv.Store.Team().GetByName(teamArg); result.Err == nil {
+	if result := <-app.Global().Srv.Store.Team().GetByName(teamArg); result.Err == nil {
 		team = result.Data.(*model.Team)
 	}
 
 	if team == nil {
-		if result := <-app.Srv.Store.Team().Get(teamArg); result.Err == nil {
+		if result := <-app.Global().Srv.Store.Team().Get(teamArg); result.Err == nil {
 			team = result.Data.(*model.Team)
 		}
 	}

--- a/cmd/platform/test.go
+++ b/cmd/platform/test.go
@@ -9,14 +9,15 @@ import (
 	"os"
 	"os/exec"
 
+	"os/signal"
+	"syscall"
+
 	"github.com/mattermost/platform/api"
 	"github.com/mattermost/platform/api4"
 	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/utils"
 	"github.com/mattermost/platform/wsapi"
 	"github.com/spf13/cobra"
-	"os/signal"
-	"syscall"
 )
 
 var testCmd = &cobra.Command{
@@ -56,9 +57,9 @@ func webClientTestsCmdF(cmd *cobra.Command, args []string) error {
 	api.InitApi()
 	wsapi.InitApi()
 	setupClientTests()
-	app.StartServer()
+	app.Global().StartServer()
 	runWebClientTests()
-	app.StopServer()
+	app.Global().StopServer()
 
 	return nil
 }
@@ -75,13 +76,13 @@ func serverForWebClientTestsCmdF(cmd *cobra.Command, args []string) error {
 	api.InitApi()
 	wsapi.InitApi()
 	setupClientTests()
-	app.StartServer()
+	app.Global().StartServer()
 
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	<-c
 
-	app.StopServer()
+	app.Global().StopServer()
 
 	return nil
 }

--- a/cmd/platform/user.go
+++ b/cmd/platform/user.go
@@ -188,7 +188,7 @@ func changeUserActiveStatus(user *model.User, userArg string, activate bool) err
 	if user.IsLDAPUser() {
 		return errors.New("You can not modify the activation status of AD/LDAP accounts. Please modify through the AD/LDAP server.")
 	}
-	if _, err := app.UpdateActive(user, activate); err != nil {
+	if _, err := app.Global().UpdateActive(user, activate); err != nil {
 		return fmt.Errorf("Unable to change activation status of user: %v", userArg)
 	}
 
@@ -241,13 +241,13 @@ func userCreateCmdF(cmd *cobra.Command, args []string) error {
 		Locale:    locale,
 	}
 
-	ruser, err := app.CreateUser(user)
+	ruser, err := app.Global().CreateUser(user)
 	if err != nil {
 		return errors.New("Unable to create user. Error: " + err.Error())
 	}
 
 	if systemAdmin {
-		app.UpdateUserRoles(ruser.Id, "system_user system_admin")
+		app.Global().UpdateUserRoles(ruser.Id, "system_user system_admin")
 	}
 
 	CommandPrettyPrintln("Created User")
@@ -310,7 +310,7 @@ func resetUserPasswordCmdF(cmd *cobra.Command, args []string) error {
 	}
 	password := args[1]
 
-	if result := <-app.Srv.Store.User().UpdatePassword(user.Id, model.HashPassword(password)); result.Err != nil {
+	if result := <-app.Global().Srv.Store.User().UpdatePassword(user.Id, model.HashPassword(password)); result.Err != nil {
 		return result.Err
 	}
 
@@ -373,7 +373,7 @@ func deleteUserCmdF(cmd *cobra.Command, args []string) error {
 			return errors.New("Unable to find user '" + args[i] + "'")
 		}
 
-		if err := app.PermanentDeleteUser(user); err != nil {
+		if err := app.Global().PermanentDeleteUser(user); err != nil {
 			return err
 		}
 	}
@@ -406,7 +406,7 @@ func deleteAllUsersCommandF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := app.PermanentDeleteAllUsers(); err != nil {
+	if err := app.Global().PermanentDeleteAllUsers(); err != nil {
 		return err
 	}
 
@@ -473,7 +473,7 @@ func verifyUserCmdF(cmd *cobra.Command, args []string) error {
 			CommandPrintErrorln("Unable to find user '" + args[i] + "'")
 			continue
 		}
-		if cresult := <-app.Srv.Store.User().VerifyEmail(user.Id); cresult.Err != nil {
+		if cresult := <-app.Global().Srv.Store.User().VerifyEmail(user.Id); cresult.Err != nil {
 			CommandPrintErrorln("Unable to verify '" + args[i] + "' email. Error: " + cresult.Err.Error())
 		}
 	}

--- a/cmd/platform/userargs.go
+++ b/cmd/platform/userargs.go
@@ -18,18 +18,18 @@ func getUsersFromUserArgs(userArgs []string) []*model.User {
 
 func getUserFromUserArg(userArg string) *model.User {
 	var user *model.User
-	if result := <-app.Srv.Store.User().GetByEmail(userArg); result.Err == nil {
+	if result := <-app.Global().Srv.Store.User().GetByEmail(userArg); result.Err == nil {
 		user = result.Data.(*model.User)
 	}
 
 	if user == nil {
-		if result := <-app.Srv.Store.User().GetByUsername(userArg); result.Err == nil {
+		if result := <-app.Global().Srv.Store.User().GetByUsername(userArg); result.Err == nil {
 			user = result.Data.(*model.User)
 		}
 	}
 
 	if user == nil {
-		if result := <-app.Srv.Store.User().Get(userArg); result.Err == nil {
+		if result := <-app.Global().Srv.Store.User().Get(userArg); result.Err == nil {
 			user = result.Data.(*model.User)
 		}
 	}

--- a/cmd/platform/version.go
+++ b/cmd/platform/version.go
@@ -31,5 +31,5 @@ func printVersion() {
 	CommandPrintln("Build Date: " + model.BuildDate)
 	CommandPrintln("Build Hash: " + model.BuildHash)
 	CommandPrintln("Build Enterprise Ready: " + model.BuildEnterpriseReady)
-	CommandPrintln("DB Version: " + app.Srv.Store.(*store.LayeredStore).DatabaseLayer.GetCurrentSchemaVersion())
+	CommandPrintln("DB Version: " + app.Global().Srv.Store.(*store.LayeredStore).DatabaseLayer.GetCurrentSchemaVersion())
 }

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"time"
 
+	"net/http"
+
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/platform/model"
-	"net/http"
 )
 
 const (

--- a/manualtesting/manual_testing.go
+++ b/manualtesting/manual_testing.go
@@ -29,7 +29,7 @@ type TestEnvironment struct {
 }
 
 func InitManualTesting() {
-	app.Srv.Router.Handle("/manualtest", api.AppHandler(manualTest)).Methods("GET")
+	app.Global().Srv.Router.Handle("/manualtest", api.AppHandler(manualTest)).Methods("GET")
 }
 
 func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
@@ -72,7 +72,7 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			Type:        model.TEAM_OPEN,
 		}
 
-		if result := <-app.Srv.Store.Team().Save(team); result.Err != nil {
+		if result := <-c.App.Srv.Store.Team().Save(team); result.Err != nil {
 			c.Err = result.Err
 			return
 		} else {
@@ -80,7 +80,7 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			createdTeam := result.Data.(*model.Team)
 
 			channel := &model.Channel{DisplayName: "Town Square", Name: "town-square", Type: model.CHANNEL_OPEN, TeamId: createdTeam.Id}
-			if _, err := app.CreateChannel(channel, false); err != nil {
+			if _, err := c.App.CreateChannel(channel, false); err != nil {
 				c.Err = err
 				return
 			}
@@ -100,8 +100,8 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		<-app.Srv.Store.User().VerifyEmail(result.Data.(*model.User).Id)
-		<-app.Srv.Store.Team().SaveMember(&model.TeamMember{TeamId: teamID, UserId: result.Data.(*model.User).Id})
+		<-c.App.Srv.Store.User().VerifyEmail(result.Data.(*model.User).Id)
+		<-c.App.Srv.Store.Team().SaveMember(&model.TeamMember{TeamId: teamID, UserId: result.Data.(*model.User).Id})
 
 		newuser := result.Data.(*model.User)
 		userID = newuser.Id
@@ -155,7 +155,7 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 
 func getChannelID(channelname string, teamid string, userid string) (id string, err bool) {
 	// Grab all the channels
-	result := <-app.Srv.Store.Channel().GetChannels(teamid, userid)
+	result := <-app.Global().Srv.Store.Channel().GetChannels(teamid, userid)
 	if result.Err != nil {
 		l4g.Debug(utils.T("manaultesting.get_channel_id.unable.debug"))
 		return "", false

--- a/manualtesting/test_autolink.go
+++ b/manualtesting/test_autolink.go
@@ -4,10 +4,11 @@
 package manualtesting
 
 import (
+	"net/http"
+
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"net/http"
 )
 
 const LINK_POST_TEXT = `

--- a/model/gitlab/gitlab.go
+++ b/model/gitlab/gitlab.go
@@ -5,11 +5,12 @@ package oauthgitlab
 
 import (
 	"encoding/json"
-	"github.com/mattermost/platform/einterfaces"
-	"github.com/mattermost/platform/model"
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/mattermost/platform/einterfaces"
+	"github.com/mattermost/platform/model"
 )
 
 type GitLabProvider struct {

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -2,12 +2,13 @@ package model
 
 import (
 	"encoding/json"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"encoding/json"
+
 	"github.com/gorilla/websocket"
 )
 

--- a/store/sql_command_store_test.go
+++ b/store/sql_command_store_test.go
@@ -4,8 +4,9 @@
 package store
 
 import (
-	"github.com/mattermost/platform/model"
 	"testing"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestCommandStoreSave(t *testing.T) {

--- a/store/sql_compliance_store_test.go
+++ b/store/sql_compliance_store_test.go
@@ -4,9 +4,10 @@
 package store
 
 import (
-	"github.com/mattermost/platform/model"
 	"testing"
 	"time"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestSqlComplianceStore(t *testing.T) {

--- a/store/sql_emoji_store_test.go
+++ b/store/sql_emoji_store_test.go
@@ -4,9 +4,10 @@
 package store
 
 import (
-	"github.com/mattermost/platform/model"
 	"testing"
 	"time"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestEmojiSaveDelete(t *testing.T) {

--- a/store/sql_job_store_test.go
+++ b/store/sql_job_store_test.go
@@ -6,8 +6,9 @@ package store
 import (
 	"testing"
 
-	"github.com/mattermost/platform/model"
 	"time"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestJobSaveGet(t *testing.T) {
@@ -17,7 +18,7 @@ func TestJobSaveGet(t *testing.T) {
 		Id:     model.NewId(),
 		Type:   model.NewId(),
 		Status: model.NewId(),
-		Data:   map[string]string{
+		Data: map[string]string{
 			"Processed":     "0",
 			"Total":         "12345",
 			"LastProcessed": "abcd",
@@ -187,7 +188,7 @@ func TestJobGetAllByStatus(t *testing.T) {
 			Type:     jobType,
 			CreateAt: 1000,
 			Status:   status,
-			Data:     map[string]string{
+			Data: map[string]string{
 				"test": "data",
 			},
 		},

--- a/store/sql_license_store_test.go
+++ b/store/sql_license_store_test.go
@@ -4,8 +4,9 @@
 package store
 
 import (
-	"github.com/mattermost/platform/model"
 	"testing"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestLicenseStoreSave(t *testing.T) {

--- a/store/sql_oauth_store_test.go
+++ b/store/sql_oauth_store_test.go
@@ -4,8 +4,9 @@
 package store
 
 import (
-	"github.com/mattermost/platform/model"
 	"testing"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestOAuthStoreSaveApp(t *testing.T) {

--- a/store/sql_session_store_test.go
+++ b/store/sql_session_store_test.go
@@ -4,8 +4,9 @@
 package store
 
 import (
-	"github.com/mattermost/platform/model"
 	"testing"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestSessionStoreSave(t *testing.T) {

--- a/utils/license_test.go
+++ b/utils/license_test.go
@@ -4,8 +4,9 @@
 package utils
 
 import (
-	"github.com/mattermost/platform/model"
 	"testing"
+
+	"github.com/mattermost/platform/model"
 )
 
 func TestSetLicense(t *testing.T) {

--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -11,10 +11,11 @@ import (
 
 	l4g "github.com/alecthomas/log4go"
 
+	"strings"
+
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 // this pattern allows us to "mock" the underlying l4g code when unit testing

--- a/utils/mail.go
+++ b/utils/mail.go
@@ -13,10 +13,11 @@ import (
 
 	"gopkg.in/gomail.v2"
 
+	"net/http"
+
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/html2text"
 	"github.com/mattermost/platform/model"
-	"net/http"
 )
 
 func encodeRFC2047Word(s string) string {

--- a/web/web.go
+++ b/web/web.go
@@ -20,7 +20,7 @@ import (
 func InitWeb() {
 	l4g.Debug(utils.T("web.init.debug"))
 
-	mainrouter := app.Srv.Router
+	mainrouter := app.Global().Srv.Router
 
 	if *utils.Cfg.ServiceSettings.WebserverMode != "disabled" {
 		staticDir, _ := utils.FindDir(model.CLIENT_DIR)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -19,29 +19,29 @@ var ApiClient *model.Client
 var URL string
 
 func Setup() {
-	if app.Srv == nil {
+	if app.Global().Srv == nil {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		app.NewServer()
-		app.InitStores()
+		app.Global().NewServer()
+		app.Global().InitStores()
 		api.InitRouter()
-		app.StartServer()
+		app.Global().StartServer()
 		api4.InitApi(false)
 		api.InitApi()
 		InitWeb()
 		URL = "http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress
 		ApiClient = model.NewClient(URL)
 
-		app.Srv.Store.MarkSystemRanUnitTests()
+		app.Global().Srv.Store.MarkSystemRanUnitTests()
 
 		*utils.Cfg.TeamSettings.EnableOpenServer = true
 	}
 }
 
 func TearDown() {
-	if app.Srv != nil {
-		app.StopServer()
+	if app.Global().Srv != nil {
+		app.Global().StopServer()
 	}
 }
 
@@ -67,16 +67,16 @@ func TestIncomingWebhook(t *testing.T) {
 
 	user := &model.User{Email: model.NewId() + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
 	user = ApiClient.Must(ApiClient.CreateUser(user, "")).Data.(*model.User)
-	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
+	store.Must(app.Global().Srv.Store.User().VerifyEmail(user.Id))
 
 	ApiClient.Login(user.Email, "passwd1")
 
 	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = ApiClient.Must(ApiClient.CreateTeam(team)).Data.(*model.Team)
 
-	app.JoinUserToTeam(team, user, "")
+	app.Global().JoinUserToTeam(team, user, "")
 
-	app.UpdateUserRoles(user.Id, model.ROLE_SYSTEM_ADMIN.Id)
+	app.Global().UpdateUserRoles(user.Id, model.ROLE_SYSTEM_ADMIN.Id)
 	ApiClient.SetTeamId(team.Id)
 
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}

--- a/wsapi/api.go
+++ b/wsapi/api.go
@@ -8,7 +8,7 @@ import (
 )
 
 func InitRouter() {
-	app.Srv.WebSocketRouter = app.NewWebSocketRouter()
+	app.Global().Srv.WebSocketRouter = app.NewWebSocketRouter()
 }
 
 func InitApi() {

--- a/wsapi/status.go
+++ b/wsapi/status.go
@@ -13,8 +13,8 @@ import (
 func InitStatus() {
 	l4g.Debug(utils.T("wsapi.status.init.debug"))
 
-	app.Srv.WebSocketRouter.Handle("get_statuses", ApiWebSocketHandler(getStatuses))
-	app.Srv.WebSocketRouter.Handle("get_statuses_by_ids", ApiWebSocketHandler(getStatusesByIds))
+	app.Global().Srv.WebSocketRouter.Handle("get_statuses", ApiWebSocketHandler(getStatuses))
+	app.Global().Srv.WebSocketRouter.Handle("get_statuses_by_ids", ApiWebSocketHandler(getStatusesByIds))
 }
 
 func getStatuses(req *model.WebSocketRequest) (map[string]interface{}, *model.AppError) {
@@ -29,7 +29,7 @@ func getStatusesByIds(req *model.WebSocketRequest) (map[string]interface{}, *mod
 		return nil, NewInvalidWebSocketParamError(req.Action, "user_ids")
 	}
 
-	statusMap, err := app.GetStatusesByIds(userIds)
+	statusMap, err := app.Global().GetStatusesByIds(userIds)
 	if err != nil {
 		return nil, err
 	}

--- a/wsapi/system.go
+++ b/wsapi/system.go
@@ -13,7 +13,7 @@ import (
 func InitSystem() {
 	l4g.Debug(utils.T("wsapi.system.init.debug"))
 
-	app.Srv.WebSocketRouter.Handle("ping", ApiWebSocketHandler(ping))
+	app.Global().Srv.WebSocketRouter.Handle("ping", ApiWebSocketHandler(ping))
 }
 
 func ping(req *model.WebSocketRequest) (map[string]interface{}, *model.AppError) {

--- a/wsapi/user.go
+++ b/wsapi/user.go
@@ -13,7 +13,7 @@ import (
 func InitUser() {
 	l4g.Debug(utils.T("wsapi.user.init.debug"))
 
-	app.Srv.WebSocketRouter.Handle("user_typing", ApiWebSocketHandler(userTyping))
+	app.Global().Srv.WebSocketRouter.Handle("user_typing", ApiWebSocketHandler(userTyping))
 }
 
 func userTyping(req *model.WebSocketRequest) (map[string]interface{}, *model.AppError) {

--- a/wsapi/webrtc.go
+++ b/wsapi/webrtc.go
@@ -13,7 +13,7 @@ import (
 func InitWebrtc() {
 	l4g.Debug(utils.T("wsapi.webtrc.init.debug"))
 
-	app.Srv.WebSocketRouter.Handle("webrtc", ApiWebSocketHandler(webrtcMessage))
+	app.Global().Srv.WebSocketRouter.Handle("webrtc", ApiWebSocketHandler(webrtcMessage))
 }
 
 func webrtcMessage(req *model.WebSocketRequest) (map[string]interface{}, *model.AppError) {

--- a/wsapi/websocket_handler.go
+++ b/wsapi/websocket_handler.go
@@ -6,10 +6,11 @@ package wsapi
 import (
 	l4g "github.com/alecthomas/log4go"
 
+	"net/http"
+
 	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
-	"net/http"
 )
 
 func ApiWebSocketHandler(wh func(*model.WebSocketRequest) (map[string]interface{}, *model.AppError)) webSocketHandler {
@@ -23,7 +24,7 @@ type webSocketHandler struct {
 func (wh webSocketHandler) ServeWebSocket(conn *app.WebConn, r *model.WebSocketRequest) {
 	l4g.Debug("/api/v3/users/websocket:%s", r.Action)
 
-	session, sessionErr := app.GetSession(conn.GetSessionToken())
+	session, sessionErr := app.Global().GetSession(conn.GetSessionToken())
 	if sessionErr != nil {
 		l4g.Error(utils.T("api.web_socket_handler.log.error"), "/api/v3/users/websocket", r.Action, r.Seq, conn.UserId, sessionErr.SystemMessage(utils.T), sessionErr.Error())
 		sessionErr.DetailedError = ""


### PR DESCRIPTION
#### Summary
This converts all of our stateful `app` functions into methods with an `*app.App` receiver. The eventual goal is to eliminate the usage of package-level variables entirely. This eliminates the package-level `Srv` variable. All references to that variable have been replaced with references to the `Srv` field of the new `App` type. I was able to easily create a script that does the vast majority of the work of propagating a variable of this type, but there are a few places where a bit more human-judgement will be necessary. In these places, a package-level global is still referenced via `app.Global()`. My immediate goal after this commit will be to comb over those places by hand and actually eliminate that package-level global entirely. From the looks of it, that won't be difficult, but it seems best to put the changes that are more subject to human error in a PR with less noise.

Here's the script used to generate the patch: [rm-srv-global.zip](https://github.com/mattermost/platform/files/1213568/rm-srv-global.zip). It only takes a few seconds to generate the entire thing from scratch, so despite its size, this PR is actually very resistant to code rot.

I'm pretty confident there are no functional changes and if anything breaks, it won't be subtle. I'm also pretty confident that while there will be other somewhat wide-reaching changes (like replacing the global config references), none of them will be nearly as wide-reaching as this one since they'll be able to piggy back off of this propagated variable (e.g. our config will be propagated with this variable as well).

I'm just requesting reviews from the people I remember having opinions. Of course, you don't all have to review it. And none of you have to review every line. It's all very systematic, so just look over a few files from different packages.

#### Ticket Link
Discussed in dev meeting.

#### Checklist
- [x] Touches the entire back-end
