### PR TITLE
[PLT-7472] Set to default value when specific config is missing

### DIFF
--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -91,7 +91,7 @@ func TestGetConfig(t *testing.T) {
 		if cfg.GitLabSettings.Secret != model.FAKE_SETTING && len(cfg.GitLabSettings.Secret) != 0 {
 			t.Fatal("did not sanitize properly")
 		}
-		if cfg.SqlSettings.DataSource != model.FAKE_SETTING {
+		if *cfg.SqlSettings.DataSource != model.FAKE_SETTING {
 			t.Fatal("did not sanitize properly")
 		}
 		if cfg.SqlSettings.AtRestEncryptKey != model.FAKE_SETTING {
@@ -114,7 +114,7 @@ func TestReloadConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+	*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 	*utils.Cfg.TeamSettings.EnableOpenServer = true
 }
 

--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -36,7 +36,7 @@ func SetupEnterprise() *TestHelper {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 		*utils.Cfg.RateLimitSettings.Enable = false
 		utils.DisableDebugLogForTest()
 		utils.License().Features.SetDefaults()
@@ -63,7 +63,7 @@ func Setup() *TestHelper {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 		*utils.Cfg.RateLimitSettings.Enable = false
 		utils.Cfg.EmailSettings.SendEmailNotifications = true
 		utils.Cfg.EmailSettings.SMTPServer = "dockerhost"
@@ -90,7 +90,7 @@ func Setup() *TestHelper {
 func ReloadConfigForSetup() {
 	utils.LoadConfig("config.json")
 	utils.InitTranslations(utils.Cfg.LocalizationSettings)
-	utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+	*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 	*utils.Cfg.RateLimitSettings.Enable = false
 	utils.Cfg.EmailSettings.SendEmailNotifications = true
 	utils.Cfg.EmailSettings.SMTPServer = "dockerhost"
@@ -133,11 +133,11 @@ func (me *TestHelper) InitSystemAdmin() *TestHelper {
 }
 
 func (me *TestHelper) CreateClient() *model.Client {
-	return model.NewClient("http://localhost" + utils.Cfg.ServiceSettings.ListenAddress)
+	return model.NewClient("http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress)
 }
 
 func (me *TestHelper) CreateWebSocketClient() (*model.WebSocketClient, *model.AppError) {
-	return model.NewWebSocketClient("ws://localhost"+utils.Cfg.ServiceSettings.ListenAddress, me.BasicClient.AuthToken)
+	return model.NewWebSocketClient("ws://localhost"+*utils.Cfg.ServiceSettings.ListenAddress, me.BasicClient.AuthToken)
 }
 
 func (me *TestHelper) CreateTeam(client *model.Client) *model.Team {

--- a/api/command_test.go
+++ b/api/command_test.go
@@ -242,7 +242,7 @@ func TestTestCommand(t *testing.T) {
 	*utils.Cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost"
 
 	cmd1 := &model.Command{
-		URL:     "http://localhost" + utils.Cfg.ServiceSettings.ListenAddress + model.API_URL_SUFFIX_V3 + "/teams/command_test",
+		URL:     "http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress + model.API_URL_SUFFIX_V3 + "/teams/command_test",
 		Method:  model.COMMAND_METHOD_POST,
 		Trigger: "testcommand",
 	}
@@ -262,7 +262,7 @@ func TestTestCommand(t *testing.T) {
 	}
 
 	cmd2 := &model.Command{
-		URL:     "http://localhost" + utils.Cfg.ServiceSettings.ListenAddress + model.API_URL_SUFFIX_V3 + "/teams/command_test",
+		URL:     "http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress + model.API_URL_SUFFIX_V3 + "/teams/command_test",
 		Method:  model.COMMAND_METHOD_GET,
 		Trigger: "test2",
 	}

--- a/api/emoji.go
+++ b/api/emoji.go
@@ -59,7 +59,7 @@ func createEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		c.Err = model.NewLocAppError("createEmoji", "api.emoji.storage.app_error", nil, "")
 		c.Err.StatusCode = http.StatusNotImplemented
 		return
@@ -137,7 +137,7 @@ func deleteEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		c.Err = model.NewLocAppError("deleteImage", "api.emoji.storage.app_error", nil, "")
 		c.Err.StatusCode = http.StatusNotImplemented
 		return
@@ -179,7 +179,7 @@ func getEmojiImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		c.Err = model.NewLocAppError("getEmojiImage", "api.emoji.storage.app_error", nil, "")
 		c.Err.StatusCode = http.StatusNotImplemented
 		return

--- a/api/file.go
+++ b/api/file.go
@@ -200,7 +200,7 @@ func getPublicFile(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getFileInfoForRequest(c *Context, r *http.Request, requireFileVisible bool) (*model.FileInfo, *model.AppError) {
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		return nil, model.NewAppError("getFileInfoForRequest", "api.file.get_info_for_request.storage.app_error", nil, "", http.StatusNotImplemented)
 	}
 
@@ -236,7 +236,7 @@ func getFileInfoForRequest(c *Context, r *http.Request, requireFileVisible bool)
 }
 
 func getPublicFileOld(c *Context, w http.ResponseWriter, r *http.Request) {
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		c.Err = model.NewLocAppError("getPublicFile", "api.file.get_public_file_old.storage.app_error", nil, "")
 		c.Err.StatusCode = http.StatusNotImplemented
 		return

--- a/api/file_test.go
+++ b/api/file_test.go
@@ -26,7 +26,7 @@ import (
 func TestUploadFile(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Logf("skipping because no file driver is enabled")
 		return
 	}
@@ -125,7 +125,7 @@ func TestUploadFile(t *testing.T) {
 func TestGetFileInfo(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -194,7 +194,7 @@ func TestGetFileInfo(t *testing.T) {
 func TestGetFile(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -276,7 +276,7 @@ func TestGetFile(t *testing.T) {
 func TestGetFileThumbnail(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -332,7 +332,7 @@ func TestGetFileThumbnail(t *testing.T) {
 func TestGetFilePreview(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -388,7 +388,7 @@ func TestGetFilePreview(t *testing.T) {
 func TestGetPublicFile(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -455,7 +455,7 @@ func TestGetPublicFile(t *testing.T) {
 func TestGetPublicFileOld(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -493,7 +493,7 @@ func TestGetPublicFileOld(t *testing.T) {
 	// reconstruct old style of link
 	siteURL := *utils.Cfg.ServiceSettings.SiteURL
 	if siteURL == "" {
-		siteURL = "http://localhost" + utils.Cfg.ServiceSettings.ListenAddress
+		siteURL = "http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress
 	}
 	link := generatePublicLinkOld(siteURL, th.BasicTeam.Id, channel.Id, th.BasicUser.Id, fileId+"/test.png")
 
@@ -539,7 +539,7 @@ func generatePublicLinkOld(siteURL, teamId, channelId, userId, filename string) 
 func TestGetPublicLink(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -608,7 +608,7 @@ func TestGetPublicLink(t *testing.T) {
 func TestMigrateFilenamesToFileInfos(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -720,7 +720,7 @@ func uploadFileOld(t *testing.T, data []byte, dest string, filename string) {
 func TestFindTeamIdForFilename(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -786,7 +786,7 @@ func TestFindTeamIdForFilename(t *testing.T) {
 func TestGetInfoForFilename(t *testing.T) {
 	th := Setup().InitBasic()
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -874,7 +874,7 @@ func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, regi
 }
 
 func cleanupTestFile(info *model.FileInfo) error {
-	if utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+	if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -901,7 +901,7 @@ func cleanupTestFile(info *model.FileInfo) error {
 				return err
 			}
 		}
-	} else if utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+	} else if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := os.Remove(utils.Cfg.FileSettings.Directory + info.Path); err != nil {
 			return err
 		}

--- a/api/user.go
+++ b/api/user.go
@@ -580,7 +580,7 @@ func getProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func uploadProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		c.Err = model.NewLocAppError("uploadProfileImage", "api.user.upload_profile_user.storage.app_error", nil, "")
 		c.Err.StatusCode = http.StatusNotImplemented
 		return

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -263,13 +263,13 @@ func TestPasswordGuessLockout(t *testing.T) {
 	Client.Must(Client.Logout())
 
 	enableSignInWithEmail := *utils.Cfg.EmailSettings.EnableSignInWithEmail
-	passwordAttempts := utils.Cfg.ServiceSettings.MaximumLoginAttempts
+	passwordAttempts := *utils.Cfg.ServiceSettings.MaximumLoginAttempts
 	defer func() {
 		*utils.Cfg.EmailSettings.EnableSignInWithEmail = enableSignInWithEmail
-		utils.Cfg.ServiceSettings.MaximumLoginAttempts = passwordAttempts
+		*utils.Cfg.ServiceSettings.MaximumLoginAttempts = passwordAttempts
 	}()
 	*utils.Cfg.EmailSettings.EnableSignInWithEmail = true
-	utils.Cfg.ServiceSettings.MaximumLoginAttempts = 2
+	*utils.Cfg.ServiceSettings.MaximumLoginAttempts = 2
 
 	// OK to log in
 	if _, err := Client.Login(user.Username, user.Password); err != nil {
@@ -689,7 +689,7 @@ func TestUserCreateImage(t *testing.T) {
 		}
 	}
 
-	if utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+	if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -726,7 +726,7 @@ func TestUserUploadProfileImage(t *testing.T) {
 	LinkUserToTeam(user, team)
 	store.Must(app.Srv.Store.User().VerifyEmail(user.Id))
 
-	if utils.Cfg.FileSettings.DriverName != "" {
+	if *utils.Cfg.FileSettings.DriverName != "" {
 
 		body := &bytes.Buffer{}
 		writer := multipart.NewWriter(body)
@@ -795,7 +795,7 @@ func TestUserUploadProfileImage(t *testing.T) {
 
 		Client.DoApiGet("/users/"+user.Id+"/image", "", "")
 
-		if utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+		if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 			endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
 			accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 			secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -934,11 +934,11 @@ func TestUserUpdatePassword(t *testing.T) {
 	}
 
 	// Test lockout
-	passwordAttempts := utils.Cfg.ServiceSettings.MaximumLoginAttempts
+	passwordAttempts := *utils.Cfg.ServiceSettings.MaximumLoginAttempts
 	defer func() {
-		utils.Cfg.ServiceSettings.MaximumLoginAttempts = passwordAttempts
+		*utils.Cfg.ServiceSettings.MaximumLoginAttempts = passwordAttempts
 	}()
-	utils.Cfg.ServiceSettings.MaximumLoginAttempts = 2
+	*utils.Cfg.ServiceSettings.MaximumLoginAttempts = 2
 
 	// Fail twice
 	if _, err := Client.UpdateUserPassword(user.Id, "badpwd", "newpwd"); err == nil {

--- a/api/websocket_test.go
+++ b/api/websocket_test.go
@@ -317,7 +317,7 @@ func TestCreateDirectChannelWithSocket(t *testing.T) {
 func TestWebsocketOriginSecurity(t *testing.T) {
 	Setup().InitBasic()
 
-	url := "ws://localhost" + utils.Cfg.ServiceSettings.ListenAddress
+	url := "ws://localhost" + *utils.Cfg.ServiceSettings.ListenAddress
 
 	// Should fail because origin doesn't match
 	_, _, err := websocket.DefaultDialer.Dial(url+model.API_URL_SUFFIX_V3+"/users/websocket", http.Header{
@@ -329,7 +329,7 @@ func TestWebsocketOriginSecurity(t *testing.T) {
 
 	// We are not a browser so we can spoof this just fine
 	_, _, err = websocket.DefaultDialer.Dial(url+model.API_URL_SUFFIX_V3+"/users/websocket", http.Header{
-		"Origin": []string{"http://localhost" + utils.Cfg.ServiceSettings.ListenAddress},
+		"Origin": []string{"http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -48,7 +48,7 @@ func SetupEnterprise() *TestHelper {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 		*utils.Cfg.RateLimitSettings.Enable = false
 		utils.Cfg.EmailSettings.SendEmailNotifications = true
 		utils.Cfg.EmailSettings.SMTPServer = "dockerhost"
@@ -85,7 +85,7 @@ func Setup() *TestHelper {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 		*utils.Cfg.RateLimitSettings.Enable = false
 		utils.Cfg.EmailSettings.SendEmailNotifications = true
 		utils.Cfg.EmailSettings.SMTPServer = "dockerhost"
@@ -212,11 +212,11 @@ func (me *TestHelper) InitSystemAdmin() *TestHelper {
 }
 
 func (me *TestHelper) CreateClient() *model.Client4 {
-	return model.NewAPIv4Client("http://localhost" + utils.Cfg.ServiceSettings.ListenAddress)
+	return model.NewAPIv4Client("http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress)
 }
 
 func (me *TestHelper) CreateWebSocketClient() (*model.WebSocketClient, *model.AppError) {
-	return model.NewWebSocketClient4("ws://localhost"+utils.Cfg.ServiceSettings.ListenAddress, me.Client.AuthToken)
+	return model.NewWebSocketClient4("ws://localhost"+*utils.Cfg.ServiceSettings.ListenAddress, me.Client.AuthToken)
 }
 
 func (me *TestHelper) CreateUser() *model.User {
@@ -658,7 +658,7 @@ func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, regi
 }
 
 func cleanupTestFile(info *model.FileInfo) error {
-	if utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+	if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -685,7 +685,7 @@ func cleanupTestFile(info *model.FileInfo) error {
 				return err
 			}
 		}
-	} else if utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+	} else if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := os.Remove(utils.Cfg.FileSettings.Directory + info.Path); err != nil {
 			return err
 		}

--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -399,7 +399,7 @@ func TestExecuteCommand(t *testing.T) {
 	postCmd := &model.Command{
 		CreatorId: th.BasicUser.Id,
 		TeamId:    th.BasicTeam.Id,
-		URL:       "http://localhost" + utils.Cfg.ServiceSettings.ListenAddress + model.API_URL_SUFFIX_V4 + "/teams/command_test",
+		URL:       "http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress + model.API_URL_SUFFIX_V4 + "/teams/command_test",
 		Method:    model.COMMAND_METHOD_POST,
 		Trigger:   "postcommand",
 	}
@@ -423,7 +423,7 @@ func TestExecuteCommand(t *testing.T) {
 	getCmd := &model.Command{
 		CreatorId: th.BasicUser.Id,
 		TeamId:    th.BasicTeam.Id,
-		URL:       "http://localhost" + utils.Cfg.ServiceSettings.ListenAddress + model.API_URL_SUFFIX_V4 + "/teams/command_test",
+		URL:       "http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress + model.API_URL_SUFFIX_V4 + "/teams/command_test",
 		Method:    model.COMMAND_METHOD_GET,
 		Trigger:   "getcommand",
 	}

--- a/api4/emoji.go
+++ b/api4/emoji.go
@@ -37,7 +37,7 @@ func createEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		c.Err = model.NewAppError("createEmoji", "api.emoji.storage.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}
@@ -147,7 +147,7 @@ func getEmojiImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		c.Err = model.NewAppError("getEmojiImage", "api.emoji.storage.app_error", nil, "", http.StatusNotImplemented)
 		return
 	}

--- a/api4/emoji_test.go
+++ b/api4/emoji_test.go
@@ -313,10 +313,10 @@ func TestGetEmojiImage(t *testing.T) {
 	Client := th.Client
 
 	EnableCustomEmoji := *utils.Cfg.ServiceSettings.EnableCustomEmoji
-	DriverName := utils.Cfg.FileSettings.DriverName
+	DriverName := *utils.Cfg.FileSettings.DriverName
 	defer func() {
 		*utils.Cfg.ServiceSettings.EnableCustomEmoji = EnableCustomEmoji
-		utils.Cfg.FileSettings.DriverName = DriverName
+		*utils.Cfg.FileSettings.DriverName = DriverName
 	}()
 	*utils.Cfg.ServiceSettings.EnableCustomEmoji = true
 
@@ -334,14 +334,14 @@ func TestGetEmojiImage(t *testing.T) {
 	CheckNotImplementedStatus(t, resp)
 	CheckErrorMessage(t, resp, "api.emoji.disabled.app_error")
 
-	utils.Cfg.FileSettings.DriverName = ""
+	*utils.Cfg.FileSettings.DriverName = ""
 	*utils.Cfg.ServiceSettings.EnableCustomEmoji = true
 
 	_, resp = Client.GetEmojiImage(emoji1.Id)
 	CheckNotImplementedStatus(t, resp)
 	CheckErrorMessage(t, resp, "api.emoji.storage.app_error")
 
-	utils.Cfg.FileSettings.DriverName = DriverName
+	*utils.Cfg.FileSettings.DriverName = DriverName
 
 	emojiImage, resp := Client.GetEmojiImage(emoji1.Id)
 	CheckNoError(t, resp)

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -124,7 +124,7 @@ func TestGetFile(t *testing.T) {
 	Client := th.Client
 	channel := th.BasicChannel
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -174,7 +174,7 @@ func TestGetFileHeaders(t *testing.T) {
 	Client := th.Client
 	channel := th.BasicChannel
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -238,7 +238,7 @@ func TestGetFileThumbnail(t *testing.T) {
 	Client := th.Client
 	channel := th.BasicChannel
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -290,7 +290,7 @@ func TestGetFileLink(t *testing.T) {
 	Client := th.Client
 	channel := th.BasicChannel
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -365,7 +365,7 @@ func TestGetFilePreview(t *testing.T) {
 	Client := th.Client
 	channel := th.BasicChannel
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -418,7 +418,7 @@ func TestGetFileInfo(t *testing.T) {
 	user := th.BasicUser
 	channel := th.BasicChannel
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
@@ -484,7 +484,7 @@ func TestGetPublicFile(t *testing.T) {
 	Client := th.Client
 	channel := th.BasicChannel
 
-	if utils.Cfg.FileSettings.DriverName == "" {
+	if *utils.Cfg.FileSettings.DriverName == "" {
 		t.Skip("skipping because no file driver is enabled")
 	}
 

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -68,7 +68,7 @@ func TestGetConfig(t *testing.T) {
 	if cfg.GitLabSettings.Secret != model.FAKE_SETTING && len(cfg.GitLabSettings.Secret) != 0 {
 		t.Fatal("did not sanitize properly")
 	}
-	if cfg.SqlSettings.DataSource != model.FAKE_SETTING {
+	if *cfg.SqlSettings.DataSource != model.FAKE_SETTING {
 		t.Fatal("did not sanitize properly")
 	}
 	if cfg.SqlSettings.AtRestEncryptKey != model.FAKE_SETTING {
@@ -99,7 +99,7 @@ func TestReloadConfig(t *testing.T) {
 		t.Fatal("should Reload the config")
 	}
 
-	utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+	*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 	*utils.Cfg.TeamSettings.EnableOpenServer = true
 }
 

--- a/api4/user.go
+++ b/api4/user.go
@@ -233,7 +233,7 @@ func setProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		c.Err = model.NewLocAppError("uploadProfileImage", "api.user.upload_profile_user.storage.app_error", nil, "")
 		c.Err.StatusCode = http.StatusNotImplemented
 		return

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1672,11 +1672,11 @@ func TestUpdateUserPassword(t *testing.T) {
 	th.LoginBasic()
 
 	// Test lockout
-	passwordAttempts := utils.Cfg.ServiceSettings.MaximumLoginAttempts
+	passwordAttempts := *utils.Cfg.ServiceSettings.MaximumLoginAttempts
 	defer func() {
-		utils.Cfg.ServiceSettings.MaximumLoginAttempts = passwordAttempts
+		*utils.Cfg.ServiceSettings.MaximumLoginAttempts = passwordAttempts
 	}()
-	utils.Cfg.ServiceSettings.MaximumLoginAttempts = 2
+	*utils.Cfg.ServiceSettings.MaximumLoginAttempts = 2
 
 	// Fail twice
 	_, resp = Client.UpdateUserPassword(th.BasicUser.Id, "badpwd", "newpwd")

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -25,7 +25,7 @@ func SetupEnterprise() *TestHelper {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 		*utils.Cfg.RateLimitSettings.Enable = false
 		utils.DisableDebugLogForTest()
 		utils.License().Features.SetDefaults()
@@ -47,7 +47,7 @@ func Setup() *TestHelper {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
 		*utils.Cfg.RateLimitSettings.Enable = false
 		utils.DisableDebugLogForTest()
 		NewServer()

--- a/app/authentication.go
+++ b/app/authentication.go
@@ -121,7 +121,7 @@ func CheckUserMfa(user *model.User, token string) *model.AppError {
 }
 
 func checkUserLoginAttempts(user *model.User) *model.AppError {
-	if user.FailedAttempts >= utils.Cfg.ServiceSettings.MaximumLoginAttempts {
+	if user.FailedAttempts >= *utils.Cfg.ServiceSettings.MaximumLoginAttempts {
 		return model.NewAppError("checkUserLoginAttempts", "api.user.check_user_login_attempts.too_many.app_error", nil, "user_id="+user.Id, http.StatusUnauthorized)
 	}
 

--- a/app/brand.go
+++ b/app/brand.go
@@ -13,7 +13,7 @@ import (
 )
 
 func SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		return model.NewAppError("SaveBrandImage", "api.admin.upload_brand_image.storage.app_error", nil, "", http.StatusNotImplemented)
 	}
 
@@ -30,7 +30,7 @@ func SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
 }
 
 func GetBrandImage() ([]byte, *model.AppError) {
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		return nil, model.NewAppError("GetBrandImage", "api.admin.get_brand_image.storage.app_error", nil, "", http.StatusNotImplemented)
 	}
 

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -197,7 +197,7 @@ func trackConfig() {
 		"connection_security":                              *utils.Cfg.ServiceSettings.ConnectionSecurity,
 		"uses_letsencrypt":                                 *utils.Cfg.ServiceSettings.UseLetsEncrypt,
 		"forward_80_to_443":                                *utils.Cfg.ServiceSettings.Forward80To443,
-		"maximum_login_attempts":                           utils.Cfg.ServiceSettings.MaximumLoginAttempts,
+		"maximum_login_attempts":                           *utils.Cfg.ServiceSettings.MaximumLoginAttempts,
 		"session_length_web_in_days":                       *utils.Cfg.ServiceSettings.SessionLengthWebInDays,
 		"session_length_mobile_in_days":                    *utils.Cfg.ServiceSettings.SessionLengthMobileInDays,
 		"session_length_sso_in_days":                       *utils.Cfg.ServiceSettings.SessionLengthSSOInDays,
@@ -235,7 +235,7 @@ func trackConfig() {
 		"enable_custom_brand":                     *utils.Cfg.TeamSettings.EnableCustomBrand,
 		"restrict_direct_message":                 *utils.Cfg.TeamSettings.RestrictDirectMessage,
 		"max_notifications_per_channel":           *utils.Cfg.TeamSettings.MaxNotificationsPerChannel,
-		"max_users_per_team":                      utils.Cfg.TeamSettings.MaxUsersPerTeam,
+		"max_users_per_team":                      *utils.Cfg.TeamSettings.MaxUsersPerTeam,
 		"max_channels_per_team":                   *utils.Cfg.TeamSettings.MaxChannelsPerTeam,
 		"teammate_name_display":                   *utils.Cfg.TeamSettings.TeammateNameDisplay,
 		"isdefault_site_name":                     isDefault(utils.Cfg.TeamSettings.SiteName, "Mattermost"),
@@ -255,10 +255,10 @@ func trackConfig() {
 	})
 
 	SendDiagnostic(TRACK_CONFIG_SQL, map[string]interface{}{
-		"driver_name":                 utils.Cfg.SqlSettings.DriverName,
+		"driver_name":                 *utils.Cfg.SqlSettings.DriverName,
 		"trace":                       utils.Cfg.SqlSettings.Trace,
-		"max_idle_conns":              utils.Cfg.SqlSettings.MaxIdleConns,
-		"max_open_conns":              utils.Cfg.SqlSettings.MaxOpenConns,
+		"max_idle_conns":              *utils.Cfg.SqlSettings.MaxIdleConns,
+		"max_open_conns":              *utils.Cfg.SqlSettings.MaxOpenConns,
 		"data_source_replicas":        len(utils.Cfg.SqlSettings.DataSourceReplicas),
 		"data_source_search_replicas": len(utils.Cfg.SqlSettings.DataSourceSearchReplicas),
 		"query_timeout":               *utils.Cfg.SqlSettings.QueryTimeout,
@@ -284,7 +284,7 @@ func trackConfig() {
 
 	SendDiagnostic(TRACK_CONFIG_FILE, map[string]interface{}{
 		"enable_public_links":     utils.Cfg.FileSettings.EnablePublicLink,
-		"driver_name":             utils.Cfg.FileSettings.DriverName,
+		"driver_name":             *utils.Cfg.FileSettings.DriverName,
 		"amazon_s3_ssl":           *utils.Cfg.FileSettings.AmazonS3SSL,
 		"amazon_s3_sse":           *utils.Cfg.FileSettings.AmazonS3SSE,
 		"amazon_s3_signv2":        *utils.Cfg.FileSettings.AmazonS3SignV2,
@@ -313,9 +313,9 @@ func trackConfig() {
 	SendDiagnostic(TRACK_CONFIG_RATE, map[string]interface{}{
 		"enable_rate_limiter":      *utils.Cfg.RateLimitSettings.Enable,
 		"vary_by_remote_address":   utils.Cfg.RateLimitSettings.VaryByRemoteAddr,
-		"per_sec":                  utils.Cfg.RateLimitSettings.PerSec,
+		"per_sec":                  *utils.Cfg.RateLimitSettings.PerSec,
 		"max_burst":                *utils.Cfg.RateLimitSettings.MaxBurst,
-		"memory_store_size":        utils.Cfg.RateLimitSettings.MemoryStoreSize,
+		"memory_store_size":        *utils.Cfg.RateLimitSettings.MemoryStoreSize,
 		"isdefault_vary_by_header": isDefault(utils.Cfg.RateLimitSettings.VaryByHeader, ""),
 	})
 
@@ -456,7 +456,7 @@ func trackServer() {
 	data := map[string]interface{}{
 		"edition":          model.BuildEnterpriseReady,
 		"version":          model.CurrentVersion,
-		"database_type":    utils.Cfg.SqlSettings.DriverName,
+		"database_type":    *utils.Cfg.SqlSettings.DriverName,
 		"operating_system": runtime.GOOS,
 	}
 

--- a/app/emoji.go
+++ b/app/emoji.go
@@ -142,7 +142,7 @@ func GetEmoji(emojiId string) (*model.Emoji, *model.AppError) {
 		return nil, model.NewAppError("deleteEmoji", "api.emoji.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		return nil, model.NewAppError("deleteImage", "api.emoji.storage.app_error", nil, "", http.StatusNotImplemented)
 	}
 

--- a/app/file.go
+++ b/app/file.go
@@ -244,7 +244,7 @@ func GeneratePublicLinkHash(fileId, salt string) string {
 }
 
 func UploadFiles(teamId string, channelId string, userId string, fileHeaders []*multipart.FileHeader, clientIds []string) (*model.FileUploadResponse, *model.AppError) {
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		return nil, model.NewAppError("uploadFile", "api.file.upload_file.storage.app_error", nil, "", http.StatusNotImplemented)
 	}
 

--- a/app/security_update_check.go
+++ b/app/security_update_check.go
@@ -45,7 +45,7 @@ func DoSecurityUpdateCheck() {
 				v.Set(PROP_SECURITY_ID, utils.CfgDiagnosticId)
 				v.Set(PROP_SECURITY_BUILD, model.CurrentVersion+"."+model.BuildNumber)
 				v.Set(PROP_SECURITY_ENTERPRISE_READY, model.BuildEnterpriseReady)
-				v.Set(PROP_SECURITY_DATABASE, utils.Cfg.SqlSettings.DriverName)
+				v.Set(PROP_SECURITY_DATABASE, *utils.Cfg.SqlSettings.DriverName)
 				v.Set(PROP_SECURITY_OS, runtime.GOOS)
 
 				if len(props[model.SYSTEM_RAN_UNIT_TESTS]) > 0 {

--- a/app/server.go
+++ b/app/server.go
@@ -133,14 +133,14 @@ func StartServer() {
 	if *utils.Cfg.RateLimitSettings.Enable {
 		l4g.Info(utils.T("api.server.start_server.rate.info"))
 
-		store, err := memstore.New(utils.Cfg.RateLimitSettings.MemoryStoreSize)
+		store, err := memstore.New(*utils.Cfg.RateLimitSettings.MemoryStoreSize)
 		if err != nil {
 			l4g.Critical(utils.T("api.server.start_server.rate_limiting_memory_store"))
 			return
 		}
 
 		quota := throttled.RateQuota{
-			MaxRate:  throttled.PerSec(utils.Cfg.RateLimitSettings.PerSec),
+			MaxRate:  throttled.PerSec(*utils.Cfg.RateLimitSettings.PerSec),
 			MaxBurst: *utils.Cfg.RateLimitSettings.MaxBurst,
 		}
 
@@ -165,13 +165,13 @@ func StartServer() {
 	Srv.GracefulServer = &graceful.Server{
 		Timeout: TIME_TO_WAIT_FOR_CONNECTIONS_TO_CLOSE_ON_SERVER_SHUTDOWN,
 		Server: &http.Server{
-			Addr:         utils.Cfg.ServiceSettings.ListenAddress,
+			Addr:         *utils.Cfg.ServiceSettings.ListenAddress,
 			Handler:      handlers.RecoveryHandler(handlers.RecoveryLogger(&RecoveryLogger{}), handlers.PrintRecoveryStack(true))(handler),
 			ReadTimeout:  time.Duration(*utils.Cfg.ServiceSettings.ReadTimeout) * time.Second,
 			WriteTimeout: time.Duration(*utils.Cfg.ServiceSettings.WriteTimeout) * time.Second,
 		},
 	}
-	l4g.Info(utils.T("api.server.start_server.listening.info"), utils.Cfg.ServiceSettings.ListenAddress)
+	l4g.Info(utils.T("api.server.start_server.listening.info"), *utils.Cfg.ServiceSettings.ListenAddress)
 
 	if *utils.Cfg.ServiceSettings.Forward80To443 {
 		go func() {

--- a/app/user.go
+++ b/app/user.go
@@ -750,7 +750,7 @@ func GetProfileImage(user *model.User) ([]byte, bool, *model.AppError) {
 	var img []byte
 	readFailed := false
 
-	if len(utils.Cfg.FileSettings.DriverName) == 0 {
+	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		var err *model.AppError
 		if img, err = CreateProfileImage(user.Username, user.Id); err != nil {
 			return nil, false, err

--- a/manualtesting/manual_testing.go
+++ b/manualtesting/manual_testing.go
@@ -55,7 +55,7 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a client for tests to use
-	client := model.NewClient("http://localhost" + utils.Cfg.ServiceSettings.ListenAddress)
+	client := model.NewClient("http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress)
 
 	// Check for username parameter and create a user if present
 	username, ok1 := params["username"]

--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -1305,7 +1305,7 @@ func (s SqlChannelStore) UpdateLastViewedAt(channelIds []string, userId string) 
 			idQuery += "ChannelId = :channelId" + strconv.Itoa(index)
 		}
 
-		if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 			query = `UPDATE
 				ChannelMembers
 			SET
@@ -1319,7 +1319,7 @@ func (s SqlChannelStore) UpdateLastViewedAt(channelIds []string, userId string) 
 			    Channels.Id = ChannelMembers.ChannelId
 			        AND UserId = :UserId
 			        AND (` + idQuery + `)`
-		} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+		} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 			query = `UPDATE
 				ChannelMembers, Channels
 			SET
@@ -1597,7 +1597,7 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 
 	if term == "" {
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
-	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 		splitTerm := strings.Fields(term)
 		for i, t := range strings.Fields(term) {
 			if i == len(splitTerm)-1 {
@@ -1611,7 +1611,7 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 
 		searchClause := fmt.Sprintf("AND (%s) @@  to_tsquery('simple', :Term)", "Name || ' ' || DisplayName")
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
-	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 		splitTerm := strings.Fields(term)
 		for i, t := range strings.Fields(term) {
 			splitTerm[i] = "+" + t + "*"

--- a/store/sql_oauth_store.go
+++ b/store/sql_oauth_store.go
@@ -529,9 +529,9 @@ func (as SqlOAuthStore) deleteOAuthAppSessions(transaction *gorp.Transaction, cl
 	result := StoreResult{}
 
 	query := ""
-	if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+	if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 		query = "DELETE FROM Sessions s USING OAuthAccessData o WHERE o.Token = s.Token AND o.ClientId = :Id"
-	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 		query = "DELETE s.* FROM Sessions s INNER JOIN OAuthAccessData o ON o.Token = s.Token WHERE o.ClientId = :Id"
 	}
 

--- a/store/sql_post_store.go
+++ b/store/sql_post_store.go
@@ -1033,7 +1033,7 @@ func (s SqlPostStore) Search(teamId string, userId string, params *model.SearchP
 		if terms == "" {
 			// we've already confirmed that we have a channel or user to search for
 			searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
-		} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 			// Parse text for wildcards
 			if wildcard, err := regexp.Compile("\\*($| )"); err == nil {
 				terms = wildcard.ReplaceAllLiteralString(terms, ":* ")
@@ -1047,7 +1047,7 @@ func (s SqlPostStore) Search(teamId string, userId string, params *model.SearchP
 
 			searchClause := fmt.Sprintf("AND %s @@  to_tsquery(:Terms)", searchType)
 			searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
-		} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+		} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 			searchClause := fmt.Sprintf("AND MATCH (%s) AGAINST (:Terms IN BOOLEAN MODE)", searchType)
 			searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
 
@@ -1121,7 +1121,7 @@ func (s SqlPostStore) AnalyticsUserCountsWithPostsByDay(teamId string) StoreChan
 			ORDER BY Name DESC
 			LIMIT 30`
 
-		if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 			query =
 				`SELECT
 					TO_CHAR(DATE(TO_TIMESTAMP(Posts.CreateAt / 1000)), 'YYYY-MM-DD') AS Name, COUNT(DISTINCT Posts.UserId) AS Value
@@ -1184,7 +1184,7 @@ func (s SqlPostStore) AnalyticsPostCountsByDay(teamId string) StoreChannel {
 			ORDER BY Name DESC
 			LIMIT 30`
 
-		if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 			query =
 				`SELECT
 					TO_CHAR(DATE(TO_TIMESTAMP(Posts.CreateAt / 1000)), 'YYYY-MM-DD') AS Name, Count(Posts.Id) AS Value

--- a/store/sql_preference_store.go
+++ b/store/sql_preference_store.go
@@ -110,7 +110,7 @@ func (s SqlPreferenceStore) save(transaction *gorp.Transaction, preference *mode
 		"Value":    preference.Value,
 	}
 
-	if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+	if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 		if _, err := transaction.Exec(
 			`INSERT INTO
 				Preferences
@@ -121,7 +121,7 @@ func (s SqlPreferenceStore) save(transaction *gorp.Transaction, preference *mode
 				Value = :Value`, params); err != nil {
 			result.Err = model.NewLocAppError("SqlPreferenceStore.save", "store.sql_preference.save.updating.app_error", nil, err.Error())
 		}
-	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 		// postgres has no way to upsert values until version 9.5 and trying inserting and then updating causes transactions to abort
 		count, err := transaction.SelectInt(
 			`SELECT

--- a/store/sql_team_store.go
+++ b/store/sql_team_store.go
@@ -385,7 +385,7 @@ func (s SqlTeamStore) GetAllTeamListing() StoreChannel {
 
 		query := "SELECT * FROM Teams WHERE AllowOpenInvite = 1"
 
-		if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 			query = "SELECT * FROM Teams WHERE AllowOpenInvite = true"
 		}
 
@@ -417,7 +417,7 @@ func (s SqlTeamStore) GetAllTeamPageListing(offset int, limit int) StoreChannel 
 
 		query := "SELECT * FROM Teams WHERE AllowOpenInvite = 1 LIMIT :Limit OFFSET :Offset"
 
-		if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 			query = "SELECT * FROM Teams WHERE AllowOpenInvite = true LIMIT :Limit OFFSET :Offset"
 		}
 
@@ -506,7 +506,7 @@ func (s SqlTeamStore) SaveMember(member *model.TeamMember) StoreChannel {
 			storeChannel <- result
 			close(storeChannel)
 			return
-		} else if int(count) >= utils.Cfg.TeamSettings.MaxUsersPerTeam {
+		} else if int(count) >= *utils.Cfg.TeamSettings.MaxUsersPerTeam {
 			result.Err = model.NewLocAppError("SqlUserStore.Save", "store.sql_user.save.max_accounts.app_error", nil, "teamId="+member.TeamId)
 			storeChannel <- result
 			close(storeChannel)

--- a/store/sql_team_store_test.go
+++ b/store/sql_team_store_test.go
@@ -690,11 +690,11 @@ func TestTeamMembers(t *testing.T) {
 func TestSaveTeamMemberMaxMembers(t *testing.T) {
 	Setup()
 
-	MaxUsersPerTeam := utils.Cfg.TeamSettings.MaxUsersPerTeam
+	MaxUsersPerTeam := *utils.Cfg.TeamSettings.MaxUsersPerTeam
 	defer func() {
-		utils.Cfg.TeamSettings.MaxUsersPerTeam = MaxUsersPerTeam
+		*utils.Cfg.TeamSettings.MaxUsersPerTeam = MaxUsersPerTeam
 	}()
-	utils.Cfg.TeamSettings.MaxUsersPerTeam = 5
+	*utils.Cfg.TeamSettings.MaxUsersPerTeam = 5
 
 	team := Must(store.Team().Save(&model.Team{
 		DisplayName: "DisplayName",
@@ -705,9 +705,9 @@ func TestSaveTeamMemberMaxMembers(t *testing.T) {
 		<-store.Team().PermanentDelete(team.Id)
 	}()
 
-	userIds := make([]string, utils.Cfg.TeamSettings.MaxUsersPerTeam)
+	userIds := make([]string, *utils.Cfg.TeamSettings.MaxUsersPerTeam)
 
-	for i := 0; i < utils.Cfg.TeamSettings.MaxUsersPerTeam; i++ {
+	for i := 0; i < *utils.Cfg.TeamSettings.MaxUsersPerTeam; i++ {
 		userIds[i] = Must(store.User().Save(&model.User{
 			Username: model.NewId(),
 			Email:    model.NewId(),
@@ -729,7 +729,7 @@ func TestSaveTeamMemberMaxMembers(t *testing.T) {
 
 	if result := <-store.Team().GetTotalMemberCount(team.Id); result.Err != nil {
 		t.Fatal(result.Err)
-	} else if count := result.Data.(int64); int(count) != utils.Cfg.TeamSettings.MaxUsersPerTeam {
+	} else if count := result.Data.(int64); int(count) != *utils.Cfg.TeamSettings.MaxUsersPerTeam {
 		t.Fatalf("should start with 5 team members, had %v instead", count)
 	}
 
@@ -750,7 +750,7 @@ func TestSaveTeamMemberMaxMembers(t *testing.T) {
 
 	if result := <-store.Team().GetTotalMemberCount(team.Id); result.Err != nil {
 		t.Fatal(result.Err)
-	} else if count := result.Data.(int64); int(count) != utils.Cfg.TeamSettings.MaxUsersPerTeam {
+	} else if count := result.Data.(int64); int(count) != *utils.Cfg.TeamSettings.MaxUsersPerTeam {
 		t.Fatalf("should still have 5 team members, had %v instead", count)
 	}
 
@@ -763,7 +763,7 @@ func TestSaveTeamMemberMaxMembers(t *testing.T) {
 
 	if result := <-store.Team().GetTotalMemberCount(team.Id); result.Err != nil {
 		t.Fatal(result.Err)
-	} else if count := result.Data.(int64); int(count) != utils.Cfg.TeamSettings.MaxUsersPerTeam-1 {
+	} else if count := result.Data.(int64); int(count) != *utils.Cfg.TeamSettings.MaxUsersPerTeam-1 {
 		t.Fatalf("should now only have 4 team members, had %v instead", count)
 	}
 
@@ -777,7 +777,7 @@ func TestSaveTeamMemberMaxMembers(t *testing.T) {
 
 	if result := <-store.Team().GetTotalMemberCount(team.Id); result.Err != nil {
 		t.Fatal(result.Err)
-	} else if count := result.Data.(int64); int(count) != utils.Cfg.TeamSettings.MaxUsersPerTeam {
+	} else if count := result.Data.(int64); int(count) != *utils.Cfg.TeamSettings.MaxUsersPerTeam {
 		t.Fatalf("should have 5 team members again, had %v instead", count)
 	}
 

--- a/store/sql_upgrade.go
+++ b/store/sql_upgrade.go
@@ -131,11 +131,11 @@ func UpgradeDatabaseToVersion33(sqlStore SqlStore) {
 			}
 
 			// increase size of Value column of Preferences table to match the size of the ThemeProps column
-			if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+			if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 				if _, err := transaction.Exec("ALTER TABLE Preferences ALTER COLUMN Value TYPE varchar(2000)"); err != nil {
 					themeMigrationFailed(err)
 				}
-			} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+			} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 				if _, err := transaction.Exec("ALTER TABLE Preferences MODIFY Value text"); err != nil {
 					themeMigrationFailed(err)
 				}

--- a/store/sql_user_access_token_store.go
+++ b/store/sql_user_access_token_store.go
@@ -101,9 +101,9 @@ func (s SqlUserAccessTokenStore) deleteSessionsAndTokensById(transaction *gorp.T
 	result := StoreResult{}
 
 	query := ""
-	if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+	if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 		query = "DELETE FROM Sessions s USING UserAccessTokens o WHERE o.Token = s.Token AND o.Id = :Id"
-	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 		query = "DELETE s.* FROM Sessions s INNER JOIN UserAccessTokens o ON o.Token = s.Token WHERE o.Id = :Id"
 	}
 
@@ -163,9 +163,9 @@ func (s SqlUserAccessTokenStore) deleteSessionsandTokensByUser(transaction *gorp
 	result := StoreResult{}
 
 	query := ""
-	if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+	if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 		query = "DELETE FROM Sessions s USING UserAccessTokens o WHERE o.Token = s.Token AND o.UserId = :UserId"
-	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 		query = "DELETE s.* FROM Sessions s INNER JOIN UserAccessTokens o ON o.Token = s.Token WHERE o.UserId = :UserId"
 	}
 

--- a/store/sql_user_store.go
+++ b/store/sql_user_store.go
@@ -1431,9 +1431,9 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 	originalTerm := term
 	postgresUseOriginalTerm := false
 	if strings.Contains(term, "@") && strings.Contains(term, ".") {
-		if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 			postgresUseOriginalTerm = true
-		} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+		} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 			lastIndex := strings.LastIndex(term, ".")
 			term = term[0:lastIndex]
 		}
@@ -1461,7 +1461,7 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 
 	if term == "" {
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
-	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
 		if postgresUseOriginalTerm {
 			term = originalTerm
 			// these chars will break the query and must be removed
@@ -1484,7 +1484,7 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 		searchType = convertMySQLFullTextColumnsToPostgres(searchType)
 		searchClause := fmt.Sprintf("AND (%s) @@  to_tsquery('simple', :Term)", searchType)
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
-	} else if utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
 		splitTerm := strings.Fields(term)
 		for i, t := range strings.Fields(term) {
 			splitTerm[i] = "+" + t + "*"

--- a/utils/config.go
+++ b/utils/config.go
@@ -20,9 +20,10 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
 
+	"net/http"
+
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/model"
-	"net/http"
 )
 
 const (
@@ -376,7 +377,7 @@ func LoadConfig(fileName string) {
 
 	configureLog(&config.LogSettings)
 
-	if config.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+	if *config.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		dir := config.FileSettings.Directory
 		if len(dir) > 0 && dir[len(dir)-1:] != "/" {
 			config.FileSettings.Directory += "/"
@@ -491,7 +492,7 @@ func getClientConfig(c *model.Config) map[string]string {
 
 	props["DefaultClientLocale"] = *c.LocalizationSettings.DefaultClientLocale
 	props["AvailableLocales"] = *c.LocalizationSettings.AvailableLocales
-	props["SQLDriverName"] = c.SqlSettings.DriverName
+	props["SQLDriverName"] = *c.SqlSettings.DriverName
 
 	props["EnableCustomEmoji"] = strconv.FormatBool(*c.ServiceSettings.EnableCustomEmoji)
 	props["EnableEmojiPicker"] = strconv.FormatBool(*c.ServiceSettings.EnableEmojiPicker)
@@ -657,8 +658,8 @@ func Desanitize(cfg *model.Config) {
 		cfg.GitLabSettings.Secret = Cfg.GitLabSettings.Secret
 	}
 
-	if cfg.SqlSettings.DataSource == model.FAKE_SETTING {
-		cfg.SqlSettings.DataSource = Cfg.SqlSettings.DataSource
+	if *cfg.SqlSettings.DataSource == model.FAKE_SETTING {
+		*cfg.SqlSettings.DataSource = *Cfg.SqlSettings.DataSource
 	}
 	if cfg.SqlSettings.AtRestEncryptKey == model.FAKE_SETTING {
 		cfg.SqlSettings.AtRestEncryptKey = Cfg.SqlSettings.AtRestEncryptKey

--- a/utils/file.go
+++ b/utils/file.go
@@ -37,7 +37,7 @@ func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, regi
 }
 
 func TestFileConnection() *model.AppError {
-	if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		endpoint := Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -65,7 +65,7 @@ func TestFileConnection() *model.AppError {
 			}
 		}
 		l4g.Info("Connection to S3 or minio is good. Bucket exists.")
-	} else if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		f := []byte("testingwrite")
 		if err := writeFileLocally(f, Cfg.FileSettings.Directory+TEST_FILE_PATH); err != nil {
 			return model.NewAppError("TestFileConnection", "Don't have permissions to write to local path specified or other error.", nil, err.Error(), http.StatusInternalServerError)
@@ -80,7 +80,7 @@ func TestFileConnection() *model.AppError {
 }
 
 func ReadFile(path string) ([]byte, *model.AppError) {
-	if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		endpoint := Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -102,7 +102,7 @@ func ReadFile(path string) ([]byte, *model.AppError) {
 		} else {
 			return f, nil
 		}
-	} else if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if f, err := ioutil.ReadFile(Cfg.FileSettings.Directory + path); err != nil {
 			return nil, model.NewLocAppError("ReadFile", "api.file.read_file.reading_local.app_error", nil, err.Error())
 		} else {
@@ -114,7 +114,7 @@ func ReadFile(path string) ([]byte, *model.AppError) {
 }
 
 func MoveFile(oldPath, newPath string) *model.AppError {
-	if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		endpoint := Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -142,7 +142,7 @@ func MoveFile(oldPath, newPath string) *model.AppError {
 		if err = s3Clnt.RemoveObject(bucket, oldPath); err != nil {
 			return model.NewLocAppError("moveFile", "api.file.move_file.delete_from_s3.app_error", nil, err.Error())
 		}
-	} else if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := os.MkdirAll(filepath.Dir(Cfg.FileSettings.Directory+newPath), 0774); err != nil {
 			return model.NewLocAppError("moveFile", "api.file.move_file.rename.app_error", nil, err.Error())
 		}
@@ -158,7 +158,7 @@ func MoveFile(oldPath, newPath string) *model.AppError {
 }
 
 func WriteFile(f []byte, path string) *model.AppError {
-	if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		endpoint := Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -186,7 +186,7 @@ func WriteFile(f []byte, path string) *model.AppError {
 		if err != nil {
 			return model.NewLocAppError("WriteFile", "api.file.write_file.s3.app_error", nil, err.Error())
 		}
-	} else if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := writeFileLocally(f, Cfg.FileSettings.Directory+path); err != nil {
 			return err
 		}
@@ -211,7 +211,7 @@ func writeFileLocally(f []byte, path string) *model.AppError {
 }
 
 func RemoveFile(path string) *model.AppError {
-	if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		endpoint := Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -228,7 +228,7 @@ func RemoveFile(path string) *model.AppError {
 		if err := s3Clnt.RemoveObject(bucket, path); err != nil {
 			return model.NewLocAppError("RemoveFile", "utils.file.remove_file.s3.app_error", nil, err.Error())
 		}
-	} else if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := os.Remove(Cfg.FileSettings.Directory + path); err != nil {
 			return model.NewLocAppError("RemoveFile", "utils.file.remove_file.local.app_error", nil, err.Error())
 		}
@@ -260,7 +260,7 @@ func getPathsFromObjectInfos(in <-chan s3.ObjectInfo) <-chan string {
 }
 
 func RemoveDirectory(path string) *model.AppError {
-	if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		endpoint := Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
@@ -284,7 +284,7 @@ func RemoveDirectory(path string) *model.AppError {
 		}
 
 		close(doneCh)
-	} else if Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
+	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := os.RemoveAll(Cfg.FileSettings.Directory + path); err != nil {
 			return model.NewLocAppError("RemoveDirectory", "utils.file.remove_directory.local.app_error", nil, err.Error())
 		}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -30,7 +30,7 @@ func Setup() {
 		api4.InitApi(false)
 		api.InitApi()
 		InitWeb()
-		URL = "http://localhost" + utils.Cfg.ServiceSettings.ListenAddress
+		URL = "http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress
 		ApiClient = model.NewClient(URL)
 
 		app.Srv.Store.MarkSystemRanUnitTests()


### PR DESCRIPTION
#### Summary
Set to default value with config is missing
- started fixing required default value with `default.json` set to empty: `{}`
- address the following
  - ServiceSettings
    - ListenAddress - fixed
    - MaximumLoginAttempts - fixed
  - TeamSettings
    - MaxUsersPerTeam - fixed
    - EnableUserCreation - no need to fix (default to false when missing, no panic, as a result no user could be created to a MM instance which is fine)
  - SqlSettings
    - MaxIdleConns - fixed
    - MaxOpenConns - fixed
    - DriverName - added to fix
    - DataSource - added to fix
  - FileSettings
    - DriverName - fixed
    - PublicLinkSalt (Theoretically, this should be used only if EnablePublicLink (whose default value is `false`) is set to true. - no need to fix, assigning a public salt is fine 
  - RateLimitSettings
    - PerSec - fixed
    - MemoryStoreSize - fixed

#### Ticket Link
Jira ticket: [PLT-7472](https://mattermost.atlassian.net/browse/PLT-7472)

#### Checklist
- [x] Touches critical sections of the codebase (config)
