### PR TITLE
PLT-7300: Add use_user_icon prop to allow bots to just use their user icon

### DIFF
--- a/app/plugin/jira/plugin.go
+++ b/app/plugin/jira/plugin.go
@@ -69,7 +69,7 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		Type:      model.POST_SLACK_ATTACHMENT,
 		UserId:    user.Id,
 		Props: map[string]interface{}{
-			"from_bot":      "true",
+			"from_webhook":  "true",
 			"use_user_icon": "true",
 			"attachments":   []*model.SlackAttachment{attachment},
 		},

--- a/app/plugin/jira/plugin.go
+++ b/app/plugin/jira/plugin.go
@@ -69,8 +69,9 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		Type:      model.POST_SLACK_ATTACHMENT,
 		UserId:    user.Id,
 		Props: map[string]interface{}{
-			"from_webhook": "true",
-			"attachments":  []*model.SlackAttachment{attachment},
+			"from_bot":      "true",
+			"use_user_icon": "true",
+			"attachments":   []*model.SlackAttachment{attachment},
 		},
 	}); err != nil {
 		http.Error(w, p.api.I18n(err.Message, r), err.StatusCode)

--- a/webapp/utils/post_utils.jsx
+++ b/webapp/utils/post_utils.jsx
@@ -39,7 +39,7 @@ export function getProfilePicSrcForPost(post, user) {
         src = Utils.imageURLForUser(post.user_id);
     }
 
-    if (post.props && post.props.from_webhook && global.window.mm_config.EnablePostIconOverride === 'true') {
+    if (post.props && post.props.from_webhook && !post.props.use_user_icon && global.window.mm_config.EnablePostIconOverride === 'true') {
         if (post.props.override_icon_url) {
             src = post.props.override_icon_url;
         } else {


### PR DESCRIPTION
#### Summary
The JIRA plugin has a requirement of "use user image" and "have bot label". Which means we either need a prop to make webhook posts use the user image or a prop to add the bot label to non-webhook posts. The "from_webhook" prop is somewhat tightly coupled with our notification handling, so the much simpler and lower risk option for good bot behavior was to use it in addition to a "use_user_icon" prop.

I think ideally we would probably create separate props that can produce the effects of "from_webhook" such as "from_bot" and "notify_user", but that requires a little more thought and effort.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7300

#### Checklist
N/A