### PR TITLE
PLT-7555: more robust file upload extension

### DIFF
--- a/webapp/components/file_upload.jsx
+++ b/webapp/components/file_upload.jsx
@@ -296,8 +296,16 @@ class FileUpload extends React.Component {
                     min = String(d.getMinutes());
                 }
 
-                const ext = file.name.lastIndexOf('.');
-                const name = formatMessage(holders.pasted) + d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + d.getDate() + ' ' + hour + '-' + min + (ext >= 0 ? file.name.substr(ext) : '');
+                var ext = '';
+                if (file.name) {
+                    if (file.name.includes('.')) {
+                        ext = file.name.substr(file.name.lastIndexOf('.'));
+                    }
+                } else if (items[i].type.includes('/')) {
+                    ext = '.' + items[i].type.split('/')[1].toLowerCase();
+                }
+
+                const name = formatMessage(holders.pasted) + d.getFullYear() + '-' + (d.getMonth() + 1) + '-' + d.getDate() + ' ' + hour + '-' + min + ext;
 
                 const request = uploadFile(
                     file,


### PR DESCRIPTION
#### Summary
The desktop app seems to be subject to this bug: https://bugs.chromium.org/p/chromium/issues/detail?id=361145

So if a file name isn't available, this falls back to using the mime type to get the extension as it did before.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7555

#### Checklist
N/A