### PR TITLE
PLT-7407: Add plugin http handler

### DIFF
--- a/plugin/hooks.go
+++ b/plugin/hooks.go
@@ -1,5 +1,9 @@
 package plugin
 
+import (
+	"net/http"
+)
+
 type Hooks interface {
 	// OnActivate is invoked when the plugin is activated.
 	OnActivate(API) error
@@ -7,4 +11,11 @@ type Hooks interface {
 	// OnDeactivate is invoked when the plugin is deactivated. This is the plugin's last chance to
 	// use the API, and the plugin will be terminated shortly after this invocation.
 	OnDeactivate() error
+
+	// ServeHTTP allows the plugin to implement the http.Handler interface. Requests destined for
+	// the /plugins/{id} path will be routed to the plugin.
+	//
+	// The Mattermost-User-Id header will be present if (and only if) the request is by an
+	// authenticated user.
+	ServeHTTP(http.ResponseWriter, *http.Request)
 }

--- a/plugin/plugintest/hooks.go
+++ b/plugin/plugintest/hooks.go
@@ -1,6 +1,8 @@
 package plugintest
 
 import (
+	"net/http"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/mattermost/platform/plugin"
@@ -18,4 +20,8 @@ func (m *Hooks) OnActivate(api plugin.API) error {
 
 func (m *Hooks) OnDeactivate() error {
 	return m.Called().Error(0)
+}
+
+func (m *Hooks) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.Called(w, r)
 }

--- a/plugin/rpcplugin/api.go
+++ b/plugin/rpcplugin/api.go
@@ -26,11 +26,6 @@ func (h *LocalAPI) LoadPluginConfiguration(args struct{}, reply *[]byte) error {
 	return nil
 }
 
-type RemoteAPI struct {
-	client *rpc.Client
-	muxer  *Muxer
-}
-
 func ServeAPI(api plugin.API, conn io.ReadWriteCloser, muxer *Muxer) {
 	server := rpc.NewServer()
 	server.Register(&LocalAPI{
@@ -38,6 +33,11 @@ func ServeAPI(api plugin.API, conn io.ReadWriteCloser, muxer *Muxer) {
 		muxer: muxer,
 	})
 	server.ServeConn(conn)
+}
+
+type RemoteAPI struct {
+	client *rpc.Client
+	muxer  *Muxer
 }
 
 var _ plugin.API = (*RemoteAPI)(nil)

--- a/plugin/rpcplugin/http.go
+++ b/plugin/rpcplugin/http.go
@@ -1,0 +1,88 @@
+package rpcplugin
+
+import (
+	"io"
+	"net/http"
+	"net/rpc"
+)
+
+type LocalHTTPResponseWriter struct {
+	w http.ResponseWriter
+}
+
+func (w *LocalHTTPResponseWriter) Header(args struct{}, reply *http.Header) error {
+	*reply = w.w.Header()
+	return nil
+}
+
+func (w *LocalHTTPResponseWriter) Write(args []byte, reply *struct{}) error {
+	_, err := w.w.Write(args)
+	return err
+}
+
+func (w *LocalHTTPResponseWriter) WriteHeader(args int, reply *struct{}) error {
+	w.w.WriteHeader(args)
+	return nil
+}
+
+func (w *LocalHTTPResponseWriter) SyncHeader(args http.Header, reply *struct{}) error {
+	dest := w.w.Header()
+	for k := range dest {
+		if _, ok := args[k]; !ok {
+			delete(dest, k)
+		}
+	}
+	for k, v := range args {
+		dest[k] = v
+	}
+	return nil
+}
+
+func ServeHTTPResponseWriter(w http.ResponseWriter, conn io.ReadWriteCloser) {
+	server := rpc.NewServer()
+	server.Register(&LocalHTTPResponseWriter{
+		w: w,
+	})
+	server.ServeConn(conn)
+}
+
+type RemoteHTTPResponseWriter struct {
+	client *rpc.Client
+	header http.Header
+}
+
+var _ http.ResponseWriter = (*RemoteHTTPResponseWriter)(nil)
+
+func (w *RemoteHTTPResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.client.Call("LocalHTTPResponseWriter.Header", struct{}{}, &w.header)
+	}
+	return w.header
+}
+
+func (w *RemoteHTTPResponseWriter) Write(b []byte) (int, error) {
+	if err := w.client.Call("LocalHTTPResponseWriter.SyncHeader", w.header, nil); err != nil {
+		return 0, err
+	}
+	if err := w.client.Call("LocalHTTPResponseWriter.Write", b, nil); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+func (w *RemoteHTTPResponseWriter) WriteHeader(statusCode int) {
+	if err := w.client.Call("LocalHTTPResponseWriter.SyncHeader", w.header, nil); err != nil {
+		return
+	}
+	w.client.Call("LocalHTTPResponseWriter.WriteHeader", statusCode, nil)
+}
+
+func (h *RemoteHTTPResponseWriter) Close() error {
+	return h.client.Close()
+}
+
+func ConnectHTTPResponseWriter(conn io.ReadWriteCloser) *RemoteHTTPResponseWriter {
+	return &RemoteHTTPResponseWriter{
+		client: rpc.NewClient(conn),
+	}
+}

--- a/plugin/rpcplugin/http_test.go
+++ b/plugin/rpcplugin/http_test.go
@@ -1,0 +1,61 @@
+package rpcplugin
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testHTTPResponseWriterRPC(w http.ResponseWriter, f func(w http.ResponseWriter)) {
+	r1, w1 := io.Pipe()
+	r2, w2 := io.Pipe()
+
+	c1 := NewMuxer(NewReadWriteCloser(r1, w2), false)
+	defer c1.Close()
+
+	c2 := NewMuxer(NewReadWriteCloser(r2, w1), true)
+	defer c2.Close()
+
+	id, server := c1.Serve()
+	go ServeHTTPResponseWriter(w, server)
+
+	remote := ConnectHTTPResponseWriter(c2.Connect(id))
+	defer remote.Close()
+
+	f(remote)
+}
+
+func TestHTTP(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	testHTTPResponseWriterRPC(w, func(w http.ResponseWriter) {
+		headers := w.Header()
+		headers.Set("Test-Header-A", "a")
+		headers.Set("Test-Header-B", "b")
+		w.Header().Set("Test-Header-C", "c")
+		w.WriteHeader(http.StatusPaymentRequired)
+		n, err := w.Write([]byte("this is "))
+		assert.Equal(t, 8, n)
+		assert.NoError(t, err)
+		n, err = w.Write([]byte("a test"))
+		assert.Equal(t, 6, n)
+		assert.NoError(t, err)
+	})
+
+	r := w.Result()
+	defer r.Body.Close()
+
+	assert.Equal(t, http.StatusPaymentRequired, r.StatusCode)
+
+	body, err := ioutil.ReadAll(r.Body)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "this is a test", body)
+
+	assert.Equal(t, "a", r.Header.Get("Test-Header-A"))
+	assert.Equal(t, "b", r.Header.Get("Test-Header-B"))
+	assert.Equal(t, "c", r.Header.Get("Test-Header-C"))
+}

--- a/plugin/rpcplugin/io.go
+++ b/plugin/rpcplugin/io.go
@@ -1,7 +1,10 @@
 package rpcplugin
 
 import (
+	"bufio"
+	"encoding/binary"
 	"io"
+	"os"
 )
 
 type rwc struct {
@@ -9,15 +12,56 @@ type rwc struct {
 	io.WriteCloser
 }
 
-func (rwc *rwc) Close() error {
-	rerr := rwc.ReadCloser.Close()
-	werr := rwc.WriteCloser.Close()
-	if rerr != nil {
-		return rerr
+func (rwc *rwc) Close() (err error) {
+	if f, ok := rwc.ReadCloser.(*os.File); ok {
+		// https://groups.google.com/d/topic/golang-nuts/i4w58KJ5-J8/discussion
+		err = os.NewFile(f.Fd(), "").Close()
+	} else {
+		err = rwc.ReadCloser.Close()
 	}
-	return werr
+	werr := rwc.WriteCloser.Close()
+	if err == nil {
+		err = werr
+	}
+	return
 }
 
 func NewReadWriteCloser(r io.ReadCloser, w io.WriteCloser) io.ReadWriteCloser {
 	return &rwc{r, w}
+}
+
+type RemoteIOReader struct {
+	conn io.ReadWriteCloser
+}
+
+func (r *RemoteIOReader) Read(b []byte) (int, error) {
+	var buf [10]byte
+	n := binary.PutVarint(buf[:], int64(len(b)))
+	if _, err := r.conn.Write(buf[:n]); err != nil {
+		return 0, err
+	}
+	return r.conn.Read(b)
+}
+
+func (r *RemoteIOReader) Close() error {
+	return r.conn.Close()
+}
+
+func ConnectIOReader(conn io.ReadWriteCloser) io.ReadCloser {
+	return &RemoteIOReader{conn}
+}
+
+func ServeIOReader(r io.Reader, conn io.ReadWriteCloser) {
+	cr := bufio.NewReader(conn)
+	defer conn.Close()
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := binary.ReadVarint(cr)
+		if err != nil {
+			break
+		}
+		if written, err := io.CopyBuffer(conn, io.LimitReader(r, n), buf); err != nil || written < n {
+			break
+		}
+	}
 }


### PR DESCRIPTION
#### Summary
This allows back-end plugins to handle HTTP requests.

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/PLT-7407

#### Checklist
- [x] Added or updated unit tests (required for all new features)