### PR TITLE
PLT-7206: Remove the "Delete Channel" option for private channels if you're the last channel member and policy setting restricts channel deletion

### DIFF
--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -680,8 +680,7 @@ export default class ChannelHeader extends React.Component {
                 );
             }
 
-            const canLeave = channel.type === Constants.PRIVATE_CHANNEL ? this.state.userCount > 1 : true;
-            if (!ChannelStore.isDefault(channel) && canLeave) {
+            if (!ChannelStore.isDefault(channel)) {
                 dropdownContents.push(
                     <li
                         key='divider-3'

--- a/webapp/components/navbar.jsx
+++ b/webapp/components/navbar.jsx
@@ -555,8 +555,7 @@ export default class Navbar extends React.Component {
                     );
                 }
 
-                const canLeave = channel.type === Constants.PRIVATE_CHANNEL ? this.state.userCount > 1 : true;
-                if (!ChannelStore.isDefault(channel) && canLeave) {
+                if (!ChannelStore.isDefault(channel)) {
                     leaveChannelOption = (
                         <li role='presentation'>
                             <a


### PR DESCRIPTION
#### Summary
Removed restriction that prevented last occupant of a channel from leaving. Any user can now leave any channel, except for the default Town Square channel

**NOTE:** This is the second PR for this ticket. The first one dealt with the ticket title, and the second one deals with @esethna's [comment](https://mattermost.atlassian.net/browse/PLT-7206?focusedCommentId=39569&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-39569) on that ticket.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7206

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes