### PR TITLE
PLT-7398 Removed flex-basis from search box

### DIFF
--- a/webapp/sass/components/_search.scss
+++ b/webapp/sass/components/_search.scss
@@ -1,8 +1,6 @@
 @charset 'UTF-8';
 
 .search-bar__container {
-    @include flex(0 0 79px);
-
     .channel-header__links {
         .sidebar--right & {
             line-height: 25px;


### PR DESCRIPTION
Somehow having the flex-basis set manually for the search box and having it set to not shrink caused it to extend off the right side of the screen
![image](https://user-images.githubusercontent.com/3277310/29287972-13b4c1ca-8105-11e7-8172-68d781c31c13.png)
and then that was causing the body of the page to shift left to try to fit it on the screen under certain circumstances (in this case changing to a channel that has unread posts). Changing it back to the default (let it shrink and have it figure out its width automatically) fixed the issue.
![image](https://user-images.githubusercontent.com/3277310/29288306-3ee17324-8106-11e7-8e45-d3e3a44914b4.png)
I could also fix it by turning the body of the page to use `position: absolute' briefly and then back to `position: relative`, but it would break again the next time the steps were performed. Basically, it's IE11 being IE11 ¯\\\_(ツ)\_/¯

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7398

#### Checklist
- Has UI changes