### PR TITLE
PLT-6609: Fix hashtag highlighting of search results

### DIFF
--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -175,7 +175,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
 
         if (this.formattingOptions.searchPatterns) {
             for (const pattern of this.formattingOptions.searchPatterns) {
-                if (pattern.test(href)) {
+                if (pattern.pattern.test(href)) {
                     output += ' search-highlight';
                     break;
                 }
@@ -189,7 +189,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         if (this.formattingOptions.siteURL) {
             const pattern = new RegExp('^' + TextFormatting.escapeRegex(this.formattingOptions.siteURL) + '\\/(?:signup_user_complete|[^\\/]+\\/(?:pl|channels))\\/');
 
-            internalLink = pattern.test(outHref);
+            internalLink = pattern.pattern.test(outHref);
         }
 
         if (internalLink) {

--- a/webapp/utils/markdown.jsx
+++ b/webapp/utils/markdown.jsx
@@ -189,7 +189,7 @@ class MattermostMarkdownRenderer extends marked.Renderer {
         if (this.formattingOptions.siteURL) {
             const pattern = new RegExp('^' + TextFormatting.escapeRegex(this.formattingOptions.siteURL) + '\\/(?:signup_user_complete|[^\\/]+\\/(?:pl|channels))\\/');
 
-            internalLink = pattern.pattern.test(outHref);
+            internalLink = pattern.test(outHref);
         }
 
         if (internalLink) {

--- a/webapp/utils/text_formatting.jsx
+++ b/webapp/utils/text_formatting.jsx
@@ -400,7 +400,10 @@ function convertSearchTermToRegex(term) {
         pattern = '\\b()(' + escapeRegex(term) + ')\\b';
     }
 
-    return new RegExp(pattern, 'gi');
+    return {
+        pattern: new RegExp(pattern, 'gi'),
+        term
+    };
 }
 
 export function highlightSearchTerms(text, tokens, searchPatterns) {
@@ -426,7 +429,21 @@ export function highlightSearchTerms(text, tokens, searchPatterns) {
         // highlight existing tokens matching search terms
         var newTokens = new Map();
         for (const [alias, token] of tokens) {
-            if (pattern.test(token.originalText)) {
+            if (pattern.pattern.test(token.originalText)) {
+                // If it's a Hashtag, skip it unless the search term is an exact match.
+                let originalText = token.originalText;
+                if (originalText.startsWith('#')) {
+                    originalText = originalText.substr(1);
+                }
+                let term = pattern.term;
+                if (term.startsWith('#')) {
+                    term = term.substr(1);
+                }
+
+                if (alias.startsWith('$MM_HASHTAG') && originalText !== term) {
+                    continue;
+                }
+
                 const index = tokens.size + newTokens.size;
                 const newAlias = `$MM_SEARCHTERM${index}`;
 
@@ -438,10 +455,10 @@ export function highlightSearchTerms(text, tokens, searchPatterns) {
                 output = output.replace(alias, newAlias);
             }
 
-            // The pattern regexes are global, so calling pattern.test() above alters their
+            // The pattern regexes are global, so calling pattern.pattern.test() above alters their
             // state. Reset lastIndex to 0 between calls to test() to ensure it returns the
             // same result every time it is called with the same value of token.originalText.
-            pattern.lastIndex = 0;
+            pattern.pattern.lastIndex = 0;
         }
 
         // the new tokens are stashed in a separate map since we can't add objects to a map during iteration
@@ -449,7 +466,7 @@ export function highlightSearchTerms(text, tokens, searchPatterns) {
             tokens.set(newToken[0], newToken[1]);
         }
 
-        output = output.replace(pattern, replaceSearchTermWithToken);
+        output = output.replace(pattern.pattern, replaceSearchTermWithToken);
     }
 
     return output;


### PR DESCRIPTION
#### Summary
Doesn't highlight `#hashtag.dot` when searching for `#hashtag`.

This time it also doesn't break when there's links involved. Look at the diff between the two commits in this PR if you want to see the fix for the bug this introduced last time round.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6609
