### PR TITLE
PLT-7186: "No teams available to join" appears while joining another team

### DIFF
--- a/webapp/components/select_team/select_team.jsx
+++ b/webapp/components/select_team/select_team.jsx
@@ -133,7 +133,7 @@ export default class SelectTeam extends React.Component {
             </div>
         );
 
-        if (!this.state.loaded) {
+        if (!this.state.loaded || this.state.loadingTeamId !== '') {
             openContent = <LoadingScreen/>;
         }
 


### PR DESCRIPTION
#### Summary
Show loading message if a team has been selected, in addition to showing it while loading the list of available teams.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7186

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes