### PR TITLE
PLT-7407: Add client4 apis needed for JIRA plugin

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5104,6 +5104,10 @@
     "translation": "could not decode"
   },
   {
+    "id": "plugin.rpcplugin.invocation.error",
+    "translation": "Error invoking plugin RPC"
+  },
+  {
     "id": "store.sql.alter_column_type.critical",
     "translation": "Failed to alter column type %v"
   },

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -1,7 +1,23 @@
 package plugin
 
+import (
+	"github.com/mattermost/platform/model"
+)
+
 type API interface {
 	// LoadPluginConfiguration loads the plugin's configuration. dest should be a pointer to a
 	// struct that the configuration JSON can be unmarshalled to.
 	LoadPluginConfiguration(dest interface{}) error
+
+	// GetTeamByName gets a team by its name.
+	GetTeamByName(name string) (*model.Team, *model.AppError)
+
+	// GetUserByUsername gets a user by their username.
+	GetUserByUsername(name string) (*model.User, *model.AppError)
+
+	// GetChannelByName gets a channel by its name.
+	GetChannelByName(name, teamId string) (*model.Channel, *model.AppError)
+
+	// CreatePost creates a post.
+	CreatePost(post *model.Post) (*model.Post, *model.AppError)
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -3,6 +3,7 @@ package plugintest
 import (
 	"github.com/stretchr/testify/mock"
 
+	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/plugin"
 )
 
@@ -14,4 +15,44 @@ var _ plugin.API = (*API)(nil)
 
 func (m *API) LoadPluginConfiguration(dest interface{}) error {
 	return m.Called(dest).Error(0)
+}
+
+func (m *API) GetTeamByName(name string) (*model.Team, *model.AppError) {
+	ret := m.Called(name)
+	if f, ok := ret.Get(0).(func(string) (*model.Team, *model.AppError)); ok {
+		return f(name)
+	}
+	team, _ := ret.Get(0).(*model.Team)
+	err, _ := ret.Get(1).(*model.AppError)
+	return team, err
+}
+
+func (m *API) GetUserByUsername(name string) (*model.User, *model.AppError) {
+	ret := m.Called(name)
+	if f, ok := ret.Get(0).(func(string) (*model.User, *model.AppError)); ok {
+		return f(name)
+	}
+	user, _ := ret.Get(0).(*model.User)
+	err, _ := ret.Get(1).(*model.AppError)
+	return user, err
+}
+
+func (m *API) GetChannelByName(name, teamId string) (*model.Channel, *model.AppError) {
+	ret := m.Called(name, teamId)
+	if f, ok := ret.Get(0).(func(_, _ string) (*model.Channel, *model.AppError)); ok {
+		return f(name, teamId)
+	}
+	channel, _ := ret.Get(0).(*model.Channel)
+	err, _ := ret.Get(1).(*model.AppError)
+	return channel, err
+}
+
+func (m *API) CreatePost(post *model.Post) (*model.Post, *model.AppError) {
+	ret := m.Called(post)
+	if f, ok := ret.Get(0).(func(*model.Post) (*model.Post, *model.AppError)); ok {
+		return f(post)
+	}
+	postOut, _ := ret.Get(0).(*model.Post)
+	err, _ := ret.Get(1).(*model.AppError)
+	return postOut, err
 }

--- a/plugin/rpcplugin/api.go
+++ b/plugin/rpcplugin/api.go
@@ -3,8 +3,10 @@ package rpcplugin
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"net/rpc"
 
+	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/plugin"
 )
 
@@ -13,9 +15,9 @@ type LocalAPI struct {
 	muxer *Muxer
 }
 
