### PR TITLE
Fix webapp plugins for production builds

### DIFF
--- a/webapp/components/profile_popover.jsx
+++ b/webapp/components/profile_popover.jsx
@@ -19,6 +19,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 export default class ProfilePopover extends React.Component {
+    static getComponentName() {
+        return 'ProfilePopover';
+    }
+
     constructor(props) {
         super(props);
 

--- a/webapp/plugins/pluggable/pluggable.jsx
+++ b/webapp/plugins/pluggable/pluggable.jsx
@@ -33,6 +33,8 @@ export default class Pluggable extends React.PureComponent {
             return null;
         }
 
+        const childName = child.getComponentName();
+
         // Include any props passed to this component or to the child component
         let props = {...this.props};
         Reflect.deleteProperty(props, 'children');
@@ -40,8 +42,8 @@ export default class Pluggable extends React.PureComponent {
         props = {...props, ...this.props.children.props};
 
         // Override the default component with any registered plugin's component
-        if (components.hasOwnProperty(child.name)) {
-            const PluginComponent = components[child.name];
+        if (components.hasOwnProperty(childName)) {
+            const PluginComponent = components[childName];
             return (
                 <PluginComponent
                     {...props}


### PR DESCRIPTION
#### Summary
Production builds weren't including the component names, causing plugin components not to render. This may not be the final solution but it's good enough for 4.2