### PR TITLE
Set charset for OAuth2 authorize page

### DIFF
--- a/api4/oauth.go
+++ b/api4/oauth.go
@@ -321,7 +321,7 @@ func authorizeOAuthPage(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	w.Header().Set("Content-Security-Policy", "frame-ancestors 'self'")
-	w.Header().Set("Content-Type", "text/html")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, max-age=31556926, public")
 
 	staticDir, _ := utils.FindDir(model.CLIENT_DIR)


### PR DESCRIPTION
#### Summary
Not having the charset set was causing me a JS unexpected token console error in dev mode. Not sure if this affects a prod client build but I'll be checking that soon.