### PR TITLE
[PLT-7475] Add S3 region to system console and add S3 validation

### DIFF
--- a/api/file_test.go
+++ b/api/file_test.go
@@ -875,17 +875,17 @@ func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, regi
 
 func cleanupTestFile(info *model.FileInfo) error {
 	if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *utils.Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *utils.Cfg.FileSettings.AmazonS3SSL
 		signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-		region := utils.Cfg.FileSettings.AmazonS3Region
+		region := *utils.Cfg.FileSettings.AmazonS3Region
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			return err
 		}
-		bucket := utils.Cfg.FileSettings.AmazonS3Bucket
+		bucket := *utils.Cfg.FileSettings.AmazonS3Bucket
 		if err := s3Clnt.RemoveObject(bucket, info.Path); err != nil {
 			return err
 		}

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -690,17 +690,17 @@ func TestUserCreateImage(t *testing.T) {
 	}
 
 	if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *utils.Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *utils.Cfg.FileSettings.AmazonS3SSL
 		signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-		region := utils.Cfg.FileSettings.AmazonS3Region
+		region := *utils.Cfg.FileSettings.AmazonS3Region
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			t.Fatal(err)
 		}
-		bucket := utils.Cfg.FileSettings.AmazonS3Bucket
+		bucket := *utils.Cfg.FileSettings.AmazonS3Bucket
 		if err = s3Clnt.RemoveObject(bucket, "/users/"+user.Id+"/profile.png"); err != nil {
 			t.Fatal(err)
 		}
