### PR TITLE
PLT-7516 Skip personal access token sessions in view sessions modal

### DIFF
--- a/webapp/components/activity_log_modal/activity_log_modal.jsx
+++ b/webapp/components/activity_log_modal/activity_log_modal.jsx
@@ -141,6 +141,10 @@ export default class ActivityLogModal extends React.Component {
             let devicePlatform = currentSession.props.platform;
             let devicePicture = '';
 
+            if (currentSession.props.type === 'UserAccessToken') {
+                continue;
+            }
+
             if (currentSession.props.platform === 'Windows') {
                 devicePicture = 'fa fa-windows';
             } else if (this.isMobileSession(currentSession)) {


### PR DESCRIPTION
#### Summary
Since personal access tokens need to be managed from the Personal Access Tokens section, it's best to avoid confusion by hiding them from the user sessions modal (logging out of a personal access token session won't revoke the token).

If later we want to show them here and allow token revoking here that's fine, but that's a 4-8 mana ticket.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7516