### PR TITLE
Remove duplicated message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -408,10 +408,6 @@
     "translation": "Plugins have been disabled by the system admin or the server has not been restarted since they were enabled."
   },
   {
-    "id": "app.plugin.disabled.app_error",
-    "translation": ""
-  },
-  {
     "id": "app.plugin.extract.app_error",
     "translation": "Encountered error extracting plugin"
   },


### PR DESCRIPTION
#### Summary
The messages labeled ID `app.plugin.disabled.app_error` are duplicated.
[platform/en.json at master · mattermost/platform](https://github.com/mattermost/platform/blob/master/i18n/en.json#L407)

It had better to remove the message having no word.

#### Ticket Link
N/A

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