-func (h *LocalAPI) LoadPluginConfiguration(args struct{}, reply *[]byte) error {
+func (api *LocalAPI) LoadPluginConfiguration(args struct{}, reply *[]byte) error {
 	var config interface{}
-	if err := h.api.LoadPluginConfiguration(&config); err != nil {
+	if err := api.api.LoadPluginConfiguration(&config); err != nil {
 		return err
 	}
 	b, err := json.Marshal(config)
@@ -23,6 +25,67 @@ func (h *LocalAPI) LoadPluginConfiguration(args struct{}, reply *[]byte) error {
 		return err
 	}
 	*reply = b
+	return nil
+}
+
+type APITeamReply struct {
+	Team  *model.Team
+	Error *model.AppError
+}
+
+func (api *LocalAPI) GetTeamByName(args string, reply *APITeamReply) error {
+	team, err := api.api.GetTeamByName(args)
+	*reply = APITeamReply{
+		Team:  team,
+		Error: err,
+	}
+	return nil
+}
+
+type APIUserReply struct {
+	User  *model.User
+	Error *model.AppError
+}
+
+func (api *LocalAPI) GetUserByUsername(args string, reply *APIUserReply) error {
+	user, err := api.api.GetUserByUsername(args)
+	*reply = APIUserReply{
+		User:  user,
+		Error: err,
+	}
+	return nil
+}
+
+type APIGetChannelByNameArgs struct {
+	Name   string
+	TeamId string
+}
+
+type APIChannelReply struct {
+	Channel *model.Channel
+	Error   *model.AppError
+}
+
+func (api *LocalAPI) GetChannelByName(args *APIGetChannelByNameArgs, reply *APIChannelReply) error {
+	channel, err := api.api.GetChannelByName(args.Name, args.TeamId)
+	*reply = APIChannelReply{
+		Channel: channel,
+		Error:   err,
+	}
+	return nil
+}
+
+type APIPostReply struct {
+	Post  *model.Post
+	Error *model.AppError
+}
+
+func (api *LocalAPI) CreatePost(args *model.Post, reply *APIPostReply) error {
+	post, err := api.api.CreatePost(args)
+	*reply = APIPostReply{
+		Post:  post,
+		Error: err,
+	}
 	return nil
 }
 
@@ -42,12 +105,47 @@ type RemoteAPI struct {
 
 var _ plugin.API = (*RemoteAPI)(nil)
 
-func (h *RemoteAPI) LoadPluginConfiguration(dest interface{}) error {
+func (api *RemoteAPI) LoadPluginConfiguration(dest interface{}) error {
 	var config []byte
-	if err := h.client.Call("LocalAPI.LoadPluginConfiguration", struct{}{}, &config); err != nil {
+	if err := api.client.Call("LocalAPI.LoadPluginConfiguration", struct{}{}, &config); err != nil {
 		return err
 	}
 	return json.Unmarshal(config, dest)
+}
+
+func (api *RemoteAPI) GetTeamByName(name string) (*model.Team, *model.AppError) {
+	var reply APITeamReply
+	if err := api.client.Call("LocalAPI.GetTeamByName", name, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetTeamByName", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Team, reply.Error
+}
+
+func (api *RemoteAPI) GetUserByUsername(name string) (*model.User, *model.AppError) {
+	var reply APIUserReply
+	if err := api.client.Call("LocalAPI.GetUserByUsername", name, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetUserByUsername", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.User, reply.Error
+}
+
+func (api *RemoteAPI) GetChannelByName(name, teamId string) (*model.Channel, *model.AppError) {
+	var reply APIChannelReply
+	if err := api.client.Call("LocalAPI.GetChannelByName", &APIGetChannelByNameArgs{
+		Name:   name,
+		TeamId: teamId,
+	}, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetChannelByName", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Channel, reply.Error
+}
+
+func (api *RemoteAPI) CreatePost(post *model.Post) (*model.Post, *model.AppError) {
+	var reply APIPostReply
+	if err := api.client.Call("LocalAPI.CreatePost", post, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.CreatePost", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Post, reply.Error
 }
 
 func (h *RemoteAPI) Close() error {


### PR DESCRIPTION
#### Summary
* ~Back-end plugin mechanism~ https://github.com/mattermost/platform/pull/7177
* ~Implement Windows IPC~ https://github.com/mattermost/platform/pull/7251
* ~Make hook methods optional (ideally without a roundtrip for unimplemented methods)~ https://github.com/mattermost/platform/pull/7263
* **Add APIs required for JIRA plugin (HTTP route registration and post creation)** (along with https://github.com/mattermost/platform/pull/7289)
* Port JIRA plugin (this'll be almost entirely build system changes once the above are done)

Very straight-forward and easy to add these APIs. `net/rpc` does all the heavy lifting. But it is a little tedious. It's certainly feasible to eliminate the tedium with some code generation.

Once @jwilander's PR (https://github.com/mattermost/platform/pull/7279) is merged, the final piece will be implementing the "API provider" to tie the backend plugins and `app` together. Then the fun begins! (Actually developing the backend plugins.)

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/PLT-7407

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates