### PR TITLE
PLT-7368: Don't clear search box on ESC in Chrome.

### DIFF
--- a/webapp/components/search_bar.jsx
+++ b/webapp/components/search_bar.jsx
@@ -15,7 +15,9 @@ import {getFlaggedPosts, performSearch} from 'actions/post_actions.jsx';
 
 import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
 
-var ActionTypes = Constants.ActionTypes;
+const ActionTypes = Constants.ActionTypes;
+const KeyCodes = Constants.KeyCodes;
+
 import {Tooltip, OverlayTrigger, Popover} from 'react-bootstrap';
 
 import PropTypes from 'prop-types';
@@ -110,8 +112,11 @@ export default class SearchBar extends React.Component {
         });
     }
 
-    handleKeyDown() {
-        // This is just to prevent a JS error
+    handleKeyDown(e) {
+        if (e.which === KeyCodes.ESCAPE) {
+            e.stopPropagation();
+            e.preventDefault();
+        }
     }
 
     handleChange(e) {

--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -323,6 +323,7 @@ export default class SuggestionBox extends React.Component {
                 e.preventDefault();
             } else if (e.which === KeyCodes.ESCAPE) {
                 GlobalActions.emitClearSuggestions(this.suggestionId);
+                e.preventDefault();
                 e.stopPropagation();
             } else if (this.props.onKeyDown) {
                 this.props.onKeyDown(e);


### PR DESCRIPTION
#### Summary
Don't clear the searchbox when pressing ESC (fixes Chrome).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7368