### PR TITLE
PLT-7473 Ignore text surrounded by multiple backquotes when parsing mentions

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -842,7 +842,7 @@ func GetExplicitMentions(message string, keywords map[string][]string) (map[stri
 var codeBlockPattern = regexp.MustCompile("(?m)^[^\\S\n]*\\`\\`\\`.*$[\\s\\S]+?(^[^\\S\n]*\\`\\`\\`$|\\z)")
 
 // Matches a backquote, either some text or any number of non-empty lines, and then a final backquote
-var inlineCodePattern = regexp.MustCompile("(?m)\\`(?:.+?|.*?\n(.*?\\S.*?\n)*.*?)\\`")
+var inlineCodePattern = regexp.MustCompile("(?m)\\`+(?:.+?|.*?\n(.*?\\S.*?\n)*.*?)\\`+")
 
 // Strips pre-formatted text and code blocks from a Markdown string by replacing them with whitespace
 func removeCodeFromMessage(message string) string {

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -382,7 +382,7 @@ func TestRemoveCodeFromMessage(t *testing.T) {
 		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
 	}
 
-	input = "this is `not\n    \ncode` because it has line with only whitespace"
+	input = "this is `not\n    \ncode` because it has a line with only whitespace"
 	expected = input
 	if actual := removeCodeFromMessage(input); actual != expected {
 		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
@@ -390,6 +390,12 @@ func TestRemoveCodeFromMessage(t *testing.T) {
 
 	input = "this is just `` two backquotes"
 	expected = input
+	if actual := removeCodeFromMessage(input); actual != expected {
+		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
+	}
+
+	input = "these are ``multiple backquotes`` around code"
+	expected = "these are   around code"
 	if actual := removeCodeFromMessage(input); actual != expected {
 		t.Fatalf("received incorrect output\n\nGot:\n%v\n\nExpected:\n%v\n", actual, expected)
 	}


### PR DESCRIPTION
Changes the regex to capture one or more repeated backquotes instead of just one. There are rare cases when this doesn't line match how inline code is handled in Markdown (it expects an equal number of backquotes), but it's unlikely we'll hit those cases

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7473

#### Checklist
- Added or updated unit tests (required for all new features)