### PR TITLE
Update mattermost-redux to webapp-4.1 branch

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -25,7 +25,7 @@
     "localforage": "1.5.0",
     "marked": "mattermost/marked#9f0c8b96fd5efedb99f5fc45cca9ac7684b5aa69",
     "match-at": "0.1.0",
-    "mattermost-redux": "mattermost/mattermost-redux#master",
+    "mattermost-redux": "mattermost/mattermost-redux#webapp-4.1",
     "object-assign": "4.1.1",
     "pdfjs-dist": "1.8.557",
     "perfect-scrollbar": "0.7.1",

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -5002,9 +5002,9 @@ math-expression-evaluator@^1.2.14:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
 
-mattermost-redux@mattermost/mattermost-redux#master:
+mattermost-redux@mattermost/mattermost-redux#webapp-4.1:
   version "0.0.1"
-  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/e5297912f528b822b61c61a36735fb4d6699d08d"
+  resolved "https://codeload.github.com/mattermost/mattermost-redux/tar.gz/31bb5c2f21b504c4b7cab6624e4884bd3fc9f294"
   dependencies:
     deep-equal "1.0.1"
     harmony-reflect "1.5.1"


### PR DESCRIPTION
#### Summary
Update mattermost-redux to webapp-4.1 branch. Includes a fix for https://mattermost.atlassian.net/browse/PLT-7341.