@@ -796,17 +796,17 @@ func TestUserUploadProfileImage(t *testing.T) {
 		Client.DoApiGet("/users/"+user.Id+"/image", "", "")
 
 		if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-			endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
+			endpoint := *utils.Cfg.FileSettings.AmazonS3Endpoint
 			accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 			secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 			secure := *utils.Cfg.FileSettings.AmazonS3SSL
 			signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-			region := utils.Cfg.FileSettings.AmazonS3Region
+			region := *utils.Cfg.FileSettings.AmazonS3Region
 			s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 			if err != nil {
 				t.Fatal(err)
 			}
-			bucket := utils.Cfg.FileSettings.AmazonS3Bucket
+			bucket := *utils.Cfg.FileSettings.AmazonS3Bucket
 			if err = s3Clnt.RemoveObject(bucket, "/users/"+user.Id+"/profile.png"); err != nil {
 				t.Fatal(err)
 			}

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -659,17 +659,17 @@ func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, regi
 
 func cleanupTestFile(info *model.FileInfo) error {
 	if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *utils.Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *utils.Cfg.FileSettings.AmazonS3SSL
 		signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-		region := utils.Cfg.FileSettings.AmazonS3Region
+		region := *utils.Cfg.FileSettings.AmazonS3Region
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			return err
 		}
-		bucket := utils.Cfg.FileSettings.AmazonS3Bucket
+		bucket := *utils.Cfg.FileSettings.AmazonS3Bucket
 		if err := s3Clnt.RemoveObject(bucket, info.Path); err != nil {
 			return err
 		}

--- a/app/admin.go
+++ b/app/admin.go
@@ -157,7 +157,7 @@ func SaveConfig(cfg *model.Config, sendConfigChangeClusterMessage bool) *model.A
 	if *cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
 		utils.ValidateAmazonS3Endpoint(cfg)
 		utils.ValidateAmazonS3Region(cfg)
-		if err := utils.ValidateAmazonS3Bucket(cfg); err != nil {
+		if _, err := utils.ValidateAmazonS3Bucket(cfg); err != nil {
 			return err
 		}
 	}

--- a/app/admin.go
+++ b/app/admin.go
@@ -11,13 +11,14 @@ import (
 
 	"runtime/debug"
 
+	"net/http"
+
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/platform/einterfaces"
 	"github.com/mattermost/platform/jobs"
 	"github.com/mattermost/platform/model"
 	"github.com/mattermost/platform/store"
 	"github.com/mattermost/platform/utils"
-	"net/http"
 )
 
 func GetLogs(page, perPage int) ([]string, *model.AppError) {
@@ -151,6 +152,14 @@ func SaveConfig(cfg *model.Config, sendConfigChangeClusterMessage bool) *model.A
 
 	if err := utils.ValidateLdapFilter(cfg); err != nil {
 		return err
+	}
+
+	if *cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+		utils.ValidateAmazonS3Endpoint(cfg)
+		utils.ValidateAmazonS3Region(cfg)
+		if err := utils.ValidateAmazonS3Bucket(cfg); err != nil {
+			return err
+		}
 	}
 
 	if *utils.Cfg.ClusterSettings.Enable && *utils.Cfg.ClusterSettings.ReadOnlyConfig {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6540,12 +6540,12 @@
     "translation": "Bad connection to S3 or Minio cloud storage. Please try again."
   },
   {
-    "id": "utils.config.set_amazon_bucket",
-    "translation": "Set Amazon S3 Bucket to '%v'."
+    "id": "utils.config.create_amazon_bucket",
+    "translation": "Create Amazon S3 Bucket: '%v'."
   },
   {
-    "id": "utils.config.set_amazon_bucket_error",
-    "translation": "Error in setting Amazon S3 Bucket to '%v'."
+    "id": "utils.config.create_amazon_bucket_error",
+    "translation": "Error in creating Amazon S3 Bucket: '%v'."
   },
   {
     "id": "utils.config.set_amazon_endpoint",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6524,6 +6524,38 @@
     "translation": "Unable to load mattermost configuration file:  Adding DefaultClientLocale to AvailableLocales."
   },
   {
+    "id": "utils.config.bucket_empty.app_error",
+    "translation": "Failed: S3 bucket empty."
+  },
+  {
+    "id": "utils.config.error_checking_bucket_exist.app_error",
+    "translation": "Error checking if bucket exist."
+  },
+  {
+    "id": "utils.config.error_creating_bucket.app_error",
+    "translation": "Error creating S3 bucket."
+  },
+  {
+    "id": "utils.config.bad_connection_to_s3_or_minio.app_error",
+    "translation": "Bad connection to S3 or minio storage."
+  },
+  {
+    "id": "utils.config.set_amazon_bucket",
+    "translation": "Set Amazon S3 Bucket to '%v'."
+  },
+  {
+    "id": "utils.config.set_amazon_bucket_error",
+    "translation": "Error in setting Amazon S3 Bucket to '%v'."
+  },
+  {
+    "id": "utils.config.set_amazon_endpoint",
+    "translation": "Set Amazon S3 Endpoint to '%v'."
+  },
+  {
+    "id": "utils.config.set_amazon_region",
+    "translation": "Set Amazon S3 Region to '%v'."
+  },
+  {
     "id": "utils.config.load_config.decoding.panic",
     "translation": "Error decoding config file={{.Filename}}, err={{.Error}}"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6525,19 +6525,19 @@
   },
   {
     "id": "utils.config.bucket_empty.app_error",
-    "translation": "Failed: S3 bucket empty."
+    "translation": "Amazon S3 Bucket field is required."
   },
   {
     "id": "utils.config.error_checking_bucket_exist.app_error",
-    "translation": "Error checking if bucket exist."
+    "translation": "Encountered an error when checking if Amazon S3 Bucket exists. The bucket may not be created yet or cannot be found on the predefined endpoint."
   },
   {
     "id": "utils.config.error_creating_bucket.app_error",
-    "translation": "Error creating S3 bucket."
+    "translation": "Encountered an error when creating the Amazon S3 Bucket. Confirm you have the proper permissions and try again."
   },
   {
     "id": "utils.config.bad_connection_to_s3_or_minio.app_error",
-    "translation": "Bad connection to S3 or minio storage."
+    "translation": "Bad connection to S3 or Minio cloud storage. Please try again."
   },
   {
     "id": "utils.config.set_amazon_bucket",

--- a/model/config.go
+++ b/model/config.go
@@ -88,6 +88,9 @@ const (
 
 	SQL_SETTINGS_DEFAULT_DATA_SOURCE = "mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
 
+	FILE_SETTINGS_DEFAULT_AMAZON_S3_ENDPOINT = "s3.amazonaws.com"
+	FILE_SETTINGS_DEFAULT_AMAZON_S3_REGION   = "us-east-1"
+
 	EMAIL_SETTINGS_DEFAULT_FEEDBACK_ORGANIZATION = ""
 
 	SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK      = "https://about.mattermost.com/default-terms/"
@@ -266,9 +269,9 @@ type FileSettings struct {
 	InitialFont             string
 	AmazonS3AccessKeyId     string
 	AmazonS3SecretAccessKey string
-	AmazonS3Bucket          string
-	AmazonS3Region          string
-	AmazonS3Endpoint        string
+	AmazonS3Bucket          *string
+	AmazonS3Region          *string
+	AmazonS3Endpoint        *string
 	AmazonS3SSL             *bool
 	AmazonS3SignV2          *bool
 	AmazonS3SSE             *bool
@@ -587,9 +590,19 @@ func (o *Config) SetDefaults() {
 		*o.FileSettings.DriverName = IMAGE_DRIVER_LOCAL
 	}
 
-	if o.FileSettings.AmazonS3Endpoint == "" {
-		// Defaults to "s3.amazonaws.com"
-		o.FileSettings.AmazonS3Endpoint = "s3.amazonaws.com"
+	if o.FileSettings.AmazonS3Bucket == nil {
+		o.FileSettings.AmazonS3Bucket = new(string)
+		*o.FileSettings.AmazonS3Bucket = ""
+	}
+
+	if o.FileSettings.AmazonS3Region == nil {
+		o.FileSettings.AmazonS3Region = new(string)
+		*o.FileSettings.AmazonS3Region = FILE_SETTINGS_DEFAULT_AMAZON_S3_REGION
+	}
+
+	if o.FileSettings.AmazonS3Endpoint == nil {
+		o.FileSettings.AmazonS3Endpoint = new(string)
+		*o.FileSettings.AmazonS3Endpoint = FILE_SETTINGS_DEFAULT_AMAZON_S3_ENDPOINT
 	}
 
 	if o.FileSettings.AmazonS3SSL == nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -18,6 +18,7 @@ import (
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/fsnotify/fsnotify"
+	s3 "github.com/minio/minio-go"
 	"github.com/spf13/viper"
 
 	"net/http"
@@ -45,6 +46,25 @@ var CfgDisableConfigWatch = false
 var ClientCfg map[string]string = map[string]string{}
 var originalDisableDebugLvl l4g.Level = l4g.DEBUG
 var siteURL = ""
+
+var awsS3EndpointMap = map[string]string{
+	"s3.amazonaws.com":                "us-east-1",
+	"s3-us-east-2.amazonaws.com":      "us-east-2",
+	"s3-us-west-2.amazonaws.com":      "us-west-2",
+	"s3-us-west-1.amazonaws.com":      "us-west-1",
+	"s3.ca-central-1.amazonaws.com":   "ca-central-1",
+	"s3-eu-west-1.amazonaws.com":      "eu-west-1",
+	"s3-eu-west-2.amazonaws.com":      "eu-west-2",
+	"s3-eu-central-1.amazonaws.com":   "eu-central-1",
+	"s3-ap-south-1.amazonaws.com":     "ap-south-1",
+	"s3-ap-southeast-1.amazonaws.com": "ap-southeast-1",
+	"s3-ap-southeast-2.amazonaws.com": "ap-southeast-2",
+	"s3-ap-northeast-1.amazonaws.com": "ap-northeast-1",
+	"s3-ap-northeast-2.amazonaws.com": "ap-northeast-2",
+	"s3-sa-east-1.amazonaws.com":      "sa-east-1",
+	"s3-us-gov-west-1.amazonaws.com":  "us-gov-west-1",
+	"s3.cn-north-1.amazonaws.com.cn":  "cn-north-1",
+}
 
 func GetSiteURL() string {
 	return siteURL
@@ -688,4 +708,76 @@ func IsLeader() bool {
 	} else {
 		return true
 	}
+}
+
+func ValidateAmazonS3Endpoint(cfg *model.Config) {
+	_, ok := awsS3EndpointMap[*cfg.FileSettings.AmazonS3Endpoint]
+	if !ok {
+		*cfg.FileSettings.AmazonS3Endpoint = model.FILE_SETTINGS_DEFAULT_AMAZON_S3_ENDPOINT
+		l4g.Warn(T("utils.config.set_amazon_endpoint"), model.FILE_SETTINGS_DEFAULT_AMAZON_S3_ENDPOINT)
+	}
+}
+
+func ValidateAmazonS3Region(cfg *model.Config) {
+	valid := false
+	for _, region := range awsS3EndpointMap {
+		if region == *cfg.FileSettings.AmazonS3Region {
+			valid = true
+			break
+		}
+	}
+
+	if !valid {
+		*cfg.FileSettings.AmazonS3Region = model.FILE_SETTINGS_DEFAULT_AMAZON_S3_REGION
+		l4g.Warn(T("utils.config.set_amazon_region"), model.FILE_SETTINGS_DEFAULT_AMAZON_S3_REGION)
+	}
+}
+
+func ValidateAmazonS3Bucket(cfg *model.Config) *model.AppError {
+	if *cfg.FileSettings.AmazonS3Bucket == "" {
+		return model.NewAppError("ValidateAmazonS3Bucket", "utils.config.bucket_empty.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	endpoint := *cfg.FileSettings.AmazonS3Endpoint
+	bucket := *cfg.FileSettings.AmazonS3Bucket
+	accessKey := cfg.FileSettings.AmazonS3AccessKeyId
+	secretKey := cfg.FileSettings.AmazonS3SecretAccessKey
+	secure := *cfg.FileSettings.AmazonS3SSL
+
+	s3Clnt, err := s3.New(endpoint, accessKey, secretKey, secure)
+	if err != nil {
+		return model.NewAppError("ValidateAmazonS3Bucket", "utils.config.bad_connection_to_s3_or_minio.app_error", nil, err.Error(), http.StatusBadRequest)
+	}
+
+	bucketLocation, err := s3Clnt.GetBucketLocation(bucket)
+	if err != nil {
+		bucketLocation = *cfg.FileSettings.AmazonS3Region
+
+		exists, err := s3Clnt.BucketExists(bucket)
+		if err != nil {
+			return model.NewAppError("ValidateAmazonS3Bucket", "utils.config.error_checking_bucket_exist.app_error", nil, err.Error(), http.StatusBadRequest)
+		}
+
+		if !exists {
+			err := s3Clnt.MakeBucket(bucket, bucketLocation)
+			if err != nil {
+				l4g.Error(T("utils.config.set_amazon_bucket_error"), bucket)
+				return model.NewAppError("ValidateAmazonS3Bucket", "utils.config.error_creating_bucket.app_error", nil, err.Error(), http.StatusBadRequest)
+			}
+			l4g.Warn(T("utils.config.set_amazon_bucket"), bucket)
+		}
+	}
+
+	for endpoint, region := range awsS3EndpointMap {
+		if region == bucketLocation {
+			*cfg.FileSettings.AmazonS3Endpoint = endpoint
+			l4g.Warn(T("utils.config.set_amazon_endpoint"), endpoint)
+
+			*cfg.FileSettings.AmazonS3Region = region
+			l4g.Warn(T("utils.config.set_amazon_region"), region)
+			break
+		}
+	}
+
+	return nil
 }

--- a/utils/file.go
+++ b/utils/file.go
@@ -38,13 +38,13 @@ func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, regi
 
 func TestFileConnection() *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
-		bucket := Cfg.FileSettings.AmazonS3Bucket
+		region := *Cfg.FileSettings.AmazonS3Region
+		bucket := *Cfg.FileSettings.AmazonS3Bucket
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
@@ -81,17 +81,17 @@ func TestFileConnection() *model.AppError {
 
 func ReadFile(path string) ([]byte, *model.AppError) {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			return nil, model.NewLocAppError("ReadFile", "api.file.read_file.s3.app_error", nil, err.Error())
 		}
-		bucket := Cfg.FileSettings.AmazonS3Bucket
+		bucket := *Cfg.FileSettings.AmazonS3Bucket
 		minioObject, err := s3Clnt.GetObject(bucket, path)
 		defer minioObject.Close()
 		if err != nil {
@@ -115,12 +115,12 @@ func ReadFile(path string) ([]byte, *model.AppError) {
 
 func MoveFile(oldPath, newPath string) *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 		encrypt := false
 		if *Cfg.FileSettings.AmazonS3SSE && IsLicensed() && *License().Features.Compliance {
 			encrypt = true
@@ -129,7 +129,7 @@ func MoveFile(oldPath, newPath string) *model.AppError {
 		if err != nil {
 			return model.NewLocAppError("moveFile", "api.file.write_file.s3.app_error", nil, err.Error())
 		}
-		bucket := Cfg.FileSettings.AmazonS3Bucket
+		bucket := *Cfg.FileSettings.AmazonS3Bucket
 
 		source := s3.NewSourceInfo(bucket, oldPath, nil)
 		destination, err := s3.NewDestinationInfo(bucket, newPath, nil, CopyMetadata(encrypt))
@@ -159,12 +159,12 @@ func MoveFile(oldPath, newPath string) *model.AppError {
 
 func WriteFile(f []byte, path string) *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 		encrypt := false
 		if *Cfg.FileSettings.AmazonS3SSE && IsLicensed() && *License().Features.Compliance {
 			encrypt = true
@@ -175,7 +175,7 @@ func WriteFile(f []byte, path string) *model.AppError {
 			return model.NewLocAppError("WriteFile", "api.file.write_file.s3.app_error", nil, err.Error())
 		}
 
-		bucket := Cfg.FileSettings.AmazonS3Bucket
+		bucket := *Cfg.FileSettings.AmazonS3Bucket
 		ext := filepath.Ext(path)
 		metaData := S3Metadata(encrypt, "binary/octet-stream")
 		if model.IsFileExtImage(ext) {
@@ -212,19 +212,19 @@ func writeFileLocally(f []byte, path string) *model.AppError {
 
 func RemoveFile(path string) *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			return model.NewLocAppError("RemoveFile", "utils.file.remove_file.s3.app_error", nil, err.Error())
 		}
 
-		bucket := Cfg.FileSettings.AmazonS3Bucket
+		bucket := *Cfg.FileSettings.AmazonS3Bucket
 		if err := s3Clnt.RemoveObject(bucket, path); err != nil {
 			return model.NewLocAppError("RemoveFile", "utils.file.remove_file.s3.app_error", nil, err.Error())
 		}
@@ -261,12 +261,12 @@ func getPathsFromObjectInfos(in <-chan s3.ObjectInfo) <-chan string {
 
 func RemoveDirectory(path string) *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
@@ -275,7 +275,7 @@ func RemoveDirectory(path string) *model.AppError {
 
 		doneCh := make(chan struct{})
 
-		bucket := Cfg.FileSettings.AmazonS3Bucket
+		bucket := *Cfg.FileSettings.AmazonS3Bucket
 		for err := range s3Clnt.RemoveObjects(bucket, getPathsFromObjectInfos(s3Clnt.ListObjects(bucket, path, true, doneCh))) {
 			if err.Err != nil {
 				doneCh <- struct{}{}

--- a/webapp/components/admin_console/storage_settings.jsx
+++ b/webapp/components/admin_console/storage_settings.jsx
@@ -34,6 +34,7 @@ export default class StorageSettings extends AdminSettings {
         config.FileSettings.AmazonS3AccessKeyId = this.state.amazonS3AccessKeyId;
         config.FileSettings.AmazonS3SecretAccessKey = this.state.amazonS3SecretAccessKey;
         config.FileSettings.AmazonS3Bucket = this.state.amazonS3Bucket;
+        config.FileSettings.AmazonS3Region = this.state.amazonS3Region;
         config.FileSettings.AmazonS3Endpoint = this.state.amazonS3Endpoint;
         config.FileSettings.AmazonS3SSL = this.state.amazonS3SSL;
         config.FileSettings.AmazonS3SSE = this.state.amazonS3SSE;
@@ -52,6 +53,7 @@ export default class StorageSettings extends AdminSettings {
             amazonS3AccessKeyId: config.FileSettings.AmazonS3AccessKeyId,
             amazonS3SecretAccessKey: config.FileSettings.AmazonS3SecretAccessKey,
             amazonS3Bucket: config.FileSettings.AmazonS3Bucket,
+            amazonS3Region: config.FileSettings.AmazonS3Region,
             amazonS3Endpoint: config.FileSettings.AmazonS3Endpoint,
             amazonS3SSL: config.FileSettings.AmazonS3SSL,
             amazonS3SSE: config.FileSettings.AmazonS3SSE
@@ -237,6 +239,25 @@ export default class StorageSettings extends AdminSettings {
                         />
                     }
                     value={this.state.amazonS3Bucket}
+                    onChange={this.handleChange}
+                    disabled={this.state.driverName !== DRIVER_S3}
+                />
+                <TextSetting
+                    id='amazonS3Region'
+                    label={
+                        <FormattedMessage
+                            id='admin.image.amazonS3RegionTitle'
+                            defaultMessage='Amazon S3 Region:'
+                        />
+                    }
+                    placeholder={Utils.localizeMessage('admin.image.amazonS3RegionExample', 'Ex "us-east-1"')}
+                    helpText={
+                        <FormattedMessage
+                            id='admin.image.amazonS3RegionDescription'
+                            defaultMessage='(Optional) AWS region you selected when creating your S3 bucket. If no region is set, Mattermost attempts to get the appropriate region from AWS, or sets it to "us-east-1" if none found.'
+                        />
+                    }
+                    value={this.state.amazonS3Region}
                     onChange={this.handleChange}
                     disabled={this.state.driverName !== DRIVER_S3}
                 />

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -475,7 +475,7 @@
   "admin.image.amazonS3IdDescription": "Obtain this credential from your Amazon EC2 administrator.",
   "admin.image.amazonS3IdExample": "E.g.: \"AKIADTOVBGERKLCBV\"",
   "admin.image.amazonS3IdTitle": "Amazon S3 Access Key ID:",
-  "admin.image.amazonS3RegionDescription": "AWS region you selected for creating your S3 bucket.",
+  "admin.image.amazonS3RegionDescription": "(Optional) AWS region you selected when creating your S3 bucket. If no region is set, Mattermost attempts to get the appropriate region from AWS, or sets it to 'us-east-1' if none found.",
   "admin.image.amazonS3RegionExample": "E.g.: \"us-east-1\"",
   "admin.image.amazonS3RegionTitle": "Amazon S3 Region:",
   "admin.image.amazonS3SSEDescription": "When true, encrypt files in Amazon S3 using server-side encryption with Amazon S3-managed keys. See <a href=\"https://about.mattermost.com/default-server-side-encryption\">documentation</a> to learn more.",


### PR DESCRIPTION
#### Summary
Add S3 region to system console and add S3 validation to endpoint, region and bucket

#### Ticket Link
Jira ticket: [PLT-7475](https://mattermost.atlassian.net/browse/PLT-7475)

#### Checklist
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (config)

@jasonblais please help validate the System Console UI, translation/logs and UX experience. Below are some key points:
1. If Driver is set to S3 and given valid credentials,
- Endpoint is validated against the predefined S3 endpoint mapping. If not found, it will be set to .default: "s3.amazonaws.com"
- Region is validated against the predefined S3 endpoint mapping. If not found, it will be set to default: "us-east-1".
- Bucket cannot be empty.
- if bucket does not exist, it will be created automatically according to endpoint/region. 
- if bucket exists, endpoint and region will be filled up / modified accordingly.
- Changes to S3 settings are logged into the console.

