### PR TITLE
Fix elasticsearch purge index url in client4.

### DIFF
--- a/model/client4.go
+++ b/model/client4.go
@@ -2729,7 +2729,7 @@ func (c *Client4) TestElasticsearch() (bool, *Response) {
 
 // PurgeElasticsearchIndexes immediately deletes all Elasticsearch indexes.
 func (c *Client4) PurgeElasticsearchIndexes() (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetElasticsearchRoute()+"/test", ""); err != nil {
+	if r, err := c.DoApiPost(c.GetElasticsearchRoute()+"/purge_indexes", ""); err != nil {
 		return false, BuildErrorResponse(r, err)
 	} else {
 		defer closeBody(r)


### PR DESCRIPTION
Fix elasticsearch purge indexes URL in client4.go

Enterprise changes: https://github.com/mattermost/enterprise/pull/190