### PR TITLE
Ignoring primary key duplication errors on status saveorupdate

### DIFF
--- a/store/sql_status_store.go
+++ b/store/sql_status_store.go
@@ -6,6 +6,7 @@ package store
 import (
 	"database/sql"
 	"strconv"
+	"strings"
 
 	"github.com/mattermost/platform/model"
 )
@@ -48,7 +49,9 @@ func (s SqlStatusStore) SaveOrUpdate(status *model.Status) StoreChannel {
 			}
 		} else {
 			if err := s.GetMaster().Insert(status); err != nil {
-				result.Err = model.NewLocAppError("SqlStatusStore.SaveOrUpdate", "store.sql_status.save.app_error", nil, err.Error())
+				if !(strings.Contains(err.Error(), "for key 'PRIMARY'") && strings.Contains(err.Error(), "Duplicate entry")) {
+					result.Err = model.NewLocAppError("SqlStatusStore.SaveOrUpdate", "store.sql_status.save.app_error", nil, err.Error())
+				}
 			}
 		}
 


### PR DESCRIPTION
Bunch of errors in Kubernetes under load: 
```
2017-08-18T17:33:10.256229156Z [2017/08/18 17:33:10 UTC] [EROR] Failed to save status for user_id=8ip6dnbqwfdrje8k6xq16k5azy, err=SqlStatusStore.SaveOrUpdate: store.sql_status.save.app_error, Error 1062: Duplicate entry '8ip6dnbqwfdrje8k6xq16k5azy' for key 'PRIMARY'
```

This ignores them since this should only happen rarely when status updates are sent in quick succession to multiple HA servers. No need to pollute the logs. 