### PR TITLE
Fix log error message for UpdateLastActivityAtIfNeeded

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -205,7 +205,7 @@ func UpdateLastActivityAtIfNeeded(session model.Session) {
 	}
 
 	if result := <-Srv.Store.Session().UpdateLastActivityAt(session.Id, now); result.Err != nil {
-		l4g.Error(utils.T("api.status.last_activity.error", session.UserId, session.Id))
+		l4g.Error(utils.T("api.status.last_activity.error"), session.UserId, session.Id)
 	}
 
 	session.LastActivityAt = now


### PR DESCRIPTION
#### Summary
Issue found by #7178 causing the server to panic cause the l4g.Error was malformed.