### PR TITLE
PLT-7408 Move webhook handling into api4 package to fix EnableAPIv3 config setting

### DIFF
--- a/api4/webhook.go
+++ b/api4/webhook.go
@@ -4,9 +4,12 @@
 package api4
 
 import (
+	"io"
 	"net/http"
+	"strings"
 
 	l4g "github.com/alecthomas/log4go"
+	"github.com/gorilla/mux"
 	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
@@ -27,6 +30,11 @@ func InitWebhook() {
 	BaseRoutes.OutgoingHook.Handle("", ApiSessionRequired(updateOutgoingHook)).Methods("PUT")
 	BaseRoutes.OutgoingHook.Handle("", ApiSessionRequired(deleteOutgoingHook)).Methods("DELETE")
 	BaseRoutes.OutgoingHook.Handle("/regen_token", ApiSessionRequired(regenOutgoingHookToken)).Methods("POST")
+
+	BaseRoutes.Root.Handle("/hooks/{id:[A-Za-z0-9]+}", ApiHandler(incomingWebhook)).Methods("POST")
+
+	// Old endpoint for backwards compatibility
+	BaseRoutes.Root.Handle("/api/v3/teams/{team_id:[A-Za-z0-9]+}/hooks/{id:[A-Za-z0-9]+}", ApiHandler(incomingWebhook)).Methods("POST")
 }
 
 func createIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -434,4 +442,47 @@ func deleteOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("success")
 	ReturnStatusOK(w)
+}
+
+func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	id := params["id"]
+
+	r.ParseForm()
+
+	var payload io.Reader
+	contentType := r.Header.Get("Content-Type")
+	if strings.Split(contentType, "; ")[0] == "application/x-www-form-urlencoded" {
+		payload = strings.NewReader(r.FormValue("payload"))
+	} else {
+		payload = r.Body
+	}
+
+	if utils.Cfg.LogSettings.EnableWebhookDebugging {
+		var err error
+		payload, err = utils.DebugReader(
+			payload,
+			utils.T("api.webhook.incoming.debug"),
+		)
+		if err != nil {
+			c.Err = model.NewLocAppError(
+				"incomingWebhook",
+				"api.webhook.incoming.debug.error",
+				nil,
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	parsedRequest := model.IncomingWebhookRequestFromJson(payload)
+
+	err := app.HandleIncomingWebhook(id, parsedRequest)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte("ok"))
 }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mattermost/platform/api"
+	"github.com/mattermost/platform/api4"
 	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
@@ -26,6 +27,7 @@ func Setup() {
 		app.InitStores()
 		api.InitRouter()
 		app.StartServer()
+		api4.InitApi(false)
 		api.InitApi()
 		InitWeb()
 		URL = "http://localhost" + utils.Cfg.ServiceSettings.ListenAddress


### PR DESCRIPTION
#### Summary
Move webhook handling into api4 package to fix EnableAPIv3 config setting that was disabling webhooks when set to false.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7408