### PR TITLE
PLT-7345: add attachments to rhs search results

### DIFF
--- a/webapp/components/search_results_item.jsx
+++ b/webapp/components/search_results_item.jsx
@@ -8,6 +8,7 @@ import ProfilePicture from './profile_picture.jsx';
 import CommentIcon from 'components/common/comment_icon.jsx';
 import DotMenu from 'components/dot_menu';
 import PostFlagIcon from 'components/post_view/post_flag_icon.jsx';
+import PostBodyAdditionalContent from 'components/post_view/post_body_additional_content.jsx';
 
 import TeamStore from 'stores/team_store.jsx';
 
@@ -253,13 +254,20 @@ export default class SearchResultsItem extends React.Component {
                 </div>
             );
 
-            message = (
+            const messageWrapper = (
                 <PostMessageContainer
                     post={post}
                     options={{
                         searchTerm: this.props.term,
                         mentionHighlight: this.props.isMentionSearch
                     }}
+                />
+            );
+
+            message = (
+                <PostBodyAdditionalContent
+                    post={post}
+                    message={messageWrapper}
                 />
             );
         }


### PR DESCRIPTION
#### Summary
> When viewed in RHS flagged posts list, integration posts are missing their "attached" content.
>
> 1. Flag an integration post that has an "attachment" (can use a Jira integration post in the Bugs channel)
> 2. Click flag icon to view flagged posts in RHS
> 
> Observed: Post appears empty
> Expected: Post content is displayed

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7345

#### Checklist
- [x] Has UI changes