### PR TITLE
Fix 'Get Team Invite Link' logic on RHS menu to match LHS menu.

### DIFF
--- a/webapp/components/sidebar_right_menu.jsx
+++ b/webapp/components/sidebar_right_menu.jsx
@@ -193,7 +193,7 @@ export default class SidebarRightMenu extends React.Component {
                 </li>
             );
 
-            if (this.props.teamType === 'O') {
+            if (this.props.teamType === Constants.OPEN_TEAM && global.mm_config.EnableUserCreation === 'true') {
                 teamLink = (
                     <li>
                         <a


### PR DESCRIPTION
There's different logic for 'Get Team Invite Link' for RHS and LHS menu. This causes that the link is displayed differently when `EnableUserCreation=false`:

- RHS menu: `webapp/components/sidebar_right_menu.jsx`
`if (this.props.teamType === 'O') {`
https://github.com/mattermost/platform/blob/master/webapp/components/sidebar_right_menu.jsx#L196
<img width="702" alt="screen shot 2017-09-05 at 12 27 49 am" src="https://user-images.githubusercontent.com/160621/30069878-77ac5624-9227-11e7-9299-916b2e802875.png">

- LHS menu: `webapp/components/sidebar_header_dropdown.jsx`
`if (this.props.teamType === Constants.OPEN_TEAM && config.EnableUserCreation === 'true') {`
https://github.com/mattermost/platform/blob/master/webapp/components/sidebar_header_dropdown.jsx#L254
<img width="890" alt="screen shot 2017-09-05 at 12 27 39 am" src="https://user-images.githubusercontent.com/160621/30069886-7c2dc9a8-9227-11e7-96bf-8bde2cdd159e.png">

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
