### PR TITLE
PLT-7373: fix svg thumbnails and non-png copy/pastes

### DIFF
--- a/webapp/components/file_preview.jsx
+++ b/webapp/components/file_preview.jsx
@@ -9,7 +9,7 @@ import loadingGif from 'images/load.gif';
 import Constants from 'utils/constants.jsx';
 import * as Utils from 'utils/utils.jsx';
 
-import {getFileThumbnailUrl} from 'mattermost-redux/utils/file_utils';
+import {getFileUrl, getFileThumbnailUrl} from 'mattermost-redux/utils/file_utils';
 
 export default class FilePreview extends React.Component {
     static propTypes = {
@@ -47,7 +47,14 @@ export default class FilePreview extends React.Component {
 
             let className = 'file-preview';
             let previewImage;
-            if (type === 'image' || type === 'svg') {
+            if (type === 'svg') {
+                previewImage = (
+                    <img
+                        className='post-image normal'
+                        src={getFileUrl(info.id)}
+                    />
+                );
+            } else if (type === 'image') {
                 let imageClassName = 'post-image';
 
                 if (info.width < Constants.THUMBNAIL_WIDTH && info.height < Constants.THUMBNAIL_HEIGHT) {

--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -250,11 +250,7 @@ class FileUpload extends React.Component {
         for (let i = 0; i < e.clipboardData.items.length; i++) {
             const item = e.clipboardData.items[i];
 
-            if (item.type.indexOf('image') === -1) {
-                continue;
-            }
-
-            if (Constants.IMAGE_TYPES.indexOf(item.type.split('/')[1].toLowerCase()) === -1) {
+            if (item.kind !== 'file') {
                 continue;
             }
 
@@ -279,8 +275,9 @@ class FileUpload extends React.Component {
 
             for (var i = 0; i < items.length && i < numToUpload; i++) {
                 var file = items[i].getAsFile();
-
-                var ext = items[i].type.split('/')[1].toLowerCase();
+                if (!file) {
+                    continue;
+                }
 
                 // generate a unique id that can be used by other components to refer back to this file upload
                 var clientId = Utils.generateId();
@@ -299,7 +296,8 @@ class FileUpload extends React.Component {
                     min = String(d.getMinutes());
                 }
 
-                const name = formatMessage(holders.pasted) + d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + d.getDate() + ' ' + hour + '-' + min + '.' + ext;
+                const ext = file.name.lastIndexOf('.');
+                const name = formatMessage(holders.pasted) + d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + d.getDate() + ' ' + hour + '-' + min + (ext >= 0 ? file.name.substr(ext) : '');
 
                 const request = uploadFile(
                     file,


### PR DESCRIPTION
#### Summary
Two bugs:

* SVG thumbnails weren't working. The client was attempting to display them in the same way as other image thumbnails: fetching a lower resolution file from the server. But this doesn't make sense for vector graphics. The fix is to just use the regular file.

* All files pasted into the message box would trigger an upload. But in Chrome, only certain file types can be uploaded (See https://bugs.chromium.org/p/chromium/issues/detail?id=487266). So the UI would break. The fix for this is to not attempt to upload files unless we can actually get a `File` object for them.

In addition, I've removed the image filtering so that non-image files can be copied/pasted on browsers if/when they support it.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7373

#### Checklist
N/A