### PR TITLE
Fixed code blocks causing minor scroll pop on first load

### DIFF
--- a/webapp/sass/layout/_markdown.scss
+++ b/webapp/sass/layout/_markdown.scss
@@ -67,8 +67,10 @@ h6 {
     code {
         border: 1px solid rgba(221,221,221,1);
         border-radius: .25em;
+        display: block;
         font-size: 13px;
         margin: 5px 0;
+        overflow-x: auto;
         padding: 6.5px;
         text-align: left;
         white-space: pre;


### PR DESCRIPTION
These styles are applied asynchronously by highlight.js so it causes the height of the code block to change slightly. There was a ticket somewhere, but I can't remember where it was
