### PR TITLE
PLT-3540: only highlight relevant fields on ldap/email switch error

### DIFF
--- a/webapp/components/claim/components/email_to_ldap.jsx
+++ b/webapp/components/claim/components/email_to_ldap.jsx
@@ -93,7 +93,21 @@ export default class EmailToLDAP extends React.Component {
                 }
             },
             (err) => {
-                this.setState({serverError: err.message, showMfa: false});
+                switch (err.id) {
+                case 'ent.ldap.do_login.user_not_registered.app_error':
+                case 'ent.ldap.do_login.user_filtered.app_error':
+                case 'ent.ldap.do_login.matched_to_many_users.app_error':
+                    this.setState({ldapError: err.message, showMfa: false});
+                    break;
+                case 'ent.ldap.do_login.invalid_password.app_error':
+                    this.setState({ldapPasswordError: err.message, showMfa: false});
+                    break;
+                case 'api.user.check_user_password.invalid.app_error':
+                    this.setState({passwordError: err.message, showMfa: false});
+                    break;
+                default:
+                    this.setState({serverError: err.message, showMfa: false});
+                }
             }
         );
     }

--- a/webapp/components/claim/components/ldap_to_email.jsx
+++ b/webapp/components/claim/components/ldap_to_email.jsx
@@ -92,7 +92,19 @@ export default class LDAPToEmail extends React.Component {
             token,
             ldapPassword || this.state.ldapPassword,
             null,
-            (err) => this.setState({serverError: err.message, showMfa: false})
+            (err) => {
+                if (err.id.startsWith('model.user.is_valid.pwd')) {
+                    this.setState({passwordError: err.message, showMfa: false});
+                } else {
+                    switch (err.id) {
+                    case 'ent.ldap.do_login.invalid_password.app_error':
+                        this.setState({ldapPasswordError: err.message, showMfa: false});
+                        break;
+                    default:
+                        this.setState({serverError: err.message, showMfa: false});
+                    }
+                }
+            }
         );
     }
 


### PR DESCRIPTION
#### Summary
> When you enter incorrect information on:  
> - Switch LDAP to Email password screen
> - Switch Email/Password Account to LDAP
>
> All the fields turn red. 
>
> Expected: Only the incorrect field turns red. 

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-3540

#### Checklist
- [x] Has UI changes