### PR TITLE
NewLocAppError -> NewAppError for utils and some other miscellaneous packages

### DIFF
--- a/manualtesting/manual_testing.go
+++ b/manualtesting/manual_testing.go
@@ -39,7 +39,7 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	// URL Parameters
 	params, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
-		c.Err = model.NewLocAppError("/manual", "manaultesting.manual_test.parse.app_error", nil, "")
+		c.Err = model.NewAppError("/manual", "manaultesting.manual_test.parse.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 

--- a/manualtesting/test_autolink.go
+++ b/manualtesting/test_autolink.go
@@ -7,6 +7,7 @@ import (
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
+	"net/http"
 )
 
 const LINK_POST_TEXT = `
@@ -24,7 +25,7 @@ func testAutoLink(env TestEnvironment) *model.AppError {
 	l4g.Info(utils.T("manaultesting.test_autolink.info"))
 	channelID, err := getChannelID(model.DEFAULT_CHANNEL, env.CreatedTeamId, env.CreatedUserId)
 	if err != true {
-		return model.NewLocAppError("/manualtest", "manaultesting.test_autolink.unable.app_error", nil, "")
+		return model.NewAppError("/manualtest", "manaultesting.test_autolink.unable.app_error", nil, "", http.StatusInternalServerError)
 	}
 
 	post := &model.Post{

--- a/utils/config.go
+++ b/utils/config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
+	"net/http"
 )
 
 const (
@@ -179,14 +180,14 @@ func SaveConfig(fileName string, config *model.Config) *model.AppError {
 
 	b, err := json.MarshalIndent(config, "", "    ")
 	if err != nil {
-		return model.NewLocAppError("SaveConfig", "utils.config.save_config.saving.app_error",
-			map[string]interface{}{"Filename": fileName}, err.Error())
+		return model.NewAppError("SaveConfig", "utils.config.save_config.saving.app_error",
+			map[string]interface{}{"Filename": fileName}, err.Error(), http.StatusBadRequest)
 	}
 
 	err = ioutil.WriteFile(fileName, b, 0644)
 	if err != nil {
-		return model.NewLocAppError("SaveConfig", "utils.config.save_config.saving.app_error",
-			map[string]interface{}{"Filename": fileName}, err.Error())
+		return model.NewAppError("SaveConfig", "utils.config.save_config.saving.app_error",
+			map[string]interface{}{"Filename": fileName}, err.Error(), http.StatusInternalServerError)
 	}
 
 	return nil
@@ -592,12 +593,12 @@ func ValidateLocales(cfg *model.Config) *model.AppError {
 	locales := GetSupportedLocales()
 	if _, ok := locales[*cfg.LocalizationSettings.DefaultServerLocale]; !ok {
 		*cfg.LocalizationSettings.DefaultServerLocale = model.DEFAULT_LOCALE
-		err = model.NewLocAppError("ValidateLocales", "utils.config.supported_server_locale.app_error", nil, "")
+		err = model.NewAppError("ValidateLocales", "utils.config.supported_server_locale.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if _, ok := locales[*cfg.LocalizationSettings.DefaultClientLocale]; !ok {
 		*cfg.LocalizationSettings.DefaultClientLocale = model.DEFAULT_LOCALE
-		err = model.NewLocAppError("ValidateLocales", "utils.config.supported_client_locale.app_error", nil, "")
+		err = model.NewAppError("ValidateLocales", "utils.config.supported_client_locale.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(*cfg.LocalizationSettings.AvailableLocales) > 0 {
@@ -606,7 +607,7 @@ func ValidateLocales(cfg *model.Config) *model.AppError {
 			if _, ok := locales[word]; !ok {
 				*cfg.LocalizationSettings.AvailableLocales = ""
 				isDefaultClientLocaleInAvailableLocales = true
-				err = model.NewLocAppError("ValidateLocales", "utils.config.supported_available_locales.app_error", nil, "")
+				err = model.NewAppError("ValidateLocales", "utils.config.supported_available_locales.app_error", nil, "", http.StatusBadRequest)
 				break
 			}
 
@@ -619,7 +620,7 @@ func ValidateLocales(cfg *model.Config) *model.AppError {
 
 		if !isDefaultClientLocaleInAvailableLocales {
 			availableLocales += "," + *cfg.LocalizationSettings.DefaultClientLocale
-			err = model.NewLocAppError("ValidateLocales", "utils.config.add_client_locale.app_error", nil, "")
+			err = model.NewAppError("ValidateLocales", "utils.config.add_client_locale.app_error", nil, "", http.StatusBadRequest)
 		}
 
 		*cfg.LocalizationSettings.AvailableLocales = strings.Join(RemoveDuplicatesFromStringArray(strings.Split(availableLocales, ",")), ",")

--- a/wsapi/websocket_handler.go
+++ b/wsapi/websocket_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattermost/platform/app"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/utils"
+	"net/http"
 )
 
 func ApiWebSocketHandler(wh func(*model.WebSocketRequest) (map[string]interface{}, *model.AppError)) webSocketHandler {
@@ -54,5 +55,5 @@ func (wh webSocketHandler) ServeWebSocket(conn *app.WebConn, r *model.WebSocketR
 }
 
 func NewInvalidWebSocketParamError(action string, name string) *model.AppError {
-	return model.NewLocAppError("/api/v3/users/websocket:"+action, "api.websocket_handler.invalid_param.app_error", map[string]interface{}{"Name": name}, "")
+	return model.NewAppError("/api/v3/users/websocket:"+action, "api.websocket_handler.invalid_param.app_error", map[string]interface{}{"Name": name}, "", http.StatusBadRequest)
 }


### PR DESCRIPTION
This replaces calls to `NewLocAppError` with `NewAppError` and sets the appropriate HTTP status code on the remaining unmigrated errors in the `utils` package and a couple of other misc packages.