### PR TITLE
[PLT-7055] Modified code arrangement for compatibility with 32-bit ARM

### DIFF
--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -34,8 +34,10 @@ const (
 	DEADLOCK_WARN        = (BROADCAST_QUEUE_SIZE * 99) / 100 // number of buffered messages before printing stack trace
 )
 
-type Hub struct {
-	connectionCount int64
+type Hub struct { 
+        // connectionCount should be kept first.
+        // See https://github.com/mattermost/platform/pull/7281
+    	connectionCount int64
 	connections     []*WebConn
 	connectionIndex int
 	register        chan *WebConn

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -27,8 +27,8 @@ const (
 )
 
 type Hub struct {
-	connections     []*WebConn
 	connectionCount int64
+	connections     []*WebConn
 	connectionIndex int
 	register        chan *WebConn
 	unregister      chan *WebConn

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -1,6 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+// Note: On both ARM and x86-32, it is the caller's responsibility to 
+// arrange for 64-bit alignment of 64-bit words accessed atomically. 
+// The first word in a global variable or in an allocated struct or 
+// slice can be relied upon to be 64-bit aligned.
+// 
+// TL;DR Add "int64" var 1st before anything else in a struct
+// Affected: Hub
+
 package app
 
 import (

--- a/store/sql_supplier.go
+++ b/store/sql_supplier.go
@@ -83,12 +83,12 @@ type SqlSupplierOldStores struct {
 }
 
 type SqlSupplier struct {
+	rrCounter      int64
+	srCounter      int64
 	next           LayeredStoreSupplier
 	master         *gorp.DbMap
 	replicas       []*gorp.DbMap
 	searchReplicas []*gorp.DbMap
-	rrCounter      int64
-	srCounter      int64
 	oldStores      SqlSupplierOldStores
 }
 

--- a/store/sql_supplier.go
+++ b/store/sql_supplier.go
@@ -1,6 +1,14 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+// Note: On both ARM and x86-32, it is the caller's responsibility to 
+// arrange for 64-bit alignment of 64-bit words accessed atomically.  
+// The first word in a global variable or in an allocated struct or
+// slice can be relied upon to be 64-bit aligned.
+// 
+// TL;DR Add "int64" var 1st before anything else in a type struct
+// Affected: SqlSupplier
+
 package store
 
 import (

--- a/store/sql_supplier.go
+++ b/store/sql_supplier.go
@@ -90,7 +90,9 @@ type SqlSupplierOldStores struct {
 	userAccessToken UserAccessTokenStore
 }
 
-type SqlSupplier struct {
+type SqlSupplier struct { 
+        // rrCounter and srCounter should be kept first.
+        // See https://github.com/mattermost/platform/pull/7281
 	rrCounter      int64
 	srCounter      int64
 	next           LayeredStoreSupplier


### PR DESCRIPTION
#### Summary
Changes the code arrangement for `store/sql_supplier.go` to prevent crashing while compiling on 32-bit ARM, contributed by @Rudloff, and `app/web_hub.go` for the Site and Team Statistics in the System Console to work properly in 32-bit ARM.

EDIT: Someone may need to create a similar `build-linux` makefile for ARM; I run `make build-linux`, copied and modified `amd64` to `arm` in order for the build to work on my machine: 
```
env GOOS=linux GOARCH=arm go install  -ldflags "-X github.com/mattermost/platform/model.BuildNumber=dev -X 'github.com/mattermost/platform/model.BuildDate=Wed Aug 23 19:47:25 UTC 2017' -X github.com/mattermost/platform/model.BuildHash=ad1e556c95ce20d6f1293d4a3197e6ea6a471fdd -X github.com/mattermost/platform/model.BuildHashEnterprise=none -X github.com/mattermost/platform/model.BuildEnterpriseReady=false" ./cmd/platform
```

#### Ticket Link
#7055 
