### PR TITLE
PLT-7353 Fixed being unable to use quotes in links

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,7 +23,7 @@
     "jquery": "3.2.1",
     "key-mirror": "1.0.1",
     "localforage": "1.5.0",
-    "marked": "mattermost/marked#9f0c8b96fd5efedb99f5fc45cca9ac7684b5aa69",
+    "marked": "mattermost/marked#5194fc037b35036910c6542b04bb471fe56b27a9",
     "match-at": "0.1.0",
     "mattermost-redux": "mattermost/mattermost-redux#master",
     "object-assign": "4.1.1",

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -4986,9 +4986,9 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@mattermost/marked#9f0c8b96fd5efedb99f5fc45cca9ac7684b5aa69:
+marked@mattermost/marked#5194fc037b35036910c6542b04bb471fe56b27a9:
   version "0.3.5"
-  resolved "https://codeload.github.com/mattermost/marked/tar.gz/9f0c8b96fd5efedb99f5fc45cca9ac7684b5aa69"
+  resolved "https://codeload.github.com/mattermost/marked/tar.gz/5194fc037b35036910c6542b04bb471fe56b27a9"
 
 match-at@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
When I made some changes to the regex last year, I accidentally left in part of the regex that only allowed quotes if they were in pairs

Marked changes here: https://github.com/mattermost/marked/commit/5194fc037b35036910c6542b04bb471fe56b27a9

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7353

#### Checklist
- Added or updated unit tests (required for all new features)