### PR TITLE
[PLT-7385] Add AuthData to IsUniqueConstraintError to indicate duplicated email entry

### DIFF
--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -321,7 +321,7 @@ func (us SqlUserStore) UpdateAuthData(userId string, service string, authData *s
 		query += " WHERE Id = :UserId"
 
 		if _, err := us.GetMaster().Exec(query, map[string]interface{}{"LastPasswordUpdate": updateAt, "UpdateAt": updateAt, "UserId": userId, "AuthService": service, "AuthData": authData, "Email": email}); err != nil {
-			if IsUniqueConstraintError(err.Error(), []string{"Email", "users_email_key", "idx_users_email_unique"}) {
+			if IsUniqueConstraintError(err.Error(), []string{"Email", "users_email_key", "idx_users_email_unique", "AuthData"}) {
 				result.Err = model.NewLocAppError("SqlUserStore.UpdateAuthData", "store.sql_user.update_auth_data.email_exists.app_error", map[string]interface{}{"Service": service, "Email": email}, "user_id="+userId+", "+err.Error())
 			} else {
 				result.Err = model.NewLocAppError("SqlUserStore.UpdateAuthData", "store.sql_user.update_auth_data.app_error", nil, "id="+userId+", "+err.Error())

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -321,7 +321,7 @@ func (us SqlUserStore) UpdateAuthData(userId string, service string, authData *s
 		query += " WHERE Id = :UserId"
 
 		if _, err := us.GetMaster().Exec(query, map[string]interface{}{"LastPasswordUpdate": updateAt, "UpdateAt": updateAt, "UserId": userId, "AuthService": service, "AuthData": authData, "Email": email}); err != nil {
-			if IsUniqueConstraintError(err.Error(), []string{"Email", "users_email_key", "idx_users_email_unique", "AuthData"}) {
+			if IsUniqueConstraintError(err.Error(), []string{"Email", "users_email_key", "idx_users_email_unique", "AuthData", "users_authdata_key"}) {
 				result.Err = model.NewLocAppError("SqlUserStore.UpdateAuthData", "store.sql_user.update_auth_data.email_exists.app_error", map[string]interface{}{"Service": service, "Email": email}, "user_id="+userId+", "+err.Error())
 			} else {
 				result.Err = model.NewLocAppError("SqlUserStore.UpdateAuthData", "store.sql_user.update_auth_data.app_error", nil, "id="+userId+", "+err.Error())


### PR DESCRIPTION
#### Summary
Add `AuthData` to `IsUniqueConstraintError` to indicate duplicated email entry, with the assumption that duplicated AuthData also means duplicated email entry.

#### Ticket Link
Jira ticket: [PLT-7385](https://mattermost.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=PLT&view=detail&selectedIssue=PLT-7385)

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)

Update: 30-Aug
- mysql error: `Error 1062: Duplicate entry 'xxx' for key 'AuthData'`
- postgresql error: `pq: duplicate key value violates unique constraint "users_authdata_key"`

`AuthData` and `users_authdata_key` were added to `IsUniqueConstraintError` when updating user's auth data.
