### PR TITLE
Convert NewLocAppError -> NewAppError in api package

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -237,13 +237,12 @@ func getAnalytics(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func uploadBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	if r.ContentLength > *utils.Cfg.FileSettings.MaxFileSize {
-		c.Err = model.NewLocAppError("uploadBrandImage", "api.admin.upload_brand_image.too_large.app_error", nil, "")
-		c.Err.StatusCode = http.StatusRequestEntityTooLarge
+		c.Err = model.NewAppError("uploadBrandImage", "api.admin.upload_brand_image.too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
 		return
 	}
 
 	if err := r.ParseMultipartForm(*utils.Cfg.FileSettings.MaxFileSize); err != nil {
-		c.Err = model.NewLocAppError("uploadBrandImage", "api.admin.upload_brand_image.parse.app_error", nil, "")
+		c.Err = model.NewAppError("uploadBrandImage", "api.admin.upload_brand_image.parse.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -251,13 +250,13 @@ func uploadBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	imageArray, ok := m.File["image"]
 	if !ok {
-		c.Err = model.NewLocAppError("uploadBrandImage", "api.admin.upload_brand_image.no_file.app_error", nil, "")
+		c.Err = model.NewAppError("uploadBrandImage", "api.admin.upload_brand_image.no_file.app_error", nil, "", http.StatusBadRequest)
 		c.Err.StatusCode = http.StatusBadRequest
 		return
 	}
 
 	if len(imageArray) <= 0 {
-		c.Err = model.NewLocAppError("uploadBrandImage", "api.admin.upload_brand_image.array.app_error", nil, "")
+		c.Err = model.NewAppError("uploadBrandImage", "api.admin.upload_brand_image.array.app_error", nil, "", http.StatusBadRequest)
 		c.Err.StatusCode = http.StatusBadRequest
 		return
 	}
@@ -350,7 +349,7 @@ func ldapTest(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func samlMetadata(c *Context, w http.ResponseWriter, r *http.Request) {
 	if result, err := app.GetSamlMetadata(); err != nil {
-		c.Err = model.NewLocAppError("loginWithSaml", "api.admin.saml.metadata.app_error", nil, "err="+err.Message)
+		c.Err = model.NewAppError("loginWithSaml", "api.admin.saml.metadata.app_error", nil, "err="+err.Message, http.StatusInternalServerError)
 		return
 	} else {
 		w.Header().Set("Content-Type", "application/xml")
@@ -370,13 +369,13 @@ func addCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	fileArray, ok := m.File["certificate"]
 	if !ok {
-		c.Err = model.NewLocAppError("addCertificate", "api.admin.add_certificate.no_file.app_error", nil, "")
+		c.Err = model.NewAppError("addCertificate", "api.admin.add_certificate.no_file.app_error", nil, "", http.StatusBadRequest)
 		c.Err.StatusCode = http.StatusBadRequest
 		return
 	}
 
 	if len(fileArray) <= 0 {
-		c.Err = model.NewLocAppError("addCertificate", "api.admin.add_certificate.array.app_error", nil, "")
+		c.Err = model.NewAppError("addCertificate", "api.admin.add_certificate.array.app_error", nil, "", http.StatusBadRequest)
 		c.Err.StatusCode = http.StatusBadRequest
 		return
 	}

--- a/api/channel.go
+++ b/api/channel.go
@@ -172,15 +172,13 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if oldChannel.DeleteAt > 0 {
-		c.Err = model.NewLocAppError("updateChannel", "api.channel.update_channel.deleted.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("updateChannel", "api.channel.update_channel.deleted.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	if oldChannel.Name == model.DEFAULT_CHANNEL {
 		if (len(channel.Name) > 0 && channel.Name != oldChannel.Name) || (len(channel.Type) > 0 && channel.Type != oldChannel.Type) {
-			c.Err = model.NewLocAppError("updateChannel", "api.channel.update_channel.tried.app_error", map[string]interface{}{"Channel": model.DEFAULT_CHANNEL}, "")
-			c.Err.StatusCode = http.StatusBadRequest
+			c.Err = model.NewAppError("updateChannel", "api.channel.update_channel.tried.app_error", map[string]interface{}{"Channel": model.DEFAULT_CHANNEL}, "", http.StatusBadRequest)
 			return
 		}
 	}
@@ -311,8 +309,7 @@ func updateChannelPurpose(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func getChannels(c *Context, w http.ResponseWriter, r *http.Request) {
 	if c.TeamId == "" {
-		c.Err = model.NewLocAppError("", "api.context.missing_teamid.app_error", nil, "TeamIdRequired")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("", "api.context.missing_teamid.app_error", nil, "TeamIdRequired", http.StatusBadRequest)
 		return
 	}
 	// user is already in the team
@@ -373,7 +370,7 @@ func getChannelCounts(c *Context, w http.ResponseWriter, r *http.Request) {
 	// user is already in the team
 
 	if counts, err := app.GetChannelCounts(c.TeamId, c.Session.UserId); err != nil {
-		c.Err = model.NewLocAppError("getChannelCounts", "api.channel.get_channel_counts.app_error", nil, err.Message)
+		c.Err = model.NewAppError("getChannelCounts", "api.channel.get_channel_counts.app_error", nil, err.Message, http.StatusInternalServerError)
 		return
 	} else if HandleEtag(counts.Etag(), "Get Channel Counts", w, r) {
 		return
@@ -483,7 +480,7 @@ func getChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if channel.TeamId != c.TeamId && !channel.IsGroupOrDirect() {
-		c.Err = model.NewLocAppError("getChannel", "api.channel.get_channel.wrong_team.app_error", map[string]interface{}{"ChannelId": id, "TeamId": c.TeamId}, "")
+		c.Err = model.NewAppError("getChannel", "api.channel.get_channel.wrong_team.app_error", map[string]interface{}{"ChannelId": id, "TeamId": c.TeamId}, "", http.StatusBadRequest)
 		return
 	}
 
@@ -519,7 +516,7 @@ func getChannelByName(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		if channel.TeamId != c.TeamId && !channel.IsGroupOrDirect() {
-			c.Err = model.NewLocAppError("getChannel", "api.channel.get_channel.wrong_team.app_error", map[string]interface{}{"ChannelName": channelName, "TeamId": c.TeamId}, "")
+			c.Err = model.NewAppError("getChannel", "api.channel.get_channel.wrong_team.app_error", map[string]interface{}{"ChannelName": channelName, "TeamId": c.TeamId}, "", http.StatusBadRequest)
 			return
 		}
 
@@ -544,8 +541,7 @@ func getChannelStats(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if channel.DeleteAt > 0 {
-		c.Err = model.NewLocAppError("getChannelStats", "api.channel.get_channel_extra_info.deleted.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("getChannelStats", "api.channel.get_channel_extra_info.deleted.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -635,7 +631,7 @@ func addMember(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var nUser *model.User
 	if nUser, err = app.GetUser(userId); err != nil {
-		c.Err = model.NewLocAppError("addMember", "api.channel.add_member.find_user.app_error", nil, err.Error())
+		c.Err = model.NewAppError("addMember", "api.channel.add_member.find_user.app_error", nil, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -649,7 +645,7 @@ func addMember(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var oUser *model.User
 	if oUser, err = app.GetUser(c.Session.UserId); err != nil {
-		c.Err = model.NewLocAppError("addMember", "api.channel.add_member.user_adding.app_error", nil, err.Error())
+		c.Err = model.NewAppError("addMember", "api.channel.add_member.user_adding.app_error", nil, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/api/emoji.go
+++ b/api/emoji.go
@@ -31,8 +31,7 @@ func InitEmoji() {
 
 func getEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !*utils.Cfg.ServiceSettings.EnableCustomEmoji {
-		c.Err = model.NewLocAppError("getEmoji", "api.emoji.disabled.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("getEmoji", "api.emoji.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
@@ -47,33 +46,28 @@ func getEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func createEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !*utils.Cfg.ServiceSettings.EnableCustomEmoji {
-		c.Err = model.NewLocAppError("createEmoji", "api.emoji.disabled.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("createEmoji", "api.emoji.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
 	if emojiInterface := einterfaces.GetEmojiInterface(); emojiInterface != nil &&
 		!emojiInterface.CanUserCreateEmoji(c.Session.Roles, c.Session.TeamMembers) {
-		c.Err = model.NewLocAppError("createEmoji", "api.emoji.create.permissions.app_error", nil, "user_id="+c.Session.UserId)
-		c.Err.StatusCode = http.StatusUnauthorized
+		c.Err = model.NewAppError("createEmoji", "api.emoji.create.permissions.app_error", nil, "user_id="+c.Session.UserId, http.StatusUnauthorized)
 		return
 	}
 
 	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
-		c.Err = model.NewLocAppError("createEmoji", "api.emoji.storage.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("createEmoji", "api.emoji.storage.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
 	if r.ContentLength > app.MaxEmojiFileSize {
-		c.Err = model.NewLocAppError("createEmoji", "api.emoji.create.too_large.app_error", nil, "")
-		c.Err.StatusCode = http.StatusRequestEntityTooLarge
+		c.Err = model.NewAppError("createEmoji", "api.emoji.create.too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
 		return
 	}
 
 	if err := r.ParseMultipartForm(app.MaxEmojiFileSize); err != nil {
-		c.Err = model.NewLocAppError("createEmoji", "api.emoji.create.parse.app_error", nil, err.Error())
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("createEmoji", "api.emoji.create.parse.app_error", nil, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -99,14 +93,12 @@ func createEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if emoji.CreatorId != c.Session.UserId {
-		c.Err = model.NewLocAppError("createEmoji", "api.emoji.create.other_user.app_error", nil, "")
-		c.Err.StatusCode = http.StatusUnauthorized
+		c.Err = model.NewAppError("createEmoji", "api.emoji.create.other_user.app_error", nil, "", http.StatusUnauthorized)
 		return
 	}
 
 	if result := <-app.Srv.Store.Emoji().GetByName(emoji.Name); result.Err == nil && result.Data != nil {
-		c.Err = model.NewLocAppError("createEmoji", "api.emoji.create.duplicate.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("createEmoji", "api.emoji.create.duplicate.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -132,14 +124,12 @@ func createEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func deleteEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !*utils.Cfg.ServiceSettings.EnableCustomEmoji {
-		c.Err = model.NewLocAppError("deleteEmoji", "api.emoji.disabled.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("deleteEmoji", "api.emoji.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
 	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
-		c.Err = model.NewLocAppError("deleteImage", "api.emoji.storage.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("deleteImage", "api.emoji.storage.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
@@ -158,8 +148,7 @@ func deleteEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if c.Session.UserId != emoji.CreatorId && !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
-		c.Err = model.NewLocAppError("deleteEmoji", "api.emoji.delete.permissions.app_error", nil, "user_id="+c.Session.UserId)
-		c.Err.StatusCode = http.StatusUnauthorized
+		c.Err = model.NewAppError("deleteEmoji", "api.emoji.delete.permissions.app_error", nil, "user_id="+c.Session.UserId, http.StatusUnauthorized)
 		return
 	}
 
@@ -174,14 +163,12 @@ func deleteEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func getEmojiImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !*utils.Cfg.ServiceSettings.EnableCustomEmoji {
-		c.Err = model.NewLocAppError("getEmojiImage", "api.emoji.disabled.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("getEmojiImage", "api.emoji.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
 	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
-		c.Err = model.NewLocAppError("getEmojiImage", "api.emoji.storage.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("getEmojiImage", "api.emoji.storage.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 

--- a/api/file.go
+++ b/api/file.go
@@ -52,8 +52,7 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.ContentLength > *utils.Cfg.FileSettings.MaxFileSize {
-		c.Err = model.NewLocAppError("uploadFile", "api.file.upload_file.too_large.app_error", nil, "")
-		c.Err.StatusCode = http.StatusRequestEntityTooLarge
+		c.Err = model.NewAppError("uploadFile", "api.file.upload_file.too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
 		return
 	}
 
@@ -113,8 +112,7 @@ func getFileThumbnail(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if info.ThumbnailPath == "" {
-		c.Err = model.NewLocAppError("getFileThumbnail", "api.file.get_file_thumbnail.no_thumbnail.app_error", nil, "file_id="+info.Id)
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("getFileThumbnail", "api.file.get_file_thumbnail.no_thumbnail.app_error", nil, "file_id="+info.Id, http.StatusBadRequest)
 		return
 	}
 
@@ -135,8 +133,7 @@ func getFilePreview(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if info.PreviewPath == "" {
-		c.Err = model.NewLocAppError("getFilePreview", "api.file.get_file_preview.no_preview.app_error", nil, "file_id="+info.Id)
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("getFilePreview", "api.file.get_file_preview.no_preview.app_error", nil, "file_id="+info.Id, http.StatusBadRequest)
 		return
 	}
 
@@ -163,8 +160,7 @@ func getFileInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func getPublicFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !utils.Cfg.FileSettings.EnablePublicLink {
-		c.Err = model.NewLocAppError("getPublicFile", "api.file.get_file.public_disabled.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
@@ -180,13 +176,11 @@ func getPublicFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		correctHash := app.GeneratePublicLinkHash(info.Id, *utils.Cfg.FileSettings.PublicLinkSalt)
 
 		if hash != correctHash {
-			c.Err = model.NewLocAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "")
-			c.Err.StatusCode = http.StatusBadRequest
+			c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "", http.StatusBadRequest)
 			return
 		}
 	} else {
-		c.Err = model.NewLocAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -219,8 +213,7 @@ func getFileInfoForRequest(c *Context, r *http.Request, requireFileVisible bool)
 	// only let users access files visible in a channel, unless they're the one who uploaded the file
 	if info.CreatorId != c.Session.UserId {
 		if len(info.PostId) == 0 {
-			err := model.NewLocAppError("getFileInfoForRequest", "api.file.get_file_info_for_request.no_post.app_error", nil, "file_id="+fileId)
-			err.StatusCode = http.StatusBadRequest
+			err := model.NewAppError("getFileInfoForRequest", "api.file.get_file_info_for_request.no_post.app_error", nil, "file_id="+fileId, http.StatusBadRequest)
 			return nil, err
 		}
 
@@ -237,12 +230,10 @@ func getFileInfoForRequest(c *Context, r *http.Request, requireFileVisible bool)
 
 func getPublicFileOld(c *Context, w http.ResponseWriter, r *http.Request) {
 	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
-		c.Err = model.NewLocAppError("getPublicFile", "api.file.get_public_file_old.storage.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("getPublicFile", "api.file.get_public_file_old.storage.app_error", nil, "", http.StatusNotImplemented)
 		return
 	} else if !utils.Cfg.FileSettings.EnablePublicLink {
-		c.Err = model.NewLocAppError("getPublicFile", "api.file.get_file.public_disabled.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
@@ -259,13 +250,11 @@ func getPublicFileOld(c *Context, w http.ResponseWriter, r *http.Request) {
 		correctHash := app.GeneratePublicLinkHash(filename, *utils.Cfg.FileSettings.PublicLinkSalt)
 
 		if hash != correctHash {
-			c.Err = model.NewLocAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "")
-			c.Err.StatusCode = http.StatusBadRequest
+			c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "", http.StatusBadRequest)
 			return
 		}
 	} else {
-		c.Err = model.NewLocAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -280,8 +269,7 @@ func getPublicFileOld(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(info.PostId) == 0 {
-		c.Err = model.NewLocAppError("getPublicFileOld", "api.file.get_public_file_old.no_post.app_error", nil, "file_id="+info.Id)
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("getPublicFileOld", "api.file.get_public_file_old.no_post.app_error", nil, "file_id="+info.Id, http.StatusBadRequest)
 		return
 	}
 
@@ -325,8 +313,7 @@ func writeFileResponse(filename string, contentType string, bytes []byte, w http
 
 func getPublicLink(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !utils.Cfg.FileSettings.EnablePublicLink {
-		c.Err = model.NewLocAppError("getPublicLink", "api.file.get_public_link.disabled.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("getPublicLink", "api.file.get_public_link.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
@@ -337,8 +324,7 @@ func getPublicLink(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(info.PostId) == 0 {
-		c.Err = model.NewLocAppError("getPublicLink", "api.file.get_public_link.no_post.app_error", nil, "file_id="+info.Id)
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("getPublicLink", "api.file.get_public_link.no_post.app_error", nil, "file_id="+info.Id, http.StatusBadRequest)
 		return
 	}
 

--- a/api/license.go
+++ b/api/license.go
@@ -34,14 +34,12 @@ func addLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	fileArray, ok := m.File["license"]
 	if !ok {
-		c.Err = model.NewLocAppError("addLicense", "api.license.add_license.no_file.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("addLicense", "api.license.add_license.no_file.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	if len(fileArray) <= 0 {
-		c.Err = model.NewLocAppError("addLicense", "api.license.add_license.array.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("addLicense", "api.license.add_license.array.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -50,7 +48,7 @@ func addLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 	file, err := fileData.Open()
 	defer file.Close()
 	if err != nil {
-		c.Err = model.NewLocAppError("addLicense", "api.license.add_license.open.app_error", nil, err.Error())
+		c.Err = model.NewAppError("addLicense", "api.license.add_license.open.app_error", nil, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -835,7 +835,7 @@ func HttpGet(url string, httpClient *http.Client, authToken string, followRedire
 	}
 
 	if rp, err := httpClient.Do(rq); err != nil {
-		return nil, model.NewLocAppError(url, "model.client.connecting.app_error", nil, err.Error())
+		return nil, model.NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0)
 	} else if rp.StatusCode == 304 {
 		return rp, nil
 	} else if rp.StatusCode == 307 {

--- a/api/post.go
+++ b/api/post.go
@@ -282,8 +282,7 @@ func getPost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		if !list.IsChannelId(channelId) {
-			c.Err = model.NewLocAppError("getPost", "api.post.get_post.permissions.app_error", nil, "")
-			c.Err.StatusCode = http.StatusForbidden
+			c.Err = model.NewAppError("getPost", "api.post.get_post.permissions.app_error", nil, "", http.StatusForbidden)
 			return
 		}
 
@@ -306,7 +305,7 @@ func getPostById(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		if len(list.Order) != 1 {
-			c.Err = model.NewLocAppError("getPostById", "api.post_get_post_by_id.get.app_error", nil, "")
+			c.Err = model.NewAppError("getPostById", "api.post_get_post_by_id.get.app_error", nil, "", http.StatusInternalServerError)
 			return
 		}
 		post := list.Posts[list.Order[0]]
@@ -395,8 +394,7 @@ func deletePost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		if post.ChannelId != channelId {
-			c.Err = model.NewLocAppError("deletePost", "api.post.delete_post.permissions.app_error", nil, "")
-			c.Err.StatusCode = http.StatusForbidden
+			c.Err = model.NewAppError("deletePost", "api.post.delete_post.permissions.app_error", nil, "", http.StatusForbidden)
 			return
 		}
 

--- a/api/preference.go
+++ b/api/preference.go
@@ -35,8 +35,7 @@ func getAllPreferences(c *Context, w http.ResponseWriter, r *http.Request) {
 func savePreferences(c *Context, w http.ResponseWriter, r *http.Request) {
 	preferences, err := model.PreferencesFromJson(r.Body)
 	if err != nil {
-		c.Err = model.NewLocAppError("savePreferences", "api.preference.save_preferences.decode.app_error", nil, err.Error())
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("savePreferences", "api.preference.save_preferences.decode.app_error", nil, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -77,8 +76,7 @@ func getPreference(c *Context, w http.ResponseWriter, r *http.Request) {
 func deletePreferences(c *Context, w http.ResponseWriter, r *http.Request) {
 	preferences, err := model.PreferencesFromJson(r.Body)
 	if err != nil {
-		c.Err = model.NewLocAppError("savePreferences", "api.preference.delete_preferences.decode.app_error", nil, err.Error())
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("savePreferences", "api.preference.delete_preferences.decode.app_error", nil, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/api/reaction.go
+++ b/api/reaction.go
@@ -29,8 +29,7 @@ func saveReaction(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if reaction.UserId != c.Session.UserId {
-		c.Err = model.NewLocAppError("saveReaction", "api.reaction.save_reaction.user_id.app_error", nil, "")
-		c.Err.StatusCode = http.StatusForbidden
+		c.Err = model.NewAppError("saveReaction", "api.reaction.save_reaction.user_id.app_error", nil, "", http.StatusForbidden)
 		return
 	}
 
@@ -59,9 +58,8 @@ func saveReaction(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = result.Err
 		return
 	} else if post = result.Data.(*model.PostList).Posts[postId]; post.ChannelId != channelId {
-		c.Err = model.NewLocAppError("saveReaction", "api.reaction.save_reaction.mismatched_channel_id.app_error",
-			nil, "channelId="+channelId+", post.ChannelId="+post.ChannelId+", postId="+postId)
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("saveReaction", "api.reaction.save_reaction.mismatched_channel_id.app_error",
+			nil, "channelId="+channelId+", post.ChannelId="+post.ChannelId+", postId="+postId, http.StatusBadRequest)
 		return
 	}
 
@@ -82,8 +80,7 @@ func deleteReaction(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if reaction.UserId != c.Session.UserId {
-		c.Err = model.NewLocAppError("deleteReaction", "api.reaction.delete_reaction.user_id.app_error", nil, "")
-		c.Err.StatusCode = http.StatusForbidden
+		c.Err = model.NewAppError("deleteReaction", "api.reaction.delete_reaction.user_id.app_error", nil, "", http.StatusForbidden)
 		return
 	}
 
@@ -158,9 +155,8 @@ func listReactions(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = result.Err
 		return
 	} else if post := result.Data.(*model.PostList).Posts[postId]; post.ChannelId != channelId {
-		c.Err = model.NewLocAppError("listReactions", "api.reaction.list_reactions.mismatched_channel_id.app_error",
-			nil, "channelId="+channelId+", post.ChannelId="+post.ChannelId+", postId="+postId)
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("listReactions", "api.reaction.list_reactions.mismatched_channel_id.app_error",
+			nil, "channelId="+channelId+", post.ChannelId="+post.ChannelId+", postId="+postId, http.StatusBadRequest)
 		return
 	}
 

--- a/api/team.go
+++ b/api/team.go
@@ -57,7 +57,7 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !app.SessionHasPermissionTo(c.Session, model.PERMISSION_CREATE_TEAM) {
-		c.Err = model.NewLocAppError("createTeam", "api.team.is_team_creation_allowed.disabled.app_error", nil, "")
+		c.Err = model.NewAppError("createTeam", "api.team.is_team_creation_allowed.disabled.app_error", nil, "", http.StatusForbidden)
 		return
 	}
 
@@ -126,8 +126,7 @@ func inviteMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 			errorId = "api.team.invite_members.restricted_team_admin.app_error"
 		}
 
-		c.Err = model.NewLocAppError("inviteMembers", errorId, nil, "")
-		c.Err.StatusCode = http.StatusForbidden
+		c.Err = model.NewAppError("inviteMembers", errorId, nil, "", http.StatusForbidden)
 		return
 	}
 
@@ -199,7 +198,7 @@ func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request)
 	} else if len(inviteId) > 0 {
 		team, err = app.AddUserToTeamByInviteId(inviteId, c.Session.UserId)
 	} else {
-		c.Err = model.NewLocAppError("addUserToTeamFromInvite", "api.user.create_user.signup_link_invalid.app_error", nil, "")
+		c.Err = model.NewAppError("addUserToTeamFromInvite", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -372,7 +371,7 @@ func importTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := r.ParseMultipartForm(10000000); err != nil {
-		c.Err = model.NewLocAppError("importTeam", "api.team.import_team.parse.app_error", nil, err.Error())
+		c.Err = model.NewAppError("importTeam", "api.team.import_team.parse.app_error", nil, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -381,28 +380,24 @@ func importTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	fileSizeStr, ok := r.MultipartForm.Value["filesize"]
 	if !ok {
-		c.Err = model.NewLocAppError("importTeam", "api.team.import_team.unavailable.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("importTeam", "api.team.import_team.unavailable.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	fileSize, err := strconv.ParseInt(fileSizeStr[0], 10, 64)
 	if err != nil {
-		c.Err = model.NewLocAppError("importTeam", "api.team.import_team.integer.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("importTeam", "api.team.import_team.integer.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	fileInfoArray, ok := r.MultipartForm.File["file"]
 	if !ok {
-		c.Err = model.NewLocAppError("importTeam", "api.team.import_team.no_file.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("importTeam", "api.team.import_team.no_file.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	if len(fileInfoArray) <= 0 {
-		c.Err = model.NewLocAppError("importTeam", "api.team.import_team.array.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("importTeam", "api.team.import_team.array.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -411,8 +406,7 @@ func importTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	fileData, err := fileInfo.Open()
 	defer fileData.Close()
 	if err != nil {
-		c.Err = model.NewLocAppError("importTeam", "api.team.import_team.open.app_error", nil, err.Error())
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("importTeam", "api.team.import_team.open.app_error", nil, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -444,7 +438,7 @@ func getInviteInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		if !(team.Type == model.TEAM_OPEN) {
-			c.Err = model.NewLocAppError("getInviteInfo", "api.team.get_invite_info.not_open_team", nil, "id="+inviteId)
+			c.Err = model.NewAppError("getInviteInfo", "api.team.get_invite_info.not_open_team", nil, "id="+inviteId, http.StatusBadRequest)
 			return
 		}
 

--- a/api/user.go
+++ b/api/user.go
@@ -550,7 +550,7 @@ func getProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		if len(users) == 0 {
-			c.Err = model.NewLocAppError("getProfileImage", "store.sql_user.get_profiles.app_error", nil, "")
+			c.Err = model.NewAppError("getProfileImage", "store.sql_user.get_profiles.app_error", nil, "", http.StatusInternalServerError)
 			return
 		}
 
@@ -581,19 +581,17 @@ func getProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func uploadProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
-		c.Err = model.NewLocAppError("uploadProfileImage", "api.user.upload_profile_user.storage.app_error", nil, "")
-		c.Err.StatusCode = http.StatusNotImplemented
+		c.Err = model.NewAppError("uploadProfileImage", "api.user.upload_profile_user.storage.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
 	if r.ContentLength > *utils.Cfg.FileSettings.MaxFileSize {
-		c.Err = model.NewLocAppError("uploadProfileImage", "api.user.upload_profile_user.too_large.app_error", nil, "")
-		c.Err.StatusCode = http.StatusRequestEntityTooLarge
+		c.Err = model.NewAppError("uploadProfileImage", "api.user.upload_profile_user.too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
 		return
 	}
 
 	if err := r.ParseMultipartForm(*utils.Cfg.FileSettings.MaxFileSize); err != nil {
-		c.Err = model.NewLocAppError("uploadProfileImage", "api.user.upload_profile_user.parse.app_error", nil, "")
+		c.Err = model.NewAppError("uploadProfileImage", "api.user.upload_profile_user.parse.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -601,14 +599,12 @@ func uploadProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	imageArray, ok := m.File["image"]
 	if !ok {
-		c.Err = model.NewLocAppError("uploadProfileImage", "api.user.upload_profile_user.no_file.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("uploadProfileImage", "api.user.upload_profile_user.no_file.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	if len(imageArray) <= 0 {
-		c.Err = model.NewLocAppError("uploadProfileImage", "api.user.upload_profile_user.array.app_error", nil, "")
-		c.Err.StatusCode = http.StatusBadRequest
+		c.Err = model.NewAppError("uploadProfileImage", "api.user.upload_profile_user.array.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
@@ -666,8 +662,7 @@ func updatePassword(c *Context, w http.ResponseWriter, r *http.Request) {
 	newPassword := props["new_password"]
 
 	if userId != c.Session.UserId {
-		c.Err = model.NewLocAppError("updatePassword", "api.user.update_password.context.app_error", nil, "")
-		c.Err.StatusCode = http.StatusForbidden
+		c.Err = model.NewAppError("updatePassword", "api.user.update_password.context.app_error", nil, "", http.StatusForbidden)
 		return
 	}
 
@@ -731,8 +726,7 @@ func updateActive(c *Context, w http.ResponseWriter, r *http.Request) {
 	isSelfDeactive := !active && userId == c.Session.UserId
 
 	if !isSelfDeactive && !app.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
-		c.Err = model.NewLocAppError("updateActive", "api.user.update_active.permissions.app_error", nil, "userId="+userId)
-		c.Err.StatusCode = http.StatusForbidden
+		c.Err = model.NewAppError("updateActive", "api.user.update_active.permissions.app_error", nil, "userId="+userId, http.StatusForbidden)
 		return
 	}
 
@@ -1017,8 +1011,7 @@ func verifyEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	c.Err = model.NewLocAppError("verifyEmail", "api.user.verify_email.bad_link.app_error", nil, "")
-	c.Err.StatusCode = http.StatusBadRequest
+	c.Err = model.NewAppError("verifyEmail", "api.user.verify_email.bad_link.app_error", nil, "", http.StatusBadRequest)
 }
 
 func resendVerification(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -1136,8 +1129,7 @@ func loginWithSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 	samlInterface := einterfaces.GetSamlInterface()
 
 	if samlInterface == nil {
-		c.Err = model.NewLocAppError("loginWithSaml", "api.user.saml.not_available.app_error", nil, "")
-		c.Err.StatusCode = http.StatusFound
+		c.Err = model.NewAppError("loginWithSaml", "api.user.saml.not_available.app_error", nil, "", http.StatusFound)
 		return
 	}
 
@@ -1180,8 +1172,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 	samlInterface := einterfaces.GetSamlInterface()
 
 	if samlInterface == nil {
-		c.Err = model.NewLocAppError("completeSaml", "api.user.saml.not_available.app_error", nil, "")
-		c.Err.StatusCode = http.StatusFound
+		c.Err = model.NewAppError("completeSaml", "api.user.saml.not_available.app_error", nil, "", http.StatusFound)
 		return
 	}
 
@@ -1193,8 +1184,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 	if len(relayState) > 0 {
 		stateStr := ""
 		if b, err := b64.StdEncoding.DecodeString(relayState); err != nil {
-			c.Err = model.NewLocAppError("completeSaml", "api.user.authorize_oauth_user.invalid_state.app_error", nil, err.Error())
-			c.Err.StatusCode = http.StatusFound
+			c.Err = model.NewAppError("completeSaml", "api.user.authorize_oauth_user.invalid_state.app_error", nil, err.Error(), http.StatusFound)
 			return
 		} else {
 			stateStr = string(b)

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -30,7 +30,7 @@ func connect(c *Context, w http.ResponseWriter, r *http.Request) {
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		l4g.Error(utils.T("api.web_socket.connect.error"), err)
-		c.Err = model.NewLocAppError("connect", "api.web_socket.connect.upgrade.app_error", nil, "")
+		c.Err = model.NewAppError("connect", "api.web_socket.connect.upgrade.app_error", nil, "", http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
I got fed up with the proliferation of `NewLocAppError` and the fact more of them keep creeping into the codebase despite the fact we're trying to move away from it.

This PR removes it entirely from the `api` package. There are more PRs that do the other packages.