### PR TITLE
Temporarily place plugins into E20

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -189,7 +189,7 @@ func StartServer() {
 		}()
 	}
 
-	if *utils.Cfg.PluginSettings.Enable {
+	if utils.IsLicensed() && *utils.License().Features.FutureFeatures && *utils.Cfg.PluginSettings.Enable {
 		StartupPlugins("plugins", "webapp/dist")
 	}
 


### PR DESCRIPTION
#### Summary
Concerns from business team need to be addressed. In the meantime, placing the experimental implementation of plugins under E20 licenses.