### PR TITLE
PLT-6441 - Fixed not being able to scroll down in message preview mode when using  only a couple of sentences in edit mode.

### DIFF
--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -415,6 +415,10 @@
         &.custom-textarea--emoji-picker {
             padding-right: 60px;
         }
+
+        &.textbox-preview-area {
+          overflow-y: auto;
+        }
     }
 
     .emoji-picker {


### PR DESCRIPTION
#### Summary
Fixed not being able to scroll down in message preview mode when using only a couple of sentences in edit mode.

#### Ticket Link
https://github.com/mattermost/platform/issues/6302

#### Checklist
- [x] Has UI changes